### PR TITLE
feat(textile): a library screen and a backfill — the module gets a human

### DIFF
--- a/apps/backend/src/admin/routes/textile-analyses/page.tsx
+++ b/apps/backend/src/admin/routes/textile-analyses/page.tsx
@@ -1,0 +1,280 @@
+import { useMemo, useState } from "react"
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { Swatch } from "@medusajs/icons"
+import {
+  Badge,
+  Container,
+  Heading,
+  Input,
+  Select,
+  Skeleton,
+  Text,
+} from "@medusajs/ui"
+import { useQuery } from "@tanstack/react-query"
+import { sdk } from "../../lib/config"
+
+/**
+ * Fabrics and garments, browsable by what a vision model saw in them.
+ *
+ * ## Why this screen exists
+ *
+ * The analysis was collected 37 times and read zero times. It lived in
+ * `MediaFile.metadata.textile_extraction` — a JSON blob `query.graph` cannot
+ * filter into — so the question it exists to answer ("what else do we have like
+ * this?") could not be asked, and nothing anywhere rendered it. Every one of
+ * those files also had a good title inside the blob and an EMPTY
+ * `MediaFile.title` beside it.
+ *
+ * Typed columns made the question askable. This is the screen that asks it.
+ *
+ * 🔑 Pictures, not rows of text. The thing being chosen is cloth; a table of
+ * `cloth_type | pattern | weight` describes fabric to someone who needs to SEE
+ * it. The filters are the typed columns, and each is indexed — which is the
+ * whole argument for them being columns.
+ */
+
+type TextileAnalysis = {
+  id: string
+  source: string
+  confidence?: number | null
+  cloth_type?: string | null
+  category?: string | null
+  pattern?: string | null
+  fabric_weight?: string | null
+  weave_or_knit?: string | null
+  primary_color?: string | null
+  title?: string | null
+  description?: string | null
+  colors?: string[] | null
+  season?: string[] | null
+  occasion?: string[] | null
+  analyzed_at?: string | null
+  media?: {
+    id: string
+    file_name: string
+    file_path: string
+    title?: string | null
+  } | null
+}
+
+type ListResponse = {
+  textile_analyses: TextileAnalysis[]
+  count: number
+}
+
+/** "" means "no filter", and must never reach the query string as `field=`. */
+const ANY = ""
+
+const FILTERS = [
+  {
+    key: "cloth_type" as const,
+    label: "Garment",
+    options: ["top", "saree", "trousers", "shirt", "scarf", "shawl", "robe", "fabric"],
+  },
+  {
+    key: "pattern" as const,
+    label: "Pattern",
+    options: ["solid", "floral", "stripe", "check", "block-print", "geometric"],
+  },
+  {
+    key: "fabric_weight" as const,
+    label: "Weight",
+    options: ["light-weight", "medium-weight", "heavy-weight"],
+  },
+  {
+    key: "weave_or_knit" as const,
+    label: "Construction",
+    options: ["woven", "knit"],
+  },
+]
+
+const TextileAnalysesPage = () => {
+  const [filters, setFilters] = useState<Record<string, string>>({})
+  const [search, setSearch] = useState("")
+
+  /**
+   * ⚠️ Blank values are DROPPED rather than sent. A `cloth_type=` in the query
+   * string filters for the empty string and returns nothing — a filter that has
+   * been opened and cleared would silently empty the catalogue, which reads as
+   * "we hold no fabric like that" rather than "you asked for nothing".
+   */
+  const queryString = useMemo(() => {
+    const params = new URLSearchParams()
+    for (const [k, v] of Object.entries(filters)) {
+      if (v && v !== ANY) params.set(k, v)
+    }
+    if (search.trim()) params.set("q", search.trim())
+    params.set("limit", "60")
+    return params.toString()
+  }, [filters, search])
+
+  const { data, isLoading } = useQuery<ListResponse>({
+    queryKey: ["textile-analyses", queryString],
+    queryFn: () =>
+      sdk.client.fetch<ListResponse>(`/admin/textile-analyses?${queryString}`),
+  })
+
+  const rows = data?.textile_analyses ?? []
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col gap-4 px-6 py-4">
+        <div>
+          <Heading level="h2">Textile library</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            What a vision model saw in every fabric and garment photo we hold —
+            filterable by garment, pattern, weight and construction.
+          </Text>
+        </div>
+
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex min-w-56 flex-col gap-1">
+            <Text size="xsmall" weight="plus">
+              Search
+            </Text>
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="indigo, poppy, handwoven…"
+              data-testid="textile-search"
+            />
+          </div>
+
+          {FILTERS.map((f) => (
+            <div key={f.key} className="flex min-w-44 flex-col gap-1">
+              <Text size="xsmall" weight="plus">
+                {f.label}
+              </Text>
+              <Select
+                value={filters[f.key] ?? ANY}
+                onValueChange={(v) =>
+                  setFilters((prev) => ({ ...prev, [f.key]: v }))
+                }
+              >
+                <Select.Trigger data-testid={`textile-filter-${f.key}`}>
+                  <Select.Value placeholder="Any" />
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value={ANY}>Any</Select.Item>
+                  {f.options.map((o) => (
+                    <Select.Item key={o} value={o}>
+                      {o.replace(/-/g, " ")}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="px-6 py-4">
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-square w-full rounded-lg" />
+            ))}
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="flex flex-col items-center gap-1 py-10">
+            <Text className="text-ui-fg-subtle">
+              Nothing matches those filters.
+            </Text>
+            {/*
+              🔑 Says WHY it might be empty. Until the backfill runs, this table
+              holds only what has been analysed since the module shipped — an
+              empty grid otherwise reads as "we own no such fabric".
+            */}
+            <Text size="xsmall" className="text-ui-fg-muted">
+              Photos analysed before this library existed are migrated by the
+              `backfill-textile-analysis` maintenance job.
+            </Text>
+          </div>
+        ) : (
+          <>
+            <Text size="xsmall" className="text-ui-fg-muted mb-3">
+              {data?.count ?? rows.length} match
+              {(data?.count ?? rows.length) === 1 ? "" : "es"}
+            </Text>
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+              {rows.map((row) => (
+                <div
+                  key={row.id}
+                  className="shadow-elevation-card-rest bg-ui-bg-component flex flex-col gap-2 rounded-lg p-2"
+                  data-testid="textile-card"
+                >
+                  {row.media?.file_path ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={row.media.file_path}
+                      alt={row.title ?? row.media.file_name}
+                      className="aspect-square w-full rounded-md object-cover"
+                    />
+                  ) : (
+                    <div className="bg-ui-bg-base-pressed flex aspect-square w-full items-center justify-center rounded-md">
+                      <Text size="xsmall" className="text-ui-fg-muted">
+                        no image
+                      </Text>
+                    </div>
+                  )}
+
+                  <Text size="xsmall" weight="plus" className="line-clamp-2">
+                    {row.title ?? row.media?.file_name ?? "Untitled"}
+                  </Text>
+
+                  <div className="flex flex-wrap gap-1">
+                    {row.cloth_type && (
+                      <Badge size="2xsmall" color="blue">
+                        {row.cloth_type}
+                      </Badge>
+                    )}
+                    {row.pattern && (
+                      <Badge size="2xsmall" color="purple">
+                        {row.pattern}
+                      </Badge>
+                    )}
+                    {row.fabric_weight && (
+                      <Badge size="2xsmall" color="grey">
+                        {row.fabric_weight.replace(/-/g, " ")}
+                      </Badge>
+                    )}
+                    {/*
+                      Where this reading came from. Our own extraction over
+                      stock we hold and a stranger's storefront upload deserve
+                      different trust, and before the module the only thing
+                      telling them apart was which metadata key someone wrote.
+                    */}
+                    {row.source === "storefront_reference" && (
+                      <Badge size="2xsmall" color="orange">
+                        customer photo
+                      </Badge>
+                    )}
+                  </div>
+
+                  {/*
+                    ⚠️ Rendered only when the extractor actually gave a number.
+                    `confidence` is nullable and 0 is a real answer — printing
+                    "0%" for "did not say" would read as certainty about being
+                    wrong.
+                  */}
+                  {typeof row.confidence === "number" && (
+                    <Text size="xsmall" className="text-ui-fg-muted">
+                      {Math.round(row.confidence * 100)}% confident
+                    </Text>
+                  )}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Textile library",
+  icon: Swatch,
+})
+
+export default TextileAnalysesPage

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-textile-analysis-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-textile-analysis-job.ts
@@ -1,0 +1,207 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { MEDIA_MODULE } from "../../../../modules/media"
+import { TEXTILE_ANALYSIS_MODULE } from "../../../../modules/textile-analysis"
+import mediaTextileAnalysisLink from "../../../../links/media-textile-analysis-link"
+import { normaliseTextileAnalysis } from "../../../../modules/textile-analysis/lib/normalise"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Move the existing `metadata.textile_extraction` blobs into typed
+ * `textile_analysis` rows.
+ *
+ * ## Why these 37 rows are worth moving
+ *
+ * Measured on production: of the media files carrying the blob, **every one had
+ * a `title` and a `description` inside it and NONE had the typed
+ * `MediaFile.title` / `description` / `alt_text` columns set** — columns that
+ * already existed, with `title` one of the two `.searchable()` fields. A good
+ * title was computed for each and the media library, SEO and screen-reader alt
+ * text all read the empty column instead.
+ *
+ * They were also unfilterable. `query.graph` cannot reach into JSON subkeys, so
+ * "show me more fabrics like this" — the reason this data is collected — could
+ * not be built on them. Until this runs, the new module holds only what has
+ * been extracted SINCE it shipped, and every earlier extraction stays invisible
+ * to the feature it was gathered for.
+ *
+ * ## What it does NOT do
+ *
+ * 🔑 It leaves `metadata.textile_extraction` in place. Deleting it would make
+ * this irreversible, and `metadata` is a bag shared with the partner upload,
+ * WhatsApp and raw-material-binding writers — a whole-object rewrite to remove
+ * one key is exactly the hazard the module was created to escape. The blob
+ * becomes vestigial, and retiring it is a separate, later decision.
+ *
+ * Idempotent: a media file that already has an `internal_extraction` row is
+ * skipped, so a re-run cannot double-create.
+ */
+
+const paramsSchema = z.object({
+  media_id: z.string().min(1).optional(),
+  limit: z.number().int().positive().max(1000).optional(),
+})
+
+export const backfillTextileAnalysisJob: MaintenanceJob = {
+  id: "backfill-textile-analysis",
+  label: "Backfill textile analysis rows from media metadata",
+  description:
+    "Create a typed `textile_analysis` row (and its media link) for every media file carrying `metadata.textile_extraction`, and mirror the extractor's title/description onto the media file's own searchable columns — which every one of those files left empty. Dry-run previews each file, what would be typed from it, and what the mirror would set. Idempotent: a file that already has an internal_extraction row is skipped. Leaves the original metadata blob in place; retiring it is a separate decision.",
+  params: [
+    {
+      name: "media_id",
+      type: "string",
+      required: false,
+      description: "Only this media file (start here — verify one before sweeping)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Cap how many files are considered (default 1000)",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params ?? {})
+    if (!parsed.success) {
+      throw new Error(parsed.error.issues.map((i) => i.message).join("; "))
+    }
+    const { media_id, limit } = parsed.data
+
+    const mediaService: any = container.resolve(MEDIA_MODULE)
+    const analysisService: any = container.resolve(TEXTILE_ANALYSIS_MODULE)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+    const files: any[] = await mediaService.listMediaFiles(
+      media_id ? { id: media_id } : {},
+      { take: limit ?? 1000 }
+    )
+
+    const candidates = files.filter((f) => f?.metadata?.textile_extraction)
+
+    /**
+     * Which of them already have an internal-extraction row.
+     *
+     * ⚠️ Checked in ONE query rather than per file. `filters: { id: [] }` is NO
+     * filter, not "no rows" (#1433), so the empty case returns before the graph
+     * is ever asked — otherwise an empty candidate list would read every link
+     * on the platform and mark everything as already done.
+     */
+    const alreadyDone = new Set<string>()
+    if (candidates.length) {
+      const { data: links = [] } = await query.graph({
+        entity: mediaTextileAnalysisLink.entryPoint,
+        fields: ["media_file_id", "textile_analysis_id"],
+        filters: { media_file_id: candidates.map((f) => f.id) },
+      })
+      for (const l of links as any[]) {
+        if (l?.media_file_id) alreadyDone.add(l.media_file_id)
+      }
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let created = 0
+
+    for (const file of candidates) {
+      if (alreadyDone.has(file.id)) {
+        changes.push({
+          entity: "media_file",
+          id: file.id,
+          field: "textile_analysis",
+          before: "already migrated",
+          after: "skipped",
+          note: "a textile_analysis row is already linked to this media file",
+        })
+        continue
+      }
+
+      const payload = file.metadata.textile_extraction as Record<string, any>
+      const normalised = normaliseTextileAnalysis(payload, {
+        source: "internal_extraction",
+        analyzed_at: file.metadata?.extracted_at ?? file.created_at ?? null,
+      })
+
+      // What the mirror would set — reported, because these columns being empty
+      // is half the reason this backfill exists.
+      const mirrorNote = [
+        !file.title && normalised.title ? `title←"${normalised.title.slice(0, 40)}"` : null,
+        !file.description && normalised.description ? "description←extractor" : null,
+        !file.alt_text && normalised.description ? "alt_text←extractor" : null,
+      ]
+        .filter(Boolean)
+        .join(", ")
+
+      changes.push({
+        entity: "media_file",
+        id: file.id,
+        field: "textile_analysis",
+        before: null,
+        after: `${normalised.cloth_type ?? "?"} / ${normalised.pattern ?? "?"} / ${
+          normalised.fabric_weight ?? "?"
+        } / ${normalised.primary_color ?? "?"}`,
+        note: mirrorNote || "typed row only (media columns already set)",
+      })
+
+      if (dry_run) {
+        created++
+        continue
+      }
+
+      try {
+        const row = await analysisService.createTextileAnalyses(normalised)
+        const analysis = Array.isArray(row) ? row[0] : row
+        if (!analysis?.id) throw new Error("no id returned")
+
+        await link.create({
+          [MEDIA_MODULE]: { media_file_id: file.id },
+          [TEXTILE_ANALYSIS_MODULE]: { textile_analysis_id: analysis.id },
+        })
+
+        /**
+         * Mirror ONLY into columns that are empty. An operator who has since
+         * written their own title should not have it overwritten by a model's
+         * — the backfill is filling gaps, not asserting authorship.
+         */
+        const mirror: Record<string, any> = {}
+        if (!file.title && normalised.title) mirror.title = normalised.title
+        if (!file.description && normalised.description) {
+          mirror.description = normalised.description
+        }
+        if (!file.alt_text && normalised.description) {
+          mirror.alt_text = normalised.description
+        }
+        if (Object.keys(mirror).length) {
+          await mediaService.updateMediaFiles({ id: file.id, ...mirror })
+        }
+
+        created++
+      } catch (e: any) {
+        errors.push({ id: file.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    const summary = `${dry_run ? "Would create" : "Created"} ${created} textile_analysis row(s) from ${
+      candidates.length
+    } media file(s) carrying metadata.textile_extraction${
+      errors.length ? ` — ${errors.length} failed` : ""
+    }`
+
+    return {
+      job_id: backfillTextileAnalysisJob.id,
+      dry_run,
+      applied: !dry_run && created > 0,
+      summary,
+      changes,
+      errors,
+    }
+  },
+}
+
+export default backfillTextileAnalysisJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -83,6 +83,7 @@ import { backfillQuoteTenancyJob } from "./backfill-quote-tenancy-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
 import { backfillShiprocketShippingOptionsJob } from "./backfill-shiprocket-shipping-options-job"
 import { correctProductionRunQuantityJob } from "./correct-production-run-quantity-job"
+import { backfillTextileAnalysisJob } from "./backfill-textile-analysis-job"
 import { backfillFreightOptionDataJob } from "./backfill-freight-option-data-job"
 import { recoverWhatsappMediaJob } from "./recover-whatsapp-media-job"
 import { auditInventoryReceiptDriftJob } from "./audit-inventory-receipt-drift-job"
@@ -5821,6 +5822,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostBulkJob,
   correctProductionRunCostJob,
   correctProductionRunQuantityJob,
+  backfillTextileAnalysisJob,
   backfillInventoryUnitCostJob,
   backfillInventoryThumbnailJob,
   backfillDesignEnergyCostJob,

--- a/apps/backend/src/api/admin/textile-analyses/route.ts
+++ b/apps/backend/src/api/admin/textile-analyses/route.ts
@@ -1,0 +1,117 @@
+/**
+ * Fabrics and garments, searchable by what a vision model saw in them.
+ *
+ *   GET /admin/textile-analyses?cloth_type=&pattern=&fabric_weight=
+ *                              &primary_color=&source=&q=&limit=&offset=
+ *
+ * ## Why this exists
+ *
+ * The analysis used to live in `MediaFile.metadata.textile_extraction`, and
+ * `query.graph` cannot filter or sort into JSON subkeys — so "show me more
+ * fabrics like this" was not buildable on it, and nothing rendered it either.
+ * The data was collected 37 times and read zero times.
+ *
+ * Typed columns made the question askable; this route is where it gets asked.
+ * Every filter here is an indexed column on `textile_analysis`, which is the
+ * entire reason those fields are columns rather than keys in a blob.
+ *
+ * 🔑 Returns the MEDIA alongside each row. An analysis without its picture is
+ * unusable for the thing it is for — choosing a fabric — and making the client
+ * fetch them separately would be N+1 over a grid.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import mediaTextileAnalysisLink from "../../../links/media-textile-analysis-link"
+import { MEDIA_MODULE } from "../../../modules/media"
+import { TEXTILE_ANALYSIS_MODULE } from "../../../modules/textile-analysis"
+
+/** Filters are normalised the way the writer normalises them, or they miss. */
+const norm = (v: unknown): string | undefined => {
+  if (typeof v !== "string") return undefined
+  const s = v.trim().toLowerCase()
+  return s.length ? s : undefined
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const q = req.query as Record<string, any>
+  const service: any = req.scope.resolve(TEXTILE_ANALYSIS_MODULE)
+  const mediaService: any = req.scope.resolve(MEDIA_MODULE)
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const limit = Math.min(Number(q.limit) || 50, 200)
+  const offset = Number(q.offset) || 0
+
+  /**
+   * ⚠️ Only filters the caller actually supplied. A key set to `undefined`
+   * would be NO filter, which is right — but a key set to `""` filters FOR the
+   * empty string and silently returns nothing, which is how a search box that
+   * has been focused and cleared empties a catalogue.
+   */
+  const filters: Record<string, any> = {}
+  for (const field of [
+    "cloth_type",
+    "pattern",
+    "fabric_weight",
+    "weave_or_knit",
+    "primary_color",
+    "source",
+  ] as const) {
+    const value = norm(q[field])
+    if (value) filters[field] = value
+  }
+
+  const [rows, count] = await service.listAndCountTextileAnalyses(filters, {
+    take: limit,
+    skip: offset,
+    order: { created_at: "DESC" },
+    ...(norm(q.q) ? { q: String(q.q).trim() } : {}),
+  })
+
+  // ── Hydrate each row's media file ───────────────────────────────────────
+  const ids = (rows ?? []).map((r: any) => r.id).filter(Boolean)
+  const mediaByAnalysis = new Map<string, any>()
+
+  // `filters: { id: [] }` is NO filter (#1433) — the empty case must not fall
+  // through into reading every link on the platform.
+  if (ids.length) {
+    const { data: links = [] } = await query.graph({
+      entity: mediaTextileAnalysisLink.entryPoint,
+      fields: ["media_file_id", "textile_analysis_id"],
+      filters: { textile_analysis_id: ids },
+    })
+
+    const mediaIds = Array.from(
+      new Set((links as any[]).map((l) => l?.media_file_id).filter(Boolean))
+    )
+
+    if (mediaIds.length) {
+      const files: any[] = await mediaService.listMediaFiles(
+        { id: mediaIds },
+        { take: mediaIds.length }
+      )
+      const fileById = new Map(files.map((f) => [f.id, f]))
+      for (const l of links as any[]) {
+        const file = fileById.get(l.media_file_id)
+        if (file) mediaByAnalysis.set(l.textile_analysis_id, file)
+      }
+    }
+  }
+
+  res.json({
+    textile_analyses: (rows ?? []).map((r: any) => ({
+      ...r,
+      media: mediaByAnalysis.get(r.id)
+        ? {
+            id: mediaByAnalysis.get(r.id).id,
+            file_name: mediaByAnalysis.get(r.id).file_name,
+            file_path: mediaByAnalysis.get(r.id).file_path,
+            title: mediaByAnalysis.get(r.id).title,
+          }
+        : null,
+    })),
+    count,
+    limit,
+    offset,
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -4559,6 +4559,16 @@ export default defineMiddlewares({
     // Consumption logs on Designs
 
     {
+      /**
+       * Fabrics searchable by what a vision model saw. A route file without a
+       * matcher entry is not a route — and this one is the only reader of a
+       * module whose whole justification is being queryable.
+       */
+      matcher: "/admin/textile-analyses",
+      method: "GET",
+      middlewares: [],
+    },
+    {
       matcher: "/admin/designs/:id/consumption-logs",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminPostConsumptionLogReq))],


### PR DESCRIPTION
Refs #1690.

`textile_analysis` shipped with **no reader and no history**. Nothing rendered a row, and the 37 production extractions still sat in `metadata.textile_extraction` where they had always been. A module whose entire justification is being queryable had nothing querying it — the #1612 shape.

## The screen

`/app/textile-analyses` — every analysed fabric and garment as **pictures**, filterable by garment, pattern, weight and construction. Each filter is an **indexed column**, which is the whole argument for those fields being columns rather than blob keys.

Pictures rather than a table, because the thing being chosen is cloth: a row of `cloth_type | pattern | weight` describes fabric to someone who needs to see it.

⚠️ Blank filter values are **dropped, never sent**. `cloth_type=` filters FOR the empty string and returns nothing — a select that has been opened and cleared would silently empty the catalogue, reading as *"we hold no such fabric"* rather than *"you asked for nothing"*.

⚠️ Confidence renders **only** when the extractor gave a number. It is nullable and `0` is a real answer, so printing "0%" for "did not say" would read as certainty about being wrong.

The empty state says **why** it might be empty — until the backfill runs, this holds only what has been analysed since the module shipped.

## The route

`GET /admin/textile-analyses` with the typed filters, returning each row's **media** alongside it. An analysis without its picture is unusable for the thing it is for, and fetching separately would be N+1 over a grid.

## The backfill

`backfill-textile-analysis` — a typed row + link for every media file carrying the old blob, and mirrors the extractor's title/description onto `MediaFile.title`/`description`/`alt_text`. Of the 37 production files, **every one had a good title inside the blob and an empty searchable column beside it**.

- **Idempotent** — a file with an existing `internal_extraction` row is skipped
- **Mirrors only into empty columns** — an operator who has since written their own title shouldn't have it overwritten by a model's. This fills gaps; it doesn't assert authorship.
- 🔑 **Leaves the metadata blob in place.** Deleting it would make the backfill irreversible, and `metadata` is shared with the partner-upload, WhatsApp and raw-material-binding writers — a whole-object rewrite to remove one key is the exact hazard the module was built to escape.
- `filters: { id: [] }` is NO filter (#1433), so the empty-candidate case returns before the graph is asked rather than reading every link on the platform and marking everything done.

691 unit tests green; `check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4