### PR TITLE
fix(quotes): the buyer link pointed at a 404 — twice, for two different reasons

### DIFF
--- a/apps/backend/src/modules/partner-quote/__tests__/quote-link.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-link.unit.spec.ts
@@ -185,14 +185,41 @@ describe("resolveQuoteBuyerLink", () => {
     ).resolves.toBe("https://unique-pashmina.jaalyantra.com/de/quotes/tok_abc")
   })
 
-  it("falls back to the house storefront when the partner has no domain at all", async () => {
+  /**
+   * 🔴 Was "falls back to the house storefront". It does not, because that link
+   * does not work: `assertQuoteVisibleToCaller` refuses any read whose key
+   * resolves to a store other than the quote's own. Verified live against quote
+   * `01M1BPV6TM…` — `GET /store/b2b/quotes/<token>` was **404** under the house
+   * publishable key and **200** under the owning partner store's.
+   *
+   * Null makes `deliverQuoteEmail` refuse to send and record why. A 404 dressed
+   * as a link would have gone to the buyer instead.
+   */
+  it("🔴 returns NULL, not a house link, when a PARTNER has no storefront", async () => {
     const scope = scopeWith([
       { id: "part_1", custom_domain: null, custom_domain_verified: false, storefront_domain: null },
     ])
 
     await expect(
       withHouse(() => resolveQuoteBuyerLink(scope, base))
-    ).resolves.toBe("https://cicilabel.com/de/quotes/tok_abc")
+    ).resolves.toBeNull()
+  })
+
+  it("🔴 a VERIFIED custom domain with no storefront is not a link either", async () => {
+    // The production row: saranshsharma.me, verified, nothing deployed behind
+    // it. It served an unrelated personal site and 404'd the quote page.
+    const scope = scopeWith([
+      {
+        id: "part_1",
+        custom_domain: "saranshsharma.me",
+        custom_domain_verified: true,
+        storefront_domain: null,
+      },
+    ])
+
+    await expect(
+      withHouse(() => resolveQuoteBuyerLink(scope, base))
+    ).resolves.toBeNull()
   })
 
   it("uses the house storefront for a quote with no partner at all", async () => {
@@ -202,14 +229,14 @@ describe("resolveQuoteBuyerLink", () => {
     ).resolves.toBe("https://cicilabel.com/de/quotes/tok_abc")
   })
 
-  it("🔴 falls back to the house link when the partner read FALLS OVER", async () => {
-    // A query that failed is not evidence the partner has no shop, and the link
-    // is the only copy of the token: a reachable page on our own domain beats
-    // no email at all.
+  it("🔴 returns null when the partner read FALLS OVER", async () => {
+    // A failed query is not evidence the partner has no shop — but nor does it
+    // make a house link work for a partner's quote, and a link to a not-found
+    // page is worse for the buyer than the mint saying it could not build one.
     const scope = scopeWith([], { throws: true })
     await expect(
       withHouse(() => resolveQuoteBuyerLink(scope, base))
-    ).resolves.toBe("https://cicilabel.com/de/quotes/tok_abc")
+    ).resolves.toBeNull()
   })
 
   it("still returns null when there is no partner domain AND no house domain", async () => {

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-producer.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-producer.unit.spec.ts
@@ -155,6 +155,25 @@ describe("producerStorefrontUrl", () => {
     ).toBe("https://unique-pashmina.jaalyantra.com")
   })
 
+  /**
+   * The production row that emailed a buyer a 404 (2026-08-31).
+   *
+   * `custom_domain_verified` is proof the DNS is ours, NOT proof a storefront
+   * is deployed behind it. The founder's own partner had a verified
+   * `saranshsharma.me` and no storefront at all — the host serves an unrelated
+   * personal site, and the quote link 404'd there. The buyer link is the only
+   * copy of the token.
+   */
+  it("🔴 refuses a VERIFIED custom domain when no storefront was ever provisioned", () => {
+    expect(
+      producerStorefrontUrl({
+        custom_domain: "saranshsharma.me",
+        custom_domain_verified: true,
+        storefront_domain: null,
+      })
+    ).toBeNull()
+  })
+
   it("is null when the partner has no reachable domain at all", () => {
     expect(
       producerStorefrontUrl({ custom_domain: null, storefront_domain: null })

--- a/apps/backend/src/modules/partner-quote/lib/quote-link.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-link.ts
@@ -27,18 +27,30 @@ import { producerStorefrontUrl } from "./quote-producer"
  * owns "which host is this partner reachable on", including the refusal to link
  * an unverified custom domain, and it is already under test.
  *
- * ## The house fallback
+ * ## The house fallback is ONLY for a house quote
  *
- * A quote minted by an admin for a partner with no domain — and, once #1486's
- * no-partner branch lands, a house quote with no partner at all — has no
- * partner host to use. It falls back to the platform storefront, from
+ * A quote with no partner falls back to the platform storefront, from
  * `ROOT_DOMAIN` (cicilabel.com) with `FRONTEND_URL` as the second choice.
  *
- * 🔑 The fallback is the LAST resort, never the first. A partner's buyer must
- * land on the partner's own shop: the quote page names the producer, prices
- * against their catalogue and, once accepted, builds a cart in their sales
- * channel. Preferring the house domain would quietly move every partner's
- * buyer onto ours.
+ * 🔴 A PARTNER's quote never does, and the reason is not preference — it is
+ * that the link would not work. `assertQuoteVisibleToCaller` refuses any read
+ * whose calling publishable key resolves to a store other than the quote's
+ * own, and that guard exists because three stores' keys once all returned 200
+ * for the same token (#1439 S15). Verified live on 2026-08-31 against quote
+ * `01M1BPV6TM…`: `GET /store/b2b/quotes/<token>` answered **404** under the
+ * house key and **200** under the owning partner store's. So a house link for
+ * a partner quote is a 404 dressed as a link, and the buyer link is the only
+ * copy of the token.
+ *
+ * Null instead. `deliverQuoteEmail` already treats a missing link as a refusal
+ * to send — "an email without the link is worse than no email" — and records
+ * it on the quote's timeline for a human to act on. A quote nobody can open is
+ * a fact worth surfacing at the mint, not one to paper over with a URL that
+ * resolves to a not-found page.
+ *
+ * 🔑 A partner's buyer must land on the partner's own shop for a second reason
+ * too: the page names the producer, prices against their catalogue and, once
+ * accepted, builds a cart in their sales channel.
  */
 
 /**
@@ -127,19 +139,22 @@ export async function resolveQuoteBuyerLink(
     })
 
     const partner = ((partners ?? []) as any[])[0]
-    if (!partner) return houseLink()
 
-    return (
-      buildQuoteBuyerUrl({
-        origin: producerStorefrontUrl(partner),
-        countryCode: input.destination_country_code,
-        token: input.token,
-      }) ?? houseLink()
-    )
+    // 🔴 NOT the house link. This quote belongs to the partner's store, and the
+    // tenant guard refuses it to every other store's key — a house URL here
+    // would 404 for the buyer.
+    if (!partner) return null
+
+    return buildQuoteBuyerUrl({
+      origin: producerStorefrontUrl(partner),
+      countryCode: input.destination_country_code,
+      token: input.token,
+    })
   } catch {
-    // 🔴 The house link, not null. A partner lookup that fell over is not
-    // evidence the partner has no shop, and the buyer link is the only copy of
-    // the token — a reachable page on our own domain beats no email at all.
-    return houseLink()
+    // Null, for the same reason. A failed lookup is not evidence the partner
+    // has no shop — but nor does it make a house link work, and "here is your
+    // quote" pointing at a not-found page is worse for the buyer than the mint
+    // telling a human the link could not be built.
+    return null
   }
 }

--- a/apps/backend/src/modules/partner-quote/lib/quote-producer.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-producer.ts
@@ -106,11 +106,30 @@ export function composeProducerTags(input: {
  * ours, linking it points a buyer at a host we do not control. The provisioned
  * subdomain is always ours, so it is the fallback rather than the second
  * choice.
+ *
+ * 🔴 `storefront_domain` is the PROOF that a storefront exists, and nothing
+ * else is. `custom_domain_verified` means the DNS is ours — it says nothing
+ * about anything being deployed behind it, and the two came apart on
+ * production: the founder's own partner carried
+ * `custom_domain: saranshsharma.me`, `custom_domain_verified: true`,
+ * `storefront_domain: null` and no deployment at all. A minted quote emailed a
+ * buyer a link to that host, which serves an unrelated personal site and
+ * answered **404** for the quote page — the only copy of the token, pointed at
+ * a stranger's website.
+ *
+ * So a partner host requires a provisioned subdomain. Without one this returns
+ * null and the caller falls back to the house storefront, which is a page that
+ * actually exists. Every partner on production who has a real shop has this
+ * column set (a `*.cicilabel.com` host); the only row it excluded was the one
+ * that had no shop.
  */
 export function producerStorefrontUrl(partner: any): string | null {
+  const provisioned = String(partner?.storefront_domain ?? "").trim()
+  if (!provisioned) return null
+
   const host = partner?.custom_domain_verified
-    ? partner?.custom_domain || partner?.storefront_domain
-    : partner?.storefront_domain
+    ? partner?.custom_domain || provisioned
+    : provisioned
 
   const clean = String(host ?? "").trim().toLowerCase()
   if (!clean) return null

--- a/apps/backend/src/workflows/partner-quote/deliver-quote-email.ts
+++ b/apps/backend/src/workflows/partner-quote/deliver-quote-email.ts
@@ -150,7 +150,9 @@ export async function deliverQuoteEmail(
     // An email without the link is worse than no email: it tells the buyer a
     // quote exists and gives them no way to open it.
     return await fail(
-      "there is no verified storefront domain for this partner and no house storefront configured, so there is no buyer link to send.",
+      "this partner has no storefront of their own, and a link on the house domain would 404 — " +
+        "the quote can only be read through its own store's key. Provision a storefront for the partner, " +
+        "or mint under one that has one.",
       "email_skipped"
     )
   }


### PR DESCRIPTION
A quote minted today emailed its buyer a link that does not work. Two causes, found one after the other.

## 1 — a verified domain is not a storefront

`producerStorefrontUrl` preferred `custom_domain` whenever `custom_domain_verified` was true. Verification proves **the DNS is ours**. It proves nothing about a storefront existing behind it:

```
custom_domain:          saranshsharma.me
custom_domain_verified: true
storefront_domain:      null
hosting_provider:       null
deployment_project_id:  null
```

`saranshsharma.me` serves an unrelated personal site on Netlify — root 200s, `/au/quotes/<token>` **404s**. `storefront_domain` is now the proof a storefront exists, and nothing else is.

Checked every partner on production before tightening it: all ten with a real shop carry a `*.cicilabel.com` `storefront_domain` plus a Vercel project. The only row newly excluded is the one with no shop.

## 2 — and the house fallback 404s too

Falling back to the house storefront looked right. It isn't, and the reason is structural: `assertQuoteVisibleToCaller` refuses any read whose publishable key resolves to a store other than the quote's own — the guard added because three stores' keys once all returned 200 for one token (#1439 S15). Proven live on the minted quote:

| key | result |
|---|---|
| Cici Label (house) | **404** |
| Saransh Sharma Store (owner) | **200** |

So a house URL for a partner's quote is a 404 dressed as a link.

`resolveQuoteBuyerLink` now returns **null** for a partner quote with no usable partner storefront, including when the lookup throws. `deliverQuoteEmail` already refuses to send without a link — *"an email without the link is worse than no email"* — and records it on the timeline; its reason now names the real cause and the remedy. The house origin stays correct for a quote with **no partner**, the only case the house key can actually read.

## The tests that were wrong

Two encoded the belief this disproves. One of them argued for it in a comment: *a reachable page on our own domain beats no email at all.* It is not reachable. Both now assert null, with the 404/200 pair written down beside them.

**Mutation-checked** — reverting the domain guard fails the new test, which is the production row verbatim. 421 quote unit tests green · `check:prod-build` green.

## Consequence, stated plainly

A partner with no storefront **cannot** be given a working buyer link. The mint now says so instead of pretending. Quote `01M1BPV6TMK0SVH32HX6SMQ25Z` is in exactly that state; this PR stops the next one and cannot repair the email that already went. The remedy for that quote is to provision a storefront for the partner (`POST /admin/partners/:id/storefront/provision`) and reissue the link from the raw token.

Refs #1420, #1439, #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4