### PR TITLE
feat(payments): bound a run's FIRST payment claim, and let a run declare no agreed quantity (#1676)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -941,6 +941,72 @@ setupSharedTestSuite(() => {
       expect(closedRow.payable_quantity).toBe(4)
     })
 
+    /**
+     * #1676 — an open-ended run keeps being offered.
+     *
+     * 🔴 Its `billable_remaining` is null because there is no ceiling to
+     * subtract from, and everywhere else null means "no arithmetic available",
+     * which a screen reads as nothing left. Without `open_ended` on the row the
+     * status folds to `billed` after the FIRST claim and no screen ever offers
+     * the run again — repeated billing is the entire point of the opt-out.
+     */
+    it("keeps offering a run with no agreed quantity after it has been billed (#1676)", async () => {
+      const d1 = await createDesign("Open Ended Row Design", {
+        estimated_cost: 100,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Open Ended Row Design", {
+        quantity: null,
+        produced_quantity: 40,
+        partner_cost_estimate: 100,
+        cost_type: "per_unit",
+      })
+
+      const before = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const row = before.data.payable_runs.find((r: any) => r.run_id === runId)
+      expect(row).toBeDefined()
+      expect(row.open_ended).toBe(true)
+      // Null, not 0. `Number(null)` is 0, and "ordered for nothing" is a very
+      // different statement from "no amount was agreed".
+      expect(row.ordered_quantity).toBeNull()
+      expect(row.payable_quantity).toBe(40)
+      expect(row.billing_status).toBe("clear")
+
+      const first = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 10 },
+          unit_amounts: { [d1]: 100 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      expect(first.status).toBe(201)
+      await api.post(
+        `/admin/payment-submissions/${first.data.payment_submission.id}/review`,
+        { action: "approve", paid_to_id: paidToId },
+        adminHeaders
+      )
+
+      const after = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const billedRow = after.data.payable_runs.find(
+        (r: any) => r.run_id === runId
+      )
+      expect(billedRow).toBeDefined()
+      expect(billedRow.open_ended).toBe(true)
+      expect(billedRow.billing_status).toBe("partly_billed")
+      // Null means NO CEILING here, and the row says which of the two it is.
+      expect(billedRow.billable_remaining).toBeNull()
+    })
+
     it("marks a run with no agreed rate unpayable instead of billing zero", async () => {
       // A run with no cost is not a zero-value payout — it is a run whose price
       // has not been settled. Surfaced, not silently dropped.
@@ -2104,6 +2170,106 @@ setupSharedTestSuite(() => {
       expect(over.status).toBe(400)
       expect(over.data.message).toContain("already paid for")
       expect(over.data.message).toContain("1 remaining")
+    })
+
+    /**
+     * #1676 — the FIRST claim was never checked against the run at all.
+     *
+     * `assessRunClaims` diffs against a tally of PRIOR claims, and a run nobody
+     * had billed yet has no tally, so it was skipped entirely: a run ordered
+     * for 9 could be billed at 100 and nothing refused it. Only a short-closed
+     * run was checked, because otherwise the close would have meant nothing.
+     */
+    it("refuses a FIRST claim for more than the run was ordered for (#1676)", async () => {
+      const d1 = await createDesign("First Claim Ceiling Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "First Claim Ceiling Design", {
+        quantity: 9,
+        produced_quantity: 9,
+      })
+
+      const over = await api
+        .post(
+          "/admin/payment-submissions",
+          {
+            partner_id: partnerId,
+            design_ids: [d1],
+            quantities: { [d1]: 100 },
+            unit_amounts: { [d1]: 1200 },
+            production_run_ids: { [d1]: [runId] },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(over.status).toBe(400)
+      expect(over.data.message).toContain("already paid for")
+      expect(over.data.message).toContain("ordered 9")
+      expect(over.data.message).toContain("asks for 100")
+    })
+
+    it("still allows a first claim within the ordered quantity (#1676)", async () => {
+      // The bound is the agreed amount, not a ban on billing a whole run.
+      const d1 = await createDesign("First Claim Within Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "First Claim Within Design", {
+        quantity: 9,
+        produced_quantity: 9,
+      })
+
+      const res = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 9 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(201)
+      expect(Number(res.data.payment_submission.total_amount)).toBe(10800)
+    })
+
+    /**
+     * #1676 — the opt-out that makes the ceiling safe to impose.
+     *
+     * A run created with NO agreed quantity is open-ended: ongoing work with no
+     * fixed order, billed as it comes. `quantity` defaulted to 1 and was NOT
+     * NULL until this issue, so "no agreed amount" was unrepresentable — an
+     * unset quantity read as a run ordered for one piece, the tightest possible
+     * ceiling rather than the absence of one.
+     */
+    it("does not cap a run created with NO agreed quantity (#1676)", async () => {
+      const d1 = await createDesign("Open Ended Run Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Open Ended Run Design", {
+        quantity: null,
+        produced_quantity: 40,
+      })
+
+      const res = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 40 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(201)
+      expect(Number(res.data.payment_submission.total_amount)).toBe(48000)
     })
 
     it("still refuses a second claim that states no quantity (#1596)", async () => {

--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -3062,6 +3062,43 @@ setupSharedTestSuite(() => {
       expect(row.billing_status).toBe("clear")
     })
 
+    /**
+     * 🔴 A `total` is the price for the JOB, on this screen too.
+     *
+     * This route priced with its own arithmetic — `runUnitCost(run) ×
+     * payable_quantity`, i.e. the derived rate re-multiplied — which is the
+     * defect #1679 removed from the admin side. On this run the two screens
+     * disagreed by 22% on the same day: ₹10,000 offered to the admin, and
+     * ₹7,777.77 offered to the partner whose work it was. Both now price
+     * through `runPayableOffer`.
+     */
+    it("offers the agreed TOTAL verbatim, not the derived rate × quantity (#1679)", async () => {
+      const d1 = await createDesign("Partner Total Priced Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Partner Total Priced Design", {
+        quantity: 9,
+        produced_quantity: 7,
+        partner_cost_estimate: 10000,
+        cost_type: "total",
+      })
+
+      const res = await api.get("/partners/payment-submissions/payable-runs", {
+        headers: partnerHeaders,
+      })
+
+      const row = res.data.payable_runs.find((r: any) => r.run_id === runId)
+      expect(row).toBeDefined()
+      expect(row.amount).toBe(10000)
+      // The old arithmetic, named so the case cannot pass for the wrong reason.
+      expect(row.amount).not.toBe(7777.77)
+      // The rate is DERIVED — display only, and the row has to say so or a
+      // screen multiplies it and re-prices the job.
+      expect(row.unit_is_derived).toBe(true)
+      expect(row.payable_quantity).toBe(7)
+    })
+
     it("never shows one partner the runs of another", async () => {
       const other = await createPartnerWithAuth(
         Math.floor(Math.random() * 100000)

--- a/apps/backend/integration-tests/http/production-runs.spec.ts
+++ b/apps/backend/integration-tests/http/production-runs.spec.ts
@@ -641,5 +641,120 @@ setupSharedTestSuite(() => {
         childRes.data.production_run.dispatched_template_ids ?? null
       ).toBeNull()
     })
+
+    /**
+     * #1676 — a run may state NO agreed quantity.
+     *
+     * `quantity` was `not null default 1`, so "there is no agreed amount" was
+     * unrepresentable: an unset quantity read as a run ordered for ONE piece,
+     * which is the tightest possible payment ceiling rather than the absence of
+     * one. Since every payment claim — including a run's first — is bounded by
+     * that quantity, this null is the explicit, per-run opt-out.
+     */
+    describe("a run with no agreed quantity (#1676)", () => {
+      it("creates one, and keeps the null rather than defaulting it to 1", async () => {
+        const { api } = getSharedTestEnv()
+
+        const res = await api.post(
+          "/admin/production-runs",
+          { design_id: designId, quantity: null },
+          adminHeaders
+        )
+
+        expect(res.status).toBe(201)
+        expect(res.data.production_run.quantity).toBeNull()
+
+        // And it reads back that way — the column is nullable, not just the
+        // response shape.
+        const detail = await api.get(
+          `/admin/production-runs/${res.data.production_run.id}`,
+          adminHeaders
+        )
+        expect(detail.data.production_run.quantity).toBeNull()
+      })
+
+      it("still defaults to 1 when the field is simply omitted", async () => {
+        // Omitting is not declaring. Only an explicit null opts out.
+        const { api } = getSharedTestEnv()
+
+        const res = await api.post(
+          "/admin/production-runs",
+          { design_id: designId },
+          adminHeaders
+        )
+
+        expect(res.status).toBe(201)
+        expect(res.data.production_run.quantity).toBe(1)
+      })
+
+      it("passes open-endedness down to the child runs on approve", async () => {
+        // 🔴 `a.quantity ?? parent.quantity ?? 1` collapsed an open-ended
+        // parent to 1 — the tightest ceiling on a run whose whole point is that
+        // it has none, and only visible when a partner's claim was refused.
+        const { api } = getSharedTestEnv()
+
+        const parent = await api.post(
+          "/admin/production-runs",
+          { design_id: designId, quantity: null },
+          adminHeaders
+        )
+        expect(parent.status).toBe(201)
+
+        const approved = await api.post(
+          `/admin/production-runs/${parent.data.production_run.id}/approve`,
+          { assignments: [{ partner_id: partnerId, role: "production" }] },
+          adminHeaders
+        )
+        expect(approved.status).toBe(200)
+
+        const child = (approved.data.result?.children || [])[0]
+        expect(child).toBeTruthy()
+        expect(child.quantity).toBeNull()
+      })
+
+      it("clears an agreed quantity on a run that has not been accepted", async () => {
+        const { api } = getSharedTestEnv()
+
+        const created = await api.post(
+          "/admin/production-runs",
+          { design_id: designId, quantity: 5 },
+          adminHeaders
+        )
+        expect(created.data.production_run.quantity).toBe(5)
+
+        const updated = await api.post(
+          `/admin/production-runs/${created.data.production_run.id}`,
+          { quantity: null },
+          adminHeaders
+        )
+
+        expect(updated.status).toBe(200)
+        expect(updated.data.production_run.quantity).toBeNull()
+      })
+
+      it("refuses a quantity of 0 — a broken number is not a declaration", async () => {
+        // `Number(null)` is 0, so the two used to be written the same way. A
+        // zero quantity IS set and is unusable, and every payment guard refuses
+        // on it; only null means open-ended.
+        const { api } = getSharedTestEnv()
+
+        const created = await api.post(
+          "/admin/production-runs",
+          { design_id: designId, quantity: 5 },
+          adminHeaders
+        )
+
+        const res = await api
+          .post(
+            `/admin/production-runs/${created.data.production_run.id}`,
+            { quantity: 0 },
+            adminHeaders
+          )
+          .catch((e: any) => e.response)
+
+        expect(res.status).toBe(400)
+        expect(res.data.message).toContain("positive number")
+      })
+    })
   })
 })

--- a/apps/backend/src/admin/components/creates/__tests__/run-line-pricing.unit.spec.ts
+++ b/apps/backend/src/admin/components/creates/__tests__/run-line-pricing.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   runBillsVerbatimTotal,
   runLineAmount,
+  runNeedsTypedPrice,
 } from "../lib/run-line-pricing"
 
 /**
@@ -108,6 +109,134 @@ describe("runBillsVerbatimTotal", () => {
     ).toBe(false)
     expect(
       runBillsVerbatimTotal({ unit_is_derived: null, hasTypedRate: false })
+    ).toBe(false)
+  })
+})
+
+/**
+ * #1596/#1676 — the REMAINDER of a partly-billed run.
+ *
+ * The admin screen used to drop a run the moment anything claimed it, so
+ * "bill the rest of this job" was not a state that could exist here. Now that
+ * the remainder is offered, an untouched total-priced row has two wrong
+ * answers available and both cost money:
+ *
+ *   - re-bill the agreed total  ⇒ ₹10,000 agreed, ₹20,000 paid. `assessRunClaims`
+ *     does NOT stop it: that guard bounds UNITS (4 + 5 ≤ 9), not money.
+ *   - multiply the derived rate ⇒ the ₹7,777.77-on-₹10,000 re-pricing of #1679.
+ *
+ * So it bills NOTHING and says so, and the screen's zero-amount guard refuses
+ * the submit until an operator states what the rest is worth.
+ */
+describe("a partly-billed run's remainder (#1676)", () => {
+  const totalPriced = {
+    quantity: 5,
+    rate: 1111.11,
+    amount: 10000,
+    unit_is_derived: true,
+  }
+
+  it("bills NOTHING for an untouched total-priced remainder", () => {
+    expect(
+      runLineAmount({
+        ...totalPriced,
+        hasTypedRate: false,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(0)
+  })
+
+  it("does not re-bill the agreed total", () => {
+    // The failure this exists to prevent, stated as its own case.
+    expect(
+      runLineAmount({
+        ...totalPriced,
+        hasTypedRate: false,
+        alreadyPartlyBilled: true,
+      })
+    ).not.toBe(10000)
+  })
+
+  it("does not multiply the derived rate either", () => {
+    // 5 x 1111.11 = 5555.55 — a re-pricing nobody decided.
+    expect(
+      runLineAmount({
+        ...totalPriced,
+        hasTypedRate: false,
+        alreadyPartlyBilled: true,
+      })
+    ).not.toBe(5555.55)
+  })
+
+  it("prices from the moment a rate is typed", () => {
+    expect(
+      runLineAmount({
+        ...totalPriced,
+        rate: 1400,
+        hasTypedRate: true,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(7000)
+  })
+
+  it("leaves a PER-UNIT run alone — its rate was agreed, so it multiplies", () => {
+    expect(
+      runLineAmount({
+        quantity: 9,
+        rate: 1200,
+        amount: 12000,
+        unit_is_derived: false,
+        hasTypedRate: false,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(10800)
+  })
+
+  it("leaves a FIRST claim on a total-priced run alone", () => {
+    // Nothing has been billed, so the agreed total still stands verbatim.
+    expect(
+      runLineAmount({
+        ...totalPriced,
+        hasTypedRate: false,
+        alreadyPartlyBilled: false,
+      })
+    ).toBe(10000)
+  })
+
+  it("stops the line-total CHANNEL from carrying a figure it no longer has", () => {
+    // `hasVerbatimTotal` decides which request field the money is sent on.
+    // A partly-billed total has no figure of its own, so it must not be sent
+    // as a line total either.
+    expect(
+      runBillsVerbatimTotal({
+        unit_is_derived: true,
+        hasTypedRate: false,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(false)
+    expect(
+      runNeedsTypedPrice({
+        unit_is_derived: true,
+        hasTypedRate: false,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(true)
+  })
+
+  it("needs no typed price once one is typed, or when nothing was claimed", () => {
+    expect(
+      runNeedsTypedPrice({
+        unit_is_derived: true,
+        hasTypedRate: true,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(false)
+    expect(
+      runNeedsTypedPrice({
+        unit_is_derived: true,
+        hasTypedRate: false,
+        alreadyPartlyBilled: false,
+      })
     ).toBe(false)
   })
 })

--- a/apps/backend/src/admin/components/creates/create-payment-submission.tsx
+++ b/apps/backend/src/admin/components/creates/create-payment-submission.tsx
@@ -29,6 +29,7 @@ import { PayableRunsGrid } from "./payable-runs-grid"
 import { PayableInventoryOrdersGrid } from "./payable-inventory-orders-grid"
 import {
   runBillsVerbatimTotal as billsVerbatimTotal,
+  runNeedsTypedPrice,
   runLineAmount,
 } from "./lib/run-line-pricing"
 /**
@@ -162,19 +163,25 @@ export const CreatePaymentSubmissionComponent = () => {
     isPending: inventoryLoading,
   } = usePayableInventoryOrders(partnerId || undefined)
 
-  /**
-   * Runs that can be billed now — everything not already paid for.
-   *
-   * 🔑 A missing rate does NOT disqualify a run. The rate lives on the run
-   * because that is where it SHOULD be recorded, but on prod 15 of 27 completed
-   * runs carry none — the partner completed the work and never entered a price.
-   * That is a gap in the record, not a statement that the work was free, and an
-   * admin who knows what was agreed must be able to pay it by typing the rate.
-   * Blocking here would have made real completed work permanently unpayable
-   * through the only screen that can pay it.
-   */
+  /** Runs that can be billed now — everything not already paid for IN FULL. */
   const selectableRuns = useMemo(
-    () => payableRuns.filter((r) => !r.billed),
+    /**
+     * 🔴 `billing_status`, not `!r.billed`.
+     *
+     * `billed` is truthy for a run that has been claimed AT ALL, so a run
+     * claimed for 1 of the 10 it was ordered for vanished from this screen —
+     * the founder's own #1596 case ("bill 1 of 10 now and the other 9 later")
+     * was unreachable from the screen payouts are actually created on, while
+     * the write guard accepted it and the partner's own screen offered it.
+     * `partly_billed` deliberately does NOT block, exactly as it does not on
+     * the partner side; only `billed` does.
+     *
+     * 🔑 A missing rate does NOT disqualify a run either. On prod 15 of 27
+     * completed runs carry none — the partner did the work and never entered a
+     * price. That is a gap in the record, not a statement that the work was
+     * free, and an admin who knows what was agreed must be able to type it.
+     */
+    () => payableRuns.filter((r) => r.billing_status !== "billed"),
     [payableRuns]
   )
 
@@ -231,22 +238,67 @@ export const CreatePaymentSubmissionComponent = () => {
     })
   }, [])
 
-  /** Units billed for a run — the produced figure unless an admin retyped it. */
-  const getRunQuantity = useCallback(
-    (run: PayableRun): number =>
-      runQuantityOverrides[run.run_id] != null
-        ? runQuantityOverrides[run.run_id]
-        : run.payable_quantity,
-    [runQuantityOverrides]
+  /** Whether a live line has already claimed part of this run (#1596/#1676). */
+  const runAlreadyPartlyBilled = useCallback(
+    (run: PayableRun): boolean => run.billing_status === "partly_billed",
+    []
   )
 
-  /** The per-unit rate — the run's agreed rate unless an admin retyped it. */
+  /**
+   * Units billed for a run — the produced figure unless an admin retyped it.
+   *
+   * 🔴 On a partly-billed run it is what is LEFT, not what was produced. The
+   * screen must offer exactly what the write guard will accept: a run ordered
+   * 10 and claimed for 1 has 9 units of headroom, and defaulting to the
+   * produced 10 puts a number in the box that `create` then refuses.
+   *
+   * `billable_remaining` is null when there is no arithmetic behind it — a
+   * claim took the run whole, or (since #1676) the run has no agreed quantity
+   * and therefore no ceiling to subtract from. Neither is a remainder of zero,
+   * so both fall back to the offered figure rather than to nothing.
+   */
+  const getRunQuantity = useCallback(
+    (run: PayableRun): number => {
+      if (runQuantityOverrides[run.run_id] != null) {
+        return runQuantityOverrides[run.run_id]
+      }
+      const remaining = run.billable_remaining
+      if (
+        runAlreadyPartlyBilled(run) &&
+        remaining != null &&
+        remaining > 0 &&
+        remaining < run.payable_quantity
+      ) {
+        return remaining
+      }
+      return run.payable_quantity
+    },
+    [runQuantityOverrides, runAlreadyPartlyBilled]
+  )
+
+  /**
+   * The per-unit rate — the run's agreed rate unless an admin retyped it.
+   *
+   * ⚠️ Empty on a partly-billed TOTAL run. Its `unit_amount` is `total /
+   * ordered`, computed for display only, and showing it beside a remainder
+   * invites copying it down a column — which is how a job agreed at ₹10,000
+   * gets re-priced by arithmetic nobody decided (#1679). The row states no rate
+   * because there is none to state.
+   */
   const getRunRate = useCallback(
-    (run: PayableRun): number =>
-      runRateOverrides[run.run_id] != null
-        ? runRateOverrides[run.run_id]
-        : run.unit_amount,
-    [runRateOverrides]
+    (run: PayableRun): number => {
+      if (runRateOverrides[run.run_id] != null) {
+        return runRateOverrides[run.run_id]
+      }
+      return runNeedsTypedPrice({
+        unit_is_derived: run.unit_is_derived,
+        hasTypedRate: false,
+        alreadyPartlyBilled: runAlreadyPartlyBilled(run),
+      })
+        ? 0
+        : run.unit_amount
+    },
+    [runRateOverrides, runAlreadyPartlyBilled]
   )
 
   /**
@@ -285,8 +337,12 @@ export const CreatePaymentSubmissionComponent = () => {
         amount: run.amount,
         unit_is_derived: run.unit_is_derived,
         hasTypedRate: runHasTypedRate(run),
+        // 🔴 Without this an untouched total-priced remainder re-bills the
+        // WHOLE agreed total, and the write guard — which bounds units, not
+        // money — would let it through.
+        alreadyPartlyBilled: runAlreadyPartlyBilled(run),
       }),
-    [getRunQuantity, getRunRate, runHasTypedRate]
+    [getRunQuantity, getRunRate, runHasTypedRate, runAlreadyPartlyBilled]
   )
 
   /**
@@ -328,8 +384,26 @@ export const CreatePaymentSubmissionComponent = () => {
       billsVerbatimTotal({
         unit_is_derived: run.unit_is_derived,
         hasTypedRate: runHasTypedRate(run),
+        // A partly-billed total does NOT go on the line-total channel: it has
+        // no figure of its own until an operator types a rate.
+        alreadyPartlyBilled: runAlreadyPartlyBilled(run),
       }),
-    [runHasTypedRate]
+    [runHasTypedRate, runAlreadyPartlyBilled]
+  )
+
+  /**
+   * The row states no price until somebody types one — an agreed TOTAL on a
+   * run that has already been billed against. The grid says so on the row, and
+   * the existing zero-amount guard refuses the submit until it is priced.
+   */
+  const runNeedsTypedPriceForRun = useCallback(
+    (run: PayableRun): boolean =>
+      runNeedsTypedPrice({
+        unit_is_derived: run.unit_is_derived,
+        hasTypedRate: runHasTypedRate(run),
+        alreadyPartlyBilled: runAlreadyPartlyBilled(run),
+      }),
+    [runHasTypedRate, runAlreadyPartlyBilled]
   )
 
   const handleRunNumberChange = (
@@ -934,6 +1008,7 @@ export const CreatePaymentSubmissionComponent = () => {
                   getAmount={getRunAmount}
                   billsVerbatimTotal={runBillsVerbatimTotal}
                   hasTypedRate={runHasTypedRate}
+                  needsTypedPrice={runNeedsTypedPriceForRun}
                 />
               </Tabs.Content>
 

--- a/apps/backend/src/admin/components/creates/lib/run-line-pricing.ts
+++ b/apps/backend/src/admin/components/creates/lib/run-line-pricing.ts
@@ -47,6 +47,18 @@ export type RunLinePricingInput = {
   unit_is_derived?: boolean | null
   /** Whether a human has typed a rate for this run. */
   hasTypedRate: boolean
+  /**
+   * Whether a LIVE line already claimed part of this run (#1596/#1676).
+   *
+   * 🔴 It changes what an untouched total-priced row bills, and it has to.
+   * `amount` is the price agreed for the WHOLE job, and this screen used to
+   * drop such a run the moment anything claimed it — so "bill it again" was
+   * never a state that could exist. Now that the remainder is offered, an
+   * untouched row would default to the full agreed total a SECOND time, and
+   * `assessRunClaims` would not stop it: that guard bounds UNITS (4 + 5 ≤ 9),
+   * not money. ₹10,000 agreed, ₹20,000 paid, nothing refused.
+   */
+  alreadyPartlyBilled?: boolean | null
 }
 
 /**
@@ -56,11 +68,46 @@ export type RunLinePricingInput = {
  * longer derived, and a genuine per-unit rate was never a total.
  */
 export const runBillsVerbatimTotal = (
-  input: Pick<RunLinePricingInput, "unit_is_derived" | "hasTypedRate">
-): boolean => !input.hasTypedRate && !!input.unit_is_derived
+  input: Pick<
+    RunLinePricingInput,
+    "unit_is_derived" | "hasTypedRate" | "alreadyPartlyBilled"
+  >
+): boolean =>
+  !input.hasTypedRate && !!input.unit_is_derived && !input.alreadyPartlyBilled
+
+/**
+ * PURE. Whether this row can state no price of its own until somebody types one.
+ *
+ * The one case: an agreed TOTAL, on a run part of which has already been
+ * billed. The total was the price for the whole job and it has been paid
+ * against once; there is no arithmetic that yields the remainder's worth.
+ * Dividing the total by the ordered quantity and re-multiplying is exactly the
+ * re-pricing that billed ₹7,777.77 on a ₹10,000 job (#1679), and re-billing the
+ * total is a straight double payment.
+ *
+ * So the row bills NOTHING and says so, and the screen's existing zero-amount
+ * guard refuses to submit until an operator states what the rest is worth.
+ * That is the same rule this screen already applies to a run carrying no agreed
+ * rate: an absent figure is never a price, and somebody who knows types it.
+ */
+export const runNeedsTypedPrice = (
+  input: Pick<
+    RunLinePricingInput,
+    "unit_is_derived" | "hasTypedRate" | "alreadyPartlyBilled"
+  >
+): boolean =>
+  !input.hasTypedRate && !!input.unit_is_derived && !!input.alreadyPartlyBilled
 
 /** PURE. What this run bills. */
 export const runLineAmount = (input: RunLinePricingInput): number => {
+  /**
+   * 🔴 BEFORE the verbatim branch and before the multiplication — both of the
+   * other answers are wrong here. Re-billing the total double-pays; multiplying
+   * the derived rate re-prices a job nobody re-negotiated.
+   */
+  if (runNeedsTypedPrice(input)) {
+    return 0
+  }
   if (runBillsVerbatimTotal(input)) {
     // Verbatim. Not rounded, not re-derived, not multiplied.
     return input.amount

--- a/apps/backend/src/admin/components/creates/payable-runs-grid.tsx
+++ b/apps/backend/src/admin/components/creates/payable-runs-grid.tsx
@@ -74,6 +74,7 @@ export const PayableRunsGrid = ({
   getAmount,
   billsVerbatimTotal,
   hasTypedRate,
+  needsTypedPrice,
 }: {
   runs: PayableRun[]
   isLoading: boolean
@@ -91,6 +92,11 @@ export const PayableRunsGrid = ({
   billsVerbatimTotal: (run: PayableRun) => boolean
   /** Whether a human has typed a rate for this run. */
   hasTypedRate: (run: PayableRun) => boolean
+  /**
+   * Whether this row states no price of its own until somebody types one — an
+   * agreed TOTAL on a run part of which is already billed (#1596/#1676).
+   */
+  needsTypedPrice: (run: PayableRun) => boolean
 }) => {
   const rows: RunRow[] = useMemo(
     () => runs.map((run, index) => ({ run, index })),
@@ -147,7 +153,20 @@ export const PayableRunsGrid = ({
         return
       }
 
-      const nextSelected = !!row?.selected && !run.billed
+      /**
+       * 🔴 `billing_status`, not `!run.billed` — the THIRD place this shortcut
+       * appeared, and the one that made the other two useless. `billed` is
+       * truthy for a PARTLY billed run, so this effect reported every such
+       * row's selection back as `false`: the checkbox ticked in the grid, the
+       * parent never heard it, `totalSelected` stayed 0 and the Create
+       * Submission button stayed disabled forever. A row that can be selected
+       * and can never be submitted is worse than one that is filtered out.
+       *
+       * Found by rendering the screen. Nothing in tsc or the suite could see
+       * it — the grid's own state was correct throughout.
+       */
+      const nextSelected =
+        !!row?.selected && run.billing_status !== "billed"
       if (nextSelected !== selectedIds.has(run.run_id)) {
         onSelectionChange(run.run_id, nextSelected)
       }
@@ -179,9 +198,14 @@ export const PayableRunsGrid = ({
         cell: (context: any) => (
           <DataGridBooleanCell
             context={context}
-            // An already-paid run cannot be billed again. Disabled rather than
-            // absent: the row still answers "where is this run".
-            disabled={!!rows[context.row.index]?.run.billed}
+            // A run billed IN FULL cannot be billed again. Disabled rather
+            // than absent: the row still answers "where is this run".
+            //
+            // ⚠️ `billing_status`, not `billed` — `billed` is truthy for a
+            // PARTLY billed run too, and its remainder is billable (#1596).
+            disabled={
+              rows[context.row.index]?.run.billing_status === "billed"
+            }
           />
         ),
       }),
@@ -213,14 +237,39 @@ export const PayableRunsGrid = ({
                 <Text size="small" className="truncate">
                   {run.design_name || "Unnamed design"}
                 </Text>
-                {run.billed && (
+                {run.billing_status === "billed" && (
                   <Badge color="orange" size="2xsmall" className="shrink-0">
                     paid
                   </Badge>
                 )}
-                {!run.payable && !run.billed && (
+                {/*
+                  #1596 — SOME of this run is already paid for, and what is on
+                  offer is the remainder. Without the badge the row looks like
+                  any other and the Qty column silently holds a smaller number
+                  than the Output column beside it.
+                */}
+                {run.billing_status === "partly_billed" && (
+                  <Badge color="blue" size="2xsmall" className="shrink-0">
+                    {run.billable_remaining != null
+                      ? `${run.billable_remaining} left`
+                      : "part billed"}
+                  </Badge>
+                )}
+                {!run.payable && run.billing_status !== "billed" && (
                   <Badge color="orange" size="2xsmall" className="shrink-0">
                     no rate
+                  </Badge>
+                )}
+                {/*
+                  🔴 An agreed TOTAL that has already been billed against. The
+                  total was the price for the WHOLE job, so the remainder has
+                  no figure of its own — re-billing it double-pays and
+                  dividing it re-prices. The row bills 0 until someone states
+                  what the rest is worth, and the submit guard refuses it.
+                */}
+                {needsTypedPrice(run) && (
+                  <Badge color="red" size="2xsmall" className="shrink-0">
+                    price the rest
                   </Badge>
                 )}
                 {/* #1596 — the produced/ordered gap on this row is SETTLED. */}
@@ -425,7 +474,14 @@ export const PayableRunsGrid = ({
     )
   }
 
-  const selectableCount = runs.filter((r) => !r.billed).length
+  /**
+   * ⚠️ `billing_status`, not `!r.billed` — `billed` is truthy for a PARTLY
+   * billed run, whose remainder is billable and whose row is selectable. The
+   * count said "0 billable of 2" above two rows an operator could bill.
+   */
+  const selectableCount = runs.filter(
+    (r) => r.billing_status !== "billed"
+  ).length
 
   return (
     <div className="flex flex-col gap-y-2">

--- a/apps/backend/src/admin/components/creates/payable-runs-grid.tsx
+++ b/apps/backend/src/admin/components/creates/payable-runs-grid.tsx
@@ -257,12 +257,30 @@ export const PayableRunsGrid = ({
           return (
             <DataGridReadOnlyCell context={context}>
               <Text size="small" className="truncate">
-                {run.produced_quantity ?? "—"} of {run.ordered_quantity ?? "—"}
-                {run.quantity_basis === "ordered"
+                {/* #1676 — an open-ended run has no denominator, and "40 of no
+                  * agreed qty" reads as a broken sentence. */}
+                {run.ordered_quantity == null
+                  ? `${run.produced_quantity ?? "—"} produced · no agreed qty`
+                  : `${run.produced_quantity ?? "—"} of ${run.ordered_quantity}`}
+                {/**
+                  * ⚠️ Read "was output recorded" off `produced_quantity`, NOT
+                  * off `quantity_basis`. Since #1676 the offer is capped at the
+                  * ordered figure, so an OVERPRODUCED run reports its basis as
+                  * "ordered" while having recorded output — inferring the note
+                  * from the basis printed "12 of 9 · no output recorded".
+                  *
+                  * ⚠️ Kept SHORT — the cell truncates, and "billing capped at
+                  * ordered" was cut to "…capped at or…". The Qty column beside
+                  * it already shows the clamped figure.
+                  */}
+                {run.produced_quantity == null
                   ? " · no output recorded"
-                  : run.short_closed_at
-                    ? " · closed short"
-                    : ""}
+                  : run.ordered_quantity != null &&
+                      run.produced_quantity > run.ordered_quantity
+                    ? " · billing capped"
+                    : run.short_closed_at
+                      ? " · closed short"
+                      : ""}
               </Text>
             </DataGridReadOnlyCell>
           )

--- a/apps/backend/src/admin/components/production-runs/production-run-edit-form.tsx
+++ b/apps/backend/src/admin/components/production-runs/production-run-edit-form.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Button, Input, Select, toast } from "@medusajs/ui"
+import { Button, Input, Label, Select, Switch, Text, toast } from "@medusajs/ui"
 import { z } from "@medusajs/framework/zod"
 import { useForm } from "react-hook-form"
 
@@ -14,6 +14,15 @@ import {
 
 const schema = z.object({
   quantity: z.number().int().min(1).optional(),
+  /**
+   * #1676 — this run has NO agreed quantity: open-ended, ongoing work.
+   *
+   * A separate switch rather than "leave the box empty", because an empty box
+   * is a person who has not typed yet. Declaring open-endedness removes the
+   * ceiling on what may be billed against this run, so it has to be an act,
+   * not an omission.
+   */
+  open_ended: z.boolean().optional(),
   role: z.string().optional(),
   run_type: z.enum(["production", "sample"]).optional(),
 })
@@ -32,6 +41,7 @@ export const EditProductionRunForm = ({ run }: EditProductionRunFormProps) => {
     resolver: zodResolver(schema),
     defaultValues: {
       quantity: run.quantity ?? undefined,
+      open_ended: run.quantity === null,
       role: run.role ?? "",
       run_type: (run.run_type as "production" | "sample") ?? "production",
     },
@@ -39,8 +49,15 @@ export const EditProductionRunForm = ({ run }: EditProductionRunFormProps) => {
 
   const onSubmit = form.handleSubmit(async (data) => {
     const payload: Record<string, any> = {}
-    if (data.quantity !== undefined && data.quantity !== run.quantity) {
-      payload.quantity = data.quantity
+    /**
+     * `null` is sent DELIBERATELY, and only when the switch is on — the API
+     * reads it as "no agreed quantity" rather than as a missing field. An
+     * untouched form still sends nothing.
+     */
+    const nextQuantity = data.open_ended ? null : data.quantity
+    const currentQuantity = run.quantity ?? null
+    if (nextQuantity !== undefined && nextQuantity !== currentQuantity) {
+      payload.quantity = nextQuantity
     }
     if ((data.role ?? "") !== (run.role ?? "")) {
       payload.role = data.role || undefined
@@ -62,6 +79,7 @@ export const EditProductionRunForm = ({ run }: EditProductionRunFormProps) => {
   })
 
   const isOverride = !!run.accepted_at || !!run.started_at
+  const openEnded = !!form.watch("open_ended")
 
   return (
     <RouteDrawer.Form form={form}>
@@ -109,7 +127,8 @@ export const EditProductionRunForm = ({ run }: EditProductionRunFormProps) => {
                     type="number"
                     min={1}
                     {...field}
-                    value={field.value ?? ""}
+                    disabled={openEnded}
+                    value={openEnded ? "" : (field.value ?? "")}
                     onChange={(e) =>
                       field.onChange(
                         e.target.value === "" ? undefined : Number(e.target.value)
@@ -117,6 +136,30 @@ export const EditProductionRunForm = ({ run }: EditProductionRunFormProps) => {
                     }
                   />
                 </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+          <Form.Field
+            control={form.control}
+            name="open_ended"
+            render={({ field: { value, onChange } }) => (
+              <Form.Item>
+                <div className="flex items-center gap-x-2">
+                  <Switch
+                    id="production-run-open-ended"
+                    checked={!!value}
+                    onCheckedChange={(checked) => onChange(!!checked)}
+                  />
+                  <Label size="xsmall" htmlFor="production-run-open-ended">
+                    No agreed quantity (open-ended)
+                  </Label>
+                </div>
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  Ongoing work with no fixed order. Payments against this run
+                  are not capped at an agreed quantity — nothing will refuse a
+                  claim for more than was ordered, because nothing was ordered.
+                </Text>
                 <Form.ErrorMessage />
               </Form.Item>
             )}

--- a/apps/backend/src/admin/components/production-runs/production-run-short-close-form.tsx
+++ b/apps/backend/src/admin/components/production-runs/production-run-short-close-form.tsx
@@ -60,7 +60,12 @@ export const ShortCloseRunForm = ({ run }: ShortCloseFormProps) => {
     defaultValues: { reason: "" },
   })
 
-  const ordered = asNumber(run.quantity)
+  /**
+   * 🔴 `Number(null)` is 0, and `asNumber` calls it FINITE — so a run with no
+   * agreed quantity (#1676) read as "ordered 0" and this drawer offered to
+   * close it "at 40 of 0 ordered". Ask the raw field first; only then coerce.
+   */
+  const ordered = run.quantity == null ? null : asNumber(run.quantity)
   const produced = asNumber(run.produced_quantity)
   const forfeited =
     ordered != null && produced != null && ordered > produced
@@ -96,10 +101,16 @@ export const ShortCloseRunForm = ({ run }: ShortCloseFormProps) => {
             <Alert variant="info">
               <Text size="small">
                 This run is closed at{" "}
-                <strong>{fmt(asNumber(run.short_closed_quantity) ?? produced)}</strong>{" "}
-                of {fmt(ordered)} ordered. Reopening makes the ordered
-                quantity billable again — use it when the close was premature, or
-                when more work is genuinely coming.
+                <strong>{fmt(asNumber(run.short_closed_quantity) ?? produced)}</strong>
+                {/* #1676 — an open-ended run has nothing to be closed "of", and
+                  * closing it is what gives it a ceiling in the first place.
+                  * "of — ordered" read as a missing number. */}
+                {ordered == null
+                  ? " — it has no agreed quantity, so this close is the only cap on it. Reopening removes that cap entirely."
+                  : ` of ${fmt(ordered)} ordered. Reopening makes the ordered quantity billable again`}
+                {ordered == null
+                  ? ""
+                  : " — use it when the close was premature, or when more work is genuinely coming."}
               </Text>
             </Alert>
           ) : (
@@ -114,14 +125,23 @@ export const ShortCloseRunForm = ({ run }: ShortCloseFormProps) => {
                 ) : (
                   <>
                     Closing declares that no more will be made. This run bills to{" "}
-                    <strong>{produced}</strong> produced instead of{" "}
-                    <strong>{fmt(ordered)}</strong> ordered
-                    {forfeited != null ? (
+                    <strong>{produced}</strong> produced
+                    {ordered == null ? (
+                      // #1676 — no agreed quantity, so nothing caps this run
+                      // today. The close IS the cap.
+                      <> — it has no agreed quantity, so nothing caps it until now</>
+                    ) : (
                       <>
-                        , so <strong>{forfeited}</strong> unit
-                        {forfeited === 1 ? "" : "s"} stop being billable
+                        {" "}
+                        instead of <strong>{fmt(ordered)}</strong> ordered
+                        {forfeited != null ? (
+                          <>
+                            , so <strong>{forfeited}</strong> unit
+                            {forfeited === 1 ? "" : "s"} stop being billable
+                          </>
+                        ) : null}
                       </>
-                    ) : null}
+                    )}
                     .
                   </>
                 )}

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -183,7 +183,17 @@ export interface PayableRun {
   design_name: string | null
   design_status: string | null
   completed_at: string | null
+  /**
+   * The agreed quantity. Null when the run states NO agreed amount (#1676) —
+   * it is open-ended, and the offer is not capped. Distinct from 0.
+   */
   ordered_quantity: number | null
+  /**
+   * #1676 — the run states no agreed quantity: open-ended, and the offer
+   * against it is not capped. Read it beside `billable_remaining`, which is
+   * null here because there is no ceiling — not because nothing is left.
+   */
+  open_ended: boolean
   /** Null when output was never recorded — distinct from "made zero". */
   produced_quantity: number | null
   rejected_quantity: number | null
@@ -193,7 +203,13 @@ export interface PayableRun {
    * the row already reflects it; this is what lets the screen SAY so.
    */
   short_closed_at: string | null
-  /** What this row bills for: produced, falling back to ordered. */
+  /**
+   * What this row bills for: produced, falling back to ordered — and NEVER
+   * above the ordered quantity (#1676), which is the ceiling the write guard
+   * enforces. A basis of "ordered" therefore means either "no output recorded"
+   * or "the produced figure was capped"; read `produced_quantity` to tell them
+   * apart rather than inferring it from the basis.
+   */
   payable_quantity: number
   quantity_basis: "produced" | "ordered"
   unit_amount: number

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -239,7 +239,39 @@ export interface PayableRun {
   /** The design's own cost, offered as a starting point. A suggestion, never a price. */
   design_estimated_cost: number | null
   design_production_cost: number | null
-  billed: { submission_id: string; status: string; quantity: number } | null
+  /**
+   * The EARLIEST live line naming this run, or null.
+   *
+   * ⚠️ Truthy for a run that has been claimed AT ALL, including one claimed
+   * for 1 of the 10 it was ordered for. Never branch on it to decide whether a
+   * run may be billed — read `billing_status`, which separates the two.
+   */
+  billed: {
+    submission_id: string
+    status: string
+    quantity: number
+    claimed_quantity: number
+    claimed_wholly: boolean
+  } | null
+  /**
+   * The field to branch on, so "we don't know" cannot be spelled the same way
+   * as "no" — `billed` | `partly_billed` | `unknown` | `clear`.
+   *
+   * 🔴 The API has always sent this and this type never declared it, so no
+   * admin screen could read it and none did. That is why this screen filtered
+   * on `!r.billed` and dropped every partly-billed run, making the #1596 case
+   * ("bill 1 of 10 now and the other 9 later") unreachable here while the write
+   * guard accepted it and the partner's own screen offered it. Same shape as
+   * `unit_is_derived` above: a field sent for months with zero consumers.
+   */
+  billing_status: "billed" | "partly_billed" | "unknown" | "clear"
+  /**
+   * Units still billable on this run, or null when there is no arithmetic
+   * behind the answer — a claim took the run whole, or the run has no agreed
+   * quantity at all (#1676, read `open_ended`). Null is NOT a remainder of
+   * zero. A number here is a promise `create` will keep.
+   */
+  billable_remaining: number | null
   design_has_open_submission: boolean
 }
 

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -16,7 +16,8 @@ const PRODUCTION_RUNS_QUERY_KEY = "production-runs" as const
 export const productionRunQueryKeys = queryKeysFactory(PRODUCTION_RUNS_QUERY_KEY)
 
 export type AdminCreateDesignProductionRunPayload = {
-  quantity?: number
+  /** `null` = no agreed quantity: an open-ended run (#1676). Omitted = 1. */
+  quantity?: number | null
   run_type?: string
   assignments?: Array<{
     partner_id: string
@@ -35,6 +36,15 @@ export type AdminProductionRun = Record<string, any> & {
   run_type?: "production" | "sample"
   partner_id?: string | null
   design_id?: string
+  /**
+   * The AGREED quantity — how many units the run was ordered for.
+   *
+   * 🔴 `null` is a statement, not a gap (#1676): this run has NO agreed amount.
+   * It is open-ended, and payment claims against it are not capped. Declared
+   * explicitly at creation or before the partner accepts; never inferred.
+   */
+  quantity?: number | null
+  produced_quantity?: number | null
   /**
    * #1596 — short close. Set means "no more will be made": the run's billable
    * ceiling is its PRODUCED quantity from here, not its ordered one.
@@ -367,7 +377,8 @@ export const useAssignProductionRunPartner = (
 }
 
 export type AdminUpdateProductionRunPayload = {
-  quantity?: number
+  /** `null` clears the agreed quantity — an open-ended run (#1676). */
+  quantity?: number | null
   role?: string
   run_type?: string
   partner_cost_estimate?: number | null
@@ -799,6 +810,12 @@ export type ProductionRunBilling = {
   } | null
   /** Units still billable, or null when there is no arithmetic behind it. */
   billable_remaining: number | null
+  /**
+   * #1676 — the run states NO agreed quantity, so nothing caps what may be
+   * billed against it. When true, a null `billable_remaining` means "no
+   * ceiling", NOT "nothing left"; the two must not render the same way.
+   */
+  open_ended: boolean
   unrecorded_claims: Array<{
     submission_id: string
     status: string

--- a/apps/backend/src/admin/routes/designs/[id]/@production-run/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/@production-run/page.tsx
@@ -5,6 +5,7 @@ import {
   Container,
   Heading,
   Input,
+  Label,
   Select,
   Switch,
   Text,
@@ -37,7 +38,15 @@ import {
 const assignmentSchema = z.object({
   partner_id: z.string().min(1, "Partner is required"),
   role: z.string().optional(),
-  quantity: z.coerce.number().positive("Quantity must be > 0"),
+  /**
+   * Units for this partner's child run.
+   *
+   * 🔴 `null` is a DECLARATION (#1676): this run has no agreed quantity —
+   * open-ended, ongoing work — and payouts against it are not capped at an
+   * agreed amount. `.nullable()` sits outside the coercion on purpose: coercing
+   * null would make it 0, which is a broken number rather than a statement.
+   */
+  quantity: z.coerce.number().positive("Quantity must be > 0").nullable(),
   order: z.coerce.number().int().positive().optional(),
   template_names: z.array(z.string()).optional(),
   template_ids: z.array(z.string()).optional(),
@@ -65,7 +74,8 @@ type FormValues = z.infer<typeof createSchema>
 type Assignment = {
   partner_id: string
   role?: string
-  quantity: number
+  /** `null` = no agreed quantity, an open-ended run (#1676). */
+  quantity: number | null
   order?: number
   template_names?: string[]
   template_ids?: string[]
@@ -318,11 +328,32 @@ const AssignmentsModal = ({
                     <Input
                       type="number"
                       min={1}
-                      value={assignment.quantity ?? ""}
+                      disabled={assignment.quantity === null}
+                      value={
+                        assignment.quantity === null
+                          ? ""
+                          : (assignment.quantity ?? "")
+                      }
                       onChange={(e) =>
                         updateField(idx, "quantity", e.target.value ? Number(e.target.value) : "")
                       }
                     />
+                    <div className="mt-2 flex items-center gap-x-2">
+                      {/* #1676 — a run with NO agreed quantity is deliberately
+                        * open-ended, and payouts against it are not capped at
+                        * an agreed amount. A switch rather than an empty box:
+                        * an empty box is somebody who has not typed yet. */}
+                      <Switch
+                        id={`assignment-open-ended-${idx}`}
+                        checked={assignment.quantity === null}
+                        onCheckedChange={(checked) =>
+                          updateField(idx, "quantity", checked ? null : 1)
+                        }
+                      />
+                      <Label size="xsmall" htmlFor={`assignment-open-ended-${idx}`}>
+                        No agreed quantity (open-ended) — payouts uncapped
+                      </Label>
+                    </div>
                   </div>
 
                   <div>

--- a/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
@@ -142,6 +142,17 @@ const ProductionRunDetailPage = () => {
   const producedQty = Number(run?.produced_quantity)
   const orderedQty = Number(run?.quantity)
   /**
+   * #1676 — no agreed quantity. Not "we don't know yet": a deliberate
+   * declaration that this run is open-ended, which is why it prints as a phrase
+   * rather than as a dash. Payment claims against it are uncapped until it is
+   * short-closed, and the screen has to say so — an uncapped run that looks
+   * identical to a run ordered for one piece is how the opt-out gets used by
+   * accident.
+   *
+   * ⚠️ Strictly `null`. `undefined` is the field not having loaded.
+   */
+  const isOpenEnded = run?.quantity === null
+  /**
    * What may be billed IN TOTAL, mirroring `runBillableCeiling` on the server.
    * Ordered quantity until the run is closed, then what it produced — and never
    * a reduction inferred from missing data.
@@ -527,8 +538,19 @@ const ProductionRunDetailPage = () => {
                       */}
                     <Text size="xsmall" className="text-ui-fg-subtle">
                       {billing.claim?.claimed_quantity} of{" "}
-                      {String(billableCeiling ?? run.quantity ?? "-")} billed —{" "}
-                      {billing.billable_remaining} still billable
+                      {billableCeiling != null
+                        ? String(billableCeiling)
+                        : isOpenEnded
+                          ? "no agreed quantity"
+                          : String(run.quantity ?? "-")}{" "}
+                      billed —{" "}
+                      {/* #1676 — an open-ended run's remainder is null because
+                        * there is no ceiling to subtract from. Printed raw it
+                        * read "null still billable", which is the one reading
+                        * it must never have. */}
+                      {isOpenEnded
+                        ? "no cap on what may still be billed"
+                        : `${billing.billable_remaining} still billable`}
                       {isShortClosed ? " (short-closed)" : ""}.
                     </Text>
                   </div>
@@ -551,7 +573,16 @@ const ProductionRunDetailPage = () => {
               <Text size="small" className="text-ui-fg-subtle">
                 Quantity
               </Text>
-              <Text>{String(run.quantity ?? "-")}</Text>
+              {isOpenEnded ? (
+                <div className="flex flex-col gap-y-1">
+                  <Text>Open-ended</Text>
+                  <Text size="xsmall" className="text-ui-fg-subtle">
+                    No agreed quantity — payouts against this run are not capped.
+                  </Text>
+                </div>
+              ) : (
+                <Text>{String(run.quantity ?? "-")}</Text>
+              )}
             </div>
             <div>
               <Text size="small" className="text-ui-fg-subtle">
@@ -608,29 +639,39 @@ const ProductionRunDetailPage = () => {
                   Output / Yield
                 </Text>
                 <div className="flex items-center gap-4 mt-1">
+                  {/**
+                    * ⚠️ A yield needs a DENOMINATOR. An open-ended run (#1676)
+                    * has none, and this block rendered "40 of  produced" beside
+                    * a "0% yield" badge — a run that made 40 pieces reported as
+                    * having made none of them.
+                    */}
                   <Text size="small">
-                    {run.produced_quantity} of {run.quantity} produced
+                    {isOpenEnded
+                      ? `${run.produced_quantity} produced (no agreed quantity)`
+                      : `${run.produced_quantity} of ${run.quantity} produced`}
                   </Text>
                   {(run.rejected_quantity || 0) > 0 && (
                     <Text size="small" className="text-ui-fg-error">
                       {run.rejected_quantity} rejected
                     </Text>
                   )}
-                  <Badge
-                    size="2xsmall"
-                    color={
-                      run.quantity > 0 && run.produced_quantity / run.quantity >= 0.9
-                        ? "green"
-                        : run.produced_quantity / run.quantity >= 0.7
-                          ? "orange"
-                          : "red"
-                    }
-                  >
-                    {run.quantity > 0
-                      ? Math.round((run.produced_quantity / run.quantity) * 100)
-                      : 0}
-                    % yield
-                  </Badge>
+                  {!isOpenEnded && (
+                    <Badge
+                      size="2xsmall"
+                      color={
+                        run.quantity > 0 && run.produced_quantity / run.quantity >= 0.9
+                          ? "green"
+                          : run.produced_quantity / run.quantity >= 0.7
+                            ? "orange"
+                            : "red"
+                      }
+                    >
+                      {run.quantity > 0
+                        ? Math.round((run.produced_quantity / run.quantity) * 100)
+                        : 0}
+                      % yield
+                    </Badge>
+                  )}
                 </div>
                 {run.rejection_reason && (
                   <Text size="xsmall" className="text-ui-fg-subtle mt-1">
@@ -658,9 +699,14 @@ const ProductionRunDetailPage = () => {
                 <div className="mt-1 flex flex-col gap-y-1">
                   <Text size="small">
                     Closed at{" "}
-                    {formatQty(run.short_closed_quantity ?? run.produced_quantity)} of{" "}
-                    {formatQty(run.quantity)} ordered — no further output
-                    expected, and the run bills to what it produced.
+                    {formatQty(run.short_closed_quantity ?? run.produced_quantity)}{" "}
+                    {/* An open-ended run (#1676) has nothing to close "of" —
+                      * closing it is what gives it a ceiling at all. */}
+                    {isOpenEnded
+                      ? "(no agreed quantity)"
+                      : `of ${formatQty(run.quantity)} ordered`}{" "}
+                    — no further output expected, and the run bills to what it
+                    produced.
                   </Text>
                   <Text size="xsmall" className="text-ui-fg-subtle">
                     {run.short_closed_by === "system"

--- a/apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
@@ -143,7 +143,7 @@ export const POST = async (
     })
     const linkedPartners = designs?.[0]?.partners || []
 
-    if (linkedPartners.length && body.quantity) {
+    if (linkedPartners.length && body.quantity != null) {
       // Single partner: assign full quantity
       // Multiple partners: split equally (admin can adjust via explicit assignments)
       const perPartner = Math.ceil(Number(body.quantity) / linkedPartners.length)
@@ -158,33 +158,69 @@ export const POST = async (
         template_ids: body.template_ids || [],
         template_names: body.template_names || [],
       }))
+    } else if (linkedPartners.length && body.quantity === null) {
+      /**
+       * An OPEN-ENDED parent (#1676). There is no quantity to split, so every
+       * linked partner gets an open-ended share rather than none at all —
+       * without this branch the run would be created with no children, which
+       * looks like the same request quietly doing less.
+       */
+      assignments = linkedPartners.map((p: any) => ({
+        partner_id: p.id,
+        quantity: null,
+        template_ids: body.template_ids || [],
+        template_names: body.template_names || [],
+      }))
     }
   }
 
-  let parentQuantity: number | undefined = body.quantity
+  /**
+   * ⚠️ Three states, not two (#1676): a number, `undefined` (infer it), and
+   * `null` (there is NO agreed quantity — an open-ended run, outside the
+   * payment ceiling). `parentQuantity ?? total` collapsed the last two, which
+   * would have silently un-declared open-endedness by filling in the sum.
+   */
+  const statedQuantity: number | null | undefined = body.quantity
+  let parentQuantity: number | null | undefined = statedQuantity
 
   if (assignments.length) {
-    const missingQty = assignments.some((a) => typeof a.quantity !== "number")
+    const missingQty = assignments.some(
+      (a) => a.quantity !== null && typeof a.quantity !== "number"
+    )
     if (missingQty) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
-        "All assignments must include quantity"
+        "All assignments must include quantity, or null for an open-ended one"
       )
     }
 
+    const anyOpenEnded = assignments.some((a) => a.quantity === null)
     const total = assignments.reduce(
       (sum, a) => sum + (Number(a.quantity) || 0),
       0
     )
 
-    if (body.quantity != null && Number(body.quantity) !== total) {
+    /**
+     * The sum rule only applies when every share is a number. One open-ended
+     * child makes the total unknowable — refusing on a sum that cannot be
+     * computed would just be refusing the feature.
+     */
+    if (
+      statedQuantity != null &&
+      !anyOpenEnded &&
+      Number(statedQuantity) !== total
+    ) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
-        `Assignments quantity sum (${total}) must match parent quantity (${body.quantity})`
+        `Assignments quantity sum (${total}) must match parent quantity (${statedQuantity})`
       )
     }
 
-    parentQuantity = parentQuantity ?? total
+    if (statedQuantity === undefined) {
+      // Inferred, as before — except that an open-ended child makes the parent
+      // open-ended too rather than understating it by that child's share.
+      parentQuantity = anyOpenEnded ? null : total
+    }
   }
 
   const { result: createdRun, errors } = await createProductionRunWorkflow(

--- a/apps/backend/src/api/admin/designs/[id]/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/production-runs/validators.ts
@@ -23,7 +23,12 @@ const RunMaterialSchema = z.object({
 const ProductionAssignmentSchema = z.object({
   partner_id: z.string().min(1),
   role: z.string().optional(),
-  quantity: z.number().positive(),
+  /**
+   * Units for this child run. `null` declares it OPEN-ENDED — no agreed
+   * quantity, and so no ceiling on what may be billed against it (#1676).
+   * A number is still required otherwise: "allocate nothing" is not a share.
+   */
+  quantity: z.number().positive().nullable(),
   order: z.number().int().positive().optional(),
   /**
    * Which of the design's inventory items THIS partner is sent, and how much.
@@ -41,7 +46,15 @@ const ProductionAssignmentSchema = z.object({
 })
 
 export const AdminCreateDesignProductionRunSchema = z.object({
-  quantity: z.number().positive().optional(),
+  /**
+   * The agreed quantity for the parent run. Omit it and it is inferred from the
+   * assignments (or defaults to 1).
+   *
+   * 🔴 `null` is NOT the same as omitting it (#1676): it declares that this run
+   * has no agreed amount — open-ended, ongoing work — which opts it out of the
+   * payment ceiling entirely.
+   */
+  quantity: z.number().positive().nullish(),
   run_type: z.enum(["production", "sample"]).optional(),
   assignments: z.array(ProductionAssignmentSchema).min(1).optional(),
   /**

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -310,7 +310,18 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         design_name: design?.name ?? null,
         design_status: design?.status ?? null,
         completed_at: run.completed_at ?? null,
-        ordered_quantity: Number.isFinite(ordered) ? ordered : null,
+        /**
+         * ⚠️ `Number(null)` is 0, so a run with NO agreed quantity (#1676) used
+         * to report `ordered_quantity: 0` — a run ordered for nothing, which is
+         * a different and much worse statement than "no amount was agreed".
+         * Read the raw field, not the coercion.
+         */
+        ordered_quantity:
+          run.quantity === null || run.quantity === undefined
+            ? null
+            : Number.isFinite(ordered)
+              ? ordered
+              : null,
         produced_quantity: hasProduced ? produced : null,
         rejected_quantity:
           run.rejected_quantity === null || run.rejected_quantity === undefined
@@ -384,6 +395,13 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
          * whole, or the run states no quantity — which is exactly when the
          * write guard refuses. A number here is a promise `create` will keep.
          */
+        /**
+         * #1676 — the run states NO agreed quantity: it is open-ended, and the
+         * offer against it is not capped. Read it beside `billable_remaining`,
+         * which is null here because there is no ceiling to subtract from —
+         * NOT because nothing is left.
+         */
+        open_ended: run.quantity === null || run.quantity === undefined,
         billable_remaining: runBillableRemaining({
           claim: billedRuns.get(String(run.id)),
           // #1596 — the CEILING, not the raw ordered quantity: a short-closed
@@ -429,6 +447,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         billed: row.billed,
         unrecordedClaims: row.unrecorded_claims,
         remaining: row.billable_remaining,
+        // #1676 — without this an open-ended run reads as fully `billed` after
+        // its first claim (its remainder is null because it has no ceiling),
+        // and no screen would ever offer it again.
+        openEnded: row.open_ended,
       }),
     }))
     .sort((a, b) => {

--- a/apps/backend/src/api/admin/production-runs/[id]/payments/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/payments/route.ts
@@ -28,6 +28,7 @@ import {
   runBillableRemaining,
   runBillingStatus,
 } from "../../../../../workflows/payment_submissions/lib/run-billing"
+import { runBillableCeiling } from "../../../../../workflows/payment_submissions/lib/run-billable-ceiling"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id } = req.params
@@ -107,13 +108,17 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     }))
 
   /**
-   * Units still billable on this run (#1596). `retrieveProductionRun` returns
-   * the whole row, so `quantity` — the ceiling the write guard uses — is
-   * genuinely present rather than merely typed.
+   * Units still billable on this run (#1596).
+   *
+   * 🔴 The CEILING, not the raw ordered quantity. Since the short close the two
+   * are different numbers on a closed run, and this route was still reading
+   * `run.quantity` — so the run page offered units the write guard refuses.
+   * `retrieveProductionRun` returns the whole row, so `produced_quantity` and
+   * `short_closed_at` are genuinely present rather than merely typed.
    */
   const billable_remaining = runBillableRemaining({
     claim,
-    ordered: run.quantity,
+    ordered: runBillableCeiling(run as any),
   })
 
   return res.status(200).json({
@@ -124,7 +129,14 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       billed: claim,
       unrecordedClaims: unrecorded_claims,
       remaining: billable_remaining,
+      // #1676 — an open-ended run has no ceiling, so its remainder is null;
+      // without this it would report `billed` after one claim and the run page
+      // would say the work is fully paid for when more may still be billed.
+      openEnded: run.quantity === null || run.quantity === undefined,
     }),
+    /** #1676 — no agreed quantity. `billable_remaining` is null because there
+     *  is no ceiling, NOT because nothing is left. */
+    open_ended: run.quantity === null || run.quantity === undefined,
     claim,
     billable_remaining,
     unrecorded_claims,

--- a/apps/backend/src/api/admin/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/route.ts
@@ -195,7 +195,30 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         "Cannot edit a completed production run"
       )
     }
-    if (body.quantity !== undefined) update.quantity = Number(body.quantity)
+    /**
+     * 🔴 `null` CLEARS the agreed quantity (#1676) — an open-ended run, with no
+     * ceiling on what may be claimed against it. `Number(null)` is 0, which
+     * would have written the opposite: a quantity that IS set and is unusable,
+     * which every payment guard refuses outright.
+     *
+     * Still gated by the structural check above, so this can only be said
+     * before the partner accepts or starts. Removing the agreed amount after
+     * work began would rewrite the deal retroactively.
+     */
+    if (body.quantity !== undefined) {
+      if (body.quantity === null) {
+        update.quantity = null
+      } else {
+        const quantity = Number(body.quantity)
+        if (!Number.isFinite(quantity) || quantity <= 0) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            "quantity must be a positive number, or null for a run with no agreed quantity"
+          )
+        }
+        update.quantity = quantity
+      }
+    }
     if (body.role !== undefined) update.role = body.role
     if (body.run_type !== undefined) update.run_type = body.run_type
   }

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -19,7 +19,12 @@ const RunMaterialSchema = z.object({
 const AssignmentSchema = z.object({
   partner_id: z.string().min(1),
   role: z.string().optional(),
-  quantity: z.number().optional(),
+  /**
+   * Units for this child run. Omit to inherit the parent's; `null` declares
+   * this child OPEN-ENDED — no agreed quantity, and so no ceiling on what may
+   * be billed against it (#1676).
+   */
+  quantity: z.number().nullish(),
   order: z.number().int().positive().optional(),
   // `.nullish()` (= optional + nullable) accepts undefined, null, or
   // an array. The admin UI sends `null` when the "Send to production"
@@ -55,7 +60,15 @@ const AssignmentSchema = z.object({
 export const AdminCreateProductionRunReq = z.object({
   design_id: z.string().min(1),
   partner_id: z.string().optional(),
-  quantity: z.number().optional(),
+  /**
+   * The agreed quantity. Omit it and the run is ordered for 1, as always.
+   *
+   * 🔴 `null` is NOT the same as omitting it (#1676): it declares that this run
+   * has no agreed amount — open-ended, ongoing work — and that declaration opts
+   * the run out of the payment ceiling, so nothing refuses a claim against it.
+   * `.nullish()` rather than `.optional()` exists solely to let that be said.
+   */
+  quantity: z.number().nullish(),
   run_type: z.enum(["production", "sample"]).optional(),
   product_id: z.string().optional(),
   variant_id: z.string().optional(),

--- a/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
@@ -146,11 +146,25 @@ export const GET = async (
       const produced = Number(run.produced_quantity)
       const hasProduced = Number.isFinite(produced) && produced > 0
       const ordered = Number(run.quantity)
-      const payable_quantity = hasProduced
-        ? produced
-        : Number.isFinite(ordered) && ordered > 0
-          ? ordered
-          : 1
+      const hasOrdered = Number.isFinite(ordered) && ordered > 0
+      const offered = hasProduced ? produced : hasOrdered ? ordered : 1
+      /**
+       * 🔴 Never more than was ORDERED (#1676). The write guard refuses a claim
+       * above the run's agreed quantity — including the run's FIRST claim — so
+       * offering the raw produced figure would put a number on the partner's
+       * screen that `create` then rejects. A run with no agreed quantity has no
+       * `ordered` to clamp against, and offers what was made.
+       *
+       * ⚠️ This route prices with its OWN arithmetic (`runUnitCost` x quantity)
+       * rather than `runPayableOffer`, which the admin screen and `create` both
+       * use. That divergence predates this change and is the shape of #1679 —
+       * a derived rate re-multiplied — sitting on the partner screen. The clamp
+       * is duplicated here rather than left out; unifying the pricer is its own
+       * change.
+       */
+      const payable_quantity = hasOrdered
+        ? Math.min(offered, ordered)
+        : offered
 
       return {
         run_id: String(run.id),
@@ -158,14 +172,28 @@ export const GET = async (
         design_name: design?.name ?? null,
         design_status: design?.status ?? null,
         completed_at: run.completed_at ?? null,
-        ordered_quantity: Number.isFinite(ordered) ? ordered : null,
+        /**
+         * ⚠️ `Number(null)` is 0, so a run with NO agreed quantity (#1676) used
+         * to report `ordered_quantity: 0` — a run ordered for nothing, which is
+         * a different and much worse statement than "no amount was agreed".
+         * Read the raw field, not the coercion.
+         */
+        ordered_quantity:
+          run.quantity === null || run.quantity === undefined
+            ? null
+            : Number.isFinite(ordered)
+              ? ordered
+              : null,
         produced_quantity: hasProduced ? produced : null,
         rejected_quantity:
           run.rejected_quantity === null || run.rejected_quantity === undefined
             ? null
             : Number(run.rejected_quantity),
         payable_quantity,
-        quantity_basis: hasProduced ? "produced" : "ordered",
+        // Honest about the clamp: a produced figure cut back to ordered IS
+        // ordered — the same rule `runPayableOffer` applies.
+        quantity_basis:
+          hasProduced && payable_quantity === produced ? "produced" : "ordered",
         unit_amount,
         amount: Math.round(unit_amount * payable_quantity * 100) / 100,
         cost_type: run.cost_type ?? null,
@@ -185,6 +213,12 @@ export const GET = async (
             ? null
             : Number(design.production_cost),
         billed: billedRuns.get(String(run.id)) ?? null,
+        /**
+         * #1676 — the run states NO agreed quantity, so the offer is not
+         * capped. Null `billable_remaining` beside this means "no ceiling",
+         * not "nothing left".
+         */
+        open_ended: run.quantity === null || run.quantity === undefined,
         // Units still billable (#1596). Null when there is no arithmetic
         // behind the answer — which is exactly when `create` refuses.
         billable_remaining: runBillableRemaining({
@@ -207,6 +241,9 @@ export const GET = async (
         billed: row.billed,
         unrecordedClaims: row.unrecorded_claims,
         remaining: row.billable_remaining,
+        // #1676 — without this an open-ended run reads as fully `billed` after
+        // its first claim and this screen would never offer it again.
+        openEnded: row.open_ended,
       }),
     }))
     .sort((a, b) => {

--- a/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
@@ -4,7 +4,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
 import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
-import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payable"
+import { runPayableOffer } from "../../../../workflows/production-runs/lib/run-payable"
 import {
   foldPartnerBilling,
   runBillableRemaining,
@@ -141,30 +141,28 @@ export const GET = async (
     .map((run) => {
       const design = designById.get(String(run.design_id))
 
-      const unit_amount = runUnitCost(run)
+      /**
+       * 🔴 ONE pricer, shared with the admin screen and with `create`.
+       *
+       * This route used to price with its own arithmetic — `runUnitCost(run) ×
+       * payable_quantity` — which is the derived rate re-multiplied, the exact
+       * defect #1679 removed from the admin side. On a real run (₹10,000
+       * agreed as a TOTAL, 9 ordered, 7 made) the two screens disagreed on the
+       * same day: the admin offered ₹10,000 and this one ₹7,777.77, a 22% cut
+       * nobody decided. Even when produced equalled ordered it lost a paisa
+       * (₹9,999.99). A partner submitting their own draft under-claimed.
+       *
+       * `runPayableOffer` bills a `total` verbatim, multiplies a `per_unit`
+       * rate, clamps the quantity at what was ordered (#1676), and says which
+       * of its numbers was agreed via `unit_is_derived`.
+       */
+      const offer = runPayableOffer(run)
+      const unit_amount = offer.unit_amount
+      const payable_quantity = offer.quantity
 
       const produced = Number(run.produced_quantity)
       const hasProduced = Number.isFinite(produced) && produced > 0
       const ordered = Number(run.quantity)
-      const hasOrdered = Number.isFinite(ordered) && ordered > 0
-      const offered = hasProduced ? produced : hasOrdered ? ordered : 1
-      /**
-       * 🔴 Never more than was ORDERED (#1676). The write guard refuses a claim
-       * above the run's agreed quantity — including the run's FIRST claim — so
-       * offering the raw produced figure would put a number on the partner's
-       * screen that `create` then rejects. A run with no agreed quantity has no
-       * `ordered` to clamp against, and offers what was made.
-       *
-       * ⚠️ This route prices with its OWN arithmetic (`runUnitCost` x quantity)
-       * rather than `runPayableOffer`, which the admin screen and `create` both
-       * use. That divergence predates this change and is the shape of #1679 —
-       * a derived rate re-multiplied — sitting on the partner screen. The clamp
-       * is duplicated here rather than left out; unifying the pricer is its own
-       * change.
-       */
-      const payable_quantity = hasOrdered
-        ? Math.min(offered, ordered)
-        : offered
 
       return {
         run_id: String(run.id),
@@ -190,12 +188,18 @@ export const GET = async (
             ? null
             : Number(run.rejected_quantity),
         payable_quantity,
-        // Honest about the clamp: a produced figure cut back to ordered IS
-        // ordered — the same rule `runPayableOffer` applies.
-        quantity_basis:
-          hasProduced && payable_quantity === produced ? "produced" : "ordered",
+        quantity_basis: offer.quantity_basis,
         unit_amount,
-        amount: Math.round(unit_amount * payable_quantity * 100) / 100,
+        /**
+         * ⚠️ Whether `unit_amount` was COMPUTED rather than agreed.
+         *
+         * True for every `cost_type: "total"` run — 97 of 100 on production.
+         * A screen that multiplies it anyway bills a figure nobody agreed to.
+         * The admin row has carried this since #1679; this one did not, which
+         * is how the two screens came to disagree by 22%.
+         */
+        unit_is_derived: offer.unit_is_derived,
+        amount: offer.amount,
         cost_type: run.cost_type ?? null,
         partner_cost_estimate:
           run.partner_cost_estimate === null ||

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260831120000.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260831120000.ts
@@ -1,0 +1,49 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * #1676 — a run may state NO agreed quantity.
+ *
+ * `quantity` has always been `not null default 1`, so "no agreed amount" was
+ * unrepresentable: an unset quantity read as a run ordered for ONE piece, which
+ * is the most restrictive ceiling possible rather than the absence of one.
+ *
+ * From #1676 every payment claim — including a run's FIRST claim — is bounded
+ * by that quantity. A null is the explicit, per-run opt-out from that ceiling:
+ * ongoing work with no fixed order, billed as it comes.
+ *
+ * 🔴 The DEFAULT stays 1. Dropping it would silently turn every future insert
+ * that omits the column into an open-ended, unguarded run — the opposite of
+ * this feature, which must be declared deliberately. Only an explicit null
+ * declares it.
+ *
+ * No backfill and no retro-nulling: every existing row keeps the quantity it
+ * has and behaves exactly as before.
+ */
+export class Migration20260831120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      alter table if exists "production_runs"
+        alter column "quantity" drop not null;
+    `);
+  }
+
+  /**
+   * ⚠️ NOT symmetric, and cannot be. Re-imposing `not null` would fail on any
+   * row that has since been declared open-ended, so the down path has to decide
+   * what those runs were ordered for — and there is no honest answer. It writes
+   * 1, the value the column defaulted to before this migration, which restores
+   * the pre-migration READING of an unset quantity (a run ordered for one) and
+   * with it the tightest possible ceiling. That is the safe direction: it can
+   * refuse a claim that would have been allowed, never allow one that would
+   * have been refused.
+   */
+  override async down(): Promise<void> {
+    this.addSql(`update "production_runs" set "quantity" = 1 where "quantity" is null;`);
+    this.addSql(`
+      alter table if exists "production_runs"
+        alter column "quantity" set not null;
+    `);
+  }
+
+}

--- a/apps/backend/src/modules/production_runs/models/production-run.ts
+++ b/apps/backend/src/modules/production_runs/models/production-run.ts
@@ -20,7 +20,21 @@ const ProductionRun = model.define("production_runs", {
     ])
     .default("pending_review"),
   run_type: model.enum(["production", "sample"]).default("production"),
-  quantity: model.float().default(1),
+  /**
+   * The AGREED quantity — how many units this run was ordered for.
+   *
+   * 🔴 Nullable, and null means something specific: there is NO agreed amount
+   * (#1676). Such a run is deliberately open-ended — ongoing work, billed as it
+   * comes — and it opts out of the billed-quantity ceiling entirely, so nothing
+   * refuses a payment claim against it. It has to be stated by a person at
+   * creation; it is never inferred, and `0` is emphatically NOT it (`0` is a
+   * broken number and still refuses).
+   *
+   * The `.default(1)` stays so that OMITTING the field keeps meaning "one
+   * piece", exactly as it has for every existing row and caller. Only an
+   * explicit `null` declares open-endedness.
+   */
+  quantity: model.float().default(1).nullable(),
 
   parent_run_id: model.text().nullable(),
   role: model.text().nullable(),

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billable-ceiling.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billable-ceiling.unit.spec.ts
@@ -1,4 +1,4 @@
-import { runBillableCeiling } from "../run-billable-ceiling"
+import { isOpenEndedRun, runBillableCeiling } from "../run-billable-ceiling"
 
 /**
  * #1596 short-close. The ceiling decides how much a partner may still claim, so
@@ -77,5 +77,44 @@ describe("runBillableCeiling", () => {
         short_closed_at: "2026-08-30T00:00:00.000Z",
       })
     ).toBe(7)
+  })
+})
+
+/**
+ * #1676 — "no agreed quantity" is a DECLARATION, and it has to be spelled
+ * differently from "no readable ceiling", which is a refusal.
+ */
+describe("isOpenEndedRun (#1676)", () => {
+  it("is true only for a quantity that is explicitly null", () => {
+    expect(isOpenEndedRun({ quantity: null })).toBe(true)
+  })
+
+  it("is FALSE for a quantity that is set but unusable", () => {
+    // `0` is not `null`. A broken number is not a declaration, and the guards
+    // still refuse on it.
+    expect(isOpenEndedRun({ quantity: 0 })).toBe(false)
+    expect(isOpenEndedRun({ quantity: -1 })).toBe(false)
+    expect(isOpenEndedRun({ quantity: "" })).toBe(false)
+  })
+
+  it("is FALSE when the row never fetched the field at all", () => {
+    // 🔴 The dangerous spelling. `run.quantity == null` would read every row of
+    // a query that forgot `quantity` as open-ended — a guard that silently
+    // allows everything. Absence of the field is absence of an answer.
+    expect(isOpenEndedRun({ produced_quantity: 9 } as any)).toBe(false)
+    expect(isOpenEndedRun({})).toBe(false)
+    expect(isOpenEndedRun(null)).toBe(false)
+    expect(isOpenEndedRun(undefined)).toBe(false)
+  })
+
+  it("still has no ceiling of its own — until it is short-closed", () => {
+    expect(runBillableCeiling({ quantity: null })).toBeNull()
+    expect(
+      runBillableCeiling({
+        quantity: null,
+        produced_quantity: 4,
+        short_closed_at: new Date("2026-08-31"),
+      })
+    ).toBe(4)
   })
 })

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billing.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billing.unit.spec.ts
@@ -219,3 +219,54 @@ describe("runBillableRemaining / runBillingStatus (#1596)", () => {
     ).toBeNull()
   })
 })
+
+/**
+ * #1676 — a run with NO agreed quantity has no ceiling, so its remainder is
+ * `null`. Everywhere else `null` means "no arithmetic available", which reads
+ * as nothing left — so without the flag, an open-ended run reports `billed`
+ * after ONE claim and no screen offers it again. The feature is repeated
+ * billing; that would be the feature, undone.
+ */
+describe("runBillingStatus — an open-ended run (#1676)", () => {
+  const claim = {
+    submission_id: "sub_1",
+    status: "Pending",
+    quantity: 4,
+    claimed_quantity: 4,
+    claimed_wholly: false,
+  }
+
+  it("stays partly_billed however much has been claimed", () => {
+    expect(
+      runBillingStatus({
+        billed: claim,
+        unrecordedClaims: [],
+        remaining: null,
+        openEnded: true,
+      })
+    ).toBe("partly_billed")
+  })
+
+  it("is billed without the flag — the null remainder reads as nothing left", () => {
+    // The exact failure the flag exists to prevent, pinned so nobody "tidies"
+    // the parameter away.
+    expect(
+      runBillingStatus({
+        billed: claim,
+        unrecordedClaims: [],
+        remaining: null,
+      })
+    ).toBe("billed")
+  })
+
+  it("does not invent a claim where there is none", () => {
+    // Open-ended says nothing about whether anybody has billed it yet.
+    expect(
+      runBillingStatus({ billed: null, unrecordedClaims: [], openEnded: true })
+    ).toBe("clear")
+  })
+
+  it("still reports a claimless open-ended run's remainder as unknown", () => {
+    expect(runBillableRemaining({ claim: null, ordered: null })).toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-claim-quantities.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-claim-quantities.unit.spec.ts
@@ -177,21 +177,28 @@ describe("assessRunClaims (#1596)", () => {
     expect(overclaimed[0]?.requested).toBeNull()
   })
 
-  it("refuses when the run states no quantity to divide", () => {
-    // No ceiling means no arithmetic. Allowing here would invent headroom on
-    // exactly the runs whose records are weakest.
+  it("refuses when the run's quantity is set but UNUSABLE", () => {
+    // No readable ceiling means no arithmetic. Allowing here would invent
+    // headroom on exactly the runs whose records are weakest.
+    //
+    // ⚠️ `0`, not `null`: since #1676 a null quantity is a DECLARATION that the
+    // run is open-ended, and it is the one case that does not refuse. A zero is
+    // still a broken number.
     const overclaimed = assessRunClaims({
       requestedByRun: requestedRunQuantities([
         { production_run_ids: ["run_a"], quantity: 1 },
       ]),
-      runs: new Map([["run_a", { quantity: null }]]),
+      runs: new Map([["run_a", { quantity: 0 }]]),
       tallies: foldRunClaimTallies([live(["run_a"], 1)]),
     })
     expect(overclaimed).toHaveLength(1)
     expect(overclaimed[0]?.ceiling).toBe(0)
   })
 
-  it("says nothing about a run nobody has claimed", () => {
+  it("says nothing about a run nobody has claimed, when the claim is unattributable", () => {
+    // An unattributable claim takes the run WHOLE, which is what it is worth.
+    // There is no number to compare — see the #1676 block for the case where
+    // there IS one.
     expect(
       assessRunClaims({
         requestedByRun: requestedRunQuantities([
@@ -235,5 +242,198 @@ describe("runsOverclaimedMessage (#1596)", () => {
     expect(message).toContain("1 remaining")
     expect(message).toContain("asks for 2")
     expect(message).toContain("sub_prior")
+  })
+})
+
+/**
+ * #1676 — a FIRST claim is bounded too.
+ *
+ * `tallies` only holds runs some PRIOR submission claimed, so a run's opening
+ * claim used to be compared against nothing at all: a run ordered for 9 could
+ * be billed at 100 and this guard would not look. Only a short-closed run was
+ * checked, because otherwise the close would have meant nothing.
+ *
+ * The founder's rule is a pair, and the second half is what makes the first
+ * half safe: bound the first claim by the agreed amount, and let a run created
+ * with NO agreed quantity be the explicit, per-run opt-out. That turns an
+ * implicit absence of validation into a declaration somebody has to make.
+ */
+describe("assessRunClaims — a first claim (#1676)", () => {
+  const first = (quantity: number | null) =>
+    requestedRunQuantities([{ production_run_ids: ["run_a"], quantity }])
+
+  it("refuses a first claim for more than the run was ordered for", () => {
+    // The headline case: ordered 9, billed 100, nobody had claimed it before.
+    const overclaimed = assessRunClaims({
+      requestedByRun: first(100),
+      runs: new Map([["run_a", { quantity: 9 }]]),
+      tallies: new Map(),
+    })
+
+    expect(overclaimed).toHaveLength(1)
+    expect(overclaimed[0]).toEqual(
+      expect.objectContaining({
+        run_id: "run_a",
+        ceiling: 9,
+        claimed_quantity: 0,
+        requested: 100,
+        claims: [],
+      })
+    )
+  })
+
+  it("allows a first claim within the ordered quantity", () => {
+    expect(
+      assessRunClaims({
+        requestedByRun: first(7),
+        runs: new Map([["run_a", { quantity: 9 }]]),
+        tallies: new Map(),
+      })
+    ).toEqual([])
+  })
+
+  it("allows the whole ordered quantity, float dust included", () => {
+    expect(
+      assessRunClaims({
+        requestedByRun: first(9.001),
+        runs: new Map([["run_a", { quantity: 9 }]]),
+        tallies: new Map(),
+      })
+    ).toEqual([])
+  })
+
+  it("names the run's own ceiling in the refusal, with no prior holder", () => {
+    const message = runsOverclaimedMessage(
+      assessRunClaims({
+        requestedByRun: first(100),
+        runs: new Map([["run_a", { quantity: 9 }]]),
+        tallies: new Map(),
+      })
+    )
+
+    expect(message).toContain("ordered 9")
+    expect(message).toContain("already claimed 0")
+    expect(message).toContain("no prior claim")
+    expect(message).toContain("asks for 100")
+  })
+
+  it("refuses when the row states a quantity that cannot be read", () => {
+    // A zero is a broken number, not a declaration — the same rule the
+    // second-and-later claims have always applied.
+    expect(
+      assessRunClaims({
+        requestedByRun: first(5),
+        runs: new Map([["run_a", { quantity: 0 }]]),
+        tallies: new Map(),
+      })
+    ).toHaveLength(1)
+  })
+
+  it("refuses when the row never FETCHED the quantity", () => {
+    // 🔴 The trap this guard is one keystroke away from: a `query.graph` that
+    // forgot `quantity` produces rows with no such key. Reading that as
+    // open-ended would silently disable the ceiling everywhere. Absence of the
+    // field is absence of an answer, so it refuses.
+    expect(
+      assessRunClaims({
+        requestedByRun: first(100),
+        runs: new Map([["run_a", { produced_quantity: 9 }]]),
+        tallies: new Map(),
+      })
+    ).toHaveLength(1)
+  })
+
+  it("says nothing about a run it was never given a row for", () => {
+    // Existence and ownership are somebody else's guard; refusing here would
+    // block a submit over a run this function was simply not told about.
+    expect(
+      assessRunClaims({
+        requestedByRun: first(100),
+        runs: new Map(),
+        tallies: new Map(),
+      })
+    ).toEqual([])
+  })
+
+  it("still refuses a first claim above what a SHORT-CLOSED run produced", () => {
+    expect(
+      assessRunClaims({
+        requestedByRun: first(9),
+        runs: new Map([
+          [
+            "run_a",
+            { quantity: 9, produced_quantity: 4, short_closed_at: new Date() },
+          ],
+        ]),
+        tallies: new Map(),
+      })
+    ).toHaveLength(1)
+  })
+})
+
+/**
+ * #1676 — the opt-out. A run created with NO agreed quantity is open-ended:
+ * ongoing work, billed as it comes, and deliberately outside the ceiling.
+ */
+describe("assessRunClaims — an open-ended run (#1676)", () => {
+  const openEnded = { quantity: null }
+
+  it("does not bound a first claim of any size", () => {
+    expect(
+      assessRunClaims({
+        requestedByRun: requestedRunQuantities([
+          { production_run_ids: ["run_a"], quantity: 1000 },
+        ]),
+        runs: new Map([["run_a", openEnded]]),
+        tallies: new Map(),
+      })
+    ).toEqual([])
+  })
+
+  it("does not bound a LATER claim either", () => {
+    expect(
+      assessRunClaims({
+        requestedByRun: requestedRunQuantities([
+          { production_run_ids: ["run_a"], quantity: 50 },
+        ]),
+        runs: new Map([["run_a", openEnded]]),
+        tallies: foldRunClaimTallies([live(["run_a"], 500)]),
+      })
+    ).toEqual([])
+  })
+
+  it("does not refuse even when a prior claim took the run WHOLE", () => {
+    // The deliberate cost of the opt-out, and the reason it has to be declared
+    // by a person rather than inferred: no agreed amount means no arithmetic
+    // for the double-pay guard to do.
+    expect(
+      assessRunClaims({
+        requestedByRun: requestedRunQuantities([
+          { production_run_ids: ["run_a"], quantity: 5 },
+        ]),
+        runs: new Map([["run_a", openEnded]]),
+        tallies: foldRunClaimTallies([live(["run_a"], null)]),
+      })
+    ).toEqual([])
+  })
+
+  it("IS bounded once it is short-closed — a close is still a statement", () => {
+    // Opting out of an agreed quantity is not opting out of "no more will be
+    // made". Without this the close would mean nothing at all on such a run.
+    const overclaimed = assessRunClaims({
+      requestedByRun: requestedRunQuantities([
+        { production_run_ids: ["run_a"], quantity: 5 },
+      ]),
+      runs: new Map([
+        [
+          "run_a",
+          { quantity: null, produced_quantity: 4, short_closed_at: new Date() },
+        ],
+      ]),
+      tallies: new Map(),
+    })
+
+    expect(overclaimed).toHaveLength(1)
+    expect(overclaimed[0]?.ceiling).toBe(4)
   })
 })

--- a/apps/backend/src/workflows/payment_submissions/lib/run-billable-ceiling.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-billable-ceiling.ts
@@ -75,3 +75,40 @@ export const runBillableCeiling = (run: RunCeilingInput | null | undefined): num
 /** Whether a run has been declared finished-for-good. */
 export const isShortClosed = (run: RunCeilingInput | null | undefined): boolean =>
   !!run?.short_closed_at
+
+/**
+ * Whether a run was created with NO agreed quantity — deliberately open-ended.
+ *
+ * ## Why this is a separate question from "the ceiling is unreadable"
+ *
+ * `runBillableCeiling` returns `null` for both "there is no number here" and
+ * "the number is unusable", and every guard reads that `null` as a REFUSAL.
+ * That is the right default and it must stay: an absent number is never
+ * permission to bill.
+ *
+ * Open-endedness is the opposite statement, so it cannot be spelled the same
+ * way. `quantity` is nullable purely so somebody can say, at creation, *there
+ * is no agreed amount for this run* — ongoing work, no fixed order. Only a
+ * literal `null` means that. A quantity of `0`, a negative, or an
+ * unparseable value is a broken number, NOT a declaration, and still refuses
+ * (`0` is not `null` — the same trap as #1565).
+ *
+ * 🔴 A run this returns true for opts OUT of the billed-quantity guard
+ * entirely: no ceiling, so no overclaim, so nothing here refuses a claim
+ * against it. That is the deliberate cost of the feature (#1676) and the reason
+ * it has to be stated per run by a person rather than inferred.
+ *
+ * ⚠️ The key must be PRESENT and the value literally `null`. `run.quantity ==
+ * null` would have been the obvious spelling and it is the dangerous one: a
+ * `query.graph` that forgot to fetch `quantity` produces a row with no such
+ * key, and every run it returned would read as open-ended — a guard that
+ * silently allows everything. Absence of the field is absence of an ANSWER, so
+ * it falls through to the ceiling, which refuses. (The mirror of that trap —
+ * a guard reading a field the query never fetched and therefore refusing every
+ * close — cost #1596 four separate graph queries.)
+ */
+export const isOpenEndedRun = (
+  run: RunCeilingInput | null | undefined
+): boolean =>
+  !!run && Object.prototype.hasOwnProperty.call(run, "quantity") && run.quantity === null
+

--- a/apps/backend/src/workflows/payment_submissions/lib/run-billing.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-billing.ts
@@ -210,8 +210,24 @@ export const runBillingStatus = (input: {
   unrecordedClaims: unknown[]
   /** Units still billable, from `runBillableRemaining`. */
   remaining?: number | null
+  /**
+   * The run states NO agreed quantity — `isOpenEndedRun` (#1676).
+   *
+   * 🔴 Load-bearing, and easy to leave out. `runBillableRemaining` returns
+   * `null` for such a run because there is no ceiling to subtract from, and
+   * `null` here otherwise reads as "nothing left" — so a run that may be billed
+   * again indefinitely would report `billed`, and every screen would stop
+   * offering it after ONE claim. That is the whole feature, undone by a null
+   * meaning two things.
+   */
+  openEnded?: boolean
 }): RunBillingStatus => {
   if (input.billed) {
+    if (input.openEnded) {
+      // More may always be billed; how much is deliberately unbounded, which
+      // is why `billable_remaining` stays null beside this.
+      return "partly_billed"
+    }
     return input.remaining != null && input.remaining > 0
       ? "partly_billed"
       : "billed"

--- a/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
@@ -40,7 +40,7 @@
  */
 
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
-import { runBillableCeiling } from "./run-billable-ceiling"
+import { runBillableCeiling, isOpenEndedRun } from "./run-billable-ceiling"
 
 export type PriorRunLine = {
   submission_id: string | null
@@ -335,6 +335,14 @@ export type OverclaimedRun = {
  * both sides are attributable and their sum fits. Every unattributable claim,
  * every unreadable ceiling, still refuses — an absent number must never read
  * as room to bill.
+ *
+ * 🔴 #1676 — EVERY claim is bounded, including the first. Until then the
+ * ceiling only started applying from the second claim onward: `tallies` holds
+ * only runs a PRIOR submission already claimed, so a run's opening claim was
+ * compared against nothing and a run ordered for 9 could be billed at 100.
+ * The single exception is a run created with NO agreed quantity, which is an
+ * explicit, per-run opt-out (`isOpenEndedRun`) rather than the accidental
+ * absence of a guard.
  */
 export function assessRunClaims(input: {
   /** Units requested per run, or null where the request cannot be attributed. */
@@ -354,37 +362,90 @@ export function assessRunClaims(input: {
     const tally = input.tallies.get(runId)
     const row = input.runs.get(runId)
 
+    // ⚠️ Derive, never read `row.ceiling` directly: `create` passes RAW run
+    // rows whose `ceiling` is undefined, so reading the field would quietly
+    // skip every check below on the path that creates most claims.
+    const rowCeiling =
+      row?.ceiling !== undefined ? row.ceiling : runBillableCeiling(row)
+
+    /**
+     * 🔴 The run states NO agreed quantity — it is deliberately open-ended
+     * (#1676). There is no ceiling to exceed, so nothing here refuses: not the
+     * first claim, not a later one, not even a prior claim that took the run
+     * whole. That is the whole point of the opt-out, and it is why it has to be
+     * declared by a person at creation rather than inferred from a number.
+     *
+     * Checked BEFORE the tally, because the alternative reading of "no
+     * quantity" — the `!(ceiling > 0)` refusal further down — is the exact
+     * inverse of what this means.
+     *
+     * ⚠️ `&& rowCeiling == null` is load-bearing. SHORT-CLOSING an open-ended
+     * run gives it a ceiling after all — the produced figure — because a close
+     * is somebody stating outright that no more will be made. Opting out of an
+     * agreed quantity is not opting out of that statement, and without this
+     * clause a close on such a run would mean nothing at all.
+     */
+    if (isOpenEndedRun(row) && rowCeiling == null) {
+      continue
+    }
+
     if (!tally) {
       /**
-       * Nobody has claimed it, so there is nothing to diff against — and a
-       * FIRST claim has never been compared to the run's own quantity. That is
-       * long-standing behaviour and is deliberately left alone here: a run can
-       * legitimately overproduce, and `payable-runs` offers the produced
-       * figure, so refusing on the ordered quantity would start rejecting
-       * honest claims.
+       * A FIRST claim. It used to be compared against nothing at all: the
+       * tally map only holds runs some PRIOR submission claimed, so a run
+       * ordered for 9 could be billed at 100 and this guard would not look
+       * (#1676). Only a short-closed run was checked, and only because the
+       * close would otherwise have meant nothing.
        *
-       * 🔴 Except once the run is SHORT-CLOSED (#1596). That is somebody
-       * stating outright that no more will be made, and it is the only reason
-       * the feature exists: without this branch a closed run's first claim
-       * could still bill the full ordered quantity and the close would mean
-       * nothing at all.
+       * It is now bounded by the same ceiling every later claim is: the agreed
+       * quantity, or what was produced once the run is short-closed.
+       *
+       * ⚠️ This DOES refuse a claim for more than was ordered on a run that
+       * genuinely overproduced — `payable-runs` offers the produced figure, so
+       * that figure is clamped at the ceiling on the offer side and the two
+       * agree. The two honest ways past it are to correct the run's ordered
+       * quantity (an audited edit) or to have created the run open-ended. An
+       * unbounded first claim by accident, everywhere, is what this replaces.
        */
-      // ⚠️ Derive, never read `row.ceiling` directly: `create` passes RAW run
-      // rows whose `ceiling` is undefined, so reading the field would quietly
-      // skip this branch on the very path that creates most claims.
-      const closedCeiling = row?.short_closed_at
-        ? row.ceiling !== undefined
-          ? row.ceiling
-          : runBillableCeiling(row)
-        : null
-      if (
-        closedCeiling != null &&
-        requested != null &&
-        requested > closedCeiling + 0.005
-      ) {
+      const ceiling = rowCeiling
+
+      /**
+       * An unattributable claim (a line naming several runs, or stating no
+       * quantity) takes the run WHOLE — which is what the run is worth by
+       * definition. There is no number to compare, and inventing one is how
+       * headroom gets manufactured. Unchanged from before this branch existed.
+       */
+      if (requested == null) {
+        continue
+      }
+
+      // No row at all — the run is unknown to this map. Ownership and
+      // existence are somebody else's guard; refusing here would block a
+      // submit over a run this function was simply not told about.
+      if (!row) {
+        continue
+      }
+
+      if (ceiling == null || !(ceiling > 0)) {
+        // A quantity IS set and it is unusable (0, negative, unparseable).
+        // That is a broken number, not a declaration of open-endedness, and
+        // the second-and-later branch has always refused it.
         overclaimed.push({
           run_id: runId,
-          ceiling: closedCeiling,
+          ceiling: 0,
+          claimed_quantity: 0,
+          claimed_wholly: false,
+          requested,
+          claims: [],
+        })
+        continue
+      }
+
+      // The same hundredth-of-a-unit tolerance the later claims use.
+      if (requested > ceiling + 0.005) {
+        overclaimed.push({
+          run_id: runId,
+          ceiling,
           claimed_quantity: 0,
           claimed_wholly: false,
           requested,
@@ -394,9 +455,7 @@ export function assessRunClaims(input: {
       continue
     }
 
-    const derived =
-      row?.ceiling !== undefined ? row.ceiling : runBillableCeiling(row)
-    const ceiling = derived != null && derived > 0 ? derived : 0
+    const ceiling = rowCeiling != null && rowCeiling > 0 ? rowCeiling : 0
 
     const refuse = () =>
       overclaimed.push({
@@ -409,8 +468,9 @@ export function assessRunClaims(input: {
       })
 
     // Somebody already claimed the whole run, or this request claims the whole
-    // run, or the run states no quantity to divide up. No arithmetic is
-    // available, so the old whole-run refusal stands.
+    // run, or the run's quantity is set but unusable. No arithmetic is
+    // available, so the old whole-run refusal stands. (A run with NO quantity
+    // has already been let through above — that is a declaration, not a gap.)
     if (tally.claimed_wholly || requested == null || !(ceiling > 0)) {
       refuse()
       continue

--- a/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
@@ -295,6 +295,42 @@ describe("runPayableOffer — a total is the agreed price, verbatim", () => {
     expect(offer.payable).toBe(false)
     expect(offer.amount).toBe(0)
   })
+
+  /**
+   * #1676 — the offer is what an operator reads and then acts on, and the write
+   * guard now refuses a claim above the run's agreed quantity, including its
+   * first. Offering more than that would put a number on the screen that
+   * `create` rejects — the very defect `runPayableOffer` exists to prevent.
+   */
+  it("never offers MORE units than were ordered", () => {
+    const offer = runPayableOffer({
+      id: "run_1",
+      partner_cost_estimate: 1200,
+      cost_type: "per_unit",
+      quantity: 9,
+      produced_quantity: 12,
+    })
+
+    expect(offer.quantity).toBe(9)
+    // Honest about the clamp: a produced figure cut back to ordered IS ordered.
+    expect(offer.quantity_basis).toBe("ordered")
+    expect(offer.amount).toBe(10800)
+  })
+
+  it("offers what was made when the run has NO agreed quantity", () => {
+    // An open-ended run (#1676) has no ordered figure to clamp against.
+    const offer = runPayableOffer({
+      id: "run_1",
+      partner_cost_estimate: 1200,
+      cost_type: "per_unit",
+      quantity: null,
+      produced_quantity: 12,
+    })
+
+    expect(offer.quantity).toBe(12)
+    expect(offer.quantity_basis).toBe("produced")
+    expect(offer.amount).toBe(14400)
+  })
 })
 
 describe("resolveRunLinePrice — a derived rate is never written down", () => {

--- a/apps/backend/src/workflows/production-runs/approve-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/approve-production-run.ts
@@ -29,7 +29,12 @@ import {
 export type ProductionRunAssignment = {
   partner_id: string
   role?: string | null
-  quantity?: number
+  /**
+   * Units for this child. Absent inherits the parent's; explicit `null`
+   * declares this child open-ended — no agreed quantity, no payment ceiling
+   * (#1676).
+   */
+  quantity?: number | null
   order?: number
   /**
    * Templates BY NAME. Kept because existing callers use it, but since #1261 a
@@ -161,7 +166,24 @@ const approveProductionRunStep = createStep(
       ((original as any).metadata ?? {}) as Record<string, any>
 
     const childPayloads = assignments.map((a, idx) => {
-      const quantity = a.quantity ?? (original as any).quantity ?? 1
+      /**
+       * A child inherits the parent's OPEN-ENDEDNESS, not just its number
+       * (#1676). `a.quantity ?? parent.quantity ?? 1` collapsed a parent with
+       * no agreed quantity to 1 — the tightest possible payment ceiling on a
+       * run whose whole point is that it has none, and the sort of inversion
+       * that only shows up when a partner's claim is refused.
+       *
+       * An assignment that states its own quantity still wins — including an
+       * explicit `null`, which declares that one child open-ended even when the
+       * parent is not. Hence `!== undefined` rather than `!= null`.
+       */
+      const parentQuantity = (original as any).quantity
+      const quantity =
+        a.quantity !== undefined
+          ? a.quantity
+          : parentQuantity === null
+            ? null
+            : parentQuantity ?? 1
       const allocation = allocationByIndex[idx] || []
 
       const originalSnapshot = (original as any).snapshot
@@ -425,7 +447,16 @@ export const approveProductionRunWorkflow = createWorkflow(
 
       const partnerId = (data.run as any)?.partner_id
       if (partnerId) {
-        return [{ partner_id: partnerId, quantity: (data.run as any)?.quantity ?? 1 }]
+        // ⚠️ `=== undefined`, not `??`: a run with NO agreed quantity (#1676)
+        // stays open-ended in its implied single assignment. `?? 1` would have
+        // capped it at one piece.
+        const runQuantity = (data.run as any)?.quantity
+        return [
+          {
+            partner_id: partnerId,
+            quantity: runQuantity === undefined ? 1 : runQuantity,
+          },
+        ]
       }
 
       return []

--- a/apps/backend/src/workflows/production-runs/create-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run.ts
@@ -47,7 +47,12 @@ export type CreateProductionRunInput = {
   // required and the snapshot is built from the product instead of a design.
   design_id?: string | null
   partner_id?: string | null
-  quantity?: number
+  /**
+   * The agreed quantity. Absent = 1, as always; explicit `null` = there is NO
+   * agreed amount, an open-ended run that opts out of the payment ceiling
+   * (#1676). The two are not interchangeable here.
+   */
+  quantity?: number | null
   // #1112 — for runs born already-`completed` (retail fulfillment), stamp the
   // produced yield up front instead of leaving it for the lifecycle to fill.
   produced_quantity?: number
@@ -336,7 +341,16 @@ const createProductionRunStep = createStep(
     const created = await productionRunService.createProductionRuns({
       design_id: input.payload.design_id ?? null,
       partner_id: input.payload.partner_id ?? null,
-      quantity: input.payload.quantity ?? 1,
+      /**
+       * 🔴 An explicit `null` is PRESERVED, not defaulted (#1676). It declares
+       * a run with no agreed quantity — open-ended — and that is the only way
+       * to say it. `?? 1` would have swallowed the declaration and written the
+       * tightest possible ceiling instead of none.
+       *
+       * Omitting the field still means one piece, exactly as before.
+       */
+      quantity:
+        input.payload.quantity === null ? null : (input.payload.quantity ?? 1),
       run_type: input.payload.run_type ?? "production",
       product_id: input.payload.product_id,
       variant_id: input.payload.variant_id,
@@ -478,6 +492,9 @@ export const createProductionRunWorkflow = createWorkflow(
             order_line_item_id: data.input.order_line_item_id,
             product_id: data.input.product_id,
             variant_id: data.input.variant_id,
+            // The SNAPSHOT's own record of what was asked for, not a ceiling
+            // — an open-ended run (`quantity: null`) records 1 here rather than
+            // leaving the provenance blank. Nothing bills from this.
             quantity: data.input.quantity ?? 1,
             partner_id: data.input.partner_id ?? null,
           },

--- a/apps/backend/src/workflows/production-runs/lib/run-payable.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-payable.ts
@@ -88,7 +88,8 @@ export const runUnitCost = (run: RunForPayout | null | undefined): number => {
  * A figure an operator reads is not the figure that gets written, and the
  * created Draft looks authoritative either way.
  *
- * ⚠️ The quantity is PRODUCED where output was recorded, ordered otherwise —
+ * ⚠️ The quantity is PRODUCED where output was recorded, ordered otherwise,
+ * and never above what was ordered (#1676) —
  * which is deliberately NOT `runPayableAmount`'s multiplier. That function
  * bills the ordered quantity (#456, and the unified-order dual-write depends on
  * it); this one bills what the screen offers. The two answer different
@@ -106,7 +107,11 @@ export type RunPayableOffer = {
   unit_amount: number
   /** Whether `unit_amount` was computed rather than agreed. */
   unit_is_derived: boolean
-  /** Units billed — produced where recorded, else ordered, never below 1. */
+  /**
+   * Units billed — produced where recorded, else ordered; never below 1 and
+   * never above the ordered quantity, which is the ceiling the write guard
+   * enforces (#1676).
+   */
   quantity: number
   quantity_basis: "produced" | "ordered"
   /**
@@ -137,11 +142,28 @@ export const runPayableOffer = (
   const produced = Number(run?.produced_quantity)
   const hasProduced = Number.isFinite(produced) && produced > 0
   const ordered = Number(run?.quantity)
-  const quantity = hasProduced
-    ? produced
-    : Number.isFinite(ordered) && ordered > 0
-      ? ordered
-      : 1
+  const hasOrdered = Number.isFinite(ordered) && ordered > 0
+  const offered = hasProduced ? produced : hasOrdered ? ordered : 1
+  /**
+   * 🔴 Never more than was ORDERED (#1676).
+   *
+   * The offer is what an operator reads and then acts on, and from #1676 the
+   * write guard refuses a claim above the run's agreed quantity — including
+   * the run's very first claim. Offering the produced figure unclamped would
+   * put a number on the screen that `create` then rejects, which is the exact
+   * defect `runPayableOffer` was extracted to prevent (#1616): a figure an
+   * operator reads must be the figure that gets written.
+   *
+   * A run that genuinely overproduced is not being cheated silently — the row
+   * still prints `produced_quantity` beside this, and the honest routes are to
+   * correct the ordered quantity (an audited edit) or to run open-ended. A run
+   * with NO agreed quantity has no `ordered` to clamp against, so it offers
+   * what was made.
+   */
+  const quantity = hasOrdered ? Math.min(offered, ordered) : offered
+  /** Honest about the clamp: a produced figure cut back to ordered IS ordered. */
+  const quantity_basis: "produced" | "ordered" =
+    hasProduced && quantity === produced ? "produced" : "ordered"
 
   const agreed = Number(run?.partner_cost_estimate)
   const hasAgreed = Number.isFinite(agreed) && agreed > 0
@@ -158,7 +180,7 @@ export const runPayableOffer = (
       unit_amount: 0,
       unit_is_derived: false,
       quantity,
-      quantity_basis: hasProduced ? "produced" : "ordered",
+      quantity_basis,
       amount: 0,
       payable: false,
     }
@@ -171,7 +193,7 @@ export const runPayableOffer = (
       unit_amount: agreed,
       unit_is_derived: false,
       quantity,
-      quantity_basis: hasProduced ? "produced" : "ordered",
+      quantity_basis,
       amount: Math.round(agreed * quantity * 100) / 100,
       payable: true,
     }
@@ -187,7 +209,7 @@ export const runPayableOffer = (
     unit_amount: Math.round((agreed / quantity) * 100) / 100,
     unit_is_derived: true,
     quantity,
-    quantity_basis: hasProduced ? "produced" : "ordered",
+    quantity_basis,
     amount: agreed,
     payable: true,
   }

--- a/apps/partner-ui/src/hooks/api/partner-payable-runs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payable-runs.tsx
@@ -15,6 +15,15 @@ export interface PayableRun {
   payable_quantity: number
   quantity_basis: "produced" | "ordered"
   unit_amount: number
+  /**
+   * 🔴 Whether `unit_amount` was COMPUTED rather than agreed.
+   *
+   * True for every `cost_type: "total"` run — 97 of 100 on production — where
+   * the rate is `total / ordered` and multiplying it back out does not
+   * reproduce `amount`. Read `amount` for the money; read this only to show a
+   * rate. Without it this screen billed ₹7,777.77 against a ₹10,000 job.
+   */
+  unit_is_derived: boolean
   amount: number
   cost_type: string | null
   partner_cost_estimate: number | null

--- a/apps/partner-ui/src/hooks/api/partner-payable-runs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payable-runs.tsx
@@ -39,6 +39,12 @@ export interface PayableRun {
    * refuses. A number here is a promise `create` will keep.
    */
   billable_remaining: number | null
+  /**
+   * #1676 — no agreed quantity, so nothing caps what may be billed against
+   * this run. A null `billable_remaining` beside this means "no ceiling", not
+   * "nothing left".
+   */
+  open_ended: boolean
 }
 
 export interface PayableRunsListResponse {

--- a/apps/partner-ui/src/lib/__tests__/payment-submission-money.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/payment-submission-money.spec.ts
@@ -5,6 +5,9 @@ import {
   money,
   perUnit,
   provenanceLabel,
+  runBillsVerbatimTotal,
+  runLineAmount,
+  runNeedsTypedPrice,
 } from "../payment-submission-money"
 
 /**
@@ -277,5 +280,88 @@ describe("groupIntoRateBands (#1596)", () => {
     const banded = bands.reduce((s, b) => s + b.quantity * b.unit_amount, 0)
     const oldTotal = runs.reduce((s, r) => s + r.quantity * r.unit_amount, 0)
     expect(Math.round(banded * 100) / 100).toBe(Math.round(oldTotal * 100) / 100)
+  })
+})
+
+/**
+ * #1679 on the PARTNER side, and #1676's remainder.
+ *
+ * This screen used to compute `unit_amount × quantity` for every run, so a job
+ * agreed at ₹10,000 as a TOTAL — 9 ordered, 7 made — was offered at ₹7,777.77
+ * here while the admin screen offered ₹10,000 for the same run on the same day.
+ * A partner submitting their own draft under-claimed by 22%, and by a paisa
+ * even when produced equalled ordered.
+ */
+describe("runLineAmount — a total is the agreed price (#1679)", () => {
+  const totalRun = {
+    quantity: 7,
+    rate: 1111.11,
+    amount: 10000,
+    unit_is_derived: true,
+    hasTypedRate: false,
+  }
+
+  it("bills the agreed total verbatim, not the derived rate × quantity", () => {
+    expect(runLineAmount(totalRun)).toBe(10000)
+    expect(runLineAmount(totalRun)).not.toBe(7777.77)
+  })
+
+  it("loses no paisa when produced equals ordered", () => {
+    // 10000/9 = 1111.11, × 9 = 9999.99. The rounding that made a ₹10,000 job
+    // pay ₹9,999.99.
+    expect(runLineAmount({ ...totalRun, quantity: 9 })).toBe(10000)
+  })
+
+  it("multiplies once a rate is typed — that is the deliberate way out", () => {
+    expect(
+      runLineAmount({ ...totalRun, rate: 1400, hasTypedRate: true })
+    ).toBe(9800)
+  })
+
+  it("multiplies a genuine per-unit rate", () => {
+    expect(
+      runLineAmount({
+        quantity: 7,
+        rate: 1200,
+        amount: 8400,
+        unit_is_derived: false,
+        hasTypedRate: false,
+      })
+    ).toBe(8400)
+  })
+
+  it("bills NOTHING for the remainder of a partly-billed total run (#1676)", () => {
+    // Re-billing the total double-pays; dividing it re-prices. Neither is an
+    // answer this screen may invent, so it states none and the submit guard
+    // refuses until somebody types one.
+    expect(
+      runLineAmount({ ...totalRun, quantity: 5, alreadyPartlyBilled: true })
+    ).toBe(0)
+    expect(
+      runNeedsTypedPrice({
+        unit_is_derived: true,
+        hasTypedRate: false,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(true)
+    expect(
+      runBillsVerbatimTotal({
+        unit_is_derived: true,
+        hasTypedRate: false,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(false)
+  })
+
+  it("prices the remainder from the moment a rate is typed", () => {
+    expect(
+      runLineAmount({
+        ...totalRun,
+        quantity: 5,
+        rate: 1400,
+        hasTypedRate: true,
+        alreadyPartlyBilled: true,
+      })
+    ).toBe(7000)
   })
 })

--- a/apps/partner-ui/src/lib/payment-submission-money.ts
+++ b/apps/partner-ui/src/lib/payment-submission-money.ts
@@ -182,3 +182,82 @@ export const provenanceLabel = (item: any): ProvenanceLabel => {
 
   return null
 }
+
+/**
+ * What one payable run BILLS on the create screen.
+ *
+ * 🔴 TWO HOMES. This is the partner-side copy of
+ * `apps/backend/src/admin/components/creates/lib/run-line-pricing.ts`. The two
+ * screens price the same runs and send the same request, and when they drifted
+ * they disagreed by 22% on the same run on the same day: this screen used to
+ * compute `unit_amount × quantity` for everything, so a job agreed at ₹10,000
+ * as a TOTAL (9 ordered, 7 made) offered ₹7,777.77 here and ₹10,000 there. A
+ * change to either file belongs in both.
+ *
+ * ## The rule
+ *
+ * A run carries either a rate or a total, and `unit_is_derived` says which. A
+ * `per_unit` run was agreed at so much per piece, so its amount is
+ * `quantity × rate` and moving the quantity moves the money.
+ *
+ * A `total` run was agreed at a price for the JOB. Its `unit_amount` is
+ * `total / ordered`, sent purely so a screen can show a rate, and multiplying
+ * it back out does NOT reproduce the total — it loses a paisa even when the
+ * numbers line up, and cuts 22% when they do not. So an untouched total-priced
+ * run bills its agreed figure VERBATIM and the quantity does not move it.
+ *
+ * Typing a rate is the way out: a human who has decided a per-unit price
+ * outranks a stored figure, and from then on the row multiplies.
+ */
+export type RunLinePricingInput = {
+  quantity: number
+  rate: number
+  /** What the API says is owed. For a total-priced run, the agreed total. */
+  amount: number
+  unit_is_derived?: boolean | null
+  hasTypedRate: boolean
+  /**
+   * Whether a live line already claimed part of this run (#1596/#1676).
+   *
+   * The remainder of a total-priced job has no figure of its own: re-billing
+   * the total double-pays, and dividing it re-prices work nobody re-negotiated.
+   */
+  alreadyPartlyBilled?: boolean | null
+}
+
+/** PURE. Whether this row still bills an agreed TOTAL rather than a rate. */
+export const runBillsVerbatimTotal = (
+  input: Pick<
+    RunLinePricingInput,
+    "unit_is_derived" | "hasTypedRate" | "alreadyPartlyBilled"
+  >
+): boolean =>
+  !input.hasTypedRate && !!input.unit_is_derived && !input.alreadyPartlyBilled
+
+/** PURE. Whether this row can state no price at all until somebody types one. */
+export const runNeedsTypedPrice = (
+  input: Pick<
+    RunLinePricingInput,
+    "unit_is_derived" | "hasTypedRate" | "alreadyPartlyBilled"
+  >
+): boolean =>
+  !input.hasTypedRate && !!input.unit_is_derived && !!input.alreadyPartlyBilled
+
+/** PURE. What this run bills. */
+export const runLineAmount = (input: RunLinePricingInput): number => {
+  // Before both other branches: re-billing the total double-pays, and
+  // multiplying the derived rate re-prices the job.
+  if (runNeedsTypedPrice(input)) {
+    return 0
+  }
+  if (runBillsVerbatimTotal(input)) {
+    // Verbatim. Not rounded, not re-derived, not multiplied.
+    return input.amount
+  }
+  const quantity = Number(input.quantity)
+  const rate = Number(input.rate)
+  if (!Number.isFinite(quantity) || !Number.isFinite(rate)) {
+    return 0
+  }
+  return Math.round(quantity * rate * 100) / 100
+}

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -739,10 +739,18 @@ const RunRow = ({
           </Badge>
           {run.billing_status === "partly_billed" && !blocked && (
             <Tooltip
-              content={`Part of this run has already been paid for. ${run.billable_remaining} of ${run.ordered_quantity} units are still billable.`}
+              content={
+                run.open_ended
+                  ? "Part of this run has already been paid for. It has no agreed quantity, so there is no cap on what may still be billed."
+                  : `Part of this run has already been paid for. ${run.billable_remaining} of ${run.ordered_quantity} units are still billable.`
+              }
             >
               <Badge color="blue" size="2xsmall">
-                {run.billable_remaining} left to bill
+                {/* #1676 — an open-ended run's remainder is null because there
+                  * is no ceiling. Rendering it raw printed "null left to bill". */}
+                {run.open_ended
+                  ? "no cap on what's left"
+                  : `${run.billable_remaining} left to bill`}
               </Badge>
             </Tooltip>
           )}
@@ -761,9 +769,25 @@ const RunRow = ({
         </div>
         <div className="mt-1 flex items-center gap-3">
           <Text size="small" className="text-ui-fg-subtle">
-            {run.quantity_basis === "produced"
-              ? `${run.produced_quantity} made of ${run.ordered_quantity} ordered`
-              : `${run.ordered_quantity} ordered`}
+            {/*
+              ⚠️ Read "was output recorded" off `produced_quantity`, NOT off
+              `quantity_basis`. Since #1676 the offer is capped at the ordered
+              quantity, so an OVERPRODUCED run reports its basis as "ordered"
+              while having recorded output — and `ordered_quantity` is null on a
+              run with no agreed quantity at all.
+            */}
+            {run.produced_quantity != null
+              ? `${run.produced_quantity} made of ${
+                  run.ordered_quantity ?? "no agreed quantity"
+                }${
+                  run.ordered_quantity != null &&
+                  run.produced_quantity > run.ordered_quantity
+                    ? " — billing capped at ordered"
+                    : " ordered"
+                }`
+              : run.ordered_quantity != null
+                ? `${run.ordered_quantity} ordered`
+                : "No agreed quantity — open-ended"}
           </Text>
           {/*
             🔴 The TAIL of the id, not the head. `prod_run_` eats 9 characters

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -23,7 +23,12 @@ import {
   usePartnerPayableRuns,
   type PayableRun,
 } from "../../../hooks/api/partner-payable-runs"
-import { groupIntoRateBands } from "../../../lib/payment-submission-money"
+import {
+  groupIntoRateBands,
+  runBillsVerbatimTotal,
+  runLineAmount,
+  runNeedsTypedPrice,
+} from "../../../lib/payment-submission-money"
 
 const ELIGIBLE_TASK_STATUSES = ["completed"]
 
@@ -197,20 +202,73 @@ export const PaymentSubmissionCreate = () => {
     [runQuantities]
   )
 
+  /** Whether a human has typed a rate for this run. */
+  const runHasTypedRate = useCallback(
+    (run: PayableRun): boolean => runUnitAmounts[run.run_id] != null,
+    [runUnitAmounts]
+  )
+
+  /** Whether a live line already claimed part of this run (#1596/#1676). */
+  const runAlreadyPartlyBilled = useCallback(
+    (run: PayableRun): boolean => run.billing_status === "partly_billed",
+    []
+  )
+
+  /**
+   * The row states no price until somebody types one — an agreed TOTAL on a
+   * run that has already been billed against. Re-billing the total double-pays
+   * and dividing it re-prices; neither is an answer this screen may invent.
+   */
+  const runNeedsPrice = useCallback(
+    (run: PayableRun): boolean =>
+      runNeedsTypedPrice({
+        unit_is_derived: run.unit_is_derived,
+        hasTypedRate: runHasTypedRate(run),
+        alreadyPartlyBilled: runAlreadyPartlyBilled(run),
+      }),
+    [runHasTypedRate, runAlreadyPartlyBilled]
+  )
+
+  /**
+   * The rate in the box.
+   *
+   * ⚠️ Empty on a partly-billed TOTAL run: its `unit_amount` is `total /
+   * ordered`, computed for display only, and showing it beside a remainder
+   * invites billing the job at a price nobody re-negotiated.
+   */
   const getEffectiveRunUnitAmount = useCallback(
     (run: PayableRun): number => {
       if (runUnitAmounts[run.run_id] != null)
         return runUnitAmounts[run.run_id]
-      return getRunUnitCost(run)
+      return runNeedsPrice(run) ? 0 : getRunUnitCost(run)
     },
-    [runUnitAmounts]
+    [runUnitAmounts, runNeedsPrice]
   )
 
+  /**
+   * 🔴 What this run bills — through the SHARED rule, not `qty × rate`.
+   *
+   * A total-priced run bills its agreed figure verbatim. This screen used to
+   * multiply the derived rate for everything, so a ₹10,000 job that produced 7
+   * of 9 was offered at ₹7,777.77 here while the admin screen offered ₹10,000
+   * for the same run on the same day (#1679).
+   */
   const getEffectiveRunTotal = useCallback(
-    (run: PayableRun): number => {
-      return getEffectiveRunQuantity(run) * getEffectiveRunUnitAmount(run)
-    },
-    [getEffectiveRunQuantity, getEffectiveRunUnitAmount]
+    (run: PayableRun): number =>
+      runLineAmount({
+        quantity: getEffectiveRunQuantity(run),
+        rate: getEffectiveRunUnitAmount(run),
+        amount: run.amount,
+        unit_is_derived: run.unit_is_derived,
+        hasTypedRate: runHasTypedRate(run),
+        alreadyPartlyBilled: runAlreadyPartlyBilled(run),
+      }),
+    [
+      getEffectiveRunQuantity,
+      getEffectiveRunUnitAmount,
+      runHasTypedRate,
+      runAlreadyPartlyBilled,
+    ]
   )
 
   const getEffectiveTaskCost = useCallback(
@@ -347,10 +405,16 @@ export const PaymentSubmissionCreate = () => {
     }
 
     // Validate runs: all must have a quantity and a unit amount
+    /**
+     * ⚠️ The AMOUNT, not the rate. A total-priced run legitimately bills
+     * without a per-unit figure, and since #1676 the remainder of one bills
+     * nothing at all until somebody states what the rest is worth — this is
+     * the guard that makes them state it, rather than a zero being submitted.
+     */
     const invalidRuns = eligibleRuns.filter(
       (r: PayableRun) =>
         selectedRunIds.has(r.run_id) &&
-        (getEffectiveRunUnitAmount(r) <= 0 || getEffectiveRunQuantity(r) <= 0)
+        (getEffectiveRunTotal(r) <= 0 || getEffectiveRunQuantity(r) <= 0)
     )
     const invalidTasks = eligibleTasks.filter(
       (t) => selectedTaskIds.has(t.id) && getEffectiveTaskCost(t) <= 0
@@ -391,6 +455,19 @@ export const PaymentSubmissionCreate = () => {
         Array<{ quantity: number; unit_amount: number }>
       > = {}
 
+      /**
+       * 🔴 Which designs still bill an agreed TOTAL rather than a rate.
+       *
+       * This decides which request field the money is SENT on, and it is not a
+       * display concern. `create` prices in a fixed order — a typed line total
+       * wins outright, then a typed RATE, and only then the runs via
+       * `runPayableOffer`. Sending a DERIVED rate as `unit_amounts` therefore
+       * outranks the one true pricer and makes the server multiply a figure
+       * that was never per-piece: ₹7,777.77 written against a ₹10,000 job
+       * (#1679, and #1616 before it).
+       */
+      const verbatimTotalDesigns = new Set<string>()
+
       for (const run of eligibleRuns) {
         if (!selectedRunIds.has(run.run_id)) continue
         const designId = run.design_id
@@ -399,12 +476,33 @@ export const PaymentSubmissionCreate = () => {
 
         ;(productionRunIds[designId] ||= []).push(run.run_id)
         quantities[designId] = (quantities[designId] ?? 0) + qty
-        exactTotals[designId] = (exactTotals[designId] ?? 0) + qty * rate
+        // The run's OWN amount, through the shared rule — a total-priced run
+        // contributes its agreed total, not `qty × a rate derived from it`.
+        exactTotals[designId] =
+          (exactTotals[designId] ?? 0) + getEffectiveRunTotal(run)
         ;(ratesByDesign[designId] ||= new Set()).add(rate)
         ;(pricedRuns[designId] ||= []).push({ quantity: qty, unit_amount: rate })
+
+        if (
+          runBillsVerbatimTotal({
+            unit_is_derived: run.unit_is_derived,
+            hasTypedRate: runHasTypedRate(run),
+            alreadyPartlyBilled: runAlreadyPartlyBilled(run),
+          })
+        ) {
+          verbatimTotalDesigns.add(designId)
+        }
       }
 
       for (const [designId, rates] of Object.entries(ratesByDesign)) {
+        if (verbatimTotalDesigns.has(designId)) {
+          // The agreed total goes on the line-total channel, which "wins
+          // outright; never multiplied by quantity" — the only field that says
+          // what this figure is.
+          costOverrides[designId] = Math.round(exactTotals[designId] * 100) / 100
+          continue
+        }
+
         if (rates.size === 1) {
           // One agreed rate across this design's runs — state it per unit, so
           // the reviewer sees the rate and the quantity that produced the sum.
@@ -609,6 +707,10 @@ export const PaymentSubmissionCreate = () => {
                       onToggle={toggleRun}
                       quantity={getEffectiveRunQuantity(row.run)}
                       unitAmount={getEffectiveRunUnitAmount(row.run)}
+                      // 🔴 The row must not re-derive this. `qty × rate` on a
+                      // total-priced run is the 22% re-pricing (#1679).
+                      total={getEffectiveRunTotal(row.run)}
+                      needsPrice={runNeedsPrice(row.run)}
                       onQuantityChange={handleRunQuantityChange}
                       onUnitAmountChange={handleRunUnitAmountChange}
                     />
@@ -699,6 +801,8 @@ const RunRow = ({
   onToggle,
   quantity,
   unitAmount,
+  total,
+  needsPrice,
   onQuantityChange,
   onUnitAmountChange,
 }: {
@@ -708,11 +812,14 @@ const RunRow = ({
   onToggle: (id: string) => void
   quantity: number
   unitAmount: number
+  /** What this row BILLS — computed once, by the shared rule. */
+  total: number
+  /** An agreed TOTAL on a run already billed against: it has no price yet. */
+  needsPrice: boolean
   onQuantityChange: (id: string, value: string) => void
   onUnitAmountChange: (id: string, value: string) => void
 }) => {
   const blocked = !!blockedReason
-  const total = quantity * unitAmount
 
   return (
     <Table.Row
@@ -751,6 +858,19 @@ const RunRow = ({
                 {run.open_ended
                   ? "no cap on what's left"
                   : `${run.billable_remaining} left to bill`}
+              </Badge>
+            </Tooltip>
+          )}
+          {/*
+            🔴 An agreed TOTAL, already billed against. The total was the price
+            for the WHOLE job, so the remainder has no figure of its own —
+            re-billing it double-pays and dividing it re-prices. The row bills
+            nothing until somebody states what the rest is worth.
+          */}
+          {needsPrice && !blocked && (
+            <Tooltip content="This run was agreed at a total price for the whole job, and part of it has already been paid. Type what the remaining work is worth.">
+              <Badge color="red" size="2xsmall">
+                Price the rest
               </Badge>
             </Tooltip>
           )}
@@ -813,9 +933,15 @@ const RunRow = ({
       </Table.Cell>
 
       <Table.Cell className="text-right">
+        {/*
+          ⚠️ The placeholder is EMPTY on a row that has no price yet (#1676).
+          `run.unit_amount` there is `total / ordered` — a division done for
+          display on a job that was agreed as a whole, and offering it as the
+          rate for the remainder re-prices work nobody re-negotiated.
+        */}
         <NumberCell
           label={`Rate for ${run.design_name || run.run_id}`}
-          placeholder={String(run.unit_amount)}
+          placeholder={needsPrice ? "Type a rate" : String(run.unit_amount)}
           value={unitAmount !== run.unit_amount ? unitAmount : undefined}
           disabled={blocked}
           onChange={(v) => onUnitAmountChange(run.run_id, v)}


### PR DESCRIPTION
Closes #1676.

## The hole

`assessRunClaims` diffs a claim against a tally of **prior** claims, and a run nobody has billed yet has no tally — so its **opening** claim was compared against nothing at all. A run ordered for 9 could be billed at a quantity of 100 and this guard would not look. Only a short-closed run was checked, and only because the close would otherwise have meant nothing.

## The rule (founder's design, 2026-08-30)

It is a **pair**, and the second half is what makes the first half safe:

1. **A first claim is bounded by the agreed quantity** — a refusal, not a warning.
2. **A run created with NO agreed quantity is the explicit, per-run opt-out.** Ongoing work with no fixed order, billed as it comes, and nothing caps it.

That turns an *implicit* absence of validation into a *declaration* somebody has to make. Short-closing such a run still bites: opting out of an agreed quantity is not opting out of "no more will be made".

## Schema

`production_runs.quantity` becomes nullable and **the default of 1 stays**. Omitting the field still means one piece, exactly as it has for every existing row and caller; only an explicit `null` declares open-endedness. No backfill, no retro-nulling.

`isOpenEndedRun` requires the key to be **present** and the value literally `null` — `quantity == null` would read every row of a query that forgot to fetch `quantity` as open-ended, which is a guard that silently allows everything.

## What else had to move

- **Children inherit it on approve.** `a.quantity ?? parent.quantity ?? 1` collapsed an open-ended parent to 1 — the tightest possible ceiling on a run whose whole point is that it has none.
- **The offer is clamped at ordered**, on both payable-runs routes. Otherwise the screen offers 12 units on a run ordered 9 and `create` rejects it — the exact defect `runPayableOffer` was extracted to prevent (#1616).
- **`runBillingStatus` takes `openEnded`.** Such a run's `billable_remaining` is `null` because there is no ceiling, and `null` everywhere else means "nothing left" — so without it the run read as fully `billed` after ONE claim and no screen would offer it again. Repeated billing is the whole feature.
- **Fixed en route:** `/admin/production-runs/:id/payments` computed its remainder from the raw ordered quantity, ignoring every short close (#1596).

## Screens

The run detail page, the edit drawer (a switch, not an empty box — an empty box is somebody who has not typed yet), the short-close drawer, the admin payable-runs grid and the partner picker all say it.

**Rendered in a browser, and that is where three defects were found** — tsc, 461 unit tests and 130 integration tests were green through all of them: `40 of  produced · 0% yield`, `closed at 40 of 0 ordered`, `12 of 9 · no output recorded`. All three were `Number(null) === 0`: a coercion is not a test for absence.

## Blast radius

Locally **0 of 313 runs overproduce** and **0 of 7 single-run lines bill above their run's ordered quantity**, so the new ceiling refuses nothing that exists today.

## Verify

```
pnpm test:integration:http:shared ./integration-tests/http/payment-submissions-api.spec.ts ./integration-tests/http/production-runs.spec.ts
TEST_TYPE=unit npx jest --testPathPattern="(payment_submissions|production-runs)"   # from apps/backend
```

## Found, not fixed

- The **admin** create screen filters `!r.billed`, so it has never offered a *partly-billed* run's remainder (the partner screen does, since #1596). Needs a decision on what a partly-billed `total`-priced run should default to.
- The partner `payable-runs` route still prices with its own `runUnitCost × qty` rather than `runPayableOffer` — the #1679 shape on the partner screen. The clamp is duplicated there rather than the pricer unified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4