### PR TITLE
fix(design-chat): one ask, one design — and stop re-asking what it already knows

### DIFF
--- a/apps/backend/integration-tests/http/storefront-design-flow.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-design-flow.spec.ts
@@ -9,7 +9,12 @@ import {
   runListRawMaterials,
   runListPartners,
 } from "../../src/mastra/agents/tools/storefront-design-catalog"
-import { runGenerateDesignImage } from "../../src/mastra/agents/tools/storefront-design-flow"
+import {
+  runCreateDesign,
+  runGenerateDesignImage,
+  findOpenChatDesign,
+  runEnsureGuestCustomer,
+} from "../../src/mastra/agents/tools/storefront-design-flow"
 import { PARTNER_MODULE } from "../../src/modules/partner"
 import { DESIGN_MODULE } from "../../src/modules/designs"
 
@@ -192,6 +197,131 @@ setupSharedTestSuite(() => {
           },
         })
       ).rejects.toThrow(/Pick one of the takes first/)
+    })
+
+    /**
+     * ── #1689: two designs, 24 seconds apart, from one ask ──────────────
+     *
+     * `create_design` was documented as idempotent, and it was — against
+     * `context.design_id`, which the CLIENT supplies after reading the
+     * finished turn's tool output. So two calls inside one turn both saw an
+     * empty context, and so did the next turn whenever the client failed to
+     * read the id. Production: `01M1B2RS6ZM6P2HNCD8VZA9TBJ` and
+     * `01M1B2SGY8RH06QBQJYYW44VHX`, same maker, same conversation.
+     *
+     * ⚠️ Each of these was run against the pre-fix code and FAILED there.
+     */
+    describe("🔴 one ask, one design", () => {
+      const BRIEF = {
+        product_type: "trousers",
+        concept_theme: "Post-industrial lounge",
+        aesthetic_keywords: ["utilitarian", "raw"],
+        color_palette: [{ name: "slate", code: "#4a5259" }],
+      }
+
+      it("a second create_design in the SAME turn returns the first design", async () => {
+        // The context object the route builds once per request and hands to
+        // every tool factory — empty, exactly as it is on a first turn.
+        const context: any = { email: "twice@jyt.test" }
+
+        const first = await runCreateDesign(
+          container,
+          { email: "twice@jyt.test", name: "Post-Industrial Lounge Trousers", brief: BRIEF },
+          context
+        )
+        const second = await runCreateDesign(
+          container,
+          { email: "twice@jyt.test", name: "Post-Industrial Trousers", brief: BRIEF },
+          context
+        )
+
+        expect(first.created).toBe(true)
+        expect(second.created).toBe(false)
+        expect(second.design_id).toBe(first.design_id)
+        // The context was stamped — that is what makes the second call see it.
+        expect(context.design_id).toBe(first.design_id)
+      })
+
+      it("a NEXT turn with an empty context still finds the maker's open design", async () => {
+        const first = await runCreateDesign(
+          container,
+          { email: "nextturn@jyt.test", name: "Indigo Kurta", brief: { ...BRIEF, product_type: "kurta" } },
+          // No context at all — the client never told us the design id.
+          undefined
+        )
+
+        const second = await runCreateDesign(
+          container,
+          { email: "nextturn@jyt.test", name: "Indigo Kurta", brief: { ...BRIEF, product_type: "kurta" } },
+          undefined
+        )
+
+        expect(second.created).toBe(false)
+        expect(second.design_id).toBe(first.design_id)
+      })
+
+      it("generate_design_image lands on the design create_design just made", async () => {
+        const context: any = { email: "gen-once@jyt.test" }
+
+        const created = await runCreateDesign(
+          container,
+          { email: "gen-once@jyt.test", name: "Indigo Kurta", brief: { ...BRIEF, product_type: "kurta" } },
+          context
+        )
+
+        const generated = await runGenerateDesignImage(
+          container,
+          {
+            email: "gen-once@jyt.test",
+            name: "Indigo Kurta",
+            brief: { ...BRIEF, product_type: "kurta" },
+          },
+          // 🔴 A FRESH context — the shape a client that missed the tool
+          // output actually sends. This is where the second design was born.
+          { email: "gen-once@jyt.test" }
+        )
+
+        expect(generated.created_design).toBe(false)
+        expect(generated.design_id).toBe(created.design_id)
+        expect(generated.candidates).toHaveLength(2)
+      })
+
+      /**
+       * 🔴 The bound that keeps "reuse the maker's design" from becoming
+       * "hijack any design they own". A design that has moved past Conceptual
+       * is in flight somewhere — a partner may already be quoting it — and a
+       * new chat must never write takes onto it.
+       */
+      it("does NOT adopt a design that has left Conceptual", async () => {
+        const context: any = { email: "moved-on@jyt.test" }
+        const created = await runCreateDesign(
+          container,
+          { email: "moved-on@jyt.test", name: "Sent Kurta", brief: { ...BRIEF, product_type: "kurta" } },
+          context
+        )
+
+        const designService = container.resolve(DESIGN_MODULE) as any
+        await designService.updateDesigns({
+          id: created.design_id,
+          status: "In_Development",
+        })
+
+        const { customer_id } = await runEnsureGuestCustomer(container, "moved-on@jyt.test")
+        expect(await findOpenChatDesign(container, customer_id)).toBeNull()
+
+        const next = await runCreateDesign(
+          container,
+          { email: "moved-on@jyt.test", name: "A new one", brief: { ...BRIEF, product_type: "kurta" } },
+          undefined
+        )
+        expect(next.created).toBe(true)
+        expect(next.design_id).not.toBe(created.design_id)
+      })
+
+      it("a maker with no design at all gets one", async () => {
+        const { customer_id } = await runEnsureGuestCustomer(container, "brand-new@jyt.test")
+        expect(await findOpenChatDesign(container, customer_id)).toBeNull()
+      })
     })
 
     it("analyzes a shared reference image and returns a shaped analysis", async () => {

--- a/apps/backend/integration-tests/http/storefront-design-references.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-design-references.spec.ts
@@ -155,6 +155,63 @@ setupSharedTestSuite(() => {
       expect(inspirations).toHaveLength(2)
     })
 
+    /**
+     * 🔴 #1689, through the upload door.
+     *
+     * The chat mints the design the moment the brief locks, and the client
+     * only learns its id from the finished turn's tool output. A maker who
+     * drags photos in before that lands sends no `design_id` — and this route
+     * used to mint a SECOND design beside the one they were talking to.
+     */
+    it("🔴 pins onto the maker's OPEN chat design when no design_id is sent", async () => {
+      const openEmail = `open-${Date.now()}@jyt.test`
+      const { runCreateDesign } = await import(
+        "../../src/mastra/agents/tools/storefront-design-flow"
+      )
+      const created = await runCreateDesign(
+        container(),
+        {
+          email: openEmail,
+          name: "Indigo Kurta",
+          brief: {
+            product_type: "kurta",
+            concept_theme: "Indigo handwoven",
+            aesthetic_keywords: ["handwoven"],
+            color_palette: [{ name: "indigo", code: "#1e3a5f" }],
+          },
+        },
+        undefined
+      )
+
+      // The client has not learned the id yet — no design_id in the body.
+      const res = await upload({ customer_email: openEmail }, [
+        { buf: PNG_1X1, name: "swatch.png" },
+      ])
+
+      expect(res.status).toBe(201)
+      expect(res.data.created_design).toBe(false)
+      expect(res.data.design_id).toBe(created.design_id)
+    })
+
+    /**
+     * The client merges each returned analysis back onto the file it came
+     * from BY NAME, so `name` echoing the uploaded filename is part of the
+     * contract, not decoration. Without it the wrong description lands on the
+     * wrong photo — silently, since both are strings.
+     */
+    it("echoes each uploaded filename so the client can match them back", async () => {
+      const res = await upload({ customer_email: `names-${Date.now()}@jyt.test` }, [
+        { buf: PNG_1X1, name: "front.png" },
+        { buf: PNG_1X1, name: "back.png" },
+      ])
+
+      expect(res.status).toBe(201)
+      expect(res.data.references.map((r: any) => r.name)).toEqual([
+        "front.png",
+        "back.png",
+      ])
+    })
+
     it("🔴 refuses a design that is not this maker's", async () => {
       const mine = await upload({ customer_email: email }, [
         { buf: PNG_1X1, name: "mine.png" },

--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -285,6 +285,16 @@ const buildDesignChatSystemResolved = async (
         aesthetic_keywords: Array.isArray(design.aesthetic_keywords)
           ? design.aesthetic_keywords
           : [],
+        // Palette entries are stored as `{ name, code }` — the prompt wants
+        // the names. A settled fact the model could not see is a question the
+        // maker gets asked twice.
+        color_palette: Array.isArray(design.color_palette)
+          ? design.color_palette
+              .map((c: any) =>
+                typeof c === "string" ? c : (c?.name ?? c?.code ?? null)
+              )
+              .filter((c: any): c is string => typeof c === "string" && !!c)
+          : [],
         thumbnail_url: design.thumbnail_url ?? undefined,
       }
 

--- a/apps/backend/src/api/store/custom/design-assistant/references/route.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/references/route.ts
@@ -55,7 +55,10 @@ import {
   normalizeCanvasScene,
 } from "../../../../../modules/designs/lib/canvas-scene"
 import { analyzeReferenceImages } from "../../../../../mastra/agents/tools/storefront-design-analysis"
-import { runEnsureGuestCustomer } from "../../../../../mastra/agents/tools/storefront-design-flow"
+import {
+  findOpenChatDesign,
+  runEnsureGuestCustomer,
+} from "../../../../../mastra/agents/tools/storefront-design-flow"
 import { createDesignWorkflow } from "../../../../../workflows/designs/create-design"
 
 /** Images only. A maker's "reference" is a picture, and nothing here reads a PDF. */
@@ -114,9 +117,23 @@ export const POST = async (
     }
   } else {
     /**
-     * No design yet — this IS the opening move. Named from the upload rather
-     * than left blank, because "Untitled" is what the maker will see on their
-     * board before the assistant has asked them anything.
+     * No design id supplied — but that does not mean there is no design.
+     *
+     * 🔴 #1689: the chat mints a design the moment the brief is locked, and
+     * the CLIENT only learns its id by reading the finished turn's tool
+     * output. A maker who drags photos in before that has landed sends no
+     * `design_id`, and this branch would mint a SECOND design beside the one
+     * they are talking to — the same two-designs-from-one-ask defect, through
+     * a different door. Ask for their open chat design first.
+     */
+    designId = await findOpenChatDesign(req.scope as any, customer_id)
+  }
+
+  if (!designId) {
+    /**
+     * Genuinely nothing open — this IS the opening move. Named from the upload
+     * rather than left blank, because "Untitled" is what the maker will see on
+     * their board before the assistant has asked them anything.
      *
      * 🔑 Deliberately NOT inferring a `product_type` here. That field is
      * load-bearing — the production spec and the cost estimate derive from it

--- a/apps/backend/src/mastra/agents/__tests__/design-chat-settled-facts.unit.spec.ts
+++ b/apps/backend/src/mastra/agents/__tests__/design-chat-settled-facts.unit.spec.ts
@@ -1,0 +1,112 @@
+import {
+  buildDesignChatSystem,
+  planDesignTurn,
+  type DesignChatContext,
+} from "../storefront-design-chat"
+
+/**
+ * #1689 — "there's a lot of asking going on."
+ *
+ * The founder's onboarding sent, in one message:
+ *
+ *   Design a kurta. Save my designs to <email>.
+ *
+ * and the assistant replied asking *which email to save it under*. Both facts
+ * were in the message that prompted the question.
+ *
+ * These assert the SETTLED block: what the record already establishes is
+ * stated back as given, and the standing "ask for their email early"
+ * instruction is switched off once there is nothing to ask for.
+ *
+ * ⚠️ Each assertion below was checked against the pre-fix prompt and FAILED
+ * there — the settled block did not exist and the email instruction was
+ * unconditional. A prompt test that passes either way tests nothing.
+ */
+const msg = (text: string) => ({
+  role: "user",
+  parts: [{ type: "text", text }],
+})
+
+describe("design chat — settled facts", () => {
+  const ONBOARDING = "Design a kurta. Save my designs to maker@example.com."
+
+  it("states an email given in the transcript back as settled", () => {
+    const plan = planDesignTurn([msg(ONBOARDING)])
+
+    expect(plan.has_email).toBe(true)
+    expect(plan.settled).toContain("maker@example.com")
+    expect(plan.settled).toMatch(/Do NOT ask for it/)
+  })
+
+  it("🔴 stops telling the model to ask for an email it already has", () => {
+    const withEmail = buildDesignChatSystem(undefined, undefined, [
+      msg(ONBOARDING),
+    ])
+
+    // The instruction that produced "just to confirm: is that the one?"
+    expect(withEmail).not.toMatch(/ask for it EARLY/)
+    expect(withEmail).toMatch(/already in hand/)
+
+    // …and it is still asked for when it genuinely has not been given.
+    const withoutEmail = buildDesignChatSystem(undefined, undefined, [
+      msg("Design a kurta."),
+    ])
+    expect(withoutEmail).toMatch(/ask for it EARLY/)
+    expect(withoutEmail).not.toMatch(/already in hand/)
+  })
+
+  it("🔴 forbids a second create_design once the design exists", () => {
+    const context: DesignChatContext = {
+      design_id: "design_01ABC",
+      email: "maker@example.com",
+      design: {
+        name: "Post-Industrial Trousers",
+        status: "Conceptual",
+        product_type: "trousers",
+        concept_theme: "post-industrial",
+        aesthetic_keywords: ["utilitarian", "raw"],
+        color_palette: ["indigo"],
+      },
+    }
+    const plan = planDesignTurn([msg("Design a kurta.")], context)
+
+    expect(plan.settled).toContain("design_01ABC")
+    expect(plan.settled).toMatch(/Do NOT call create_design again/)
+    // The turn plan must not be asking for it at the same time.
+    expect(plan.directive).toMatch(/Do NOT call create_design again/)
+    expect(plan.directive).not.toMatch(/call create_design \(once\)/)
+  })
+
+  it("carries the agreed brief so it is not renegotiated", () => {
+    const plan = planDesignTurn([msg("hello")], {
+      design_id: "design_01ABC",
+      design: {
+        product_type: "saree",
+        concept_theme: "monsoon indigo",
+        aesthetic_keywords: ["handwoven", "drapey"],
+        color_palette: ["indigo", "ecru"],
+      },
+    })
+
+    expect(plan.settled).toMatch(/saree/)
+    expect(plan.settled).toMatch(/monsoon indigo/)
+    expect(plan.settled).toMatch(/handwoven, drapey/)
+    expect(plan.settled).toMatch(/indigo, ecru/)
+  })
+
+  it("emits nothing when nothing is settled — a first turn stays open", () => {
+    expect(planDesignTurn([msg("hi")]).settled).toBe("")
+  })
+
+  /**
+   * 🔑 The block is the model's memory of its own tool calls, because the
+   * chat route strips every tool part out of the history before the model
+   * sees it. If that sentence goes, the model has no reason to believe the
+   * block over the transcript.
+   */
+  it("says why the block exists — the model cannot see its own tool calls", () => {
+    const plan = planDesignTurn([msg("Design a kurta for maker@example.com")])
+    expect(plan.settled).toMatch(/cannot see your own earlier tool calls/)
+    expect(plan.settled).toMatch(/PREFER ACTING OVER ASKING/)
+  })
+})

--- a/apps/backend/src/mastra/agents/storefront-design-chat.ts
+++ b/apps/backend/src/mastra/agents/storefront-design-chat.ts
@@ -37,6 +37,7 @@ export type DesignChatContext = {
     product_type?: string | null
     concept_theme?: string | null
     aesthetic_keywords?: string[]
+    color_palette?: string[]
     thumbnail_url?: string
     // Moodboard summary — so the agent is grounded on the board without an
     // extra get_design_state round-trip.
@@ -80,6 +81,8 @@ const DESIGN_CONTEXT = (ctx: DesignChatContext): string => {
   if (d.concept_theme) lines.push(`- Concept: ${d.concept_theme}`)
   if (d.aesthetic_keywords?.length)
     lines.push(`- Aesthetic keywords: ${d.aesthetic_keywords.join(", ")}`)
+  if (d.color_palette?.length)
+    lines.push(`- Palette: ${d.color_palette.join(", ")}`)
   if (d.thumbnail_url) lines.push(`- Current design image: ${d.thumbnail_url}`)
 
   // Moodboard summary — canvas takes + reference analyses, so the agent is
@@ -141,6 +144,72 @@ export type PlannedTurn = {
   garment_type: string | null
   has_email: boolean
   directive: string
+  /** Everything already established, stated back to the model as given. */
+  settled: string
+}
+
+/**
+ * ── SETTLED FACTS ───────────────────────────────────────────────────────
+ *
+ * 🔴 #1689: "there's a lot of asking going on, it should concretely ask and
+ * perform and actually carry on what has been done." Seen verbatim — the
+ * onboarding sent `Design a kurta. Save my designs to <email>.` and the reply
+ * was *"what email should I save this design under? You mentioned <the same
+ * email>, but just to confirm…"*.
+ *
+ * Two causes, and neither is the model being careless:
+ *
+ *   1. The route PRUNES every tool part out of the history before the model
+ *      sees it (provider shims reject the tool-call shapes). Its own comment
+ *      says so: "the model can't remember it searched already". So each turn
+ *      the model genuinely does not know what it has already done.
+ *   2. The standing instructions say "ask for their email EARLY", with nothing
+ *      to switch that off once the email is in hand. The turn plan said the
+ *      email was captured; the flow above it still said to go and ask.
+ *
+ * The fix is the same move the board state already gets: reconstruct what is
+ * established SERVER-SIDE and state it as given, then forbid re-opening it.
+ * A fact restated is cheaper than a question re-asked.
+ */
+const buildSettledFacts = (
+  garment: string | null,
+  email: string | null,
+  context?: DesignChatContext
+): string => {
+  const d = context?.design
+  const facts: string[] = []
+
+  if (email) facts.push(`- Email: **${email}** — already given. Use it. Do NOT ask for it or ask them to confirm it.`)
+  const garmentType = d?.product_type || garment
+  if (garmentType) facts.push(`- Garment: **${garmentType}** — already decided. Do NOT re-ask what they are designing.`)
+  if (d?.concept_theme) facts.push(`- Concept: **${d.concept_theme}** — already agreed.`)
+  if (d?.aesthetic_keywords?.length)
+    facts.push(`- Aesthetic keywords: **${d.aesthetic_keywords.join(", ")}** — already agreed.`)
+  if (d?.color_palette?.length)
+    facts.push(`- Palette: **${d.color_palette.join(", ")}** — already agreed.`)
+  if (context?.design_id)
+    facts.push(
+      `- The design is ALREADY SAVED (${context.design_id})${d?.name ? ` as "${d.name}"` : ""}. Do NOT call create_design again — calling it a second time is the exact defect this rule exists to stop.`
+    )
+  if (d?.board?.inspirations?.length)
+    facts.push(
+      `- ${d.board.inspirations.length} reference photo(s) are on their board and already analysed (descriptions above). Do NOT ask them to upload again, and do NOT re-analyse.`
+    )
+  if (d?.board?.canvas_count)
+    facts.push(
+      `- ${d.board.canvas_count} take(s) already generated${d.board.active_canvas?.letter ? `, take ${d.board.active_canvas.letter} is the active pick` : ""}.`
+    )
+
+  if (!facts.length) return ""
+
+  return [
+    "",
+    "# SETTLED — treat every line as GIVEN (route-computed from the record, not from the transcript)",
+    ...facts,
+    "",
+    "🔴 You cannot see your own earlier tool calls: the history is stripped of them before it reaches you. This block IS your memory of them. Anything listed here has happened. Do not ask for it, do not ask them to confirm it, do not redo it.",
+    "🔴 PREFER ACTING OVER ASKING. Explicit consent is required for ONE thing only — image generation, which costs real money. For everything else, if this block or the context gives you what you need, do it and say what you did. At most one short question per reply, and only about something genuinely not settled.",
+  ].join("\n")
 }
 
 export const planDesignTurn = (
@@ -163,7 +232,15 @@ export const planDesignTurn = (
   const garment = GARMENT_KEYWORDS.find((k) =>
     new RegExp(`\\b${escapeRegExp(k)}\\b`).test(userText)
   )
-  const hasEmail = Boolean(context?.email) || EMAIL_RE.test(userText)
+  /**
+   * The email as a VALUE, not just a boolean. The settled-facts block states
+   * it back verbatim, which is what stops "you mentioned X, but just to
+   * confirm: is that the one?" — a question whose answer was already in the
+   * message that prompted it.
+   */
+  const resolvedEmail =
+    context?.email?.trim().toLowerCase() || userText.match(EMAIL_RE)?.[0] || null
+  const hasEmail = Boolean(resolvedEmail)
 
   const lines: string[] = ["", "# TURN PLAN (route-computed — follow EXACTLY)"]
   if (!garment) {
@@ -179,6 +256,13 @@ export const planDesignTurn = (
     lines.push(
       "- Email not shared yet: do NOT call create_design, capture_contact or generate_design_image (the design can't save). You may brief, browse fabrics and partners. Ask for the email once, naturally, right after the brief."
     )
+  } else if (context?.design_id) {
+    // The design exists. Saying "call create_design" here is how one ask
+    // produced two designs (#1689) — the tool now refuses to duplicate, but
+    // the instruction should not be asking for it either.
+    lines.push(
+      "- Email captured AND the design is already saved. Do NOT call create_design again. capture_contact may run (once)."
+    )
   } else {
     lines.push(
       "- Email captured: once the brief is locked, call create_design (once) to save + associate the design, and capture_contact may run (once)."
@@ -190,13 +274,11 @@ export const planDesignTurn = (
 
   return {
     garment_type: garment ?? null,
-    has_email: has_email_safe(context?.email, userText),
+    has_email: hasEmail,
     directive: lines.join("\n"),
+    settled: buildSettledFacts(garment ?? null, resolvedEmail, context),
   }
 }
-
-const has_email_safe = (contextEmail?: string, userText?: string): boolean =>
-  Boolean(contextEmail) || EMAIL_RE.test(userText ?? "")
 
 export const buildDesignChatSystem = (
   prefs?: UserPrefs,
@@ -205,6 +287,7 @@ export const buildDesignChatSystem = (
 ): string => {
   const hasProduct = Boolean(context?.product)
   const hasDesign = Boolean(context?.design)
+  const plan = planDesignTurn(messages, context)
 
   return `You are Cici's designer — a warm, hands-on design guide for Cici Label, a slow-fashion brand under Jaal Yantra Textiles (JYT). You help a maker design a real garment: you ground everything in their product or brief, our fabrics, and our production partners, and you keep the iteration loop going until they love a take.
 
@@ -224,7 +307,7 @@ export const buildDesignChatSystem = (
 - Render tool results as the UI cards (fabric chips, partner cards, canvas A/B) — never list them in prose by hand.
 - The board is the maker's: canvas takes, inspirations and the active pick all live on one Excalidraw board they can see. Describe state in board terms ("your board now has two takes — A indigo, B natural").
 - Uploaded references are pre-analysed (vision) and carry their description on the board — call get_design_state and read the inspirations' descriptions/suggestions instead of re-analysing the same image.
-- Email: ask for it EARLY — right after the brief, because the design saves under it. Ask once, naturally ("what email should I save this design under?"). Call create_design after they give it; call capture_contact once.
+- Email: ${plan.has_email ? "already in hand (see SETTLED below) — use it silently. Do NOT ask for it and do NOT ask them to confirm it." : "ask for it EARLY — right after the brief, because the design saves under it. Ask once, naturally (\"what email should I save this design under?\")."} Call create_design once the brief is locked; call capture_contact once.
 - 🔴 NEVER auto-generate: image generation costs real quota and ~20s. Always ask for an explicit yes first ("ready for me to generate two takes on this?") and only call generate_design_image after they confirm. If they describe changes instead of confirming, treat it as a revision request and confirm again.
 - Estimates/checkout come later: once a take is active and fabric + partner are chosen, point them to Checkout (the estimate renders there from the design + selected fabric + partner). Don't fabricate prices.
 - Match their energy. Short paragraphs. You suggest; they decide.
@@ -244,7 +327,8 @@ ${hasProduct ? PRODUCT_CONTEXT(context!) : ""}${hasDesign ? DESIGN_CONTEXT(conte
 
 # Maker preferences (from onboarding)
 ${formatPrefs(prefs)}
-${planDesignTurn(messages, context).directive}
+${plan.settled}
+${plan.directive}
 
 Weave preferences into every generation (badges) and fabric/partner suggestions. If empty, ask at most one short question at a time.
 `

--- a/apps/backend/src/mastra/agents/tools/storefront-design-flow.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-design-flow.ts
@@ -38,6 +38,7 @@ import {
   readGenerationReference,
   appendCanvasElements,
   markActiveCanvas,
+  appendInspirationElements,
   type CanvasScene,
   type CanvasMarker,
 } from "../../../modules/designs/lib/canvas-scene"
@@ -46,11 +47,148 @@ import { createDesignWorkflow } from "../../../workflows/designs/create-design"
 import { linkProductWithDesignWorkflow } from "../../../workflows/products/link-unlink-products-with-designs"
 import { generateDesignAiImageWorkflow } from "../../../workflows/ai/generate-design-image"
 import { analyzeReferenceImages } from "./storefront-design-analysis"
+import designCustomerLink from "../../../links/design-customer-link"
 
 // ── Shared resolvers ───────────────────────────────────────────────────
 
 const resolveDesignService = (container: MedusaContainer): DesignService =>
   container.resolve(DESIGN_MODULE) as unknown as DesignService
+
+/**
+ * ── The design a chat is already working on ─────────────────────────────
+ *
+ * 🔴 #1689: one ask produced TWO designs, 24 seconds apart. `create_design`
+ * was described as idempotent, and it is — but only against
+ * `context.design_id`, which is supplied by the CLIENT. The client learns the
+ * id by scanning the finished turn's tool output, so:
+ *
+ *   - two `create_design` calls inside ONE turn both see an empty context, and
+ *   - a turn whose tool parts the client failed to read leaves the next turn
+ *     with an empty context too.
+ *
+ * Either way the "idempotent" tool mints a second design. An idempotency key
+ * that only the client can supply is not an idempotency key.
+ *
+ * So the maker is asked instead of the client: does this maker already have a
+ * chat design open? Bounded three ways, because "reuse the maker's design" is
+ * a dangerous instruction without limits — it must never adopt a design from
+ * last week that they have since sent to a partner.
+ *
+ *   1. it came from THIS flow (the `chat-editor` tag),
+ *   2. it is still `Conceptual` — nothing downstream has happened to it,
+ *   3. it was created inside the window below.
+ *
+ * A maker who wants a genuinely new design says "start a new design", which
+ * the client handles as a domain keyword — and would otherwise land here. That
+ * is what the window is for: a new session tomorrow is a new design; a second
+ * tool call this minute is the same one.
+ */
+const OPEN_CHAT_DESIGN_WINDOW_MS = 2 * 60 * 60 * 1000
+
+export const findOpenChatDesign = async (
+  container: MedusaContainer,
+  customerId: string
+): Promise<string | null> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+  const { data: links = [] } = await query
+    .graph({
+      entity: designCustomerLink.entryPoint,
+      fields: ["design_id"],
+      filters: { customer_id: customerId },
+    })
+    .catch(() => ({ data: [] }))
+
+  // ⚠️ An empty relation comes back as a single all-null row, not an empty
+  // array — filter on the value, not on `links.length`.
+  const designIds = [
+    ...new Set(
+      (links as any[]).map((l) => l?.design_id).filter((id): id is string => !!id)
+    ),
+  ]
+  if (!designIds.length) return null
+
+  const designService = resolveDesignService(container)
+  const designs: any[] = await (designService as any)
+    .listDesigns(
+      { id: designIds, status: "Conceptual" },
+      { order: { created_at: "DESC" }, take: 50 }
+    )
+    .catch(() => [])
+
+  const cutoff = Date.now() - OPEN_CHAT_DESIGN_WINDOW_MS
+  const open = designs.find((d) => {
+    const tags = Array.isArray(d?.tags) ? d.tags : []
+    if (!tags.includes("chat-editor")) return false
+    const createdAt = d?.created_at ? new Date(d.created_at).getTime() : NaN
+    return Number.isFinite(createdAt) && createdAt >= cutoff
+  })
+
+  return open?.id ?? null
+}
+
+/**
+ * Resolve the design this turn should write to, creating one only if the maker
+ * genuinely has none open.
+ *
+ * 🔑 It MUTATES `context.design_id` on the way out. The context object is
+ * built once per request and handed to every tool factory, so stamping it is
+ * what makes a second `create_design` — or a `generate_design_image` that
+ * follows in the same turn — resolve to the design that was just made rather
+ * than mint another beside it.
+ */
+export const resolveOrCreateChatDesign = async (
+  container: MedusaContainer,
+  input: {
+    customerId: string
+    name?: string
+    brief: DesignBrief
+    context?: DesignContext
+  }
+): Promise<{ design_id: string; created: boolean }> => {
+  const { context, customerId, brief } = input
+
+  const contextId = context?.design_id
+  if (contextId) {
+    const designService = resolveDesignService(container)
+    const existing = await designService
+      .retrieveDesign(contextId)
+      .catch(() => null)
+    if (existing) return { design_id: contextId, created: false }
+  }
+
+  const open = await findOpenChatDesign(container, customerId)
+  if (open) {
+    if (context) context.design_id = open
+    return { design_id: open, created: false }
+  }
+
+  const { result, errors } = await createDesignWorkflow(container as any).run({
+    input: {
+      name:
+        input.name?.trim() ||
+        brief.concept_theme ||
+        `${brief.product_type} design`,
+      description: brief.concept_theme || undefined,
+      design_type: "Custom",
+      status: "Conceptual",
+      origin_source: "ai-other",
+      concept_theme: brief.concept_theme || undefined,
+      aesthetic_keywords: brief.aesthetic_keywords.length
+        ? (brief.aesthetic_keywords as unknown as Record<string, any>)
+        : undefined,
+      color_palette: brief.color_palette.length
+        ? (brief.color_palette as unknown as Record<string, any>)
+        : undefined,
+      customer_id_for_link: customerId,
+      tags: ["custom", "customer-design", "chat-editor"],
+    } as any,
+  })
+  if (errors?.length) throw errors[0]
+
+  const designId = (result as any).id
+  if (context) context.design_id = designId
+  return { design_id: designId, created: true }
+}
 
 /**
  * Find-or-create the guest customer keyed on the maker's email.
@@ -342,15 +480,6 @@ export const runCreateDesign = async (
   args: z.infer<typeof CreateDesignSchema>,
   context?: DesignContext
 ): Promise<CreateDesignResult> => {
-  const existingId = context?.design_id
-  if (existingId) {
-    const designService = resolveDesignService(container)
-    const existing = await designService
-      .retrieveDesign(existingId)
-      .catch(() => null)
-    if (existing) return { design_id: existingId, created: false }
-  }
-
   const email = (args.email ?? context?.email)?.trim().toLowerCase()
   if (!email) {
     throw new Error(
@@ -366,32 +495,18 @@ export const runCreateDesign = async (
 
   const { customer_id } = await runEnsureGuestCustomer(container, email)
 
-  const { result: designResult, errors: designErrors } = await createDesignWorkflow(
-    container as any
-  ).run({
-    input: {
-      name: args.name?.trim() || brief.concept_theme || `${brief.product_type} design`,
-      description: brief.concept_theme || undefined,
-      design_type: "Custom",
-      status: "Conceptual",
-      origin_source: "ai-other",
-      concept_theme: brief.concept_theme || undefined,
-      aesthetic_keywords: brief.aesthetic_keywords.length
-        ? (brief.aesthetic_keywords as unknown as Record<string, any>)
-        : undefined,
-      color_palette: brief.color_palette.length
-        ? (brief.color_palette as unknown as Record<string, any>)
-        : undefined,
-      customer_id_for_link: customer_id,
-      tags: ["custom", "customer-design", "chat-editor"],
-    },
+  /**
+   * The resolver checks the context, then the maker's open chat design, then
+   * creates — and stamps `context.design_id` either way, so a SECOND
+   * `create_design` in this same turn lands on the design this one made.
+   * See #1689: two designs, 24 seconds apart, from one ask.
+   */
+  return resolveOrCreateChatDesign(container, {
+    customerId: customer_id,
+    name: args.name,
+    brief,
+    context,
   })
-
-  if (designErrors?.length) {
-    throw designErrors[0]
-  }
-
-  return { design_id: (designResult as any).id, created: true }
 }
 
 export const createCreateDesignTool = (
@@ -536,104 +651,68 @@ export const runGenerateDesignImage = async (
     }
     scene = loaded.scene
   } else {
-    // First generation creates the design — brief + email REQUIRED.
+    // No design yet. This is where the second design used to come from
+    // (#1689): the branch minted unconditionally, so any turn that reached it
+    // with an empty context made another one. It now resolves the maker's
+    // open chat design first and only creates when there genuinely is none.
     if (!email) {
       throw new Error(
         "I need your email to save the design before I can generate. What email should I use?"
       )
     }
-    missingSetup.push("design")
-    if (!productId) {
-      // Standalone design (no base product) still needs a name.
-    }
     const { customer_id } = await runEnsureGuestCustomer(container, email)
 
-    // Seed the moodboard scene with the maker's inspirations. Each reference is
-    // analysed on the fly — the vision result is stamped onto the media's
-    // metadata and onto the element so the generation (and later turns) can
-    // ground on a pre-computed description.
-    let seedScene = normalizeCanvasScene(null)
-    if (args.inspiration_images?.length) {
-      const analyses = await analyzeReferenceImages(container, args.inspiration_images)
-      for (const url of args.inspiration_images) {
-        const fileId = `insp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-        const analysis = analyses.get(url)
-        seedScene.files[fileId] = {
-          id: fileId,
-          dataURL: url,
-          mimeType: "image/png",
-          created: Date.now(),
-          lastRetrieved: Date.now(),
-        }
-        seedScene.elements.push({
-          id: `el-${fileId}`,
-          type: "image",
-          x: 40 + (seedScene.elements.length % 2) * 300,
-          y: 40 + Math.floor(seedScene.elements.length / 2) * 300,
-          width: 260,
-          height: 260,
-          angle: 0,
-          strokeColor: "transparent",
-          backgroundColor: "transparent",
-          fillStyle: "solid",
-          strokeWidth: 1,
-          strokeStyle: "solid",
-          roughness: 1,
-          opacity: 100,
-          roundness: null,
-          isDeleted: false,
-          boundElements: null,
-          updated: Date.now(),
-          link: url,
-          locked: true,
-          fileId,
-          mimeType: "image/png",
-          customData: {
-            source: "inspiration",
-            ...(analysis
-              ? {
-                  media_id: analysis.media_id,
-                  analysis: {
-                    title: analysis.title,
-                    description: analysis.description,
-                    suggestions: analysis.suggestions,
-                    analyzed_at: analysis.analyzed_at,
-                  },
-                }
-              : {}),
-          },
-        })
-      }
-    }
-
-    const { result: designResult, errors: designErrors } = await createDesignWorkflow(
-      container as any
-    ).run({
-      input: {
-        name: args.name?.trim() || brief.concept_theme || `${brief.product_type} design`,
-        description: brief.concept_theme || undefined,
-        design_type: "Custom",
-        status: "Conceptual",
-        origin_source: "ai-other",
-        concept_theme: brief.concept_theme || undefined,
-        aesthetic_keywords: brief.aesthetic_keywords.length
-          ? (brief.aesthetic_keywords as unknown as Record<string, any>)
-          : undefined,
-        color_palette: brief.color_palette.length
-          ? (brief.color_palette as unknown as Record<string, any>)
-          : undefined,
-        moodboard: seedScene as unknown as Record<string, any>,
-        customer_id_for_link: customer_id,
-        tags: ["custom", "customer-design", "chat-editor"],
-      },
+    const resolvedDesign = await resolveOrCreateChatDesign(container, {
+      customerId: customer_id,
+      name: args.name,
+      brief,
+      context,
     })
+    designId = resolvedDesign.design_id
+    createdDesign = resolvedDesign.created
+    if (createdDesign) missingSetup.push("design")
 
-    if (designErrors?.length) {
-      throw designErrors[0]
+    /**
+     * Start from what is already on the board. A resolved (rather than freshly
+     * created) design may already carry the maker's photos — the reference
+     * upload route puts them there before a single word is typed — and seeding
+     * a blank scene over it would erase them.
+     */
+    const loaded = await loadDesignScene(container, designId as string)
+    scene = loaded?.scene ?? normalizeCanvasScene(null)
+
+    // Seed the maker's inspirations. Each is analysed on the fly so the
+    // generation (and later turns) can ground on a pre-computed description.
+    //
+    // 🔑 `appendInspirationElements`, not an inline rebuild. This block WAS
+    // the inline original; #1691 extracted it for the upload route and left
+    // the twin behind here. Two homes for one shape is how the run-line
+    // pricer drifted 22% apart.
+    if (args.inspiration_images?.length) {
+      const analyses = await analyzeReferenceImages(
+        container,
+        args.inspiration_images
+      ).catch(() => new Map())
+      scene = appendInspirationElements(
+        scene,
+        args.inspiration_images.map((url) => {
+          const analysis: any = analyses.get(url)
+          return {
+            url,
+            media_id: analysis?.media_id ?? null,
+            analysis: analysis
+              ? {
+                  title: analysis.title ?? null,
+                  description: analysis.description ?? null,
+                  suggestions: analysis.suggestions ?? [],
+                  analyzed_at: analysis.analyzed_at ?? null,
+                }
+              : null,
+          }
+        })
+      )
+      await saveScene(container, designId as string, scene)
     }
-    designId = (designResult as any).id
-    createdDesign = true
-    scene = seedScene
 
     // Link the base product (variant designs) — first-class product-design
     // link, NOT metadata.

--- a/apps/storefront/src/modules/products/components/design-chat/components/attachments.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/components/attachments.tsx
@@ -154,7 +154,14 @@ export function AttachButton({
       <input
         ref={inputRef}
         type="file"
-        accept="image/jpeg,image/png,image/webp,image/gif"
+        /**
+         * Kept in step with `ACCEPTED_TYPES` in `lib/design-uploads`, which is
+         * itself kept in step with the upload route's own list. A type the
+         * picker filters out never reaches the validator that would have
+         * accepted it — the maker just sees their photo greyed out with no
+         * reason given. HEIC matters here: it is what an iPhone hands you.
+         */
+        accept="image/jpeg,image/png,image/webp,image/gif,image/avif,image/heic,image/heif"
         multiple
         onChange={handleChange}
         className="hidden"

--- a/apps/storefront/src/modules/products/components/design-chat/index.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/index.tsx
@@ -23,7 +23,8 @@ import {
   createReference,
   isAcceptedImage,
   releaseReference,
-  uploadDesignReference,
+  uploadDesignReferences,
+  MAX_REFERENCES_PER_UPLOAD,
   type DesignReference,
 } from "./lib/design-uploads"
 import {
@@ -431,7 +432,14 @@ export default function DesignChat({
   const addFiles = React.useCallback((files: File[]) => {
     const accepted = files.filter(isAcceptedImage)
     if (!accepted.length) return
-    setAttachments((prev) => [...prev, ...accepted.map(createReference)])
+    // The upload route refuses more than MAX_REFERENCES_PER_UPLOAD per
+    // request, so stop at the cap here rather than letting the whole batch
+    // 400 with the maker's message attached to it.
+    setAttachments((prev) => {
+      const room = MAX_REFERENCES_PER_UPLOAD - prev.length
+      if (room <= 0) return prev
+      return [...prev, ...accepted.slice(0, room).map(createReference)]
+    })
   }, [])
 
   const removeAttachment = React.useCallback((id: string) => {
@@ -462,17 +470,65 @@ export default function DesignChat({
     setStickToBottom(true)
 
     // Upload pending references first so the message carries their permanent
-    // URLs (guests keep session-only previews — thumbnails still render).
+    // URLs — the model can only look at a picture that exists server-side.
     let resolved: DesignReference[] = attachments
     if (attachments.length) {
       setUploading(true)
       setAttachments((prev) => prev.map((a) => ({ ...a, status: "uploading" })))
-      resolved = await Promise.all(attachments.map(uploadDesignReference))
+      /**
+       * ONE request for the whole batch, carrying the maker's email and the
+       * design if there is one. The route resolves-or-CREATES the design, so
+       * a per-file fan-out would mint a design per photo — the same shape as
+       * the two-designs-from-one-ask defect this issue opens with.
+       *
+       * `emailMatch` is read rather than `meta.email` because the state set
+       * above has not flushed yet: on the turn where the maker first types
+       * their email, `meta.email` is still undefined.
+       */
+      const email =
+        meta.email ?? (emailMatch ? emailMatch[0].toLowerCase() : null)
+      const upload = await uploadDesignReferences(attachments, {
+        email,
+        designId,
+      })
+      resolved = upload.references
+      // The photos may have brought the design into existence. Adopt it, or
+      // the next turn asks the model to create one and we are back to two.
+      if (upload.designId && upload.designId !== designId) {
+        setDesignId(upload.designId)
+      }
       setUploading(false)
+
+      /**
+       * The route pins the photos to the design's moodboard server-side, so
+       * the board is stale the moment the upload returns.
+       *
+       * 🔴 Caught by RENDERING it, not by a test: every assertion passed while
+       * the panel sat there saying "Your board is empty" beside two photos
+       * that were already on the board in the database. Nothing was broken —
+       * the screen was just lying, which is the failure mode this whole issue
+       * is made of.
+       */
+      if (upload.references.some((r) => r.publicUrl)) {
+        refreshScene(upload.designId ?? undefined)
+      }
     }
 
-    const referenceLines = resolved
-      .filter((r) => r.publicUrl)
+    const uploaded = resolved.filter((r) => r.publicUrl)
+    const failed = resolved.filter((r) => !r.publicUrl)
+
+    /**
+     * A failed upload stays in the tray with its message rather than riding
+     * along as a thumbnail with no URL behind it. That silent version is the
+     * exact shape of this bug: the maker saw their photo, the model never
+     * did, and nothing said so.
+     */
+    if (failed.length && !text && !uploaded.length) {
+      setAttachments(failed)
+      return
+    }
+
+    const referenceLines = uploaded
       .map((r) => {
         const a = r.analysis
         const note =
@@ -485,10 +541,11 @@ export default function DesignChat({
     const referenceBlock = referenceLines.length
       ? `\n\nReference image${referenceLines.length > 1 ? "s" : ""} — my on-the-fly read of each:\n${referenceLines.join("\n")}`
       : ""
-    const composed = `${text}${referenceBlock}`.trim() || "I've attached some inspirations."
+    const composed =
+      `${text}${referenceBlock}`.trim() || "I've attached some inspirations."
 
-    pendingSendRef.current = resolved
-    setAttachments([])
+    pendingSendRef.current = uploaded
+    setAttachments(failed)
     sendMessage({ text: composed })
   }
 

--- a/apps/storefront/src/modules/products/components/design-chat/lib/design-uploads.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/design-uploads.ts
@@ -1,21 +1,31 @@
 "use client"
 
-import { presignDesignImageUpload } from "@lib/data/uploads"
-import { analyzeDesignReference } from "@lib/data/design-references"
-
 /**
- * Design reference uploads — the chat design editor's file-upload utility.
+ * Design reference uploads — the chat's file-upload utility.
  *
- * The maker drops / picks reference images (inspirations, photos of garments
- * they want to riff on). Each file is:
- *   1. previewed immediately as an object URL (no server round-trip), then
- *   2. uploaded to storage via a presigned S3 URL when the maker is signed in,
- *   3. analysed on the fly — the vision description is attached so the chat
- *      can show it and the message can ground the model on it.
+ * ## Why this does not presign
  *
- * Guests keep their session-local preview (thumbnails still render across the
- * chat) — the presign endpoint is customer-authenticated, so a guest upload
- * degrades to `status: "preview"` instead of failing the whole send.
+ * 🔴 It used to. `presignDesignImageUpload` returns `AUTH_REQUIRED` before it
+ * makes any request when there are no customer auth headers — and the design
+ * chat is a GUEST flow, identified by an email and nothing else. So every
+ * attached photo degraded to `status: "preview"`: an object URL in the tab,
+ * rendered as a thumbnail, gone when the tab closed. Nothing downstream could
+ * work, because there was no public URL to work from. Production bore it out:
+ * **0 media files have ever carried `metadata.source = "design-reference"`.**
+ *
+ * The server route (#1691) removed the auth wall by taking the bytes itself.
+ * This module is the other half — until it pointed here, that route had no
+ * caller and the count stayed at 0.
+ *
+ *   POST /store/custom/design-assistant/references   (multipart: files[])
+ *
+ * One request for the whole batch, not one per file: the route resolves-or-
+ * CREATES the design, and N concurrent requests with no `design_id` would mint
+ * N designs. That is the same defect as #1689's "two designs from one ask",
+ * arriving by a different door.
+ *
+ * The route also analyses each image and pins it to the board, so there is no
+ * separate `analyzeDesignReference` round-trip from here any more.
  */
 
 export type ReferenceAnalysis = {
@@ -36,14 +46,25 @@ export type DesignReference = {
   publicUrl: string | null
   /** preview → uploading → ready | error */
   status: "preview" | "uploading" | "ready" | "error"
-  /** Human-readable error for guests / failed uploads. */
+  /** Human-readable error for failed uploads. */
   error?: string
-  /** Vision analysis attached after the on-the-fly read. */
+  /** Vision analysis attached by the server as it stored each image. */
   analysis?: ReferenceAnalysis | null
 }
 
-const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"]
+/** Mirrors the route's own ALLOWED list. */
+const ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "image/avif",
+  "image/heic",
+  "image/heif",
+]
 const MAX_SIZE_BYTES = 10 * 1024 * 1024
+/** The route refuses more than this per request. */
+export const MAX_REFERENCES_PER_UPLOAD = 8
 
 let idCounter = 0
 const nextId = () => `ref-${Date.now()}-${idCounter++}`
@@ -64,62 +85,137 @@ export const releaseReference = (ref: DesignReference): void => {
   URL.revokeObjectURL(ref.previewUrl)
 }
 
+export type UploadReferencesResult = {
+  references: DesignReference[]
+  /** The design the photos landed on — new when the chat had none yet. */
+  designId: string | null
+  createdDesign: boolean
+}
+
 /**
- * Upload a single reference to storage. Resolves with an updated reference —
- * `publicUrl` is set on success, otherwise `status: "error"` + a friendly
- * message (guests are told to sign in rather than shown a raw 401).
+ * ⚠️ `sdk.client.fetch` is not usable here: it defaults `content-type` to
+ * `application/json` and then `JSON.stringify`s the body, which turns a
+ * `FormData` into the string `"[object FormData]"`. Multipart has to go
+ * through plain `fetch`, with the publishable key supplied by hand.
  */
-export const uploadDesignReference = async (
-  ref: DesignReference
-): Promise<DesignReference> => {
-  if (ref.status === "ready" && ref.publicUrl) {
-    return ref
+const backendUrl = (): string =>
+  process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || "http://localhost:9000"
+
+/**
+ * Upload the whole pending batch. Resolves with updated references —
+ * `publicUrl` + `analysis` set on success, otherwise `status: "error"` and a
+ * message the maker can act on.
+ *
+ * Never throws: a failed upload must not swallow the maker's message.
+ */
+export const uploadDesignReferences = async (
+  refs: DesignReference[],
+  opts: { email?: string | null; designId?: string | null }
+): Promise<UploadReferencesResult> => {
+  const pending = refs.filter((r) => !(r.status === "ready" && r.publicUrl))
+  if (!pending.length) {
+    return { references: refs, designId: opts.designId ?? null, createdDesign: false }
   }
 
-  const result = await presignDesignImageUpload({
-    name: ref.file.name || "reference.jpg",
-    type: ref.file.type || "image/jpeg",
-    size: ref.file.size,
-  })
-
-  if (result.error) {
+  const email = (opts.email ?? "").trim().toLowerCase()
+  if (!email) {
+    // The route saves references against the maker's design, and a design
+    // belongs to a maker. Without an email there is nowhere to put them —
+    // say so rather than degrading to a preview that looks like it worked.
     return {
-      ...ref,
-      status: "error",
-      error:
-        result.error.code === "AUTH_REQUIRED"
-          ? "Sign in to add references to your board."
-          : result.error.message || "Upload failed.",
+      references: refs.map((r) =>
+        r.status === "ready" && r.publicUrl
+          ? r
+          : {
+              ...r,
+              status: "error" as const,
+              error: "Tell me your email first and I'll save these to your board.",
+            }
+      ),
+      designId: opts.designId ?? null,
+      createdDesign: false,
     }
   }
 
-  const { url: presignedUrl, public_url } = result.presign!
-  const uploadRes = await fetch(presignedUrl, {
-    method: "PUT",
-    body: ref.file,
-    headers: { "Content-Type": ref.file.type || "image/jpeg" },
-  })
-
-  if (!uploadRes.ok) {
-    return {
-      ...ref,
-      status: "error",
-      error: "Upload failed — try again.",
-    }
+  const form = new FormData()
+  form.append("customer_email", email)
+  if (opts.designId) form.append("design_id", opts.designId)
+  for (const ref of pending) {
+    form.append("files", ref.file, ref.file.name || "reference.jpg")
   }
 
-  // On-the-fly vision read — attach the analysis so the chat can show it and
-  // the message can ground the model on it. Best-effort (never blocks upload).
-  const { analysis } = await analyzeDesignReference({
-    url: public_url,
-    name: ref.file.name,
-    mime_type: ref.file.type || undefined,
-  })
+  try {
+    const response = await fetch(
+      `${backendUrl()}/store/custom/design-assistant/references`,
+      {
+        method: "POST",
+        body: form,
+        headers: {
+          "x-publishable-api-key":
+            process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY ?? "",
+        },
+      }
+    )
 
-  return {
-    ...ref,
-    publicUrl: public_url,
-    status: "ready",
-    analysis: analysis ?? null,
+    if (!response.ok) {
+      const text = await response.text().catch(() => "")
+      throw new Error(text || `HTTP ${response.status}`)
+    }
+
+    const data = (await response.json()) as {
+      design_id: string | null
+      created_design: boolean
+      references: Array<{
+        url: string
+        name: string
+        media_id: string | null
+        analysis: Omit<ReferenceAnalysis, "media_id"> | null
+      }>
+    }
+
+    /**
+     * Match by filename, in order. The route preserves the order it was given
+     * but drops anything it could not store, so a positional match alone would
+     * silently attach the wrong analysis to the wrong photo.
+     */
+    const remaining = [...(data.references ?? [])]
+    const merged = refs.map((ref) => {
+      if (ref.status === "ready" && ref.publicUrl) return ref
+      const idx = remaining.findIndex((r) => r.name === (ref.file.name || "reference.jpg"))
+      if (idx === -1) {
+        return {
+          ...ref,
+          status: "error" as const,
+          error: "That image could not be stored — try again.",
+        }
+      }
+      const [hit] = remaining.splice(idx, 1)
+      return {
+        ...ref,
+        publicUrl: hit.url,
+        status: "ready" as const,
+        error: undefined,
+        analysis: hit.analysis
+          ? { ...hit.analysis, media_id: hit.media_id ?? null }
+          : null,
+      }
+    })
+
+    return {
+      references: merged,
+      designId: data.design_id ?? opts.designId ?? null,
+      createdDesign: Boolean(data.created_design),
+    }
+  } catch (error: any) {
+    console.error("[design-uploads] reference upload failed:", error?.message ?? error)
+    return {
+      references: refs.map((r) =>
+        r.status === "ready" && r.publicUrl
+          ? r
+          : { ...r, status: "error" as const, error: "Upload failed — try again." }
+      ),
+      designId: opts.designId ?? null,
+      createdDesign: false,
+    }
   }
 }


### PR DESCRIPTION
Closes the three defects left open on #1689. All four on that issue are now fixed.

## 1. Reference photos never left the browser

The client presigned through a **customer-authenticated** endpoint inside a **guest** flow, so every attachment degraded to an object URL in the tab. #1691 built the public route; nothing pointed at it, so `metadata.source = "design-reference"` stayed at **0 on prod**. It points there now.

**One multipart request for the batch**, not one per file — the route resolves-or-CREATES the design, so a per-file fan-out would mint a design per photo. `sdk.client.fetch` can't carry it: it defaults `content-type` to JSON and `JSON.stringify`s a `FormData` into `"[object FormData]"`.

A failed upload now **stays in the tray with its reason** instead of riding along as a thumbnail with no URL behind it. That silent version is the shape of the bug itself: the maker saw their photo, the model never did, and nothing said so.

## 2. Two designs from one ask

`create_design` was documented idempotent, and was — against `context.design_id`, which **only the client can supply**, by scanning a finished turn's tool output. So two calls in one turn both saw an empty context, and so did any turn whose tool parts the client failed to read. Prod: `01M1B2RS6ZM6P2HNCD8VZA9TBJ` and `01M1B2SGY8RH06QBQJYYW44VHX`, one conversation, **24 seconds apart**.

> 🔴 An idempotency key only the client can supply is not an idempotency key.

`resolveOrCreateChatDesign` asks the **maker** instead: context → their open chat design → create. It mutates `context.design_id` on the way out, which is what makes a second call *in the same turn* land on the first one's design. Bounded three ways — `chat-editor` tag, still `Conceptual`, inside a 2 h window — because "reuse the maker's design" unbounded would let a new chat write takes onto a design a partner is already quoting.

There was a **third door**: the public upload route also minted a design when no `design_id` was posted — which is exactly what a maker who drags photos in before the client has learned the id actually sends. It asks for the open one first now.

Also removes the inline moodboard-seeding twin that #1691 extracted for the upload route and left behind here. Two homes for one shape is how the run-line pricer drifted 22% apart.

## 3. It re-asks settled questions

Not the model. The chat route **strips every tool part out of the history** before the model sees it (provider shims reject the shapes); its own comment says *"the model can't remember it searched already"*. Meanwhile the prompt said "ask for their email EARLY" with nothing to switch it off. So the onboarding sent `Design a kurta. Save my designs to <email>.` and the reply asked which email to use.

A route-computed **SETTLED** block now states what the record establishes as *given* — email (as a **value**; the planner kept only a boolean and threw the address away), garment, concept, keywords, palette, design-already-exists, board counts — and says plainly that the model cannot see its own tool calls and that this block is its memory of them. The conflicting instruction is conditional now.

## Verified by rendering it, not only by tests

Every fix is **mutation-checked**: reverting the settled block fails 5/6 unit tests, the resolver 3 integration tests, the route guard 1. *(The two negative-bound tests pass either way — they guard against over-reach, they do not prove the fix.)*

The browser found two things no test did:

- the board panel said **"Your board is empty"** beside photos already pinned to that design's moodboard in the database — it never refreshed after upload;
- the file input's `accept` was narrower than the accepted-types list, so the **browser filtered out HEIC** before any validator ran. HEIC is what an iPhone hands you.

Live evidence: `POST … ← http://localhost:8000/ (201)`, `design-reference` media rows carrying `vision_analysis`, one email → **one** design, and the assistant answering *"your email is saved as `<email>`"* instead of asking for it.

## Tests

13 new (6 unit, 7 integration). 16/16 pass across both integration specs; `check:prod-build` and the storefront build are green.

## Not in scope, worth a look

`apps/storefront/.../design-editor/hooks/use-design-editor.ts` still calls `presignDesignImageUpload` in three places. Separate surface from the chat, but if that editor is guest-reachable it has the same auth wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
