### PR TITLE
fix(quotes): make a design quotable at all — catalogue, typed weight, and the enum that refused it (#1683)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-design-catalogue.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-design-catalogue.spec.ts
@@ -1,0 +1,305 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import {
+  mintBody,
+  setupQuoteFixture,
+  type QuoteFixture,
+} from "../helpers/setup-quote-fixture"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+import { createProductFromDesignWorkflow } from "../../src/workflows/designs/create-product-from-design"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * A made-to-order design product, and whose catalogue it is in.
+ *
+ * ## The two defects this pins
+ *
+ * Quoting a design for a partner was impossible — not difficult, impossible —
+ * and had been since the feature shipped. Readiness answered with two blocking
+ * rows for every design, and both of them were wrong for the same underlying
+ * reason: nothing on the write side knew who was being quoted for.
+ *
+ * 1. `create-product-from-design` read `listStores({})[0]` and used THAT
+ *    store's default sales channel. On a platform with fifteen stores that is
+ *    whichever row Postgres handed back first — in practice the core "Default
+ *    Sales Channel", never the quoting partner's. All twelve custom-design
+ *    products on production landed there, so `variant_not_in_catalogue` was
+ *    unavoidable.
+ *
+ * 2. `unit_weight_grams` — the operator's own figure, which exists precisely
+ *    because "a design quoted before its garment has ever been weighed has none
+ *    by definition" — was sent by the wizard, accepted by the validator,
+ *    declared on the input type, and read by NOTHING in the weight check. Three
+ *    producers, zero consumers.
+ *
+ * ## Why this runs against a container
+ *
+ * Both are wiring. The pure halves (`isMadeToOrderDesignProduct`,
+ * `resolveUnitWeight`) were always correct in isolation, and every unit test
+ * over them passed throughout. What was broken is which arguments reached them,
+ * which is only observable end to end.
+ *
+ * 🔑 The fixture deliberately mints the product the OLD way — no
+ * `sales_channel_id` — so the starting state is the production one. The
+ * precondition is asserted rather than assumed: if the fallback ever happened
+ * to pick the partner's own store, every assertion below would pass while
+ * testing nothing.
+ */
+
+setupSharedTestSuite(() => {
+  describe("Quoting a made-to-order design (#1486 catalogue + weight)", () => {
+    let seed: QuoteFixture
+    let designId: string
+    let designVariantId: string
+    let designProductId: string
+
+    const container = () => getSharedTestEnv().getContainer()
+
+    const productOf = async (variantId: string) => {
+      const query: any = container().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "variant",
+        fields: [
+          "id",
+          "product.id",
+          "product.metadata",
+          "product.sales_channels.id",
+        ],
+        filters: { id: [variantId] },
+      })
+      return (data?.[0] as any)?.product
+    }
+
+    const readiness = async (lines: any[]) => {
+      const { api } = getSharedTestEnv()
+      const body = mintBody(seed, {})
+      const res = await api.post(
+        "/partners/quotes/readiness",
+        {
+          lines,
+          destination_country_code: body.destination_country_code,
+          destination_postal_code: body.destination_postal_code,
+          currency_code: body.currency_code,
+          carrier: body.carrier,
+        },
+        { headers: seed.headers }
+      )
+      return res.data.readiness
+    }
+
+    const codes = (r: any) => (r?.issues ?? []).map((i: any) => i.code)
+    const severityOf = (r: any, code: string) =>
+      (r?.issues ?? []).find((i: any) => i.code === code)?.severity ?? null
+
+    beforeAll(async () => {
+      await createAdminUser(container())
+      seed = await setupQuoteFixture(getSharedTestEnv().api, () => container())
+
+      const designs: any = container().resolve(DESIGN_MODULE)
+      const created = await designs.createDesigns({
+        name: `Oshen Scarves ${seed.unique}`,
+        description: "A design with no product behind it yet.",
+        owner_partner_id: seed.partnerId,
+      })
+      designId = (Array.isArray(created) ? created[0] : created).id
+
+      /**
+       * Minted WITHOUT a sales channel, on purpose — this is the production
+       * shape, and the state every existing custom-design product is in.
+       */
+      const { result } = await createProductFromDesignWorkflow(
+        container()
+      ).run({
+        input: {
+          design_id: designId,
+          estimated_cost: 900,
+          unit_price: 900,
+          currency_code: seed.currencyCode,
+          made_to_order: true,
+        } as any,
+      })
+
+      designVariantId = (result as any).variant_id
+      designProductId = (result as any).product_id
+
+      const product = await productOf(designVariantId)
+
+      // 🔴 Precondition, asserted rather than assumed. A fixture that happened
+      // to start in the partner's own channel would make every catalogue
+      // assertion below vacuous while still going green.
+      expect(product?.metadata?.is_custom_design).toBe(true)
+      expect(
+        (product?.sales_channels ?? []).map((c: any) => c.id)
+      ).not.toContain(seed.salesChannelId)
+    })
+
+    it("🔴 a design line's catalogue miss is a WARNING, because the mint fixes it", async () => {
+      const r = await readiness([
+        { variant_id: designVariantId, design_id: designId, quantity: 5 },
+      ])
+
+      // Not the blocking row that made this unquotable.
+      expect(codes(r)).not.toContain("variant_not_in_catalogue")
+      expect(severityOf(r, "design_catalogue_pending")).toBe("warning")
+    })
+
+    it("🔴 the same product quoted as a plain variant is still REFUSED", async () => {
+      // The boundary. Nothing attaches a catalogue link for a line that never
+      // named a design, so a warning here would be a promise no code keeps —
+      // and softening it for every custom-design product is exactly how a
+      // tenancy guard stops guarding.
+      const r = await readiness([{ variant_id: designVariantId, quantity: 5 }])
+
+      expect(severityOf(r, "variant_not_in_catalogue")).toBe("blocking")
+      expect(codes(r)).not.toContain("design_catalogue_pending")
+    })
+
+    it("🔴 a typed unit_weight_grams answers the weight the catalogue cannot", async () => {
+      const without = await readiness([
+        { variant_id: designVariantId, design_id: designId, quantity: 5 },
+      ])
+      // A made-to-order design has no weight at either level, by definition.
+      expect(severityOf(without, "weight_missing")).toBe("blocking")
+
+      const withWeight = await readiness([
+        {
+          variant_id: designVariantId,
+          design_id: designId,
+          quantity: 5,
+          unit_weight_grams: 320,
+        },
+      ])
+
+      // The figure the wizard has always sent, now actually read.
+      expect(codes(withWeight)).not.toContain("weight_missing")
+      // And the estimate it was meant to feed can finally run: `weight_missing`
+      // gates `canEstimate`, so while it was raised the freight leg never even
+      // executed.
+      expect(withWeight.freight).toBeDefined()
+    })
+
+    it("minting puts the design's product in the quoting partner's catalogue", async () => {
+      const { api } = getSharedTestEnv()
+
+      const res = await api.post(
+        "/partners/quotes",
+        mintBody(seed, {
+          buyer_email: `design-cat-${seed.unique}@jaalyantra.test`,
+          lines: [
+            {
+              variant_id: designVariantId,
+              design_id: designId,
+              quantity: 5,
+              unit_weight_grams: 320,
+            },
+          ],
+        }),
+        { headers: seed.headers }
+      )
+        .catch((e: any) => e.response)
+
+      // The message, not just the code — a bare 500 says nothing about which
+      // of the four things this route now does went wrong.
+      expect([res.status, String(res.data?.message ?? "")]).toEqual([201, ""])
+
+      const product = await productOf(designVariantId)
+      expect(product.id).toBe(designProductId)
+      // Added, not replaced — the same design can be quoted by another partner
+      // tomorrow, and a design belongs to nobody before a production run.
+      const channelIds = (product.sales_channels ?? []).map((c: any) => c.id)
+      expect(channelIds).toContain(seed.salesChannelId)
+      expect(channelIds.length).toBeGreaterThan(1)
+
+      /**
+       * And the warning has answered itself — the loop closes.
+       *
+       * ⚠️ Asserted HERE rather than as a following test, and that is not a
+       * style choice: the runner restores a database snapshot before every
+       * test, so a second `it` would read the product as it was before this
+       * mint and report the warning again. A test built that way fails for a
+       * reason that has nothing to do with the code.
+       */
+      const after = await readiness([
+        {
+          variant_id: designVariantId,
+          design_id: designId,
+          quantity: 5,
+          unit_weight_grams: 320,
+        },
+      ])
+
+      expect(codes(after)).not.toContain("design_catalogue_pending")
+      expect(codes(after)).not.toContain("variant_not_in_catalogue")
+    })
+
+    /**
+     * The admin surface, which is where this was actually reported.
+     *
+     * 🔴 It has a gate the partner surface does not: `assertVariantsInStore`
+     * throws a 400 for anything outside the named partner's channel, and it
+     * runs on the MINT, after the preflight has already said the basket is
+     * fine. So a readiness fix alone would have moved the refusal one step
+     * later rather than removing it — the preflight would go green and the
+     * mint would answer "these variants are not in X's catalogue". The order
+     * of the two calls in the route is the whole point.
+     */
+    it("🔴 an admin can quote a design on a partner's behalf, past the store assertion", async () => {
+      const { api } = getSharedTestEnv()
+      const adminHeaders = await getAuthHeaders(api)
+      const body = mintBody(seed, {})
+
+      const pre = await api.post(
+        "/admin/quotes/readiness",
+        {
+          partner_id: seed.partnerId,
+          lines: [
+            {
+              variant_id: designVariantId,
+              design_id: designId,
+              quantity: 5,
+              unit_weight_grams: 320,
+            },
+          ],
+          destination_country_code: body.destination_country_code,
+          destination_postal_code: body.destination_postal_code,
+          currency_code: body.currency_code,
+          carrier: body.carrier,
+        },
+        adminHeaders
+      )
+
+      const preCodes = (pre.data.readiness?.issues ?? []).map(
+        (i: any) => i.code
+      )
+      expect(preCodes).not.toContain("variant_not_in_catalogue")
+      expect(preCodes).not.toContain("weight_missing")
+
+      const res = await api
+        .post(
+          "/admin/quotes",
+          {
+            ...body,
+            partner_id: seed.partnerId,
+            buyer_email: `admin-design-${seed.unique}@jaalyantra.test`,
+            lines: [
+              {
+                variant_id: designVariantId,
+                design_id: designId,
+                quantity: 5,
+                unit_weight_grams: 320,
+              },
+            ],
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      // The message, because `assertVariantsInStore` refuses BY NAME and a
+      // bare status would not say which of the two gates spoke.
+      expect([res.status, String(res.data?.message ?? "")]).toEqual([201, ""])
+    })
+  })
+})

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -279,6 +279,15 @@ export const MintQuoteForm = () => {
           ...(l.unit_weight_grams
             ? { unit_weight_grams: l.unit_weight_grams }
             : {}),
+          /**
+           * 🔴 Dropped here until now, and the mint sent it. A made-to-order
+           * design product is put in the partner's catalogue BY THE MINT, and
+           * the assessor can only know that if it knows the line came from a
+           * design — so without this the preflight refused, as
+           * `variant_not_in_catalogue`, every basket the mint would have
+           * accepted. The two calls have to describe the same basket.
+           */
+          ...(l.design_id ? { design_id: l.design_id } : {}),
         })),
         destination_country_code: data.destination_country_code,
         destination_postal_code: data.destination_postal_code || null,

--- a/apps/backend/src/api/admin/quotes/readiness/route.ts
+++ b/apps/backend/src/api/admin/quotes/readiness/route.ts
@@ -81,6 +81,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     variant_port: makeDesignVariantPort(req.scope, {
       currency_code: body.currency_code,
       partner_id: null,
+      // Where the mint WOULD put it. Nothing is created on this path
+      // (`dry_run: true`), and stating it here keeps the preview and the mint
+      // describing the same product rather than two.
+      catalogue_sales_channel_id: store.default_sales_channel_id,
     }),
     currency_code: body.currency_code,
   })

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -9,7 +9,10 @@ import { resolveQuoteDesignLines } from "../../../modules/partner-quote/lib/desi
 import { deliverQuoteEmail } from "../../../workflows/partner-quote/deliver-quote-email"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
 import { assertVariantsInStore } from "./lib/assert-variants-in-store"
-import { makeDesignVariantPort } from "../../../workflows/partner-quote/ensure-design-quote-variant"
+import {
+  ensureDesignProductsInCatalogue,
+  makeDesignVariantPort,
+} from "../../../workflows/partner-quote/ensure-design-quote-variant"
 
 /**
  * Admin quotes (#1389 S5).
@@ -120,7 +123,25 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     variant_port: makeDesignVariantPort(req.scope, {
       currency_code: body.currency_code,
       partner_id: null,
+      // Unscoped for VISIBILITY, catalogued for THIS partner. Two questions,
+      // two inputs — see `catalogue_sales_channel_id`.
+      catalogue_sales_channel_id: store.default_sales_channel_id,
     }),
+  })
+
+  /**
+   * A design already carrying a made-to-order product is not re-minted — the
+   * port returns straight away — so the channel it was born in is the one it
+   * keeps unless something adds this partner's. That is what this does, for
+   * the designs the mint above did not create.
+   *
+   * Before the assertion below, deliberately: the assertion is the gate, and
+   * this is the last chance to make it true. It adds only to custom-design
+   * products; anything else still gets refused, which is right.
+   */
+  await ensureDesignProductsInCatalogue(req.scope, {
+    lines: lines as any,
+    sales_channel_id: store.default_sales_channel_id,
   })
 
   // 🔴 An admin picks the partner from one dropdown and the variants from

--- a/apps/backend/src/api/partners/quotes/readiness/route.ts
+++ b/apps/backend/src/api/partners/quotes/readiness/route.ts
@@ -46,6 +46,8 @@ export const POST = async (
     variant_port: makeDesignVariantPort(req.scope, {
       currency_code: body.currency_code,
       partner_id: partner.id,
+      // Where the mint WOULD put it. Nothing is created here (`dry_run: true`).
+      catalogue_sales_channel_id: (store as any).default_sales_channel_id,
     }),
     currency_code: body.currency_code,
   })

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -9,7 +9,10 @@ import { totalQuotedQuantity } from "../../../modules/partner-quote/lib/quote-em
 import { deliverQuoteEmail } from "../../../workflows/partner-quote/deliver-quote-email"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
 import { getPartnerStore, tryGetPartnerStore } from "../helpers"
-import { makeDesignVariantPort } from "../../../workflows/partner-quote/ensure-design-quote-variant"
+import {
+  ensureDesignProductsInCatalogue,
+  makeDesignVariantPort,
+} from "../../../workflows/partner-quote/ensure-design-quote-variant"
 
 /**
  * The partner's own quotes. Scoped by `partner_id`, never listed globally.
@@ -88,7 +91,23 @@ export const POST = async (
     variant_port: makeDesignVariantPort(req.scope, {
       currency_code: body.currency_code,
       partner_id: partner.id,
+      // The partner's own catalogue. Same fix as the admin route: without it
+      // the minted product went to whichever store `listStores({})` returned
+      // first, which was never this one.
+      catalogue_sales_channel_id: (store as any).default_sales_channel_id,
     }),
+  })
+
+  /**
+   * And for a design that already had a product, which the port returns
+   * without touching. There is no `assertVariantsInStore` on this surface —
+   * a partner picks from their own catalogue — but `assertProductOwnership`
+   * and the readiness check both read the same sales-channel membership, and
+   * a made-to-order design product minted before this fix is in none of them.
+   */
+  await ensureDesignProductsInCatalogue(req.scope, {
+    lines: lines as any,
+    sales_channel_id: (store as any).default_sales_channel_id,
   })
 
   const { result } = await mintQuoteWorkflow(req.scope).run({

--- a/apps/backend/src/modules/partner-quote/__tests__/design-lines.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/design-lines.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   applyDesignResolutions,
   designsNeedingAVariant,
+  isMadeToOrderDesignProduct,
   withDesignIssues,
   type DesignResolution,
 } from "../lib/design-lines"
@@ -388,5 +389,49 @@ describe("designsNeedingAVariant", () => {
     )
     // Two mints would leave the design resolving to two variants.
     expect(out).toEqual(["d1"])
+  })
+})
+
+/**
+ * Whose catalogue a design-led line may be added to (#1486 tail).
+ *
+ * 🔴 The interesting cases are the two REFUSALS, not the acceptance. A custom
+ * product quoted as a plain variant has nothing running that would attach the
+ * catalogue link, so calling it "pending" is a promise no code keeps; and a
+ * design resolved through a real catalogue product points at something another
+ * partner owns, where an automatic attach is a cross-tenant write. Both must be
+ * false, and a test that only asserts the happy path would pass through either.
+ */
+describe("isMadeToOrderDesignProduct", () => {
+  const minted = { metadata: { is_custom_design: true, design_id: "d1" } }
+
+  it("is true only for a minted design product ON a design line", () => {
+    expect(isMadeToOrderDesignProduct(minted, true)).toBe(true)
+  })
+
+  it("🔴 is false for the same product quoted as a plain variant", () => {
+    // Nothing in the design machinery runs for that line, so nothing would
+    // ever attach the channel this would be promising.
+    expect(isMadeToOrderDesignProduct(minted, false)).toBe(false)
+  })
+
+  it("🔴 is false for a real catalogue product reached through a design", () => {
+    // Someone else owns this catalogue. Adding it to the quoting partner's
+    // sales channel would be the #1419 failure with an extra step.
+    expect(
+      isMadeToOrderDesignProduct({ metadata: { design_id: "d1" } }, true)
+    ).toBe(false)
+    expect(isMadeToOrderDesignProduct({ metadata: null }, true)).toBe(false)
+    expect(isMadeToOrderDesignProduct(null, true)).toBe(false)
+  })
+
+  it("does not accept a truthy-but-not-true flag", () => {
+    // `metadata` is untyped JSON; "false" and 1 both arrive from somewhere.
+    expect(
+      isMadeToOrderDesignProduct({ metadata: { is_custom_design: "false" } }, true)
+    ).toBe(false)
+    expect(
+      isMadeToOrderDesignProduct({ metadata: { is_custom_design: 1 } }, true)
+    ).toBe(false)
   })
 })

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -94,7 +94,13 @@ export type QuoteViewLineRow = {
   quoted_unit_amount?: number | null
   quoted_subtotal?: number | null
   quoted_unit_weight_grams?: number | null
-  quoted_weight_source?: "variant" | "product" | null
+  /**
+   * `"manual"` included: a frozen line CAN say a human supplied the weight.
+   * The reader below already fell back to this field, so while the type
+   * excluded the value the one provenance an operator can vouch for was the
+   * one the frozen document could not express.
+   */
+  quoted_weight_source?: "variant" | "product" | "manual" | null
 }
 
 export type QuoteViewQuote = {

--- a/apps/backend/src/modules/partner-quote/lib/design-lines.ts
+++ b/apps/backend/src/modules/partner-quote/lib/design-lines.ts
@@ -294,6 +294,36 @@ export type QuoteLineInput = {
 }
 
 /**
+ * PURE: is this product one the quote flow MINTED for a design, on a line that
+ * actually named that design?
+ *
+ * ## Why the question has two halves
+ *
+ * `create-product-from-design` stamps `metadata.is_custom_design` on everything
+ * it makes, and that alone is not enough. A partner can put a custom-design
+ * product on a plain variant line, with no `design_id` anywhere — nothing in
+ * the design machinery runs for that line, so nothing would attach the
+ * catalogue link, and calling it "pending" would be a promise no code keeps.
+ *
+ * 🔴 And the metadata half cannot be dropped either. A design that resolves
+ * through `product_design` points at a REAL catalogue product belonging to
+ * whoever owns that catalogue. Treating that as attachable would let one
+ * partner's quote silently add another partner's product to its own sales
+ * channel — a cross-tenant catalogue write, which is the family of failure
+ * `assertVariantsInStore` was written for (#1419).
+ *
+ * So: minted for a design AND quoted as a design. Both, or the ordinary
+ * refusal stands.
+ */
+export function isMadeToOrderDesignProduct(
+  product: { metadata?: Record<string, any> | null } | null | undefined,
+  quotedFromADesignLine: boolean
+): boolean {
+  if (!quotedFromADesignLine) return false
+  return product?.metadata?.is_custom_design === true
+}
+
+/**
  * PURE: fold resolutions into the basket, and collect every failure.
  *
  * 🔑 Every failure, not the first. A partner fixing a five-line basket one

--- a/apps/backend/src/modules/partner-quote/lib/quote-readiness.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-readiness.ts
@@ -5,6 +5,7 @@ import {
   resolveUnitWeight,
 } from "../../../lib/shipping-estimate"
 import { pickFreightOption } from "./build-quote-view"
+import { isMadeToOrderDesignProduct } from "./design-lines"
 
 /**
  * Can this basket actually be quoted? (#1445 / #1439 S6)
@@ -50,6 +51,11 @@ export type QuoteReadinessCode =
   /** A line named a design that cannot be resolved to one variant (#1486). */
   | "design_unresolved"
   | "variant_not_in_catalogue"
+  /**
+   * A made-to-order design product that the MINT will add to this partner's
+   * catalogue. A warning, never blocking — see the branch that raises it.
+   */
+  | "design_catalogue_pending"
   | "line_unpriced"
   | "weight_missing"
   | "no_freight_option"
@@ -179,6 +185,15 @@ export type QuoteReadinessInput = {
     variant_id: string
     quantity: number
     unit_weight_grams?: number | null
+    /**
+     * Set when this line was picked as a DESIGN rather than as a variant. It
+     * rides along from `resolveDesignLinesForReadiness` and decides one thing:
+     * whether a catalogue miss is the mint's job to fix or the operator's.
+     *
+     * ⚠️ It was already arriving here at runtime and was simply not declared,
+     * so nothing could read it — the same shape as `unit_is_derived` (#1679).
+     */
+    design_id?: string | null
   }>
   store: {
     id?: string | null
@@ -253,12 +268,49 @@ export async function assessQuoteReadiness(
       "product.id",
       "product.title",
       "product.weight",
+      "product.metadata",
       "product.sales_channels.id",
     ],
     filters: { id: variantIds },
   })
 
   const byId = new Map<string, any>((variants ?? []).map((v: any) => [v.id, v]))
+
+  /**
+   * The operator's own weight for a line, by variant.
+   *
+   * 🔴 Without this the check below asked `resolveUnitWeight(variant)` with no
+   * second argument, so the typed figure was read for the freight estimate and
+   * NOWHERE else — and since `weight_missing` also gates `canEstimate`, the
+   * estimate it was meant to feed never ran either. The wizard has always sent
+   * it ("Or the preflight refuses a basket the mint would have priced"), the
+   * validator has always accepted it, the input type has always declared it,
+   * and no reader ever consulted it: three producers, zero consumers. A
+   * design-led quote has no catalogue weight BY DEFINITION, so this was the
+   * whole difference between "type the weight" and "this cannot be quoted".
+   *
+   * ⚠️ Keyed by variant because the checks below are per VARIANT while a
+   * weight is per LINE. Both wizards emit one line per variant; if that ever
+   * stops being true, a weight typed on one line would silently answer for
+   * another, so the first positive figure wins and the collision is named here
+   * rather than discovered in a landed total.
+   */
+  const manualWeightByVariant = new Map<string, number>()
+  for (const line of lines) {
+    const grams = Number(line.unit_weight_grams)
+    if (!Number.isFinite(grams) || grams <= 0) continue
+    if (!manualWeightByVariant.has(line.variant_id)) {
+      manualWeightByVariant.set(line.variant_id, grams)
+    }
+  }
+
+  /**
+   * Which variants arrived on a line that named a DESIGN. Load-bearing for the
+   * catalogue verdict below — see `isMadeToOrderDesignProduct`.
+   */
+  const designLineVariants = new Set(
+    lines.filter((l) => l.design_id).map((l) => l.variant_id)
+  )
 
   for (const id of variantIds) {
     const variant = byId.get(id)
@@ -282,23 +334,47 @@ export async function assessQuoteReadiness(
       if (
         !channels.some((c) => c?.id === input.store.default_sales_channel_id)
       ) {
-        issues.push({
-          code: "variant_not_in_catalogue",
-          severity: "blocking",
-          message: `"${label}" is not in ${input.partner_label || "this partner"}'s catalogue, so it cannot be quoted for them.`,
-          variant_id: id,
-        })
+        /**
+         * A made-to-order design product is put in the quoting partner's
+         * catalogue BY THE MINT, so reporting it as blocking here refuses a
+         * basket the mint would have accepted — the same preflight/mint split
+         * `freight_override_amount` exists to avoid.
+         *
+         * 🔴 Narrow on purpose, and the narrowness is the whole safety
+         * argument. Only a product the quote flow itself minted for a design
+         * qualifies: a design that resolves to a REAL catalogue product
+         * belongs to whoever owns that catalogue, and quietly adding it to
+         * another partner's sales channel would be a cross-tenant catalogue
+         * write dressed up as a convenience. Every other line keeps the hard
+         * refusal, which is the one #1419 was written for.
+         */
+        if (isMadeToOrderDesignProduct(variant.product, designLineVariants.has(id))) {
+          issues.push({
+            code: "design_catalogue_pending",
+            severity: "warning",
+            message: `"${label}" is a made-to-order design product and will be added to ${input.partner_label || "this partner"}'s catalogue when this quote is minted.`,
+            variant_id: id,
+          })
+        } else {
+          issues.push({
+            code: "variant_not_in_catalogue",
+            severity: "blocking",
+            message: `"${label}" is not in ${input.partner_label || "this partner"}'s catalogue, so it cannot be quoted for them.`,
+            variant_id: id,
+          })
+        }
       }
     }
 
-    if (!resolveUnitWeight(variant)) {
+    if (!resolveUnitWeight(variant, manualWeightByVariant.get(id))) {
       // 140 of 183 variants are null at BOTH levels. Without a weight the
       // freight leg is a guess, and a guessed landed total is the number a
-      // buyer commits to.
+      // buyer commits to. The operator's own figure counts — see
+      // `manualWeightByVariant`.
       issues.push({
         code: "weight_missing",
         severity: "blocking",
-        message: `"${label}" has no weight on the variant or its product, so freight for it would be a guess.`,
+        message: `"${label}" has no weight on the variant or its product, so freight for it would be a guess. Enter a weight for this line, or set one on the variant.`,
         variant_id: id,
       })
     }

--- a/apps/backend/src/modules/partner-quote/migrations/.snapshot-partner-quote.json
+++ b/apps/backend/src/modules/partner-quote/migrations/.snapshot-partner-quote.json
@@ -915,7 +915,8 @@
           "comment": null,
           "enumItems": [
             "variant",
-            "product"
+            "product",
+            "manual"
           ],
           "mappedType": "enum"
         },

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260831140000.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260831140000.ts
@@ -1,0 +1,46 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Let a quote line record that a HUMAN supplied its weight.
+ *
+ * ## What was broken
+ *
+ * `quoted_weight_source` is a check constraint over `('variant','product')`,
+ * and `resolveUnitWeight` has always answered `"manual"` for an operator-typed
+ * `unit_weight_grams`. `mint-quote` writes that value straight onto the line,
+ * so every quote minted with a hand-typed weight died at the INSERT with
+ * `CheckConstraintViolationException` and returned a bare 500 with an HTML
+ * error page — no message a partner or an operator could act on.
+ *
+ * The input exists precisely for the baskets the catalogue cannot weigh: 140
+ * of 183 variants carry no weight at either level, and a made-to-order design
+ * quoted before its garment was ever weighed has none by definition. So the
+ * one path that makes those quotable is the one that could not be written.
+ *
+ * 🔑 Widening, never narrowing: every existing row is `variant`, `product` or
+ * null and stays valid, so this cannot fail on data. The constraint is dropped
+ * and recreated rather than altered because Postgres has no `alter constraint`
+ * for a check body.
+ *
+ * ⚠️ `drop constraint if exists` + a uniquely-named recreate, so a re-run is a
+ * no-op (#1208) — this module's migrations are replayed on every deploy.
+ */
+export class Migration20260831140000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote_line" drop constraint if exists "partner_quote_line_quoted_weight_source_check";`);
+    this.addSql(`alter table if exists "partner_quote_line" add constraint "partner_quote_line_quoted_weight_source_check" check ("quoted_weight_source" in ('variant', 'product', 'manual'));`);
+  }
+
+  override async down(): Promise<void> {
+    // 🔴 Narrowing again would fail on any row minted with a typed weight in
+    // the meantime, so those are neutralised first. The weight itself
+    // (`quoted_unit_weight_grams`) is kept — the figure the buyer was quoted
+    // against must survive a rollback; only its provenance label cannot be
+    // expressed by the older constraint.
+    this.addSql(`update "partner_quote_line" set "quoted_weight_source" = null where "quoted_weight_source" = 'manual';`);
+    this.addSql(`alter table if exists "partner_quote_line" drop constraint if exists "partner_quote_line_quoted_weight_source_check";`);
+    this.addSql(`alter table if exists "partner_quote_line" add constraint "partner_quote_line_quoted_weight_source_check" check ("quoted_weight_source" in ('variant', 'product'));`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-quote/models/partner-quote-line.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote-line.ts
@@ -57,7 +57,25 @@ const PartnerQuoteLine = model.define("partner_quote_line", {
   quoted_subtotal: model.bigNumber().nullable(),
   /** Unit weight used, and which level it came from. See the header. */
   quoted_unit_weight_grams: model.number().nullable(),
-  quoted_weight_source: model.enum(["variant", "product"]).nullable(),
+  /**
+   * 🔴 `"manual"` was missing here, and the enum is a CHECK CONSTRAINT.
+   *
+   * `resolveUnitWeight` has always returned `weight_source: "manual"` for an
+   * operator-typed figure, `mint-quote` has always written `l.weight_source`
+   * straight through, and this column's own docblock two files up says the line
+   * is frozen "with `quoted_weight_source: \"manual\"`". The column simply
+   * never learned the value — so every quote minted with a hand-typed
+   * `unit_weight_grams` died at the INSERT with a
+   * `CheckConstraintViolationException` and answered the partner with a bare
+   * 500 carrying an HTML error page.
+   *
+   * Nothing caught it because nothing could reach it: the readiness preflight
+   * ignored the typed weight too and refused the basket first, so the mint was
+   * never called with one. Two defects in series, each hiding the other, on the
+   * one input that makes the 140 weightless variants and every made-to-order
+   * design quotable at all.
+   */
+  quoted_weight_source: model.enum(["variant", "product", "manual"]).nullable(),
 
   // ===== The trade price, and how it was arrived at (#1439 S7) =============
   /**

--- a/apps/backend/src/workflows/designs/create-product-from-design.ts
+++ b/apps/backend/src/workflows/designs/create-product-from-design.ts
@@ -60,6 +60,23 @@ type CreateProductFromDesignInput = {
    * see `resolveListedPrice` for what changed and why.
    */
   unit_price?: number | null;
+  /**
+   * The sales channel the new product belongs in — the catalogue of whoever is
+   * quoting or selling it.
+   *
+   * 🔴 Until this existed the branch below read `listStores({})[0]` and used
+   * THAT store's default channel. On a platform with 15 stores that is
+   * whichever row Postgres returned first, which in practice was always the
+   * core "Default Sales Channel" — so every made-to-order design product ever
+   * minted landed in a catalogue belonging to nobody who was quoting it. All
+   * 12 on production did. `assertVariantsInStore` then refused the mint, and
+   * the readiness preflight refused before that, which is how a whole feature
+   * could be shipped, tested and never once produce a quotable design.
+   *
+   * Omitted, the store default is still the fallback: the approve path creates
+   * a catalogue product for the core store and that behaviour is unchanged.
+   */
+  sales_channel_id?: string | null;
 };
 
 type CreateProductFromDesignOutput = {
@@ -230,10 +247,19 @@ const createProductAndVariantStep = createStep(
       variant_id = createdVariant.id;
     } else {
       // Need to create a new product
-      const storeService = container.resolve(Modules.STORE) as any;
-      const [store] = await storeService.listStores({});
+      //
+      // The caller's channel wins. Only when nobody named one do we fall back
+      // to the store default — see `sales_channel_id` for what that fallback
+      // silently did to every design quote.
+      let salesChannelId = input.sales_channel_id || null;
 
-      if (!store?.default_sales_channel_id) {
+      if (!salesChannelId) {
+        const storeService = container.resolve(Modules.STORE) as any;
+        const [store] = await storeService.listStores({});
+        salesChannelId = store?.default_sales_channel_id || null;
+      }
+
+      if (!salesChannelId) {
         throw new Error("No default sales channel configured for the store");
       }
 
@@ -256,7 +282,7 @@ const createProductAndVariantStep = createStep(
           design_id: design.id,
           design_type: design.design_type,
         },
-        sales_channels: [{ id: store.default_sales_channel_id }],
+        sales_channels: [{ id: salesChannelId }],
         options: [
           {
             title: "Type",

--- a/apps/backend/src/workflows/partner-quote/ensure-design-quote-variant.ts
+++ b/apps/backend/src/workflows/partner-quote/ensure-design-quote-variant.ts
@@ -5,10 +5,14 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { linkProductsToSalesChannelWorkflow } from "@medusajs/medusa/core-flows"
 
 import { applyRate, fetchExchangeRate } from "../../lib/fx/exchange-rate"
 import { designQuoteUnitPrice } from "../../modules/partner-quote/lib/design-quote-price"
-import { resolveDesignVariants } from "../../modules/partner-quote/lib/design-lines"
+import {
+  isMadeToOrderDesignProduct,
+  resolveDesignVariants,
+} from "../../modules/partner-quote/lib/design-lines"
 import { estimateDesignCostWorkflow } from "../designs/estimate-design-cost"
 import { createProductFromDesignWorkflow } from "../designs/create-product-from-design"
 
@@ -56,6 +60,19 @@ export type EnsureDesignQuoteVariantInput = {
   partner_id?: string | null
   /** Override the 20% uplift. The wizard does not; ops might. */
   markup_percent?: number
+  /**
+   * The catalogue the minted product belongs in — the quoting partner's
+   * default sales channel.
+   *
+   * 🔑 Deliberately NOT `partner_id`. That field scopes VISIBILITY, and on the
+   * admin surface it is passed as null on purpose: a design is not owned by
+   * anyone before a production run, so an admin quotes any design for any
+   * partner. Whose catalogue the product lands in is a different question with
+   * a different answer, and folding the two together would either re-scope the
+   * picker or put the product in nobody's catalogue — which is exactly what
+   * happened while this input did not exist.
+   */
+  catalogue_sales_channel_id?: string | null
   /**
    * Answer the question without creating anything.
    *
@@ -235,6 +252,9 @@ const ensureVariantStep = createStep(
         unit_price: priced.unit_price,
         currency_code: to,
         made_to_order: true,
+        // Whose catalogue this is. Without it the product went to whichever
+        // store came back first from `listStores({})`.
+        sales_channel_id: input.catalogue_sales_channel_id ?? null,
       } as any,
     })
 
@@ -269,7 +289,13 @@ export const ensureDesignQuoteVariantWorkflow = createWorkflow(
  */
 export function makeDesignVariantPort(
   scope: any,
-  config: { currency_code: string; partner_id?: string | null; markup_percent?: number }
+  config: {
+    currency_code: string
+    partner_id?: string | null
+    markup_percent?: number
+    /** The quoting partner's catalogue. See `catalogue_sales_channel_id`. */
+    catalogue_sales_channel_id?: string | null
+  }
 ) {
   return async (input: { design_id: string; dry_run: boolean }) => {
     const { result } = await ensureDesignQuoteVariantWorkflow(scope).run({
@@ -278,6 +304,7 @@ export function makeDesignVariantPort(
         currency_code: config.currency_code,
         partner_id: config.partner_id ?? null,
         markup_percent: config.markup_percent,
+        catalogue_sales_channel_id: config.catalogue_sales_channel_id ?? null,
         dry_run: input.dry_run,
       },
     })
@@ -291,6 +318,91 @@ export function makeDesignVariantPort(
       reason: out?.reason ?? null,
     }
   }
+}
+
+/**
+ * Put every made-to-order design product in this basket into the quoting
+ * partner's catalogue.
+ *
+ * ## Why minting into the right channel is not enough on its own
+ *
+ * `ensureDesignQuoteVariant` is idempotent by design: a design that already
+ * resolves to a variant returns straight away and creates nothing. That is
+ * correct — a second mint would attach a SECOND variant to the design and make
+ * it unquotable for the opposite reason. But it means the channel fix on the
+ * mint path only ever reaches designs quoted for the FIRST time, and every
+ * design already carrying a product stays in whatever catalogue it was born
+ * in. All 12 on production were born in the wrong one.
+ *
+ * It is also the case that genuinely needs handling twice over: a design is not
+ * owned by any partner before a production run, so the same made-to-order
+ * product can legitimately be quoted by two different partners. Sales-channel
+ * membership is many-to-many precisely so that both can be true, which is why
+ * this ADDS and never replaces.
+ *
+ * 🔴 `isMadeToOrderDesignProduct` is the whole safety boundary. Only a product
+ * the quote flow itself minted qualifies; a design that resolves through
+ * `product_design` points at a real catalogue product someone else owns, and
+ * adding that to this partner's channel would be a cross-tenant catalogue
+ * write. It is skipped, and `assertVariantsInStore` refuses it a moment later,
+ * which is the correct answer.
+ *
+ * Writes only what is missing — `link.create` is not idempotent, so a product
+ * already in the channel is filtered out rather than re-linked.
+ */
+export async function ensureDesignProductsInCatalogue(
+  scope: any,
+  input: {
+    lines: Array<{ variant_id?: string | null; design_id?: string | null }>
+    sales_channel_id?: string | null
+  }
+): Promise<{ added_product_ids: string[] }> {
+  const salesChannelId = input.sales_channel_id || null
+  if (!salesChannelId) return { added_product_ids: [] }
+
+  const variantIds = Array.from(
+    new Set(
+      (input.lines ?? [])
+        .filter((l) => l?.design_id && l?.variant_id)
+        .map((l) => String(l.variant_id))
+    )
+  )
+  // `filters: { id: [] }` is NO filter, not "no rows" (#1433) — this would
+  // otherwise read every variant on the platform.
+  if (!variantIds.length) return { added_product_ids: [] }
+
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  const { data: variants = [] } = await query.graph({
+    entity: "variant",
+    fields: [
+      "id",
+      "product.id",
+      "product.metadata",
+      "product.sales_channels.id",
+    ],
+    filters: { id: variantIds },
+  })
+
+  const productIds = new Set<string>()
+  for (const variant of (variants ?? []) as any[]) {
+    const product = variant?.product
+    if (!product?.id) continue
+    // Quoted from a design line by construction — that is how it got here.
+    if (!isMadeToOrderDesignProduct(product, true)) continue
+    const channels = (product.sales_channels ?? []) as any[]
+    if (channels.some((c) => c?.id === salesChannelId)) continue
+    productIds.add(product.id)
+  }
+
+  if (!productIds.size) return { added_product_ids: [] }
+
+  const added = Array.from(productIds)
+  await linkProductsToSalesChannelWorkflow(scope).run({
+    input: { id: salesChannelId, add: added },
+  })
+
+  return { added_product_ids: added }
 }
 
 export default ensureDesignQuoteVariantWorkflow

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
@@ -5,10 +5,11 @@ import { FieldPath, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { z } from "@medusajs/framework/zod"
 
-import {
-  RouteFocusModal,
-  useRouteModal,
-} from "../../../../../components/modals"
+// `useRouteModal` was imported and never used. Harmless until now: partner-ui
+// CI type-checks CHANGED FILES ONLY, so an unused import sits quietly until
+// someone edits the file it lives in — and then fails their build for a line
+// they did not write.
+import { RouteFocusModal } from "../../../../../components/modals"
 import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
 import { useDocumentDirection } from "../../../../../hooks/use-document-direction"
 import {
@@ -172,6 +173,15 @@ export const QuoteCreateForm = ({
         lines: lines.map((l) => ({
           variant_id: l.variant_id,
           quantity: l.quantity,
+          /**
+           * 🔴 Dropped here until now, while the mint sent it — so the two
+           * calls described different baskets. A made-to-order design product
+           * is put in the partner's catalogue by the MINT, and the assessor
+           * can only know that if it knows the line came from a design;
+           * without this it refused, as `variant_not_in_catalogue`, a basket
+           * the mint would have accepted.
+           */
+          ...(l.design_id ? { design_id: l.design_id } : {}),
         })),
         destination_country_code: data.destination_country_code,
         destination_postal_code: data.destination_postal_code || null,


### PR DESCRIPTION
Closes #1683.

Quoting a design for a partner has never worked, for anyone — the admin wizard
answered with two blocking readiness rows per design. Three defects in series,
each hiding the next.

## 1. Every design product was minted into a catalogue belonging to nobody

`create-product-from-design.ts` resolved its sales channel as
`listStores({})[0]` — whichever store Postgres returned first, in practice
always the core `Default Sales Channel`. Verified on prod: **all 12
custom-design products are in `sc_01JNQG1YX55…`**, while Saransh Sharma's store
channel is `sc_01KKK1DNJ20WX2VHXWXD7Z4XKZ`.

Not cosmetic — `accept-quote` builds the buyer's cart in the partner store's
default sales channel, so a product outside it mints fine and then **fails at
acceptance**. The check had to be satisfied, not relaxed.

## 2. `unit_weight_grams` had three producers and no readers

A made-to-order design has no catalogue weight *by definition*, which is why
the per-line operator weight exists. It was typed into the wizard, sent with
the comment *"Or the preflight refuses a basket the mint would have priced"*,
accepted by the validator, and declared on `QuoteReadinessInput` — and
`quote-readiness.ts` called `resolveUnitWeight(variant)` with **no second
argument**. Read for the freight estimate and nowhere else; and since
`weight_missing` gates `canEstimate`, the estimate it was meant to feed never
ran either. Same shape as `unit_is_derived` in #1679.

Both wizards also dropped `design_id` from the readiness payload while sending
it on the mint, so the two calls described different baskets.

## 3. A typed weight could not be written at all — 500 at the INSERT

**Found by the new test, not by reading.** `quoted_weight_source` is
`enum(["variant","product"])` — a CHECK CONSTRAINT — while `resolveUnitWeight`
returns `"manual"` and `mint-quote` writes it straight through. Every quote
minted with a hand-typed weight died with `CheckConstraintViolationException`
and answered with a bare 500 carrying an HTML error page. The model's own
docblock says the line is frozen *"with `quoted_weight_source: "manual"`"*. The
column never learned the value, and nothing could reach it while defect 2
refused the basket first.

## The fix, and where the line is drawn

- `create-product-from-design` takes `sales_channel_id`; both quote surfaces
  pass the quoting partner's. Store default remains the fallback, so the
  approve path is unchanged.
- `ensureDesignProductsInCatalogue` **adds** that channel (never replaces) for a
  design that already had a product — the mint is idempotent and returns early,
  so a mint-side fix alone would only ever reach first-time quotes.
  Many-to-many is right here: a design belongs to nobody before a production
  run, so the same product can legitimately be quoted by two partners.
- 🔴 Gated on `isMadeToOrderDesignProduct` — only a product the quote flow
  itself minted, on a line that named a design. A design resolving to a **real
  catalogue product** still gets the hard refusal; auto-attaching that would be
  the #1419 cross-tenant catalogue write.
- Readiness reports the miss as a **warning** (`design_catalogue_pending`) for a
  design line only. The same product on a plain variant line is still blocked.
- **Visibility scoping is untouched and deliberately separate**: `partner_id`
  still answers *whose designs may I quote* (partner routes pass their own,
  admin passes `null` so it can quote any design), while the new
  `catalogue_sales_channel_id` answers *whose catalogue does this land in*.
- `quoted_weight_source` gains `"manual"` (`Migration20260831140000`). Widening
  only — every existing row stays valid, so it cannot fail on data.

## Verification

New `integration-tests/http/partner-quote-design-catalogue.spec.ts`, 5 cases,
including the admin path past `assertVariantsInStore` and both refusals that
form the safety boundary.

**Mutation-checked**: reverting the weight read fails 2 cases; neutering the
catalogue attach fails 1. The fixture mints the product the **old** way and
asserts the precondition, so it cannot go vacuously green.

`339` partner-quote unit tests, `26` neighbouring integration tests, and
`check:prod-build` all green. No new tsc errors in any touched file;
`apps/partner-ui` gated the way CI does (changed files only).

## Not fixed here

- **`apps/partner-ui` has no weight input at all.** The API accepts
  `unit_weight_grams`, the partner wizard never offers it, so the 140
  weightless variants stay unquotable on that surface — a capability with no
  screen (#1612 shape).
- The 12 existing prod products are left alone: the mint now attaches the
  partner's channel on the first quote, so no hand repair is needed.

⚠️ **This PR carries a migration.** Read the deploy's migrate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
