### PR TITLE
fix(textile): the library threw on render, and its backfill saw 1000 of 1671 files

### DIFF
--- a/apps/backend/src/admin/routes/textile-analyses/page.tsx
+++ b/apps/backend/src/admin/routes/textile-analyses/page.tsx
@@ -62,8 +62,17 @@ type ListResponse = {
   count: number
 }
 
-/** "" means "no filter", and must never reach the query string as `field=`. */
-const ANY = ""
+/**
+ * The "no filter" option's value.
+ *
+ * 🔴 NOT `""`. Radix — which `Select` is built on — reserves the empty string
+ * for "cleared, show the placeholder" and throws on a `Select.Item` that uses
+ * it, so the whole screen died in an error boundary the moment it rendered.
+ * A sentinel says the same thing without colliding with that meaning, and is
+ * dropped when the query string is built so it never reaches the API as
+ * `field=`.
+ */
+const ANY = "__any__"
 
 const FILTERS = [
   {

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-textile-analysis.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-textile-analysis.unit.spec.ts
@@ -1,0 +1,185 @@
+import { backfillTextileAnalysisJob } from "../backfill-textile-analysis-job"
+
+/**
+ * #1697 — move `metadata.textile_extraction` into typed `textile_analysis` rows.
+ *
+ * The job shipped with no test of its own and a single 1000-row read. Production
+ * holds **1671** media files, so the sweep never opened 671 of them and reported
+ * "3 of 3 candidates" while **37** carried the blob — a silent truncation that
+ * reads exactly like a finished job.
+ *
+ * These run against a fake container that PAGES the way the real service does,
+ * so the assertion is about what the sweep reaches, not about what it decides
+ * once it gets there.
+ */
+
+type File = Record<string, any>
+
+const blob = (over: Record<string, any> = {}) => ({
+  cloth_type: "Saree",
+  pattern: "floral",
+  fabric_weight: "light",
+  primary_color: "indigo",
+  title: "Indigo Floral Saree",
+  description: "A handwoven indigo saree.",
+  ...over,
+})
+
+const file = (i: number, over: Partial<File> = {}): File => ({
+  // ids sort the way the sweep orders them
+  id: `media_${String(i).padStart(5, "0")}`,
+  title: null,
+  description: null,
+  alt_text: null,
+  created_at: new Date("2026-01-01T00:00:00.000Z"),
+  metadata: {},
+  ...over,
+})
+
+const makeContainer = (files: File[], opts: { linkedIds?: string[] } = {}) => {
+  const listMediaFiles = jest.fn(async (filters: any, config: any = {}) => {
+    const pool = filters?.id
+      ? files.filter((f) => f.id === filters.id)
+      : [...files].sort((a, b) => (a.id < b.id ? -1 : 1))
+    const skip = config.skip ?? 0
+    const take = config.take ?? pool.length
+    return pool.slice(skip, skip + take)
+  })
+  const updateMediaFiles = jest.fn().mockResolvedValue(undefined)
+  const createTextileAnalyses = jest.fn(async (row: any) => ({
+    id: `ta_${row.title ?? "x"}`,
+    ...row,
+  }))
+  const linkCreate = jest.fn().mockResolvedValue(undefined)
+  const graph = jest.fn(async () => ({
+    data: (opts.linkedIds ?? []).map((id) => ({
+      media_file_id: id,
+      textile_analysis_id: `ta_existing_${id}`,
+    })),
+  }))
+
+  return {
+    listMediaFiles,
+    updateMediaFiles,
+    createTextileAnalyses,
+    linkCreate,
+    graph,
+    container: {
+      resolve: (key: string) => {
+        if (key === "media") return { listMediaFiles, updateMediaFiles }
+        if (key === "textile_analysis") return { createTextileAnalyses }
+        if (key === "query") return { graph }
+        if (key === "link") return { create: linkCreate }
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    } as any,
+  }
+}
+
+describe("backfill-textile-analysis (#1697)", () => {
+  it("reaches a blob past the first page — the truncation that hid 34 of 37", async () => {
+    // 1671 files, as production has, with the blobs sitting beyond one page.
+    const files = Array.from({ length: 1671 }, (_, i) =>
+      i >= 1200 && i < 1234 ? file(i, { metadata: { textile_extraction: blob() } }) : file(i)
+    )
+    const { container } = makeContainer(files)
+
+    const res = await backfillTextileAnalysisJob.run(container, {
+      dry_run: true,
+      params: {},
+    } as any)
+
+    expect(res.changes).toHaveLength(34)
+    expect(res.summary).toContain("1671 file(s) scanned")
+  })
+
+  it("says how many files it scanned, so a short sweep is visible", async () => {
+    const files = Array.from({ length: 30 }, (_, i) =>
+      i === 0 ? file(i, { metadata: { textile_extraction: blob() } }) : file(i)
+    )
+    const { container } = makeContainer(files)
+
+    const res = await backfillTextileAnalysisJob.run(container, {
+      dry_run: true,
+      params: {},
+    } as any)
+
+    expect(res.summary).toContain("30 file(s) scanned")
+  })
+
+  it("writes the row, the link and only the EMPTY media columns", async () => {
+    const files = [
+      file(1, {
+        metadata: { textile_extraction: blob() },
+        title: "An operator's own title",
+      }),
+    ]
+    const { container, createTextileAnalyses, linkCreate, updateMediaFiles } =
+      makeContainer(files)
+
+    const res = await backfillTextileAnalysisJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(res.applied).toBe(true)
+    expect(createTextileAnalyses).toHaveBeenCalledTimes(1)
+    expect(createTextileAnalyses.mock.calls[0][0]).toMatchObject({
+      source: "internal_extraction",
+      cloth_type: "saree",
+      pattern: "floral",
+    })
+    expect(linkCreate).toHaveBeenCalledTimes(1)
+
+    // the human-written title survives; the empty columns get filled
+    const mirror = updateMediaFiles.mock.calls[0][0]
+    expect(mirror.title).toBeUndefined()
+    expect(mirror.description).toBe("A handwoven indigo saree.")
+    expect(mirror.alt_text).toBe("A handwoven indigo saree.")
+  })
+
+  it("skips a media file that already has an analysis linked", async () => {
+    const files = [file(1, { metadata: { textile_extraction: blob() } })]
+    const { container, createTextileAnalyses } = makeContainer(files, {
+      linkedIds: ["media_00001"],
+    })
+
+    const res = await backfillTextileAnalysisJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(createTextileAnalyses).not.toHaveBeenCalled()
+    expect(res.changes[0]).toMatchObject({ after: "skipped" })
+  })
+
+  it("limit caps the CANDIDATES processed, not the files looked at", async () => {
+    const files = Array.from({ length: 1200 }, (_, i) =>
+      i % 100 === 0 ? file(i, { metadata: { textile_extraction: blob() } }) : file(i)
+    )
+    const { container } = makeContainer(files)
+
+    const res = await backfillTextileAnalysisJob.run(container, {
+      dry_run: true,
+      params: { limit: 4 },
+    } as any)
+
+    expect(res.changes).toHaveLength(4)
+  })
+
+  it("media_id reads that one file only", async () => {
+    const files = Array.from({ length: 50 }, (_, i) =>
+      file(i, { metadata: { textile_extraction: blob() } })
+    )
+    const { container, listMediaFiles } = makeContainer(files)
+
+    const res = await backfillTextileAnalysisJob.run(container, {
+      dry_run: true,
+      params: { media_id: "media_00007" },
+    } as any)
+
+    expect(listMediaFiles).toHaveBeenCalledTimes(1)
+    expect(res.changes).toHaveLength(1)
+    expect(res.changes[0].id).toBe("media_00007")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-textile-analysis-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-textile-analysis-job.ts
@@ -47,6 +47,20 @@ const paramsSchema = z.object({
   limit: z.number().int().positive().max(1000).optional(),
 })
 
+/**
+ * How many media files are read per round-trip while sweeping.
+ *
+ * 🔴 The sweep PAGES. It used to take a single page of 1000 — and production
+ * holds 1671 media files, so 671 of them were never looked at. The first run
+ * reported "Would create 3 … from 3 media file(s) carrying
+ * metadata.textile_extraction" while **37** carried the blob: a silent
+ * truncation that reads exactly like a finished job.
+ */
+const PAGE_SIZE = 500
+
+/** A runaway guard, not a limit anyone should hit: 200 pages = 100k files. */
+const MAX_PAGES = 200
+
 export const backfillTextileAnalysisJob: MaintenanceJob = {
   id: "backfill-textile-analysis",
   label: "Backfill textile analysis rows from media metadata",
@@ -63,7 +77,8 @@ export const backfillTextileAnalysisJob: MaintenanceJob = {
       name: "limit",
       type: "number",
       required: false,
-      description: "Cap how many files are considered (default 1000)",
+      description:
+        "Cap how many CANDIDATES are processed (default: all of them). The sweep pages through every media file regardless — it is not a cap on what is looked at.",
     },
   ],
   run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
@@ -78,12 +93,49 @@ export const backfillTextileAnalysisJob: MaintenanceJob = {
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const link: any = container.resolve(ContainerRegistrationKeys.LINK)
 
-    const files: any[] = await mediaService.listMediaFiles(
-      media_id ? { id: media_id } : {},
-      { take: limit ?? 1000 }
-    )
+    /**
+     * Read every media file, a page at a time, and keep the ones carrying the
+     * blob.
+     *
+     * The filter cannot be pushed into the query — `metadata.textile_extraction`
+     * is a JSON subkey, which is the whole reason this backfill exists — so the
+     * files have to be walked. Ordered by `id` so the pages are stable and a
+     * row cannot be skipped or read twice as the sweep advances.
+     */
+    const scanned: { files: number; pages: number; truncated: boolean } = {
+      files: 0,
+      pages: 0,
+      truncated: false,
+    }
+    const candidates: any[] = []
+    const maxCandidates = limit ?? Number.POSITIVE_INFINITY
 
-    const candidates = files.filter((f) => f?.metadata?.textile_extraction)
+    if (media_id) {
+      const files: any[] = await mediaService.listMediaFiles({ id: media_id }, { take: 1 })
+      scanned.files = files?.length ?? 0
+      scanned.pages = 1
+      for (const f of files ?? []) {
+        if (f?.metadata?.textile_extraction) candidates.push(f)
+      }
+    } else {
+      for (let page = 0; page < MAX_PAGES; page++) {
+        const files: any[] = await mediaService.listMediaFiles(
+          {},
+          { take: PAGE_SIZE, skip: page * PAGE_SIZE, order: { id: "ASC" } }
+        )
+        scanned.pages++
+        scanned.files += files?.length ?? 0
+
+        for (const f of files ?? []) {
+          if (f?.metadata?.textile_extraction) candidates.push(f)
+        }
+
+        if (!files?.length || files.length < PAGE_SIZE) break
+        if (candidates.length >= maxCandidates) break
+        if (page === MAX_PAGES - 1) scanned.truncated = true
+      }
+      if (candidates.length > maxCandidates) candidates.length = maxCandidates
+    }
 
     /**
      * Which of them already have an internal-extraction row.
@@ -187,9 +239,16 @@ export const backfillTextileAnalysisJob: MaintenanceJob = {
       }
     }
 
+    /**
+     * 🔑 Says what was SCANNED, not only what was found. "3 of 3 candidates" and
+     * "3 of 3 candidates, 1000 files scanned" read identically as success while
+     * only the second lets anyone notice that 671 files were never opened.
+     */
     const summary = `${dry_run ? "Would create" : "Created"} ${created} textile_analysis row(s) from ${
       candidates.length
-    } media file(s) carrying metadata.textile_extraction${
+    } media file(s) carrying metadata.textile_extraction — ${
+      scanned.files
+    } file(s) scanned${scanned.truncated ? ` (STOPPED at ${MAX_PAGES} pages — more remain)` : ""}${
       errors.length ? ` — ${errors.length} failed` : ""
     }`
 


### PR DESCRIPTION
Two defects in #1697 — one found by opening the screen, one by running the job against production.

## 1 — the screen died on render

```
A <Select.Item /> must have a value prop that is not an empty string.
```

`ANY = ""`. Radix reserves the empty string for "cleared, show the placeholder" and **throws** on an item that uses it, so the Textile library page went straight to the error boundary. The sentinel that meant *no filter* collided with the one value Radix will not accept.

`ANY` is now `"__any__"` and is still dropped when the query string is built, so it never reaches the API as `cloth_type=` — the thing the empty string was there to prevent.

## 2 — the sweep never opened 671 files

`listMediaFiles({}, { take: limit ?? 1000 })` read ONE page. Production holds **1671** media files and **37** carry `metadata.textile_extraction`. The first dry-run said:

> Would create 3 … from **3** media file(s) carrying metadata.textile_extraction

A silent truncation that reads exactly like a finished job — and `limit` maxes at 1000, so no parameter could have reached the rest.

The sweep now pages (500 at a time, ordered by `id` so nothing is skipped or read twice as it advances) and the summary states how many files it **scanned**. `limit` now caps the *candidates processed*; capping what is looked at is the bug.

## Tests

The job shipped with none. Six now, **mutation-checked** — reverting the pagination fails 3 (past-the-first-page reach, the scanned count, `limit`'s new meaning). The other 3 pass either way: guards, not proof.

690 maintenance-job unit tests green · `check:prod-build` green.

## Already run on production

| step | result |
|---|---|
| one file (`01KM869HSN…`) | `txan_01M1BKY3C7…` created, linked to its media, `White Linen Shirt` mirrored onto the empty `title`/`description`/`alt_text` |
| same file again | `already migrated → skipped` — idempotent against a real DB, not just a fake one |
| sweep | all 3 files the deployed code can see |

The remaining **34** need this deploy before they are reachable at all.

## Watch-out for the next pass

Two of the three migrated rows have prose where the filter expects a vocabulary — `cloth_type = "silk (assumed based on drape and sheen)"`, `pattern = "geometric and floral"`. The Garment chip offers `top · saree · shirt …`, so those rows are in the library but no filter can reach them. That is #1690's "one textile vocabulary", not this PR.

Refs #1697, #1690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4