### PR TITLE
feat(shipping): add ShipGlobal to the external-platforms settings form

### DIFF
--- a/apps/backend/src/admin/components/social-platforms/__tests__/api-config.unit.spec.ts
+++ b/apps/backend/src/admin/components/social-platforms/__tests__/api-config.unit.spec.ts
@@ -50,3 +50,54 @@ describe("inferAuthType — ai", () => {
     expect(inferAuthType("ai", undefined)).toBe("bearer")
   })
 })
+
+describe("buildApiConfig — shipping", () => {
+  it("builds the ShipGlobal Basic-auth blob (username/password/service)", () => {
+    const config = buildApiConfig("shipping", {
+      provider_type: "shipglobal",
+      mode: "live",
+      username: "ship@example.com",
+      password: "secret",
+      service: "sgdirecteuyun",
+    })
+    expect(config).toEqual({
+      provider: "shipglobal",
+      mode: "live",
+      username: "ship@example.com",
+      password: "secret",
+      service: "sgdirecteuyun",
+    })
+  })
+
+  it("omits a blank service code so the edit overlay keeps the stored value", () => {
+    const config = buildApiConfig("shipping", {
+      provider_type: "shipglobal",
+      username: "ship@example.com",
+      password: "secret",
+      service: "",
+    })
+    expect(config).not.toHaveProperty("service")
+    expect(config.username).toBe("ship@example.com")
+  })
+
+  it("still builds the Shiprocket email/password blob", () => {
+    const config = buildApiConfig("shipping", {
+      provider_type: "shiprocket",
+      email: "ship@example.com",
+      password: "secret",
+      pickup_location: "Primary",
+    })
+    expect(config.provider).toBe("shiprocket")
+    expect(config.email).toBe("ship@example.com")
+    expect(config).not.toHaveProperty("api_key")
+  })
+})
+
+describe("inferAuthType — shipping", () => {
+  it("uses basic auth for ShipGlobal and Shiprocket, api_key otherwise", () => {
+    expect(inferAuthType("shipping", "shipglobal")).toBe("basic")
+    expect(inferAuthType("shipping", "shiprocket")).toBe("basic")
+    expect(inferAuthType("shipping", "dhl")).toBe("api_key")
+    expect(inferAuthType("shipping", "delhivery")).toBe("api_key")
+  })
+})

--- a/apps/backend/src/admin/components/social-platforms/api-config.ts
+++ b/apps/backend/src/admin/components/social-platforms/api-config.ts
@@ -126,6 +126,15 @@ export function buildApiConfig(
           password: data.password,
           pickup_location: data.pickup_location,
         })
+      } else if (data.provider_type === "shipglobal") {
+        // ShipGlobal authenticates with username/password (HTTP Basic) and a
+        // region-specific service code (sgdirecteuyun EU / sgdirectyungb GB).
+        Object.assign(config, {
+          mode: data.mode || "test",
+          username: data.username,
+          password: data.password,
+          service: data.service,
+        })
       } else {
         Object.assign(config, {
           mode: data.mode || "test",
@@ -224,7 +233,9 @@ export function inferAuthType(category: string, providerType?: string): string {
     case "payment":
       return "api_key"
     case "shipping":
-      return providerType === "shiprocket" ? "basic" : "api_key"
+      return providerType === "shiprocket" || providerType === "shipglobal"
+        ? "basic"
+        : "api_key"
     case "analytics":
       return "api_key"
     case "storage":

--- a/apps/backend/src/admin/components/social-platforms/create-social-platform-component.tsx
+++ b/apps/backend/src/admin/components/social-platforms/create-social-platform-component.tsx
@@ -55,6 +55,7 @@ const CreateSocialPlatformSchema = z.object({
   account_number: z.string().optional(),
   email: z.string().optional(),
   pickup_location: z.string().optional(),
+  service: z.string().optional(),
   // Analytics fields
   tracking_id: z.string().optional(),
   project_token: z.string().optional(),
@@ -94,6 +95,10 @@ const CreateSocialPlatformSchema = z.object({
   if (data.category === "shipping" && data.provider_type === "shiprocket") {
     if (!data.email) ctx.addIssue({ code: "custom", path: ["email"], message: "Shiprocket account email is required" })
     if (!data.password) ctx.addIssue({ code: "custom", path: ["password"], message: "Shiprocket password is required" })
+  }
+  if (data.category === "shipping" && data.provider_type === "shipglobal") {
+    if (!data.username) ctx.addIssue({ code: "custom", path: ["username"], message: "ShipGlobal account email is required" })
+    if (!data.password) ctx.addIssue({ code: "custom", path: ["password"], message: "ShipGlobal password is required" })
   }
   if (data.category === "communication" && data.provider_type === "whatsapp") {
     if (!data.phone_number_id) ctx.addIssue({ code: "custom", path: ["phone_number_id"], message: "Phone Number ID is required" })

--- a/apps/backend/src/admin/components/social-platforms/shipping-provider-fields.tsx
+++ b/apps/backend/src/admin/components/social-platforms/shipping-provider-fields.tsx
@@ -3,7 +3,7 @@ import { type Control, type UseFormWatch } from "react-hook-form"
 import { Form } from "../common/form"
 
 export type ShippingProviderFieldValues = {
-  provider_type: "delhivery" | "shiprocket" | "dhl" | "fedex" | "ups" | "australia_post"
+  provider_type: "delhivery" | "shiprocket" | "dhl" | "fedex" | "ups" | "australia_post" | "shipglobal"
   api_key?: string
   account_number?: string
   api_secret?: string
@@ -13,6 +13,9 @@ export type ShippingProviderFieldValues = {
   email?: string
   password?: string
   pickup_location?: string
+  // ShipGlobal (username/password Basic auth + region-specific service code)
+  username?: string
+  service?: string
 }
 
 type ShippingProviderFieldsProps = {
@@ -35,6 +38,7 @@ export const ShippingProviderFields = ({
     fedex: { apiKey: "FedEx API key", account: "FedEx Account Number" },
     ups: { apiKey: "UPS Client ID", account: "UPS Account Number" },
     australia_post: { apiKey: "Australia Post API key", account: "Account Number" },
+    shipglobal: { apiKey: "n/a", account: "Service code (sgdirecteuyun / sgdirectyungb)" },
   }
 
   const current = placeholders[providerType] || placeholders.dhl
@@ -63,6 +67,7 @@ export const ShippingProviderFields = ({
                   <Select.Item value="fedex">FedEx</Select.Item>
                   <Select.Item value="ups">UPS</Select.Item>
                   <Select.Item value="australia_post">Australia Post</Select.Item>
+                  <Select.Item value="shipglobal">ShipGlobal</Select.Item>
                 </Select.Content>
               </Select>
             </Form.Control>
@@ -146,7 +151,60 @@ export const ShippingProviderFields = ({
         </>
       )}
 
-      {providerType && providerType !== "shiprocket" && (
+      {providerType === "shipglobal" && (
+        <>
+          <Form.Field
+            control={control}
+            name="username"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Account Email / Username</Form.Label>
+                <Form.Control>
+                  <Input {...field} type="email" placeholder="ShipGlobal account email" />
+                </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={control}
+            name="password"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>
+                  Password
+                  {isEditing && (
+                    <span className="text-ui-fg-subtle ml-1">
+                      (leave blank to keep existing)
+                    </span>
+                  )}
+                </Form.Label>
+                <Form.Control>
+                  <Input {...field} type="password" placeholder="ShipGlobal password" />
+                </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={control}
+            name="service"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label optional>Service Code</Form.Label>
+                <Form.Control>
+                  <Input {...field} placeholder={current.account} />
+                </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+        </>
+      )}
+
+      {providerType && providerType !== "shiprocket" && providerType !== "shipglobal" && (
         <>
           <Form.Field
             control={control}


### PR DESCRIPTION
## Summary

Adds **ShipGlobal** as a selectable carrier in **Settings → External Platforms → Create/Edit**, so the ShipGlobal account can be configured via the `SocialPlatform` store (encrypted secrets) instead of env vars.

This is the admin-side companion to the ShipGlobal carrier provider. The carrier resolver already reads ShipGlobal credentials from the `category: "shipping"` platform record (`username` / `password` / `service`), so configuring a platform row here is what activates the carrier — `SHIPGLOBAL_*` env vars remain only a fallback.

## Changes

- **`shipping-provider-fields.tsx`** — new `ShipGlobal` carrier option with **Account Email / Username**, **Password**, and **Service Code** (`sgdirecteuyun` EU / `sgdirectyungb` GB) fields. ShipGlobal is excluded from the generic API-key field block (it uses HTTP Basic auth).
- **`api-config.ts`** — `buildApiConfig("shipping")` emits `{ provider: "shipglobal", mode, username, password, service }`; `inferAuthType` returns `basic` for ShipGlobal (and Shiprocket).
- **`create-social-platform-component.tsx`** — ShipGlobal username/password validation.
- **`__tests__/api-config.unit.spec.ts`** — 4 new tests for the ShipGlobal config blob, blank-service omission, and auth-type inference.

## Testing

- `social-platforms` unit suites: 4 suites / 35 tests passing.
- `tsc --noEmit` adds no new errors (pre-existing `Control`-generic errors in `create-social-platform-component.tsx` are unchanged at HEAD).