### PR TITLE
fix(mcp): the quote tools could describe a design quote they could never mint

### DIFF
--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -18,7 +18,18 @@ import { z } from "@medusajs/framework/zod"
  * number and a plausible typo, and an ACTIVE price of zero is one the cart
  * cheerfully charges — see the note in `lib/line-override.ts`.
  */
-const QuoteLine = z
+/**
+ * The line's FIELDS, before the cross-field refinements.
+ *
+ * 🔑 Exported so the MCP tool schema can be checked against it. The tools'
+ * coverage test compares top-level body keys to the mint validator, but a
+ * quote's real vocabulary is mostly INSIDE a line — and the nested half went
+ * unchecked until `unit_weight_grams` was found missing from the tool schema,
+ * which is the one field a design-led quote cannot be priced without.
+ * `.refine()` returns a ZodEffects with no `.shape`, so the raw object has to
+ * be named to be readable.
+ */
+export const QuoteLineShape = z
   .object({
     /**
      * Optional ONLY because a line may name a `design_id` instead — see the
@@ -63,6 +74,9 @@ const QuoteLine = z
      */
     unit_weight_grams: z.number().positive().max(1_000_000).nullish(),
   })
+
+/** The line as the routes accept it: the shape plus its cross-field rules. */
+const QuoteLine = QuoteLineShape
   .refine((l) => Boolean(l.variant_id) || Boolean(l.design_id), {
     message: "A line must name either a variant_id or a design_id.",
     path: ["variant_id"],

--- a/apps/backend/src/lib/mcp-core/__tests__/quote-tool-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/quote-tool-field-coverage.unit.spec.ts
@@ -35,11 +35,13 @@ import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
 import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
 import {
   PartnerMintQuoteShape,
+  QuoteLineShape,
   QuoteReadinessShape,
 } from "../../../api/partners/quotes/validators"
 import {
   QUOTE_MINT_BODY_PARAMS,
   QUOTE_MINT_READINESS_BODY_PARAMS,
+  QUOTE_MINT_WRITE_GUIDANCE,
   quoteMintSchemaProps,
   quoteReadinessSchemaProps,
 } from "../../../modules/partner-quote/tool-schema"
@@ -77,6 +79,30 @@ describe("quote MCP tools — the body vocabulary matches its validators (#1439)
       for (const key of Object.keys(quoteMintSchemaProps())) {
         expect(QUOTE_MINT_BODY_PARAMS).toContain(key)
       }
+    })
+
+    /**
+     * 🔴 The checks above are all TOP-LEVEL, and a quote's real vocabulary is
+     * mostly inside a line. That blind spot cost `unit_weight_grams`: the
+     * validator accepted it, the dispatcher forwarded it (the allowlist walks
+     * the body, not the line), and the tool schema never mentioned it — so the
+     * model was never told the one field a DESIGN line cannot be priced
+     * without. Freight is rated on the summed basket weight and refuses the
+     * whole basket on the first line it cannot weigh, and a design has no
+     * weight of its own. The tool could describe a design quote it could never
+     * successfully mint.
+     */
+    it("describes every field a LINE accepts", () => {
+      const described = Object.keys(
+        (quoteMintSchemaProps() as any).lines.items.properties
+      )
+      expect(described.sort()).toEqual(Object.keys(QuoteLineShape.shape).sort())
+    })
+
+    it("tells the model how a design line differs", () => {
+      // The two refusals a design line hits that a variant line never does.
+      expect(QUOTE_MINT_WRITE_GUIDANCE).toContain("unit_weight_grams")
+      expect(QUOTE_MINT_WRITE_GUIDANCE).toContain("design_id")
     })
   })
 

--- a/apps/backend/src/modules/partner-quote/tool-schema.ts
+++ b/apps/backend/src/modules/partner-quote/tool-schema.ts
@@ -75,6 +75,8 @@ export const QUOTE_MINT_WRITE_GUIDANCE = [
   "Cross-border freight IS rated now (#1498): when the partner's own pickup pin cannot be carried, the rate is retried from one of our own export warehouses and the domestic first leg is added, so a real carrier number is quoted. Do NOT reach for `freight_override_amount` by reflex — hand-typed international rates have run 2-3x the rated route, and the buyer is charged the difference. Supply it only when readiness actually refuses for want of freight, and pass `freight_basis` saying where the number came from; it is shown to the buyer as quoted by hand.",
   "`duties_prepaid: true` is a promise that the buyer pays nothing at their border. It requires a duty figure alongside it — either `duty_rate_percent` (preferred, applied to the basket actually priced) or `duty_total`. Promising DDP with no amount funds it out of margin.",
   "Tax follows the SELLER's jurisdiction, never the buyer's. An export from India is zero-rated whatever the destination's VAT rate is; do not add destination VAT to the lines.",
+  "A DESIGN line (`design_id`) is quoted before the garment exists as a product. Two things follow that a variant line never needs. (1) Send `unit_weight_grams` on it — the design has no weight of its own, and the freight estimate refuses the whole basket on the first line it cannot weigh, so one design line with no weight kills the quote. (2) The mint CREATES a made-to-order product for that design and adds it to the partner's catalogue; readiness reports this as a `design_catalogue_pending` warning, which is expected and not a problem to solve.",
+  "`override_unit_amount` is read in the PARTNER STORE's default currency and converted at the live rate — it is not in the quote currency. On an INR store quoting in AUD, `40` means forty rupees, about A$0.58. Quote the price the seller means in their own currency, or state the buyer-facing figure and let a human convert it.",
 ].join(" ")
 
 /**
@@ -137,7 +139,12 @@ export const quoteMintSchemaProps = () => ({
         override_unit_amount: {
           type: "number",
           description:
-            "A flat unit price in the partner store's default currency. Beats the catalogue and any discount.",
+            "A flat unit price in the partner store's DEFAULT currency, not the quote currency — it is converted at the live rate on mint. Beats the catalogue and any discount.",
+        },
+        unit_weight_grams: {
+          type: "number",
+          description:
+            "Weight of ONE unit, in grams. REQUIRED IN PRACTICE ON A DESIGN LINE: freight is rated on the summed basket weight and the estimate refuses the WHOLE basket on the first line it cannot weigh, and a design quoted before its garment was ever weighed has no weight to find. Prices this quote only — it is never written back to the variant.",
         },
       },
       required: ["quantity"],


### PR DESCRIPTION
`unit_weight_grams` was accepted by the validator, forwarded by the dispatcher (the allowlist walks the **body**, not the line), and described **nowhere** in the tool schema — so the model was never told about the one field a design line cannot be priced without.

Not cosmetic: freight is rated on the summed basket weight and `buildShippingEstimate` refuses the **whole basket** on the first line it cannot weigh. A design is quoted before the garment exists as a product, so it has no weight to find. An assistant minting a design-led quote would hit a refusal it had no vocabulary to answer.

## Changed

- `unit_weight_grams` described on the line, saying why a design line needs it.
- Guidance the model gets *before* it calls: what a design line does differently (needs a weight; the mint **creates** a made-to-order product, so `design_catalogue_pending` is expected and not a fault), and that `override_unit_amount` is read in the **partner store's** currency and converted — on an INR store quoting AUD, `40` means forty rupees, ≈ A$0.58.

## The class of bug, not the instance

The coverage spec compared the tool's vocabulary to the validator's — but only at the **top level**, and a quote's real vocabulary is mostly inside a line. A nested field could go missing forever with every assertion green.

`QuoteLineShape` is now exported from the partner validator (`.refine()` returns a ZodEffects with no `.shape`, so the raw object had to be named), and the spec asserts the line's schema properties equal it **in both directions**.

**Mutation-checked** — reverting the schema change fails both new assertions. 838 quote + MCP unit tests green · `check:prod-build` green.

## Found while minting a real quote

This came out of quoting Design for Oshen's four components (`01M1BPV6TM…`, live) — a design-led, cross-border, override-priced basket, which is exactly the shape the tool could describe but not complete.

Refs #1439, #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4