### PR TITLE
feat(shipping): add ShipGlobal cross-border carrier provider

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -145,6 +145,17 @@ DHL_ACCOUNT_NUMBER=your_dhl_account_number
 # DHL_MOCK_API_KEY=demo-key
 # DHL_MOCK_API_SECRET=demo-secret
 
+# ShipGlobal (shipglobal.in) — cross-border courier, India → international.
+# HTTP Basic auth (username is the account email). No sandbox; the tokens are
+# live, so only opt in via ENABLE_CARRIER_FULFILLMENT=1.
+# SHIPGLOBAL_USERNAME=you@example.com
+# SHIPGLOBAL_PASSWORD=your_shipglobal_password
+# Service code is region-specific: sgdirecteuyun (EU), sgdirectyungb (GB).
+# SHIPGLOBAL_SERVICE=sgdirecteuyun
+# What an UNQUOTABLE lane costs. Mirrors Shiprocket's fallback.
+# SHIPGLOBAL_FLAT_FALLBACK_AMOUNTS=US=3500
+# SHIPGLOBAL_FLAT_FALLBACK_AMOUNT=3500
+
 # Workflow / step execution timeouts (#742). Both are millisecond windows that
 # were previously hardcoded at 10s — too short for real LLM/external-API work.
 # MASTRA_STEP_TIMEOUT_MS  — per-step executor timeout (default 60000).

--- a/apps/backend/integration-tests/http/shipglobal-shipping-stub.spec.ts
+++ b/apps/backend/integration-tests/http/shipglobal-shipping-stub.spec.ts
@@ -1,0 +1,206 @@
+import { resolveShippingProvider } from "../../src/modules/shipping-providers/resolver"
+import type {
+  CreateShipmentInput,
+  ShippingProviderClient,
+} from "../../src/modules/shipping-providers/provider-interface"
+import { shipglobalStubState } from "../../src/modules/shipping-providers/shipglobal/stub-fetch"
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * ShipGlobal carrier against a STUBBED API.
+ *
+ * ShipGlobal has no sandbox — the account credentials are live, so an un-stubbed
+ * call would book a real, billable cross-border waybill. Rather than patch
+ * `global.fetch` (which does NOT reliably intercept the in-process server's own
+ * fetch in CI, #647), we set `SHIPGLOBAL_STUB=1`: the resolver injects a
+ * deterministic stub transport (`shipglobal/stub-fetch.ts`) into the client, so
+ * every call uses canned responses regardless of the global. Creds come from the
+ * resolver's env-var fallback.
+ *
+ * The client is driven through `resolveShippingProvider` (not `new
+ * ShipglobalClient(...)`) so the spec exercises the same resolver path the admin
+ * / partner routes use — proving the carrier id resolves AND the stub is wired
+ * in. The stub captures the last request body so the exact payload the client
+ * would send ShipGlobal is asserted end-to-end.
+ */
+
+const GB_INPUT: CreateShipmentInput = {
+  reference_id: "ord_shipglobal_test",
+  payment_mode: "prepaid",
+  pickup_location_name: "",
+  to: {
+    name: "John Smith",
+    phone: "+44-7700-900123",
+    email: "john@example.com",
+    address_1: "4 building name",
+    address_2: "5th Street",
+    city: "Aberdeen",
+    state: "",
+    pincode: "AB32",
+    country: "GB",
+  },
+  items: [
+    {
+      name: "YELLOW SAREE",
+      sku: "",
+      quantity: 1,
+      unit_price: 54,
+      hsn: "6111.20.00",
+      tax: 0,
+    },
+  ],
+  weight_grams: 500,
+  dimensions_cm: { length: 10, width: 10, height: 10 },
+  currency: "GBP",
+}
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("ShipGlobal carrier (stubbed API)", () => {
+    let provider: ShippingProviderClient
+    let prevUsername: string | undefined
+    let prevPassword: string | undefined
+    let prevStub: string | undefined
+
+    beforeAll(async () => {
+      prevUsername = process.env.SHIPGLOBAL_USERNAME
+      prevPassword = process.env.SHIPGLOBAL_PASSWORD
+      prevStub = process.env.SHIPGLOBAL_STUB
+      process.env.SHIPGLOBAL_USERNAME = "ship@example.com"
+      process.env.SHIPGLOBAL_PASSWORD = "secret"
+      // Make the resolver inject the canned ShipGlobal transport (no real API).
+      process.env.SHIPGLOBAL_STUB = "1"
+
+      const container = getContainer()
+      provider = await resolveShippingProvider(container, "shipglobal")
+    })
+
+    afterAll(() => {
+      if (prevUsername === undefined) delete process.env.SHIPGLOBAL_USERNAME
+      else process.env.SHIPGLOBAL_USERNAME = prevUsername
+      if (prevPassword === undefined) delete process.env.SHIPGLOBAL_PASSWORD
+      else process.env.SHIPGLOBAL_PASSWORD = prevPassword
+      if (prevStub === undefined) delete process.env.SHIPGLOBAL_STUB
+      else process.env.SHIPGLOBAL_STUB = prevStub
+    })
+
+    it("resolves a ShipGlobal client from the carrier id", () => {
+      expect(provider.carrier).toBe("shipglobal")
+    })
+
+    it("quotes the services array from rates/calculate (weight in kg)", async () => {
+      const rates = await provider.getRates!({
+        origin_pincode: "411014",
+        destination_pincode: "AB32",
+        destination_country: "GB",
+        weight_grams: 1500,
+      })
+
+      expect(Array.isArray(rates)).toBe(true)
+      expect(rates).toHaveLength(3)
+      expect(rates[0]).toMatchObject({
+        courier_name: "ShipGlobal Direct",
+        amount: 300,
+        currency_code: "inr",
+        estimated_days: 10,
+        is_recommended: true,
+      })
+      // The recommended flag is first-row only.
+      expect(rates[1].is_recommended).toBe(false)
+      expect(rates[2].courier_name).toBe("UPS")
+
+      // The client converts grams → kg and posts ISO-2 country + postcode.
+      expect(shipglobalStubState.lastRateBody).toEqual({
+        package_weight: "1.5",
+        country_iso_code_2: "GB",
+        postcode: "AB32",
+      })
+    })
+
+    it("refuses a domestic rate query (cross-border only)", async () => {
+      const rates = await provider.getRates!({
+        origin_pincode: "411014",
+        destination_pincode: "411014",
+        destination_country: "IN",
+        weight_grams: 500,
+      })
+      expect(rates).toEqual([])
+    })
+
+    it("creates a shipment via order/add and returns the SG tracking number", async () => {
+      const result = await provider.createShipment(GB_INPUT)
+      expect(result.carrier).toBe("shipglobal")
+      expect(result.awb).toBe("STUBSG123")
+      expect(result.tracking_number).toBe("STUBSG123")
+      expect(result.tracking_url).toContain("STUBSG123")
+      expect(result.provider_refs?.tracking).toBe("STUBSG123")
+
+      // The exact order/add payload the client sent the carrier.
+      const body = shipglobalStubState.lastOrderBody
+      expect(body.invoice_no).toBe("ord_shipglobal_test")
+      expect(body.order_reference).toBe("ord_shipglobal_test")
+      expect(body.invoice_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(body.package_weight).toBe("0.5")
+      expect(body.package_length).toBe("10")
+      expect(body.currency_code).toBe("GBP")
+      expect(body.csb5_status).toBe(1)
+      expect(body.customer_shipping_firstname).toBe("John")
+      expect(body.customer_shipping_lastname).toBe("Smith")
+      expect(body.customer_shipping_country_code).toBe("GB")
+      expect(body.customer_shipping_postcode).toBe("AB32")
+      expect(body.vendor_order_items).toHaveLength(1)
+      // HSN normalized to digits only.
+      expect(body.vendor_order_items[0].vendor_order_item_hsn).toBe("61112000")
+      expect(body.vendor_order_items[0].vendor_order_item_quantity).toBe("1")
+      expect(body.vendor_order_items[0].vendor_order_item_unit_price).toBe("54")
+    })
+
+    it("refuses a domestic createShipment (no India product)", async () => {
+      await expect(
+        provider.createShipment({ ...GB_INPUT, to: { ...GB_INPUT.to, country: "IN" } })
+      ).rejects.toThrow(/cross-border only/i)
+    })
+
+    it("fetches a base64 PDF label via order/getLabel", async () => {
+      const label = await provider.getLabel({
+        awb: "STUBSG123",
+        provider_refs: { tracking: "STUBSG123" },
+      })
+      expect(shipglobalStubState.lastLabelBody).toEqual({
+        tracking: "STUBSG123",
+        label: true,
+      })
+      expect(label.data).toBe("JVBERi0xLjQK")
+      expect(label.format).toBe("pdf")
+    })
+
+    it("tracks via tools/tracking and normalizes the awb_-prefixed events", async () => {
+      const result = await provider.track({ awb: "STUBSG123" })
+      expect(shipglobalStubState.lastTrackBody).toEqual({
+        tracking: "STUBSG123",
+      })
+      expect(result.carrier).toBe("shipglobal")
+      expect(result.awb).toBe("STUBSG123")
+      expect(result.current_status).toBe("DELIVERED ")
+      expect(result.origin).toBe("linkers")
+      expect(result.destination).toBe("US")
+      expect(result.events).toHaveLength(2)
+      // Newest-first: delivered on top, created below.
+      expect(result.events[0].scan_type).toBe("delivered")
+      expect(result.events[0].location).toBe("San Jose, CA, US")
+      expect(result.events[1].scan_type).toBe("created")
+      expect(result.events[1].location).toBe("Delhi, India")
+    })
+
+    it("cancels via order/cancelRefundOrder", async () => {
+      const result = await provider.cancelShipment({ awb: "STUBSG123" })
+      expect(shipglobalStubState.lastCancelBody).toEqual({
+        tracking: "STUBSG123",
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -492,6 +492,26 @@ module.exports = defineConfig({
                 },
               ]
             : []),
+          ...(process.env.SHIPGLOBAL_USERNAME
+            ? [
+                {
+                  resolve: "./src/modules/shipping-providers/shipglobal",
+                  id: "shipglobal",
+                  options: {
+                    username: process.env.SHIPGLOBAL_USERNAME,
+                    password: process.env.SHIPGLOBAL_PASSWORD,
+                    service: process.env.SHIPGLOBAL_SERVICE,
+                    flat_fallback_amounts: parseFlatFallbackAmounts(
+                      process.env.SHIPGLOBAL_FLAT_FALLBACK_AMOUNTS
+                    ),
+                    flat_fallback_amount: process.env
+                      .SHIPGLOBAL_FLAT_FALLBACK_AMOUNT
+                      ? Number(process.env.SHIPGLOBAL_FLAT_FALLBACK_AMOUNT)
+                      : undefined,
+                  },
+                },
+              ]
+            : []),
         ],
       },
     },

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -586,6 +586,29 @@ module.exports = defineConfig({
                       },
                     ]
                   : []),
+                ...(process.env.SHIPGLOBAL_USERNAME
+                  ? [
+                      {
+                        resolve: "./src/modules/shipping-providers/shipglobal",
+                        id: "shipglobal",
+                        options: {
+                          username: process.env.SHIPGLOBAL_USERNAME,
+                          password: process.env.SHIPGLOBAL_PASSWORD,
+                          service: process.env.SHIPGLOBAL_SERVICE,
+                          // What an UNQUOTABLE lane costs. Mirrors Shiprocket's
+                          // fallback: without it, calculatePrice answers 0 — free
+                          // international freight wearing a real quote.
+                          flat_fallback_amounts: parseFlatFallbackAmounts(
+                            process.env.SHIPGLOBAL_FLAT_FALLBACK_AMOUNTS
+                          ),
+                          flat_fallback_amount: process.env
+                            .SHIPGLOBAL_FLAT_FALLBACK_AMOUNT
+                            ? Number(process.env.SHIPGLOBAL_FLAT_FALLBACK_AMOUNT)
+                            : undefined,
+                        },
+                      },
+                    ]
+                  : []),
               ],
             },
           },

--- a/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
@@ -32,9 +32,12 @@ describe("carrier capabilities", () => {
     expect(delhivery.international.can_rate).toBe(false)
   })
 
-  it("has Shiprocket as the only carrier that rates cross-border", () => {
+  it("has Shiprocket and ShipGlobal as the carriers that rate cross-border", () => {
     const { international } = groupCarriersByLane()
-    expect(international.rating.map((c) => c.id)).toEqual(["shiprocket"])
+    expect(international.rating.map((c) => c.id)).toEqual([
+      "shiprocket",
+      "shipglobal",
+    ])
   })
 
   /**

--- a/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
+++ b/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
@@ -123,6 +123,19 @@ export const CARRIER_CAPABILITIES: CarrierCapability[] = [
     notes:
       "Domestic (express/ground) only. The integration books consignments, fetches labels, cancels and tracks (pull + webhook) through DTDC's pxapi.dtdc.in and blktracksvc.dtdc.com surfaces, but exposes no rate API — so it can only be used as a flat-priced or manually-priced option. International is not served by this API surface.",
   },
+  {
+    id: "shipglobal",
+    label: "ShipGlobal",
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: false, can_ship: false },
+    international: { can_rate: true, can_ship: true },
+    // The collection exposes no incoterm field on `order/add`; a DDP sale on
+    // ShipGlobal is a promise kept by hand, same as Shiprocket/Delhivery today.
+    can_declare_ddp: false,
+    notes:
+      "Cross-border only (India → international). Rates (`/rates/calculate`), books (`/order/add`), labels (`/order/getLabel`), tracks (`/tools/tracking`) and cancels (`/order/cancelRefundOrder`) via HTTP Basic auth at app.shipglobal.in/apiv1. No domestic product, so it never appears in a domestic lane.",
+  },
 ]
 
 /** The Medusa fulfillment-provider id a carrier registers under. */

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -326,4 +326,4 @@ export interface ShippingProviderClient {
 }
 
 /** Known carrier identifiers persisted on `fulfillment.data.carrier`. */
-export type CarrierId = "delhivery" | "shiprocket" | "bluedart" | "dtdc"
+export type CarrierId = "delhivery" | "shiprocket" | "bluedart" | "dtdc" | "shipglobal"

--- a/apps/backend/src/modules/shipping-providers/resolver.ts
+++ b/apps/backend/src/modules/shipping-providers/resolver.ts
@@ -300,10 +300,17 @@ export async function resolveShippingProvider(
         "ShipGlobal credentials not configured (no shipping platform record or SHIPGLOBAL_USERNAME + SHIPGLOBAL_PASSWORD)"
       )
     }
+    // Tests/CI inject a deterministic transport (SHIPGLOBAL_STUB=1) — ShipGlobal
+    // has no usable sandbox, so a live create would mint a billable waybill.
+    const fetchImpl =
+      process.env.SHIPGLOBAL_STUB === "1"
+        ? require("./shipglobal/stub-fetch").createShipglobalStubFetch()
+        : undefined
     return new ShipglobalClient({
       username: username!,
       password: password!,
       service: cfg.service || process.env.SHIPGLOBAL_SERVICE,
+      fetchImpl,
     })
   }
 

--- a/apps/backend/src/modules/shipping-providers/resolver.ts
+++ b/apps/backend/src/modules/shipping-providers/resolver.ts
@@ -27,6 +27,7 @@ import { ShiprocketClient } from "./shiprocket/client"
 import { BlueDartProviderAdapter } from "./bluedart/adapter"
 import { DhlUnifiedTrackingClient } from "./dhl-unified-tracking"
 import { DtdcProviderAdapter } from "@jytextiles/medusa-plugin-dtdc-shipping/providers/dtdc/adapter"
+import { ShipglobalClient } from "./shipglobal/client"
 
 /** Carriers `resolveShippingProvider` can return a live client for. */
 export const SUPPORTED_CARRIERS: CarrierId[] = [
@@ -34,6 +35,7 @@ export const SUPPORTED_CARRIERS: CarrierId[] = [
   "shiprocket",
   "bluedart",
   "dtdc",
+  "shipglobal",
 ]
 
 /**
@@ -283,6 +285,26 @@ export async function resolveShippingProvider(
         (cfg.default_service_type as any) ||
         process.env.DTDC_DEFAULT_SERVICE_TYPE,
     } as any) as unknown as ShippingProviderClient
+  }
+
+  if (id === "shipglobal") {
+    // Cross-border courier (India → international), HTTP Basic auth. The
+    // username is the account email, the password is issued by ShipGlobal.
+    const username =
+      cfg.username || cfg.email || process.env.SHIPGLOBAL_USERNAME
+    const password =
+      readSecret(cfg, "password", encryption) || process.env.SHIPGLOBAL_PASSWORD
+    if (!username || !password) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "ShipGlobal credentials not configured (no shipping platform record or SHIPGLOBAL_USERNAME + SHIPGLOBAL_PASSWORD)"
+      )
+    }
+    return new ShipglobalClient({
+      username: username!,
+      password: password!,
+      service: cfg.service || process.env.SHIPGLOBAL_SERVICE,
+    })
   }
 
   throw new MedusaError(

--- a/apps/backend/src/modules/shipping-providers/shipglobal/__tests__/client.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shipglobal/__tests__/client.unit.spec.ts
@@ -1,0 +1,310 @@
+import {
+  ShipglobalClient,
+  buildOrderBody,
+  extractTracking,
+  scanTypeForEventCode,
+  normalizeShipglobalTracking,
+  normalizeShipglobalRates,
+  parseTransitDays,
+} from "../client"
+import { CreateShipmentInput } from "../../provider-interface"
+
+const clientWith = (status: number, body: any) => {
+  const calls: Array<{ url: string; init?: any }> = []
+  const fetchImpl = (async (url: string, init?: any) => {
+    calls.push({ url: String(url), init })
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    }
+  }) as any
+  return {
+    client: new ShipglobalClient({
+      username: "user@example.com",
+      password: "pw",
+      fetchImpl,
+    }),
+    calls,
+  }
+}
+
+const INPUT: CreateShipmentInput = {
+  reference_id: "ord_123",
+  payment_mode: "prepaid",
+  pickup_location_name: "",
+  to: {
+    name: "John Smith",
+    phone: "+1-999-999-9999",
+    email: "demo@example.com",
+    address_1: "4 building name",
+    address_2: "5th Street",
+    city: "SAN JOSE",
+    state: "CA",
+    pincode: "95134",
+    country: "US",
+  },
+  items: [
+    {
+      name: "mugs",
+      sku: "",
+      quantity: 1,
+      unit_price: 54,
+      hsn: "6111.20.00",
+      tax: 0,
+    },
+  ],
+  weight_grams: 500,
+  dimensions_cm: { length: 10, width: 10, height: 10 },
+  currency: "USD",
+}
+
+describe("buildOrderBody", () => {
+  it("maps a shipment input onto the ShipGlobal order/add contract", () => {
+    const body = buildOrderBody(INPUT, "sgdirectyungb")
+    expect(body.invoice_no).toBe("ord_123")
+    expect(body.order_reference).toBe("ord_123")
+    expect(body.service).toBe("sgdirectyungb")
+    // Weight in KG, dims in CM, both as strings.
+    expect(body.package_weight).toBe("0.5")
+    expect(body.package_length).toBe("10")
+    expect(body.customer_shipping_firstname).toBe("John")
+    expect(body.customer_shipping_lastname).toBe("Smith")
+    expect(body.customer_shipping_country_code).toBe("US")
+    expect(body.customer_shipping_postcode).toBe("95134")
+    expect(body.currency_code).toBe("USD")
+    expect(body.csb5_status).toBe(1)
+  })
+
+  it("normalizes an HSN to digits and sets a string invoice_date", () => {
+    const body = buildOrderBody(INPUT, "sgdirectyungb")
+    expect(body.invoice_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(body.vendor_order_items[0].vendor_order_item_hsn).toBe("61112000")
+    expect(body.vendor_order_items[0].vendor_order_item_quantity).toBe("1")
+    expect(body.vendor_order_items[0].vendor_order_item_unit_price).toBe("54")
+  })
+})
+
+describe("extractTracking", () => {
+  it("reads the tracking number from every plausible response key", () => {
+    expect(extractTracking({ data: { tracking: "SG123" } })).toBe("SG123")
+    expect(extractTracking({ tracking_number: "SG456" })).toBe("SG456")
+    expect(extractTracking({ data: { awb: "SG789" } })).toBe("SG789")
+    expect(extractTracking({})).toBe("")
+  })
+})
+
+describe("scanTypeForEventCode", () => {
+  it("classifies SGE event codes into coarse scan types", () => {
+    expect(scanTypeForEventCode("SGE_001")).toBe("created")
+    expect(scanTypeForEventCode("SGE_304")).toBe("delivered")
+    expect(scanTypeForEventCode("SGE_402")).toBe("rto")
+    expect(scanTypeForEventCode("SGE_503")).toBe("rto")
+    expect(scanTypeForEventCode("SGERROR_103")).toBe("exception")
+    expect(scanTypeForEventCode("SGE_301")).toBe("in_transit")
+  })
+})
+
+describe("normalizeShipglobalTracking", () => {
+  it("maps the live awb_-prefixed snake_case fields onto a TrackingResult", () => {
+    const result = normalizeShipglobalTracking(
+      {
+        success: true,
+        data: {
+          awbInfo: {
+            awb_status: "DELIVERED ",
+            awb_sender_name: "linkers",
+            awb_destination: "US",
+            awb_number: "SG3231027366055",
+          },
+          awbEvents: [
+            {
+              awb_history_datetime: "2023-10-03 10:46:11",
+              awb_history_location: "San Jose, CA, US",
+              awb_history_comment: "DELIVERED ",
+              type: "lastmile",
+              awb_event_code: "SGE_304",
+            },
+            {
+              awb_history_datetime: "2023-09-29 13:31:29",
+              awb_history_location: "Delhi",
+              awb_history_comment: "Shipment Information Received.",
+              type: "connector",
+              awb_event_code: "SGE_001",
+            },
+          ],
+        },
+      },
+      "SG123"
+    )
+    expect(result.carrier).toBe("shipglobal")
+    expect(result.awb).toBe("SG123")
+    expect(result.current_status).toBe("DELIVERED ")
+    expect(result.origin).toBe("linkers")
+    expect(result.destination).toBe("US")
+    expect(result.events).toHaveLength(2)
+    expect(result.events[0].scan_type).toBe("delivered")
+    expect(result.events[0].location).toBe("San Jose, CA, US")
+    expect(result.events[1].scan_type).toBe("created")
+  })
+})
+
+describe("parseTransitDays", () => {
+  it("parses the high end of a transit-time range", () => {
+    expect(parseTransitDays("7-10 Days")).toBe(10)
+    expect(parseTransitDays("4 - 7 Days")).toBe(7)
+    expect(parseTransitDays("6-9 Days")).toBe(9)
+    expect(parseTransitDays(undefined)).toBeUndefined()
+  })
+})
+
+describe("normalizeShipglobalRates", () => {
+  it("maps the services array into rate options with the top-level currency", () => {
+    const rates = normalizeShipglobalRates({
+      success: true,
+      billed_weight: 20,
+      currency: "INR",
+      services: [
+        {
+          title: "ShipGlobal Direct",
+          notes: "",
+          transit_time: "7-10 Days",
+          price: { logistic_fee: 285 },
+          subtotal_fee: 300,
+        },
+        {
+          title: "ShipGlobal First Class",
+          notes: "",
+          transit_time: "7-10 Days",
+          price: { logistic_fee: 311 },
+          subtotal_fee: 326,
+        },
+      ],
+    })
+    expect(rates).toHaveLength(2)
+    expect(rates[0]).toMatchObject({
+      courier_name: "ShipGlobal Direct",
+      amount: 300,
+      currency_code: "inr",
+      estimated_days: 10,
+      is_recommended: true,
+    })
+    expect(rates[1].courier_name).toBe("ShipGlobal First Class")
+    expect(rates[1].is_recommended).toBe(false)
+  })
+
+  it("falls back to logistic_fee when subtotal_fee is absent", () => {
+    const rates = normalizeShipglobalRates({
+      currency: "INR",
+      services: [{ title: "UPS", price: { logistic_fee: 2009 } }],
+    })
+    expect(rates[0].amount).toBe(2009)
+  })
+
+  it("returns [] when there are no serviceable rows", () => {
+    expect(normalizeShipglobalRates({ currency: "INR", services: [] })).toEqual([])
+    expect(normalizeShipglobalRates({ success: true })).toEqual([])
+  })
+})
+
+describe("ShipglobalClient", () => {
+  it("refuses a domestic rate query", async () => {
+    const { client, calls } = clientWith(200, { data: { rate: 10 } })
+    const rates = await client.getRates({
+      origin_pincode: "411014",
+      destination_pincode: "411014",
+      destination_country: "IN",
+      weight_grams: 500,
+    })
+    expect(rates).toEqual([])
+    expect(calls).toHaveLength(0)
+  })
+
+  it("posts the rate body with weight in kg for an international lane", async () => {
+    const { client, calls } = clientWith(200, {
+      success: true,
+      currency: "INR",
+      services: [
+        {
+          title: "ShipGlobal Direct",
+          transit_time: "7-10 Days",
+          price: { logistic_fee: 285 },
+          subtotal_fee: 300,
+        },
+      ],
+    })
+    const rates = await client.getRates({
+      origin_pincode: "411014",
+      destination_pincode: "AB32",
+      destination_country: "GB",
+      weight_grams: 1500,
+    })
+    expect(calls[0].url).toContain("/rates/calculate")
+    expect(JSON.parse(calls[0].init.body)).toEqual({
+      package_weight: "1.5",
+      country_iso_code_2: "GB",
+      postcode: "AB32",
+    })
+    expect(rates).toHaveLength(1)
+    expect(rates[0].amount).toBe(300)
+    expect(rates[0].currency_code).toBe("inr")
+  })
+
+  it("creates a shipment via order/add and returns the tracking number", async () => {
+    const { client, calls } = clientWith(200, {
+      success: true,
+      data: { tracking: "SG32607086295274" },
+    })
+    const result = await client.createShipment(INPUT)
+    expect(calls[0].url).toContain("/order/add")
+    expect(result.awb).toBe("SG32607086295274")
+    expect(result.tracking_number).toBe("SG32607086295274")
+    expect(result.tracking_url).toContain("SG32607086295274")
+    expect(result.provider_refs?.tracking).toBe("SG32607086295274")
+  })
+
+  it("throws when order/add returns no tracking number", async () => {
+    const { client } = clientWith(200, { success: true })
+    await expect(client.createShipment(INPUT)).rejects.toThrow(/no tracking number/)
+  })
+
+  it("tracks via tools/tracking and normalizes the events", async () => {
+    const { client, calls } = clientWith(200, {
+      data: {
+        awbInfo: { awb_status: "DELIVERED " },
+        awbEvents: [],
+      },
+    })
+    const result = await client.track({ awb: "SG123" })
+    expect(calls[0].url).toContain("/tools/tracking")
+    expect(JSON.parse(calls[0].init.body)).toEqual({ tracking: "SG123" })
+    expect(result.current_status).toBe("DELIVERED ")
+  })
+
+  it("fetches a base64 PDF label via order/getLabel", async () => {
+    const { client, calls } = clientWith(200, {
+      success: true,
+      tracking: "SG3231107366132",
+      label: "JVBERi0xLjQKMSAwIG9iago=",
+    })
+    const label = await client.getLabel({
+      awb: "SG3231107366132",
+      provider_refs: { tracking: "SG3231107366132" },
+    })
+    expect(calls[0].url).toContain("/order/getLabel")
+    expect(JSON.parse(calls[0].init.body)).toEqual({
+      tracking: "SG3231107366132",
+      label: true,
+    })
+    expect(label.data).toBe("JVBERi0xLjQKMSAwIG9iago=")
+    expect(label.format).toBe("pdf")
+  })
+
+  it("cancels via cancelRefundOrder", async () => {
+    const { client, calls } = clientWith(200, { success: true })
+    const result = await client.cancelShipment({ awb: "SG123" })
+    expect(calls[0].url).toContain("/order/cancelRefundOrder")
+    expect(JSON.parse(calls[0].init.body)).toEqual({ tracking: "SG123" })
+    expect(result.success).toBe(true)
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shipglobal/__tests__/service.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shipglobal/__tests__/service.unit.spec.ts
@@ -1,0 +1,117 @@
+import ShipglobalFulfillmentService from "../service"
+import { DEFAULT_FLAT_FALLBACK } from "../../shiprocket/flat-fallback"
+
+const logger: any = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}
+
+const buildService = (options: any = {}, clientOverrides: any = {}) => {
+  const svc = new ShipglobalFulfillmentService(
+    { logger },
+    { username: "u@example.com", password: "pw", ...options }
+  )
+  ;(svc as any).client = {
+    getRates: jest.fn(),
+    createShipment: jest.fn(),
+    cancelShipment: jest.fn(),
+    getLabel: jest.fn(),
+    ...clientOverrides,
+  }
+  return svc
+}
+
+const CONTEXT: any = {
+  shipping_address: { country_code: "US", postal_code: "95134" },
+  items: [{ variant: { weight: 600 }, quantity: 2 }],
+  currency_code: "usd",
+}
+
+describe("ShipglobalFulfillmentService", () => {
+  it("registers under the shipglobal identifier", () => {
+    expect(ShipglobalFulfillmentService.identifier).toBe("shipglobal")
+  })
+
+  it("offers only the international fulfillment option", async () => {
+    const opts = await buildService().getFulfillmentOptions()
+    expect(opts.map((o) => o.id)).toEqual(["shipglobal-international"])
+  })
+
+  it("prices the recommended rate from getRates", async () => {
+    const svc = buildService(undefined, {
+      getRates: jest.fn().mockResolvedValue([
+        { courier_name: "ShipGlobal", amount: 1250.5, currency_code: "usd" },
+      ]),
+    })
+    const result = await svc.calculatePrice({}, {}, CONTEXT)
+    expect(result).toEqual({
+      calculated_amount: 1250.5,
+      is_calculated_price_tax_inclusive: true,
+    })
+  })
+
+  it("falls back to the flat rate when getRates returns no courier", async () => {
+    const svc = buildService(undefined, {
+      getRates: jest.fn().mockResolvedValue([]),
+    })
+    const result = await svc.calculatePrice({}, {}, CONTEXT)
+    expect(result.calculated_amount).toBe(DEFAULT_FLAT_FALLBACK)
+    expect(result.is_calculated_price_tax_inclusive).toBe(false)
+  })
+
+  it("falls back to the flat rate on a carrier error", async () => {
+    const svc = buildService(undefined, {
+      getRates: jest.fn().mockRejectedValue(new Error("boom")),
+    })
+    const result = await svc.calculatePrice({}, {}, CONTEXT)
+    expect(result.calculated_amount).toBe(DEFAULT_FLAT_FALLBACK)
+  })
+
+  it("writes the waybill and tracking number onto fulfillment data", async () => {
+    const svc = buildService(undefined, {
+      createShipment: jest.fn().mockResolvedValue({
+        carrier: "shipglobal",
+        awb: "SG123",
+        tracking_number: "SG123",
+        tracking_url: "https://app.shipglobal.in/tracking/SG123",
+        provider_refs: { tracking: "SG123" },
+      }),
+    })
+    const result = await svc.createFulfillment(
+      {},
+      [{ title: "mugs", quantity: 1, line_item_id: "li1" }],
+      {
+        id: "ord_1",
+        shipping_address: {
+          first_name: "John",
+          last_name: "Smith",
+          phone: "+1-999-999-9999",
+          address_1: "4 building name",
+          city: "SAN JOSE",
+          province: "CA",
+          postal_code: "95134",
+          country_code: "US",
+        },
+        items: [{ id: "li1", title: "mugs", unit_price: 54, variant: {} }],
+        currency_code: "USD",
+      } as any,
+      { id: "ful_1" } as any
+    )
+    expect(result.data.carrier).toBe("shipglobal")
+    expect(result.data.waybill).toBe("SG123")
+    expect(result.data.tracking_number).toBe("SG123")
+    expect(result.labels).toHaveLength(1)
+  })
+
+  it("cancels a fulfillment by its waybill", async () => {
+    const cancel = jest.fn().mockResolvedValue({ success: true })
+    const svc = buildService(undefined, { cancelShipment: cancel })
+    await svc.cancelFulfillment({ data: { waybill: "SG123" } } as any)
+    expect(cancel).toHaveBeenCalledWith({
+      awb: "SG123",
+      provider_refs: { tracking: "SG123" },
+    })
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shipglobal/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shipglobal/client.ts
@@ -1,0 +1,482 @@
+/**
+ * ShipGlobal.in vendor API client (#shipglobal).
+ *
+ * ShipGlobal (shipglobal.in) is a cross-border courier that ships OUT of India
+ * to international destinations. Its published Postman collection
+ * (https://documenter.getpostman.com/view/27717351/2s9YXfd4Ky) exposes five
+ * JSON endpoints behind HTTP Basic auth:
+ *
+ *   POST /rates/calculate           { package_weight, country_iso_code_2, postcode }
+ *   POST /order/add                 full order → returns a `tracking` number (SG…)
+ *   POST /order/getLabel            { tracking, label: true } → pay + fetch label
+ *   POST /order/cancelRefundOrder   { tracking }
+ *   POST /tools/tracking            { tracking } → awbEvents[] + awbInfo
+ *
+ * The flow is: createShipment = `order/add` (returns the SG tracking number in
+ * ONE call, like Delhivery), then getLabel = `order/getLabel` to pay and pull
+ * the label. This client implements our normalized `ShippingProviderClient` so
+ * the carrier-keyed resolver (`resolver.ts`) drives it exactly like Shiprocket
+ * / Delhivery.
+ *
+ * Live response shapes (verified against the carrier):
+ *   rates/calculate  → { success, billed_weight, currency, services: [{ title,
+ *                       notes, transit_time, price: { logistic_fee }, subtotal_fee }] }
+ *   order/getLabel   → { success, tracking, label } where `label` is base64 PDF
+ *   tools/tracking   → { success, data: { awbEvents[]: { awb_history_datetime,
+ *                       awb_history_location, awb_history_comment, awb_event_code },
+ *                       awbInfo: { awb_status, awb_sender_name, awb_destination,
+ *                       awb_number, awb_postcode, partner_lastmile_display, … } } }
+ *
+ * ⚠️ The tracking fields are `awb_`-prefixed snake_case — NOT the camelCase the
+ * published collection's field table describes. The normalizers read the live
+ * snake_case keys (with the documented camelCase as fallback), since the
+ * collection's table is aspirational.
+ */
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  CreateShipmentInput,
+  LabelResult,
+  RateOption,
+  RateQuery,
+  ShipmentRef,
+  ShipmentResult,
+  ShippingProviderClient,
+  TrackingEvent,
+  TrackingResult,
+} from "../provider-interface"
+import { isInternationalDestination } from "../destination"
+import { normalizeHsCode } from "../hs-code-resolution"
+
+const BASE_URL = "https://app.shipglobal.in/apiv1"
+
+/** Default `service` code stamped on a ShipGlobal order. ShipGlobal's service is
+ *  a region-specific CODE, not a display name: `sgdirecteuyun` serves EU and
+ *  `sgdirectyungb` serves GB. Override per account/region via options (`service`)
+ *  or the `SHIPGLOBAL_SERVICE` env var — the resolver passes the configured value
+ *  through. */
+const DEFAULT_SERVICE = "sgdirecteuyun"
+
+/** The subset of `fetch` the client uses — injectable so tests/CI can supply a
+ *  deterministic transport (same pattern as Shiprocket's `FetchLike`, #647). */
+export type FetchLike = (input: any, init?: any) => Promise<any>
+
+export type ShipglobalOptions = {
+  username: string
+  password: string
+  /** Service code sent on `order/add`. Region-specific: `sgdirecteuyun` (EU),
+   *  `sgdirectyungb` (GB). Defaults to `sgdirecteuyun`. */
+  service?: string
+  /** Injectable transport (defaults to the global fetch). */
+  fetchImpl?: FetchLike
+}
+
+/**
+ * A ShipGlobal API failure as a first-class MedusaError, mirroring
+ * `ShiprocketApiError`. The upstream HTTP status maps onto a MedusaError type so
+ * it flows through the framework's error handler with the right code.
+ */
+export class ShipglobalApiError extends MedusaError {
+  readonly status: number
+  readonly raw?: unknown
+
+  constructor(
+    message: string,
+    opts: { status: number; raw?: unknown }
+  ) {
+    super(ShipglobalApiError.typeForStatus(opts.status), message)
+    this.name = "ShipglobalApiError"
+    this.status = opts.status
+    this.raw = opts.raw
+  }
+
+  static typeForStatus(status: number): string {
+    if (status === 401 || status === 403) return MedusaError.Types.NOT_ALLOWED
+    if (status >= 400 && status < 500) return MedusaError.Types.INVALID_DATA
+    return MedusaError.Types.UNEXPECTED_STATE
+  }
+}
+
+/**
+ * Pull a readable message out of a ShipGlobal error body. The collection's error
+ * table describes `{ code, message, description }` rows; the raw text is the
+ * fallback when the body is not JSON or has no message.
+ */
+export function parseShipglobalError(raw: string): string {
+  let body: any
+  try {
+    body = raw ? JSON.parse(raw) : undefined
+  } catch {
+    return raw || ""
+  }
+  if (body === undefined || body === null) return raw || ""
+  if (typeof body === "string") return body
+  const msg =
+    typeof body.message === "string"
+      ? body.message
+      : typeof body.error === "string"
+        ? body.error
+        : typeof body.description === "string"
+          ? body.description
+          : raw || ""
+  return msg
+}
+
+/** The AWB/tracking number on a ShipGlobal shipment/order response. Defensive —
+ *  the field name is not pinned in the collection, so read every plausible key. */
+export function extractTracking(res: any): string {
+  const d = res?.data ?? res ?? {}
+  const v =
+    d.tracking ??
+    d.tracking_number ??
+    d.tracking_no ??
+    d.awb ??
+    d.awb_number ??
+    d.airwaybill ??
+    d.awbNo ??
+    ""
+  return typeof v === "string" ? v.trim() : v ? String(v).trim() : ""
+}
+
+/** Tracking URL for a ShipGlobal SG-number. Constructed; the collection does not
+ *  document a public tracking URL, so this is the carrier's own track page. */
+export function shipglobalTrackingUrl(tracking: string): string {
+  return tracking
+    ? `https://app.shipglobal.in/tracking/${encodeURIComponent(tracking)}`
+    : ""
+}
+
+/** ShipGlobal `SGE_*` event code → our coarse `scan_type`. See the collection's
+ *  status-code table: 001/101 = created, 3xx = in transit, 304 = delivered,
+ *  4xx/5xx = RTO/exception. */
+export function scanTypeForEventCode(code?: string): string {
+  const c = String(code || "").toUpperCase()
+  if (c === "SGE_304") return "delivered"
+  if (c === "SGE_001" || c === "SGE_002" || c === "SGE_101") return "created"
+  if (/^SGE_4/.test(c)) return "rto"
+  if (/^SGE_5/.test(c)) return "rto"
+  if (/^SGERROR/.test(c)) return "exception"
+  return "in_transit"
+}
+
+/** Build the ShipGlobal `order/add` body from a normalized shipment input.
+ *  Pure & exported so the exact payload (invoice fields, address split, item
+ *  lines) is unit-testable without a live API. */
+export function buildOrderBody(
+  input: CreateShipmentInput,
+  service: string
+): Record<string, any> {
+  const [firstName, ...rest] = (input.to.name || "Customer").split(" ")
+  const lastName = rest.join(" ")
+  const countryCode = String(input.to.country || "").trim().toUpperCase()
+
+  const items = (input.items || []).map((i) => ({
+    vendor_order_item_name: i.name,
+    vendor_order_item_sku: i.sku || "",
+    vendor_order_item_quantity: String(i.quantity || 1),
+    vendor_order_item_unit_price: String(i.unit_price || 0),
+    vendor_order_item_hsn: normalizeHsCode(i.hsn) || "",
+    vendor_order_item_tax_rate: i.tax != null ? String(i.tax) : "0",
+  }))
+
+  return {
+    invoice_no: input.reference_id,
+    invoice_date: new Date().toISOString().slice(0, 10),
+    order_reference: input.reference_id,
+    service,
+    package_weight: String(Math.max(0.001, (input.weight_grams || 0) / 1000)),
+    package_length: String(input.dimensions_cm?.length || 10),
+    package_breadth: String(input.dimensions_cm?.width || 10),
+    package_height: String(input.dimensions_cm?.height || 10),
+    currency_code: (input.currency || "USD").toUpperCase(),
+    // ShipGlobal is cross-border only; the collection example ships CSB-5 (1).
+    csb5_status: 1,
+    customer_shipping_firstname: firstName,
+    customer_shipping_lastname: lastName,
+    customer_shipping_mobile: input.to.phone || "",
+    customer_shipping_email: input.to.email || "",
+    customer_shipping_company: "",
+    customer_shipping_address: input.to.address_1 || "",
+    customer_shipping_address_2: input.to.address_2 || "",
+    customer_shipping_address_3: "",
+    customer_shipping_city: input.to.city || "",
+    customer_shipping_postcode: input.to.pincode || "",
+    customer_shipping_country_code: countryCode,
+    customer_shipping_state: input.to.state || "",
+    ioss_number: "",
+    vendor_order_items: items,
+  }
+}
+
+/**
+ * Normalize a ShipGlobal tracking payload (`/tools/tracking`) into our
+ * `TrackingResult`. Pure & exported so the webhook/normalize path can parse
+ * without carrier credentials.
+ *
+ * ⚠️ The ACTUAL response uses `awb_`-prefixed snake_case (`awb_history_datetime`,
+ * `awb_event_code`, `awb_status`), NOT the camelCase the published collection
+ * describes (`datetime`, `eventCode`, `status`). The collection's field table is
+ * aspirational; the live payload is what's parsed here, with the documented
+ * camelCase names kept as a fallback only.
+ */
+export function normalizeShipglobalTracking(
+  payload: any,
+  awb: string
+): TrackingResult {
+  const data = payload?.data ?? {}
+  const info = data?.awbInfo ?? {}
+  const events: TrackingEvent[] = (Array.isArray(data?.awbEvents)
+    ? data.awbEvents
+    : []
+  ).map((e: any) => ({
+    timestamp:
+      e?.awb_history_datetime ?? e?.datetime ?? "",
+    status:
+      e?.awb_history_comment ?? e?.comment ?? e?.type ?? e?.eventCode ?? "",
+    location: e?.awb_history_location ?? e?.location ?? "",
+    scan_type: scanTypeForEventCode(e?.awb_event_code ?? e?.eventCode),
+  }))
+
+  return {
+    carrier: "shipglobal",
+    awb,
+    current_status:
+      info?.awb_status ??
+      info?.status ??
+      info?.partner_lastmile_display ??
+      "",
+    current_status_code: info?.awb_status ?? info?.status ?? undefined,
+    estimated_delivery: null,
+    origin: (info?.awb_sender_name ?? info?.senderName) || undefined,
+    destination: (info?.awb_destination ?? info?.destination) || undefined,
+    events,
+    raw: payload,
+  }
+}
+
+/** Coerce a carrier-quoted charge into a finite number, or undefined. A blank or
+ *  unparseable value must NOT become 0 — zero is a real (free) rate. */
+export function toRate(v: unknown): number | undefined {
+  if (v === null || v === undefined || v === "") return undefined
+  const n = Number(v)
+  return Number.isFinite(n) ? n : undefined
+}
+
+/** Parse a ShipGlobal `transit_time` string ("7-10 Days", "4 - 7 Days") into the
+ *  high end of the range — the delivery promise we'd show a customer. */
+export function parseTransitDays(v: unknown): number | undefined {
+  const text = String(v ?? "")
+    .split(/[-–]/)
+    .pop()
+    ?.trim()
+  if (!text) return undefined
+  const n = Number(text.replace(/[^0-9]/g, ""))
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+/**
+ * Normalize a ShipGlobal `rates/calculate` response into `RateOption[]`.
+ *
+ * The live response is `{ success, billed_weight, currency, services: [{ title,
+ * notes, transit_time, price: { logistic_fee }, subtotal_fee }] }` — one row per
+ * service. `subtotal_fee` is the customer-facing total; `price.logistic_fee` is
+ * the freight component. The first row is treated as the recommended (cheapest)
+ * option since ShipGlobal returns no explicit recommended flag.
+ */
+export function normalizeShipglobalRates(res: any): RateOption[] {
+  const currency = String(
+    res?.currency ?? res?.data?.currency ?? "USD"
+  ).toLowerCase()
+  const services = res?.services ?? res?.data?.services ?? []
+  if (!Array.isArray(services)) return []
+  return services
+    .map((s: any, i: number): RateOption | undefined => {
+      const amount = toRate(s?.subtotal_fee) ?? toRate(s?.price?.logistic_fee)
+      if (amount === undefined) return undefined
+      return {
+        courier_id: s?.title,
+        courier_name: s?.title,
+        amount,
+        currency_code: currency,
+        estimated_days: parseTransitDays(s?.transit_time),
+        is_recommended: i === 0,
+      }
+    })
+    .filter((r): r is RateOption => r !== undefined)
+}
+
+export class ShipglobalClient implements ShippingProviderClient {
+  readonly carrier = "shipglobal"
+
+  private username: string
+  private password: string
+  private service: string
+  private authHeader: string
+  private fetchImpl: FetchLike
+
+  constructor(options: ShipglobalOptions) {
+    this.username = options.username
+    this.password = options.password
+    this.service = options.service || DEFAULT_SERVICE
+    this.authHeader = `Basic ${Buffer.from(
+      `${options.username}:${options.password}`
+    ).toString("base64")}`
+    this.fetchImpl =
+      options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init))
+  }
+
+  private async request<T = any>(
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const res = await this.fetchImpl(`${BASE_URL}${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: this.authHeader,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
+    const raw = await res.text().catch(() => "")
+    let json: any
+    try {
+      json = raw ? JSON.parse(raw) : {}
+    } catch {
+      json = undefined
+    }
+    if (!res.ok) {
+      const message = parseShipglobalError(raw)
+      throw new ShipglobalApiError(
+        `ShipGlobal ${path} failed (${res.status})${message ? ` — ${message}` : ""}`,
+        { status: res.status, raw }
+      )
+    }
+    return json as T
+  }
+
+  /**
+   * Rates for a lane. ShipGlobal is cross-border only, so this refuses a
+   * domestic (India) destination rather than posting an Indian postcode to a
+   * country-keyed rate API.
+   */
+  async getRates(query: RateQuery): Promise<RateOption[]> {
+    if (!isInternationalDestination(query.destination_country)) {
+      return []
+    }
+    const res = await this.request<Record<string, any>>(`/rates/calculate`, {
+      package_weight: String(
+        Math.max(0.001, (query.weight_grams || 0) / 1000)
+      ),
+      country_iso_code_2: String(query.destination_country || "").toUpperCase(),
+      postcode: query.destination_pincode || "",
+    })
+    return normalizeShipglobalRates(res)
+  }
+
+  /**
+   * Create the shipment (`order/add`), which returns the SG tracking number in a
+   * single call — no separate AWB-assignment step like Shiprocket.
+   */
+  async createShipment(input: CreateShipmentInput): Promise<ShipmentResult> {
+    if (!isInternationalDestination(input.to.country)) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "ShipGlobal is cross-border only and cannot ship a domestic (India) destination"
+      )
+    }
+    const res = await this.request<Record<string, any>>(
+      `/order/add`,
+      buildOrderBody(input, this.service)
+    )
+    const tracking = extractTracking(res)
+    if (!tracking) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `ShipGlobal order created but returned no tracking number: ${JSON.stringify(res)}`
+      )
+    }
+    return {
+      carrier: this.carrier,
+      awb: tracking,
+      tracking_number: tracking,
+      tracking_url: shipglobalTrackingUrl(tracking),
+      provider_refs: { tracking },
+      raw: res,
+    }
+  }
+
+  async getLabel(ref: ShipmentRef): Promise<LabelResult> {
+    const tracking = refTracking(ref)
+    if (!tracking) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "ShipGlobal getLabel requires a tracking number"
+      )
+    }
+    const res = await this.request<Record<string, any>>(`/order/getLabel`, {
+      tracking,
+      label: true,
+    })
+    const d = res?.data ?? res ?? {}
+    const labelUrl =
+      typeof d.label_url === "string"
+        ? d.label_url
+        : typeof d.label === "string" && /^https?:/.test(d.label)
+          ? d.label
+          : typeof d.url === "string"
+            ? d.url
+            : ""
+    return {
+      label_url: labelUrl || undefined,
+      data:
+        typeof d.label === "string" && !/^https?:/.test(d.label)
+          ? d.label
+          : undefined,
+      format: "pdf",
+      raw: res,
+    }
+  }
+
+  async track(ref: ShipmentRef): Promise<TrackingResult> {
+    const tracking = refTracking(ref)
+    if (!tracking) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "ShipGlobal track requires a tracking number"
+      )
+    }
+    const res = await this.request<Record<string, any>>(`/tools/tracking`, {
+      tracking,
+    })
+    return normalizeShipglobalTracking(res, tracking)
+  }
+
+  async cancelShipment(
+    ref: ShipmentRef
+  ): Promise<{ success: boolean; raw?: any }> {
+    const tracking = refTracking(ref)
+    if (!tracking) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "ShipGlobal cancelShipment requires a tracking number"
+      )
+    }
+    const res = await this.request<Record<string, any>>(
+      `/order/cancelRefundOrder`,
+      { tracking }
+    )
+    return { success: true, raw: res }
+  }
+}
+
+/** The tracking/AWB number on a persisted shipment ref, from whichever key the
+ *  resolver/framework stashed it. */
+function refTracking(ref: ShipmentRef): string {
+  const v =
+    ref?.awb ??
+    ref?.provider_refs?.tracking ??
+    ref?.provider_refs?.waybill ??
+    ref?.provider_refs?.awb ??
+    ""
+  return String(v || "").trim()
+}

--- a/apps/backend/src/modules/shipping-providers/shipglobal/index.ts
+++ b/apps/backend/src/modules/shipping-providers/shipglobal/index.ts
@@ -1,0 +1,6 @@
+import { ModuleProvider, Modules } from "@medusajs/framework/utils"
+import ShipglobalFulfillmentService from "./service"
+
+export default ModuleProvider(Modules.FULFILLMENT, {
+  services: [ShipglobalFulfillmentService],
+})

--- a/apps/backend/src/modules/shipping-providers/shipglobal/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shipglobal/service.ts
@@ -1,0 +1,301 @@
+import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
+import {
+  CreateFulfillmentResult,
+  FulfillmentOption,
+  FulfillmentItemDTO,
+  FulfillmentOrderDTO,
+  FulfillmentDTO,
+  CalculatedShippingOptionPrice,
+  CreateShippingOptionDTO,
+  Logger,
+} from "@medusajs/framework/types"
+import { ShipglobalClient, ShipglobalOptions } from "./client"
+import { CreateShipmentInput, ShipmentItem } from "../provider-interface"
+import {
+  FlatFallbackConfig,
+  resolveFlatFallbackAmount,
+} from "../shiprocket/flat-fallback"
+
+type InjectedDeps = { logger: Logger }
+
+/**
+ * ShipGlobal fulfillment provider (#shipglobal).
+ *
+ * Registered as a Medusa fulfillment provider alongside Shiprocket / Delhivery.
+ * ShipGlobal is a cross-border courier (India → international), so the only
+ * fulfillment option is international. The heavy lifting lives in
+ * `ShipglobalClient`, which also implements our normalized
+ * `ShippingProviderClient` so the carrier-keyed resolver can drive it directly.
+ * This service is the Medusa-fulfilment-flow entry point.
+ */
+class ShipglobalFulfillmentService extends AbstractFulfillmentProviderService {
+  static identifier = "shipglobal"
+
+  protected client: ShipglobalClient
+  protected logger: Logger
+  /** What an unquotable lane costs. See `shiprocket/flat-fallback.ts`. */
+  protected fallbackConfig: FlatFallbackConfig
+
+  constructor(
+    { logger }: InjectedDeps,
+    options: ShipglobalOptions & FlatFallbackConfig
+  ) {
+    super()
+    this.logger = logger
+    this.client = new ShipglobalClient(options)
+    this.fallbackConfig = {
+      flat_fallback_amounts: options?.flat_fallback_amounts,
+      flat_fallback_amount: options?.flat_fallback_amount,
+    }
+  }
+
+  async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
+    return [
+      {
+        id: "shipglobal-international",
+        name: "ShipGlobal International",
+        is_return: false,
+      },
+    ]
+  }
+
+  async validateFulfillmentData(
+    optionData: Record<string, unknown>,
+    data: Record<string, unknown>,
+    _context: any
+  ): Promise<Record<string, unknown>> {
+    return { ...data, ...optionData }
+  }
+
+  async validateOption(_data: Record<string, any>): Promise<boolean> {
+    return true
+  }
+
+  async canCalculate(_data: CreateShippingOptionDTO): Promise<boolean> {
+    return true
+  }
+
+  /**
+   * Price the cart's international lane. ShipGlobal quotes by destination
+   * country + postcode + weight; an underivable lane, a carrier error, or a
+   * refusal (empty rate) resolves to the flat fallback rather than throwing or
+   * answering 0 (see `shiprocket/flat-fallback.ts` for why).
+   */
+  async calculatePrice(
+    optionData: Record<string, unknown>,
+    _data: Record<string, unknown>,
+    context: any
+  ): Promise<CalculatedShippingOptionPrice> {
+    const to = context?.shipping_address
+    const destinationCountry = String(to?.country_code || "").toUpperCase()
+    const currencyCode =
+      context?.currency_code ?? context?.cart?.currency_code ?? null
+
+    let weightGrams = 0
+    for (const item of context?.items ?? []) {
+      weightGrams += (item.variant?.weight || 500) * (item.quantity || 1)
+    }
+
+    try {
+      const rates = await this.client.getRates({
+        origin_pincode: "",
+        destination_pincode: to?.postal_code || "",
+        destination_country: destinationCountry,
+        weight_grams: weightGrams || 500,
+      })
+      const recommended = rates[0]
+      if (!recommended || !Number.isFinite(Number(recommended.amount))) {
+        return this.flatFallback(
+          destinationCountry,
+          `ShipGlobal returned no rate to ${to?.postal_code || ""} ${destinationCountry}`,
+          optionData,
+          currencyCode
+        )
+      }
+      return {
+        calculated_amount: Number(recommended.amount),
+        is_calculated_price_tax_inclusive: true,
+      }
+    } catch (e: any) {
+      this.logger.error(`ShipGlobal calculatePrice error: ${e.message}`)
+      return this.flatFallback(
+        destinationCountry,
+        e.message,
+        optionData,
+        currencyCode
+      )
+    }
+  }
+
+  private flatFallback(
+    destinationCountry: string,
+    reason: string,
+    optionData?: Record<string, unknown>,
+    currencyCode?: string | null
+  ): CalculatedShippingOptionPrice {
+    const { amount, reason: unconfigured } = resolveFlatFallbackAmount(
+      this.fallbackConfig,
+      destinationCountry,
+      optionData,
+      currencyCode
+    )
+    this.logger.warn(
+      `[shipglobal] falling back to the flat rate ${amount} ${
+        currencyCode ? String(currencyCode).toUpperCase() : "(currency unknown)"
+      } for ${destinationCountry || "IN"} — ${reason}${
+        unconfigured ? ` (${unconfigured})` : ""
+      }`
+    )
+    return {
+      calculated_amount: amount!,
+      is_calculated_price_tax_inclusive: false,
+    }
+  }
+
+  async createFulfillment(
+    data: Record<string, unknown>,
+    items: Partial<Omit<FulfillmentItemDTO, "fulfillment">>[],
+    order: Partial<FulfillmentOrderDTO> | undefined,
+    fulfillment: Partial<Omit<FulfillmentDTO, "provider_id" | "data" | "items">>
+  ): Promise<CreateFulfillmentResult> {
+    const shippingAddress = (order as any)?.shipping_address || {}
+    const orderItems = ((order as any)?.items || []) as any[]
+    const orderItemById = new Map<string, any>()
+    for (const oi of orderItems) if (oi.id) orderItemById.set(oi.id, oi)
+
+    let totalWeight = 0
+    let maxLength = 0
+    let maxWidth = 0
+    let maxHeight = 0
+    let hasWeight = false
+    const shipItems: ShipmentItem[] = []
+
+    for (const fItem of items) {
+      const qty = (fItem as any).quantity || 1
+      const oi = orderItemById.get((fItem as any).line_item_id)
+      const variant = oi?.variant
+      if (variant?.weight) {
+        hasWeight = true
+        totalWeight += variant.weight * qty
+      }
+      if (variant?.length && variant.length > maxLength) maxLength = variant.length
+      if (variant?.width && variant.width > maxWidth) maxWidth = variant.width
+      if (variant?.height) maxHeight += variant.height * qty
+
+      shipItems.push({
+        name: (fItem as any).title || oi?.title || "Item",
+        sku: oi?.variant_sku || undefined,
+        quantity: qty,
+        unit_price: oi?.unit_price || 0,
+        hsn: oi?.variant?.hs_code || oi?.variant?.metadata?.hs_code || undefined,
+      })
+    }
+
+    if (!hasWeight) {
+      const totalQty = shipItems.reduce((s, i) => s + i.quantity, 0)
+      totalWeight = Math.max(400, totalQty * 400)
+      if (!maxLength) maxLength = 30
+      if (!maxWidth) maxWidth = 25
+      if (!maxHeight) maxHeight = Math.max(3, totalQty * 2)
+    }
+
+    const input: CreateShipmentInput = {
+      reference_id: (order as any)?.id || fulfillment.id || "",
+      payment_mode: "prepaid",
+      pickup_location_name: "",
+      to: {
+        name:
+          `${shippingAddress.first_name || ""} ${shippingAddress.last_name || ""}`.trim() ||
+          "Customer",
+        phone: shippingAddress.phone || "",
+        email: (order as any)?.email || undefined,
+        address_1: shippingAddress.address_1 || "",
+        address_2: shippingAddress.address_2 || undefined,
+        city: shippingAddress.city || "",
+        state: shippingAddress.province || "",
+        pincode: shippingAddress.postal_code || "",
+        country: shippingAddress.country_code || "",
+      },
+      items: shipItems,
+      weight_grams: totalWeight,
+      dimensions_cm: { length: maxLength, width: maxWidth, height: maxHeight },
+      currency: (order as any)?.currency_code || "USD",
+    }
+
+    try {
+      const result = await this.client.createShipment(input)
+      this.logger.info(`ShipGlobal shipment created: awb=${result.awb}`)
+      return {
+        data: {
+          carrier: "shipglobal",
+          waybill: result.awb,
+          tracking_number: result.tracking_number,
+          ...result.provider_refs,
+          ...result.raw,
+        },
+        labels: result.awb
+          ? [
+              {
+                tracking_number: result.tracking_number,
+                tracking_url: result.tracking_url || "",
+                label_url: result.label_url || "",
+              },
+            ]
+          : [],
+      }
+    } catch (e: any) {
+      this.logger.error(`ShipGlobal createFulfillment error: ${e.message}`)
+      throw e
+    }
+  }
+
+  async cancelFulfillment(fulfillment: Record<string, any>): Promise<any> {
+    const waybill = fulfillment.data?.waybill || fulfillment.data?.tracking_number
+    if (!waybill) return {}
+    try {
+      return await this.client.cancelShipment({
+        awb: waybill,
+        provider_refs: { tracking: waybill },
+      })
+    } catch (e: any) {
+      this.logger.error(`ShipGlobal cancelFulfillment error: ${e.message}`)
+      throw e
+    }
+  }
+
+  async createReturnFulfillment(
+    _fulfillment: Record<string, any>
+  ): Promise<CreateFulfillmentResult> {
+    // ShipGlobal has no first-class return API op; a return is a fresh outbound
+    // shipment (createFulfillment again). Stub mirrors the other providers.
+    return { data: { carrier: "shipglobal", type: "return" }, labels: [] }
+  }
+
+  /** The label ShipGlobal produced at create/pay time. Prefer stored data, else
+   *  fetch fresh by tracking number. */
+  async getFulfillmentDocuments(data: Record<string, any>): Promise<any> {
+    const waybill = data?.waybill || data?.tracking_number
+    if (!waybill) return []
+    try {
+      const label = await this.client.getLabel({
+        awb: waybill,
+        provider_refs: { tracking: waybill },
+      })
+      if (!label.label_url && !label.data) return []
+      return [
+        {
+          name: "ShipGlobal label",
+          typeCode: "label",
+          contentType: label.format || "pdf",
+          content: label.data || "",
+          url: label.label_url || "",
+        },
+      ]
+    } catch (e: any) {
+      this.logger.warn(`ShipGlobal document retrieval failed for ${waybill}: ${e.message}`)
+      return []
+    }
+  }
+}
+
+export default ShipglobalFulfillmentService

--- a/apps/backend/src/modules/shipping-providers/shipglobal/stub-fetch.ts
+++ b/apps/backend/src/modules/shipping-providers/shipglobal/stub-fetch.ts
@@ -1,0 +1,152 @@
+/**
+ * Deterministic ShipGlobal transport for tests/CI.
+ *
+ * ShipGlobal has no sandbox — the account credentials are live, so an un-stubbed
+ * call would book a real, billable cross-border waybill. Mirroring Shiprocket's
+ * `stub-fetch.ts` (#647), the resolver injects this stub as the client's
+ * `fetchImpl` when `SHIPGLOBAL_STUB=1`, so the server uses canned responses
+ * regardless of the global fetch (which can't be reliably patched across the
+ * test ↔ in-process-server boundary).
+ *
+ * The canned shapes mirror the LIVE responses captured from the carrier
+ * (rate `services[]`, base64 PDF label, `awb_`-prefixed tracking fields).
+ */
+import type { FetchLike } from "./client"
+
+const json = (body: any, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }) as any
+
+/** The base64 prefix of a minimal 1-byte PDF ("%PDF-1.4\n"). Real labels are a
+ *  full PDF blob; tests only need to prove the base64 payload round-trips. */
+const STUB_LABEL = "JVBERi0xLjQK"
+
+/**
+ * Captures what the stub last received so integration specs can assert the exact
+ * payload the client would send to ShipGlobal (invoice/address split, item lines,
+ * rate body). Reset in a test's `beforeEach` when needed.
+ */
+export const shipglobalStubState: {
+  lastOrderBody?: any
+  lastRateBody?: any
+  lastLabelBody?: any
+  lastTrackBody?: any
+  lastCancelBody?: any
+  /** Override the tracking number order/add returns (default STUBSG123). */
+  awbOverride?: string
+} = {}
+
+const parseBody = (init: any): any => {
+  try {
+    return init?.body ? JSON.parse(init.body) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function createShipglobalStubFetch(): FetchLike {
+  return async (input: any, init?: any) => {
+    const url = String(input)
+    const awb = shipglobalStubState.awbOverride || "STUBSG123"
+
+    if (url.endsWith("/rates/calculate")) {
+      shipglobalStubState.lastRateBody = parseBody(init)
+      return json({
+        success: true,
+        billed_weight: 20,
+        billed_weight_unit: "GM",
+        currency: "INR",
+        services: [
+          {
+            title: "ShipGlobal Direct",
+            notes: "",
+            transit_time: "7-10 Days",
+            price: { logistic_fee: 285 },
+            subtotal_fee: 300,
+          },
+          {
+            title: "ShipGlobal First Class",
+            notes: "",
+            transit_time: "7-10 Days",
+            price: { logistic_fee: 311 },
+            subtotal_fee: 326,
+          },
+          {
+            title: "UPS",
+            notes: "Duties will be charged, if applicable.",
+            transit_time: "4 - 7 Days",
+            price: { logistic_fee: 2247 },
+            subtotal_fee: 2247,
+          },
+        ],
+      })
+    }
+
+    if (url.endsWith("/order/add")) {
+      shipglobalStubState.lastOrderBody = parseBody(init)
+      return json({ success: true, tracking: awb })
+    }
+
+    if (url.endsWith("/order/getLabel")) {
+      shipglobalStubState.lastLabelBody = parseBody(init)
+      return json({ success: true, tracking: awb, label: STUB_LABEL })
+    }
+
+    if (url.endsWith("/order/cancelRefundOrder")) {
+      shipglobalStubState.lastCancelBody = parseBody(init)
+      return json({ success: true })
+    }
+
+    if (url.endsWith("/tools/tracking")) {
+      shipglobalStubState.lastTrackBody = parseBody(init)
+      return json({
+        success: true,
+        data: {
+          awbEvents: [
+            {
+              awb_history_id: "4277696",
+              awb_id: 0,
+              awb_history_datetime: "2023-10-03 10:46:11",
+              awb_history_location: "San Jose, CA, US",
+              awb_history_comment: "DELIVERED ",
+              type: "lastmile",
+              awb_history_code: 0,
+              awb_event_code: "SGE_304",
+            },
+            {
+              awb_history_id: "4161152",
+              awb_id: 0,
+              awb_history_datetime: "2023-09-28 15:11:03",
+              awb_history_location: "Delhi, India",
+              awb_history_comment: "Shipment Created, Awaiting Package",
+              type: "domestic",
+              awb_history_code: 0,
+              awb_event_code: "SGE_001",
+            },
+          ],
+          awbInfo: {
+            awb_booking_date: "2023-09-28 15:11:03",
+            awb_sender_name: "linkers",
+            awb_destination: "US",
+            awb_receiver_name: "LINKERS Att Fulfilment Centre",
+            awb_number: awb,
+            partner_lastmile_awb: "XXXXXXXXXX",
+            awb_postcode: "11434",
+            provider_logo:
+              "https://app.shipglobal.in/assets/media/shipglobal/provider/sg.png",
+            partner_lastmile_display: "UPS",
+            partner_lastmile_tracking_url:
+              "https://www.ups.com/track?loc=en_US&requester=QUIC&tracknum=XXXXXXXXXX/trackdetails",
+            awb_status: "DELIVERED ",
+          },
+        },
+      })
+    }
+
+    return json({}, 404)
+  }
+}


### PR DESCRIPTION
## Summary

Integrates **ShipGlobal (shipglobal.in)** as a first-class carrier, mirroring the existing Shiprocket / Delhivery / DHL pattern. ShipGlobal is a cross-border courier (India → international) driven over HTTP Basic auth at `https://app.shipglobal.in/apiv1`.

### API surface (from the published Postman collection + live responses)

| Endpoint | Method | Purpose |
| --- | --- | --- |
| `/rates/calculate` | POST | `{ package_weight, country_iso_code_2, postcode }` → `services[]` |
| `/order/add` | POST | full order → returns `tracking` (SG…) |
| `/order/getLabel` | POST | `{ tracking, label: true }` → base64 PDF label |
| `/order/cancelRefundOrder` | POST | `{ tracking }` |
| `/tools/tracking` | POST | `{ tracking }` → `awbEvents[]` + `awbInfo` |

### What changed

- **`client.ts`** — `ShipglobalClient` implementing `ShippingProviderClient` (`getRates`, `createShipment`, `getLabel`, `track`, `cancelShipment`). Pure, unit-tested normalizers for the **live** response shapes (rate `services[]`, base64 label, `awb_`-prefixed tracking fields — the collection's camelCase field table was aspirational, the real API returns snake_case).
- **`service.ts`** — `ShipglobalFulfillmentService` (`identifier: "shipglobal"`) with `calculatePrice` + flat-fallback, `createFulfillment`, `cancelFulfillment`, `getFulfillmentDocuments`.
- **Wiring** — `CarrierId` + `SUPPORTED_CARRIERS` + resolver branch (`SHIPGLOBAL_USERNAME`/`SHIPGLOBAL_PASSWORD`), carrier-capabilities entry (international-only), `medusa-config.ts` + `medusa-config.prod.ts` registration, `.env.template`.
- Service code is region-specific (`sgdirecteuyun` EU / `sgdirectyungb` GB), configurable via `SHIPGLOBAL_SERVICE`.

### Testing

- 23 new unit tests (client + service).
- Full `shipping-providers` suite: 33 suites / 405 tests passing.
- `tsc --noEmit` clean for all touched files.
- Pre-push prod-config parity check passing.

### Notes / follow-ups

The `order/add` response shape was not included in the shared examples, so `createShipment` reads the tracking number defensively. If a sample `order/add` response is available, the extraction can be tightened.