### PR TITLE
test(e2e): the payout screen OFFERS a partly-billed run's remainder

### DIFF
--- a/e2e/specs/payment-submission-payable-runs.spec.ts
+++ b/e2e/specs/payment-submission-payable-runs.spec.ts
@@ -257,16 +257,72 @@ test.describe("Payment submission from production runs (#1556)", () => {
      */
   })
 
-  test("refuses to offer a run that has already been paid for", async ({
+  /**
+   * 🔴 This case used to assert that billing a run ONCE retired it — "refuses to
+   * offer a run that has already been paid for", expecting the row to read
+   * "paid" with a disabled checkbox.
+   *
+   * That was true, and it was the bug. The screen hid a run behind `!r.billed`
+   * in three places, so a run billed for SOME of its quantity vanished and its
+   * REMAINDER could never be claimed — #1596's own case was unreachable from
+   * the screen payouts are made on. #1682 fixed it, and this assertion went red
+   * the first time these specs actually ran.
+   *
+   * The previous case bills 7 of 9. So the run is PARTLY billed, and the right
+   * assertion is the opposite of the old one: it is still offered, with 2 left.
+   * Then billing those 2 is what retires it — which is the behaviour worth
+   * covering, and the half the old spec could never reach.
+   */
+  test("offers a partly-billed run's REMAINDER, and retires it once that is billed", async ({
     page,
   }) => {
     await login(page)
     await openCreateForPartner(page)
 
-    // Depends on the previous case having created the payout against it.
+    // Depends on the previous case having billed 7 of this run's 9.
     const row = runRow(page, seed.billableRunId)
     await expect(row).toBeVisible({ timeout: 15000 })
-    await expect(row).toContainText("paid")
-    await expect(row.getByRole("checkbox")).toBeDisabled()
+
+    // Still offered, and it says how much is left rather than hiding the run.
+    await expect(row).toContainText("2 left")
+    await expect(row.getByRole("checkbox")).toBeEnabled()
+
+    await row.getByRole("checkbox").click()
+
+    /**
+     * The quantity box opens on the REMAINDER, not on the produced quantity —
+     * offering 4 again on a run with 2 left is how a double-bill starts.
+     */
+    await expect(qtyBox(row)).toHaveValue("2", { timeout: 10000 })
+
+    const total = page.getByTestId("submission-total")
+    await expect(total).toHaveText("INR 2,400", { timeout: 10000 })
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r: any) =>
+          r.url().includes("/admin/payment-submissions") &&
+          r.request().method() === "POST"
+      ),
+      page.getByRole("button", { name: /Create Submission/i }).click(),
+    ])
+    expect(response.status()).toBeLessThan(400)
+
+    await page.waitForURL(
+      /\/app\/payment-submissions\/(?!create$)[^/]+$/,
+      { timeout: 20000 }
+    )
+
+    /**
+     * NOW it is wholly billed, and only now does the original assertion hold.
+     * "paid" and "N left" are different badges on different statuses — `billed`
+     * renders the first, `partly_billed` the second — so this asserts the state
+     * positively rather than by the absence of the other.
+     */
+    await openCreateForPartner(page)
+    const settled = runRow(page, seed.billableRunId)
+    await expect(settled).toBeVisible({ timeout: 15000 })
+    await expect(settled).toContainText("paid")
+    await expect(settled.getByRole("checkbox")).toBeDisabled()
   })
 })


### PR DESCRIPTION
`payment-submission-payable-runs.spec.ts:269` has been **red on `main` and on every PR since #1682 merged** — including PRs that touch nothing near it. #1688 is currently blocked by it.

The case asserted that billing a run once retired it — *"refuses to offer a run that has already been paid for"*, expecting `paid` and a disabled checkbox.

## 🔴 That was true, and it was the bug

The screen hid a run behind `!r.billed` in three places, so a run billed for **some** of its quantity vanished and its **remainder** could never be claimed — #1596's own case was unreachable from the screen payouts are actually made on. #1682 fixed it, and this assertion went red the first time these specs ever ran. Per the #352 handoffs they had been rewritten and never executed; the e2e job overwrites `.env`, so nobody could run them locally either.

The preceding case bills **7 of 9**. So the run is partly billed, and the correct assertion is the opposite of the old one.

## What it covers now

- partly billed → **still offered**, "2 left", checkbox **enabled**
- the Qty box opens on the **remainder** (2), not the produced quantity — offering 4 again on a run with 2 left is how a double-bill starts
- billing the remainder → the run reads **"paid"** and is disabled

## Grounded, not guessed

These specs can't be run locally, so every assertion was checked against the component:

- `getRunQuantity` returns `billable_remaining` when a run is partly billed and the remainder is smaller than the payable quantity → the box holds **2**
- the `"N left"` badge renders **only** for `billing_status === "partly_billed"`; `billed` renders `"paid"`. Different badges on different statuses — so the final state is asserted **positively** as "paid" rather than as the absence of "left", which would have required not-rendering a "0 left" that never exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4