### PR TITLE
fix(social-posts): filter platform dropdown to social category on create

### DIFF
--- a/apps/backend/src/admin/components/creates/create-social-post-steps.tsx
+++ b/apps/backend/src/admin/components/creates/create-social-post-steps.tsx
@@ -58,7 +58,7 @@ export const CreateSocialPostSteps = () => {
   const { handleSuccess } = useRouteModal()
   const { mutateAsync: createPost, isPending: isPostPending } = useCreateSocialPost()
   const { mutateAsync: createCampaign, isPending: isCampaignPending } = useCreateCampaign()
-  const { socialPlatforms = [], isLoading: isPlatformsLoading } = useSocialPlatforms()
+  const { socialPlatforms = [], isLoading: isPlatformsLoading } = useSocialPlatforms({ category: "social" })
   const { products = [], isLoading: isProductsLoading } = useProducts({ limit: 100 })
   const { data: contentRulesData } = useContentRules()
   


### PR DESCRIPTION
## What

The `/social-posts/create` modal (rendered by `CreateSocialPostSteps`) called `useSocialPlatforms()` with no category filter, so the platform dropdown listed **all** external providers — shipping, payment, email, SMS, analytics, CRM, storage, and AI — alongside actual social platforms.

## Fix

Scope the fetch to `{ category: "social" }`, matching what `create-social-post-component.tsx` already does. The backend `GET /admin/social-platforms` already honors the `category` query param, so no server change is needed.

## Test

- Open `/social-posts/create` → the Platform dropdown now only shows social-media platforms (Facebook, Instagram, FBINSTA, etc.).