### PR TITLE
feat(consumption): edit + retire a consumption log, with an ops audit row

### DIFF
--- a/apps/backend/integration-tests/http/design-consumption-log-edit.spec.ts
+++ b/apps/backend/integration-tests/http/design-consumption-log-edit.spec.ts
@@ -1,0 +1,169 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+import { CONSUMPTION_LOG_MODULE } from "../../src/modules/consumption_log"
+import { OPS_AUDIT_MODULE } from "../../src/modules/ops_audit"
+
+jest.setTimeout(180 * 1000)
+
+/**
+ * Correcting a consumption log.
+ *
+ * ## Why this route had to exist
+ *
+ * There was no edit path. The design and run consumption routes are POST + GET;
+ * `updateConsumptionLogs` was reachable only from the commit flow and two ops
+ * jobs. So the figure that decides BOTH stock deduction and design cost could
+ * be recorded wrong and then only ever added to.
+ *
+ * 🔴 The case that surfaced it: one garment cut from muslin (2 m) and two from
+ * kala cotton (2 m each) — 6 m over 3 pieces — recorded as two `per_piece`
+ * logs of 2. `per_piece × pieces` applies ONE piece count to EVERY material,
+ * so applying those would have deducted 2×3 and 2×3 = 12 m. Exactly double,
+ * and silently, because nothing in the pipeline compares a deduction to what
+ * anyone believed was used.
+ */
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("PATCH/DELETE /admin/designs/:id/consumption-logs/:logId", () => {
+    let headers: any
+    let designId: string
+
+    const logs = () => getContainer().resolve(CONSUMPTION_LOG_MODULE) as any
+
+    const seedLog = async (over: Record<string, any> = {}) =>
+      await logs().createConsumptionLogs({
+        design_id: designId,
+        inventory_item_id: `iitem_${Date.now()}${Math.floor(Math.random() * 1e5)}`,
+        quantity: 2,
+        quantity_basis: "per_piece",
+        unit_of_measure: "Meter",
+        consumption_type: "sample",
+        is_committed: true,
+        consumed_by: "admin",
+        consumed_at: new Date(),
+        ...over,
+      })
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      headers = await getAuthHeaders(api)
+
+      const designs: any = container.resolve(DESIGN_MODULE)
+      const design = await designs.createDesigns({
+        name: `Consumption Edit ${Date.now()}`,
+        description: "fixture",
+        design_type: "Custom",
+        status: "Conceptual",
+      })
+      designId = (Array.isArray(design) ? design[0] : design).id
+    })
+
+    it("🔴 corrects a per_piece basis to total — the multiple, not the magnitude", async () => {
+      const log = await seedLog({ quantity: 2, quantity_basis: "per_piece" })
+
+      const res = await api.patch(
+        `/admin/designs/${designId}/consumption-logs/${log.id}`,
+        { quantity: 4, quantity_basis: "total" },
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.consumption_log.quantity).toBe(4)
+      expect(res.data.consumption_log.quantity_basis).toBe("total")
+
+      // Read back from the service, not the echo — a 200 that echoes the
+      // request body proves nothing about what was stored.
+      const fresh = await logs().retrieveConsumptionLog(log.id)
+      expect(Number(fresh.quantity)).toBe(4)
+      expect(fresh.quantity_basis).toBe("total")
+    })
+
+    it("🔴 REFUSES a log whose stock movement already happened", async () => {
+      const log = await seedLog({
+        inventory_applied_at: new Date(),
+      })
+
+      const err = await api
+        .patch(
+          `/admin/designs/${designId}/consumption-logs/${log.id}`,
+          { quantity: 99 },
+          headers
+        )
+        .catch((e: any) => e.response)
+
+      // Once stock has moved the number describes a decrement that occurred.
+      // Editing it leaves the log and the stock level disagreeing with nothing
+      // to reconcile them — that needs a reversing entry, not an edit.
+      expect(err.status).toBe(400)
+      expect(String(err.data?.message ?? "")).toMatch(/reversing entry/i)
+
+      const fresh = await logs().retrieveConsumptionLog(log.id)
+      expect(Number(fresh.quantity)).toBe(2)
+    })
+
+    it("🔴 refuses a log belonging to another design", async () => {
+      const designs: any = getContainer().resolve(DESIGN_MODULE)
+      const other = await designs.createDesigns({
+        name: `Other ${Date.now()}`,
+        description: "fixture",
+        design_type: "Custom",
+        status: "Conceptual",
+      })
+      const otherId = (Array.isArray(other) ? other[0] : other).id
+      const log = await seedLog()
+
+      // Without the ownership check a log is editable through ANY design's URL.
+      const err = await api
+        .patch(
+          `/admin/designs/${otherId}/consumption-logs/${log.id}`,
+          { quantity: 9 },
+          headers
+        )
+        .catch((e: any) => e.response)
+
+      expect(err.status).toBe(404)
+    })
+
+    it("refuses an empty correction rather than silently no-opping", async () => {
+      const log = await seedLog()
+      const err = await api
+        .patch(`/admin/designs/${designId}/consumption-logs/${log.id}`, {}, headers)
+        .catch((e: any) => e.response)
+
+      expect(err.status).toBe(400)
+    })
+
+    it("retires a duplicate, and writes an ops audit row carrying before/after", async () => {
+      const log = await seedLog({ quantity: 2 })
+
+      const res = await api.delete(
+        `/admin/designs/${designId}/consumption-logs/${log.id}`,
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.deleted).toBe(true)
+
+      const gone = await logs().retrieveConsumptionLog(log.id).catch(() => null)
+      expect(gone).toBeNull()
+
+      // 🔑 A corrected material figure must be traceable to who changed it and
+      // from what — that is the whole reason an edit path is safe to have.
+      const audit: any = getContainer().resolve(OPS_AUDIT_MODULE)
+      const [rows] = await audit.listAndCountOpsMaintenanceRuns(
+        { job_id: "admin.consumption-log.delete" },
+        { order: { created_at: "DESC" }, take: 5 }
+      )
+      const mine = (rows ?? []).find(
+        (r: any) => r.params?.consumption_log_id === log.id
+      )
+      expect(mine).toBeTruthy()
+      expect(mine.applied).toBe(true)
+      expect(mine.changes?.[0]?.before?.id).toBe(log.id)
+      expect(mine.changes?.[0]?.after).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/admin/components/designs/design-consumption-logs-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-consumption-logs-section.tsx
@@ -22,6 +22,8 @@ import {
   useDesignInventory,
   useLogConsumption,
   useCommitConsumption,
+  useUpdateConsumptionLog,
+  useDeleteConsumptionLog,
 } from "../../hooks/api/designs"
 
 interface DesignConsumptionLogsSectionProps {
@@ -65,6 +67,62 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
   const { data: inventoryData } = useDesignInventory(design.id)
   const { mutateAsync: logConsumption, isPending: isLogging } = useLogConsumption(design.id)
   const { mutateAsync: commitConsumption, isPending: isCommitting } = useCommitConsumption(design.id)
+  const { mutateAsync: updateLog } = useUpdateConsumptionLog(design.id)
+  const { mutateAsync: deleteLog } = useDeleteConsumptionLog(design.id)
+
+  /** The log being corrected, plus the two fields worth correcting. */
+  const [editing, setEditing] = useState<ConsumptionLog | null>(null)
+  const [editQuantity, setEditQuantity] = useState("")
+  const [editBasis, setEditBasis] = useState<"total" | "per_piece">("total")
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState<string | null>(null)
+
+  const beginEdit = (log: ConsumptionLog) => {
+    setEditing(log)
+    setEditQuantity(String(log.quantity ?? ""))
+    // An unset basis opens on "total" — the reading that does NOT multiply, so
+    // an operator who saves without thinking cannot silently inflate a
+    // deduction by the piece count.
+    setEditBasis(log.quantity_basis === "per_piece" ? "per_piece" : "total")
+  }
+
+  const handleSaveEdit = async () => {
+    if (!editing) return
+    const quantity = parseFloat(editQuantity)
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      toast.error("Quantity must be a positive number")
+      return
+    }
+    setSaving(true)
+    try {
+      await updateLog({ logId: editing.id, quantity, quantity_basis: editBasis })
+      toast.success(
+        `Corrected to ${quantity} ${editing.unit_of_measure} (${editBasis === "per_piece" ? "per piece" : "total"})`
+      )
+      setEditing(null)
+    } catch (e: any) {
+      toast.error(e?.message ?? "Could not correct this log")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (log: ConsumptionLog) => {
+    const ok = await prompt({
+      title: "Retire this consumption log?",
+      description: `${log.quantity} ${log.unit_of_measure} will no longer count towards stock deduction or design cost. An audit row records who retired it.`,
+    })
+    if (!ok) return
+    setDeleting(log.id)
+    try {
+      await deleteLog(log.id)
+      toast.success("Consumption log retired")
+    } catch (e: any) {
+      toast.error(e?.message ?? "Could not retire this log")
+    } finally {
+      setDeleting(null)
+    }
+  }
 
   const logs: ConsumptionLog[] = logsData?.logs || []
   const inventoryItems: LinkedInventoryItem[] = inventoryData?.inventory_items || []
@@ -389,6 +447,24 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                       ) : (
                         <Badge size="2xsmall" color="grey">pending</Badge>
                       )}
+                      {/*
+                        🔴 What the quantity MEASURES, which decides the number
+                        by a multiple: `q` under total, `q × pieces` under
+                        per-piece. It was rendered nowhere, so "2 Meter" could
+                        deduct 2 or 6 and this row looked the same either way.
+                        An unset basis is called out in red because it is not a
+                        default — the apply job refuses to guess and skips.
+                      */}
+                      {log.quantity_basis === "per_piece" ? (
+                        <Badge size="2xsmall" color="orange">per piece</Badge>
+                      ) : log.quantity_basis === "total" ? (
+                        <Badge size="2xsmall" color="blue">total</Badge>
+                      ) : (
+                        <Badge size="2xsmall" color="red">basis unset</Badge>
+                      )}
+                      {log.inventory_applied_at && (
+                        <Badge size="2xsmall" color="purple">stock applied</Badge>
+                      )}
                     </div>
                     <Text size="xsmall" className="text-ui-fg-subtle">
                       {getInventoryLabel(log.inventory_item_id)}
@@ -406,6 +482,34 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                     <Text size="xsmall" className="text-ui-fg-muted">
                       {formatDate(log.consumed_at)}
                     </Text>
+                    {/*
+                      Correcting a log was impossible from anywhere — the API
+                      had no edit path, so a wrong quantity or basis could only
+                      be added to. Hidden once the stock movement has happened:
+                      past that point the number describes a decrement that
+                      occurred, and it takes a reversing entry, not an edit.
+                    */}
+                    {!log.inventory_applied_at && (
+                      <div className="mt-1 flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => beginEdit(log)}
+                          className="text-[11px] text-ui-fg-interactive hover:underline"
+                          data-testid={`consumption-log-edit-${log.id}`}
+                        >
+                          Correct
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(log)}
+                          disabled={deleting === log.id}
+                          className="text-[11px] text-ui-fg-error hover:underline disabled:opacity-50"
+                          data-testid={`consumption-log-delete-${log.id}`}
+                        >
+                          {deleting === log.id ? "Retiring…" : "Retire"}
+                        </button>
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>
@@ -413,6 +517,86 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
           )}
         </div>
       )}
+
+      {/*
+        Correcting a log. Quantity and basis only — everything else identifies
+        the log rather than measuring it.
+
+        🔑 The basis selector spells out what each option DOES, because the
+        difference is a multiple and the words "total" and "per piece" do not
+        make that obvious on their own. This is the field that would have
+        deducted 12 m where 6 m was used.
+      */}
+      <Drawer open={!!editing} onOpenChange={(o) => !o && setEditing(null)}>
+        <Drawer.Content>
+          <Drawer.Header>
+            <Drawer.Title>Correct consumption</Drawer.Title>
+          </Drawer.Header>
+          <Drawer.Body className="flex flex-col gap-4">
+            {editing && (
+              <>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {getInventoryLabel(editing.inventory_item_id)} ·{" "}
+                  {editing.consumption_type} · logged by {editing.consumed_by}
+                </Text>
+
+                <div className="flex flex-col gap-1">
+                  <Text size="small" weight="plus">
+                    Quantity ({editing.unit_of_measure})
+                  </Text>
+                  <Input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={editQuantity}
+                    onChange={(e) => setEditQuantity(e.target.value)}
+                    data-testid="consumption-log-edit-quantity"
+                  />
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <Text size="small" weight="plus">
+                    What does that measure?
+                  </Text>
+                  <Select
+                    value={editBasis}
+                    onValueChange={(v) => setEditBasis(v as "total" | "per_piece")}
+                  >
+                    <Select.Trigger data-testid="consumption-log-edit-basis">
+                      <Select.Value />
+                    </Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="total">
+                        Total — deduct this much, once
+                      </Select.Item>
+                      <Select.Item value="per_piece">
+                        Per piece — multiply by the pieces produced
+                      </Select.Item>
+                    </Select.Content>
+                  </Select>
+                  <Text size="xsmall" className="text-ui-fg-muted">
+                    {editBasis === "per_piece"
+                      ? "Only correct when EVERY piece uses this material. A run where one garment used one fabric and the rest another is not per-piece — record each material's own total."
+                      : "Deducts exactly this amount when the stock movement is applied."}
+                  </Text>
+                </div>
+              </>
+            )}
+          </Drawer.Body>
+          <Drawer.Footer>
+            <Button variant="secondary" onClick={() => setEditing(null)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSaveEdit}
+              isLoading={saving}
+              data-testid="consumption-log-edit-save"
+            >
+              Save correction
+            </Button>
+          </Drawer.Footer>
+        </Drawer.Content>
+      </Drawer>
     </Container>
   )
 }

--- a/apps/backend/src/admin/hooks/api/designs.ts
+++ b/apps/backend/src/admin/hooks/api/designs.ts
@@ -1387,6 +1387,20 @@ export interface ConsumptionLog {
   notes?: string | null;
   location_id?: string | null;
   metadata?: Record<string, any> | null;
+  /**
+   * 🔴 What `quantity` MEASURES — and it was declared nowhere and rendered
+   * nowhere. The same figure deducts `q` under "total" and `q × pieces` under
+   * "per_piece", so a row reading "2 Meter" could mean 2 or 6 and the screen
+   * looked identical either way. On the design that surfaced this, two
+   * `per_piece` logs of 2 would have deducted 12 m where 6 m was used.
+   */
+  quantity_basis?: "total" | "per_piece" | null;
+  /**
+   * Set once the stock movement actually happened. A log past this point is
+   * frozen — the number then describes a decrement that occurred, so it takes
+   * a reversing entry rather than an edit.
+   */
+  inventory_applied_at?: string | null;
   created_at?: string;
   updated_at?: string;
 }
@@ -1452,6 +1466,61 @@ export const useLogConsumption = (
       sdk.client.fetch<{ consumption_log: ConsumptionLog }>(
         `/admin/designs/${designId}/consumption-logs`,
         { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: designQueryKeys.detail(designId) })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+/**
+ * Correct one consumption log, or retire a duplicate.
+ *
+ * There was no edit path at all — the routes were POST + GET — so the figure
+ * that decides both stock deduction and design cost could only ever be added
+ * to. The server refuses a log already applied to stock and writes an ops
+ * audit row carrying before/after for every write.
+ */
+export const useUpdateConsumptionLog = (
+  designId: string,
+  options?: UseMutationOptions<
+    { consumption_log: ConsumptionLog },
+    FetchError,
+    { logId: string } & Partial<
+      Pick<
+        ConsumptionLog,
+        "quantity" | "quantity_basis" | "unit_cost" | "notes" | "location_id"
+      >
+    >
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ logId, ...body }) =>
+      sdk.client.fetch<{ consumption_log: ConsumptionLog }>(
+        `/admin/designs/${designId}/consumption-logs/${logId}`,
+        { method: "PATCH", body }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: designQueryKeys.detail(designId) })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+export const useDeleteConsumptionLog = (
+  designId: string,
+  options?: UseMutationOptions<{ deleted: boolean }, FetchError, string>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (logId: string) =>
+      sdk.client.fetch<{ deleted: boolean }>(
+        `/admin/designs/${designId}/consumption-logs/${logId}`,
+        { method: "DELETE" }
       ),
     onSuccess: (data, variables, _mutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: designQueryKeys.detail(designId) })

--- a/apps/backend/src/api/admin/designs/[id]/consumption-logs/[logId]/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/consumption-logs/[logId]/route.ts
@@ -1,0 +1,159 @@
+/**
+ * Correct or retire one consumption log.
+ *
+ *   PATCH  /admin/designs/:id/consumption-logs/:logId
+ *   DELETE /admin/designs/:id/consumption-logs/:logId
+ *
+ * ## Why this exists
+ *
+ * There was no way to fix a consumption log. `/admin/designs/:id/
+ * consumption-logs` is POST and GET; the run-level route is the same;
+ * `updateConsumptionLogs` was reachable only from the commit flow and two ops
+ * jobs. So a wrong material quantity — the figure that decides stock deduction
+ * AND design cost — could be recorded and then only ever added to.
+ *
+ * Found on a real design: three logs, one of them a duplicate of another, and
+ * two carrying a `per_piece` basis that could not express what happened. One
+ * garment was cut from muslin (2 m) and two from kala cotton (2 m each) — 6 m
+ * over 3 pieces. `per_piece × pieces` applies ONE piece count to EVERY
+ * material, so those logs would have deducted 2×3 and 2×3 = 12 m: exactly
+ * double, silently, the first time anyone applied them.
+ *
+ * ## 🔴 What it refuses
+ *
+ * A log whose stock movement has already happened (`inventory_applied_at`
+ * set) is NOT editable. At that point the number is not a claim about the
+ * world, it is a description of a decrement that occurred — editing it would
+ * leave the log and the stock level disagreeing with nothing to reconcile
+ * them. That needs a reversing entry, which is a different operation and a
+ * deliberate one.
+ *
+ * Every write lands an `ops_maintenance_run` audit row carrying the BEFORE and
+ * AFTER, so a corrected number can always be traced to who changed it and from
+ * what. Best-effort, exactly as the maintenance-job route treats it: the
+ * correction already happened, so an audit failure must not fail the request.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+
+import { CONSUMPTION_LOG_MODULE } from "../../../../../../modules/consumption_log"
+import { OPS_AUDIT_MODULE } from "../../../../../../modules/ops_audit"
+
+/** The fields a correction may touch. Everything else identifies the log. */
+const EDITABLE = ["quantity", "quantity_basis", "unit_cost", "notes", "location_id"] as const
+
+const loadOwnedLog = async (
+  req: MedusaRequest,
+  designId: string,
+  logId: string
+) => {
+  const service: any = req.scope.resolve(CONSUMPTION_LOG_MODULE)
+  const log = await service.retrieveConsumptionLog(logId).catch(() => null)
+
+  // 🔴 Ownership, not just existence — the design id in the path must be the
+  // one the log belongs to, or a log could be edited through any design's URL.
+  if (!log || log.design_id !== designId) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Consumption log not found")
+  }
+  return { service, log }
+}
+
+const assertNotApplied = (log: any) => {
+  const applied = log.inventory_applied_at ?? log.metadata?.inventory_applied_at
+  if (applied) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This log's stock movement has already been applied — correct it with a reversing entry, not an edit."
+    )
+  }
+}
+
+const audit = async (
+  req: MedusaRequest,
+  input: { action: string; before: any; after: any; summary: string }
+) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const actorId = (req as any).auth_context?.actor_id ?? "unknown"
+
+  logger.info(
+    `[consumption-log] actor=${actorId} ${input.action} log=${input.before?.id} ${input.summary}`
+  )
+
+  try {
+    const store: any = req.scope.resolve(OPS_AUDIT_MODULE)
+    await store.createOpsMaintenanceRuns({
+      job_id: `admin.${input.action}`,
+      actor_id: actorId,
+      dry_run: false,
+      applied: true,
+      change_count: 1,
+      error_count: 0,
+      summary: input.summary,
+      params: { consumption_log_id: input.before?.id, design_id: input.before?.design_id },
+      changes: [{ before: input.before, after: input.after }],
+      errors: [],
+    })
+  } catch (e: any) {
+    // The correction already happened; losing the audit row must not fail it.
+    logger.error(`[consumption-log] audit persist failed: ${e?.message ?? e}`)
+  }
+}
+
+export const PATCH = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: designId, logId } = req.params
+  const { service, log } = await loadOwnedLog(req, designId, logId)
+  assertNotApplied(log)
+
+  const body = (req.validatedBody ?? req.body ?? {}) as Record<string, any>
+  const update: Record<string, any> = {}
+  for (const field of EDITABLE) {
+    if (body[field] !== undefined) update[field] = body[field]
+  }
+
+  if (!Object.keys(update).length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Nothing to change — pass one of: ${EDITABLE.join(", ")}.`
+    )
+  }
+
+  /**
+   * ⚠️ `quantity_basis` is the field this route mostly exists for, and it is
+   * the one that changes MEANING rather than magnitude: the same `quantity`
+   * deducts `q` under "total" and `q × pieces` under "per_piece". A correction
+   * that sets it is not a tidy-up.
+   */
+  await service.updateConsumptionLogs({ id: logId, ...update })
+  const after = await service.retrieveConsumptionLog(logId)
+
+  await audit(req, {
+    action: "consumption-log.edit",
+    before: log,
+    after,
+    summary: Object.keys(update)
+      .map((k) => `${k}: ${JSON.stringify((log as any)[k])} → ${JSON.stringify(update[k])}`)
+      .join("; "),
+  })
+
+  res.json({ consumption_log: after })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: designId, logId } = req.params
+  const { service, log } = await loadOwnedLog(req, designId, logId)
+  assertNotApplied(log)
+
+  await service.deleteConsumptionLogs(logId)
+
+  await audit(req, {
+    action: "consumption-log.delete",
+    before: log,
+    after: null,
+    summary: `retired ${log.quantity} ${log.unit_of_measure} of ${log.inventory_item_id ?? log.consumption_type}`,
+  })
+
+  res.status(200).json({ id: logId, object: "consumption_log", deleted: true })
+}

--- a/apps/backend/src/api/admin/designs/[id]/consumption-logs/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/consumption-logs/validators.ts
@@ -47,3 +47,29 @@ export const AdminPostCommitConsumptionReq = z.object({
 })
 
 export type AdminPostCommitConsumptionReq = z.infer<typeof AdminPostCommitConsumptionReq>
+
+/**
+ * Correcting an existing log (PATCH). Every field optional — the route refuses
+ * an empty body rather than silently no-opping.
+ *
+ * 🔴 `quantity_basis` is the reason this exists. The same `quantity` deducts
+ * `q` under "total" and `q × pieces` under "per_piece", so a log recorded with
+ * the wrong basis is not slightly wrong, it is wrong by a multiple. On the
+ * design that prompted this, two `per_piece` logs would have deducted 12 m
+ * where 6 m was used.
+ *
+ * `quantity` is `.positive()` for the same reason the create schema is: a 0
+ * consumption is not a correction, it is a deletion wearing a disguise — and
+ * DELETE exists for that, with its own audit line.
+ */
+export const AdminPatchConsumptionLogReq = z.object({
+  quantity: z.number().positive().optional(),
+  quantity_basis: z.enum(["total", "per_piece"]).nullish(),
+  unit_cost: z.number().nonnegative().nullish(),
+  notes: z.string().max(2000).nullish(),
+  location_id: z.string().trim().min(1).nullish(),
+})
+
+export type AdminPatchConsumptionLogReq = z.infer<
+  typeof AdminPatchConsumptionLogReq
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -179,7 +179,7 @@ import {
 } from "./admin/websites/[id]/pages/validators";
 import { createBlocksSchema, ReadBlocksQuerySchema, updateBlockSchema } from "./admin/websites/[id]/pages/[pageId]/blocks/validators";
 import { AdminPostDesignInventoryReq, AdminDeleteDesignInventoryReq } from "./admin/designs/[id]/inventory/validators";
-import { AdminPostConsumptionLogReq, AdminPostCommitConsumptionReq } from "./admin/designs/[id]/consumption-logs/validators";
+import { AdminPostConsumptionLogReq, AdminPostCommitConsumptionReq, AdminPatchConsumptionLogReq } from "./admin/designs/[id]/consumption-logs/validators";
 import { AdminPostRunConsumptionLogReq, AdminPostRunCommitConsumptionReq } from "./admin/production-runs/[id]/consumption-logs/validators";
 import { AdminAttachSubmissionDocumentsReq } from "./admin/payment-submissions/[id]/documents/validators";
 import { AdminPostDesignInquiryReq, AdminPostDesignInquiryPreviewReq, AdminPostCloseDesignInquiryReq } from "./admin/designs/[id]/inquiries/validators";
@@ -4562,6 +4562,23 @@ export default defineMiddlewares({
       matcher: "/admin/designs/:id/consumption-logs",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminPostConsumptionLogReq))],
+    },
+    {
+      /**
+       * Correct one consumption log. There was no edit path at all — the
+       * figure that decides stock deduction AND design cost could only ever be
+       * added to, so a `per_piece` basis recorded where `total` was meant
+       * stayed wrong by a multiple. Refuses a log already applied to stock.
+       */
+      matcher: "/admin/designs/:id/consumption-logs/:logId",
+      method: "PATCH",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminPatchConsumptionLogReq))],
+    },
+    {
+      // Retire a duplicate. Same applied-to-stock refusal, same audit row.
+      matcher: "/admin/designs/:id/consumption-logs/:logId",
+      method: "DELETE",
+      middlewares: [],
     },
 
     // #1531 — spec-driven capability inquiries.


### PR DESCRIPTION
There was **no way to fix a consumption log**. The design and run routes are POST + GET; `updateConsumptionLogs` was reachable only from the commit flow and two ops jobs. So the figure that decides **both stock deduction and design cost** could be recorded wrong and then only ever added to.

## The case that surfaced it

One design, three logs. One garment cut from muslin (2 m), two from kala cotton (2 m each) — **6 m across 3 pieces**. Recorded as two `per_piece` logs of 2, plus a third duplicating part of the kala consumption.

`per_piece` resolves as `quantity × pieces`, applying **one** piece count to **every** material. It cannot express "one of the three pieces used a different fabric". Applying those logs would have deducted 2×3 and 2×3 = **12 m where 6 m was used** — exactly double, silently, because nothing compares a deduction against what anyone believed was used.

The correct record is two `total` logs (2 and 4) with the duplicate retired. **None of those three edits was possible.**

## What this adds

- `PATCH /admin/designs/:id/consumption-logs/:logId` — quantity, basis, unit cost, notes, location
- `DELETE` on the same path — retire a duplicate
- Both write an `ops_maintenance_run` audit row carrying **before and after**

## 🔴 What it refuses

A log whose stock movement already happened (`inventory_applied_at`) is **not editable**. Past that point the number describes a decrement that occurred — editing it leaves the log and the stock level disagreeing with nothing to reconcile them. That needs a reversing entry.

Ownership is checked: the design in the path must own the log, or a log is editable through any design's URL.

## UI

`quantity_basis` was declared on **no client type and rendered nowhere** — a row reading "2 Meter" could deduct 2 or 6 and the screen looked identical. Now a badge on every row, with an unset basis in **red** (the apply job refuses to guess and skips those). `inventory_applied_at` shows as "stock applied" and hides the actions.

The basis selector says what each option **does** rather than naming it, and warns against per-piece for exactly the split that caused this. An unset basis opens on "total" — the reading that does not multiply.

## Tests

5 integration tests: basis correction, applied-to-stock refusal, cross-design refusal, empty-body refusal, and the audit row's before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4