### PR TITLE
fix(quotes): an open quote told its buyer it was closed

### DIFF
--- a/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
+++ b/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
@@ -4,6 +4,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
 import { buildQuoteView } from "../../../../../modules/partner-quote/lib/build-quote-view"
 import { composeQuoteAcceptance } from "../../../../../modules/partner-quote/lib/quote-acceptance-view"
+import { effectiveQuoteLines } from "../../../../../modules/partner-quote/lib/effective-quote-lines"
 import { resolveQuoteParties } from "../../../../../modules/partner-quote/lib/quote-parties"
 import { assertQuoteVisibleToCaller } from "../../../../../modules/partner-quote/lib/quote-tenant-guard"
 import { hashQuoteToken } from "../../../../../modules/partner-quote/lib/token"
@@ -41,31 +42,17 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const lines = await service.listPartnerQuoteLines({ quote_id: quote.id })
 
-  // The buyer may move their quantities; absent that, the quoted basket stands.
-  const requested = (req.query.lines as string | undefined) ?? null
-  let effectiveLines = (lines ?? []).map((l: any) => ({
-    variant_id: l.variant_id,
-    quantity: l.quantity,
-    position: l.position,
-    note: l.note,
-  }))
-
-  if (requested) {
-    try {
-      const dialled = JSON.parse(requested) as Array<{
-        variant_id: string
-        quantity: number
-      }>
-      const byVariant = new Map(dialled.map((d) => [d.variant_id, d.quantity]))
-      effectiveLines = effectiveLines.map((l: any) => ({
-        ...l,
-        quantity: Number(byVariant.get(l.variant_id) ?? l.quantity),
-      }))
-    } catch {
-      // A malformed dial is not worth a 400 — show the quoted basket instead of
-      // failing a buyer's page over a query string.
-    }
-  }
+  /**
+   * The buyer may move their quantities; absent that, the quoted basket stands.
+   *
+   * 🔑 `effectiveQuoteLines` carries `quoted_unit_weight_grams` through as the
+   * line's `unit_weight_grams`. Omitting it here is what made every design-led
+   * quote report itself closed — see that function's docblock.
+   */
+  const effectiveLines = effectiveQuoteLines(
+    lines as any,
+    (req.query.lines as string | undefined) ?? null
+  )
 
   // 🔴 The store's PICKUP LOCATION, not just its id.
   //

--- a/apps/backend/src/modules/partner-quote/__tests__/effective-quote-lines.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/effective-quote-lines.unit.spec.ts
@@ -1,0 +1,61 @@
+import { effectiveQuoteLines } from "../lib/effective-quote-lines"
+
+/**
+ * The basket the buyer's page prices.
+ *
+ * Written because a field went missing from an inline `.map()` and nothing
+ * could see it: `quoted_unit_weight_grams` — the weight the mint was given for
+ * a line the catalogue cannot weigh — was dropped, so every DESIGN-led quote
+ * refused to price its freight and told the buyer the quote was closed.
+ */
+
+const line = (over: Record<string, any> = {}) => ({
+  variant_id: "variant_1",
+  quantity: 3,
+  position: 0,
+  note: "Tea towels",
+  quoted_unit_weight_grams: 333,
+  ...over,
+})
+
+describe("effectiveQuoteLines", () => {
+  it("🔴 carries the frozen unit weight — a design line has no other source", () => {
+    const [l] = effectiveQuoteLines([line()])
+    expect(l.unit_weight_grams).toBe(333)
+  })
+
+  it("is null, not zero, when the line was never weighed", () => {
+    // 🔑 Zero is a weightless consignment, which every carrier rates at its
+    // floor. Null means "ask the catalogue", which the estimate can refuse.
+    const [l] = effectiveQuoteLines([line({ quoted_unit_weight_grams: null })])
+    expect(l.unit_weight_grams).toBeNull()
+  })
+
+  it("keeps the weight when the buyer dials a new quantity", () => {
+    const [l] = effectiveQuoteLines(
+      [line()],
+      JSON.stringify([{ variant_id: "variant_1", quantity: 9 }])
+    )
+    expect(l.quantity).toBe(9)
+    expect(l.unit_weight_grams).toBe(333)
+  })
+
+  it("leaves undialled lines at their quoted quantity", () => {
+    const out = effectiveQuoteLines(
+      [line(), line({ variant_id: "variant_2", quantity: 2 })],
+      JSON.stringify([{ variant_id: "variant_1", quantity: 9 }])
+    )
+    expect(out.map((l) => l.quantity)).toEqual([9, 2])
+  })
+
+  it("ignores a mangled dial rather than failing the page", () => {
+    const out = effectiveQuoteLines([line()], "not json{")
+    expect(out[0].quantity).toBe(3)
+    expect(out[0].unit_weight_grams).toBe(333)
+  })
+
+  it("is empty for an empty quote, and does not throw on null", () => {
+    expect(effectiveQuoteLines(null)).toEqual([])
+    expect(effectiveQuoteLines(undefined, "[]")).toEqual([])
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/effective-quote-lines.ts
+++ b/apps/backend/src/modules/partner-quote/lib/effective-quote-lines.ts
@@ -1,0 +1,87 @@
+/**
+ * PURE: the basket the buyer's page prices, from the quote's frozen lines and
+ * whatever quantities they have dialled.
+ *
+ * ## Why it is a function rather than four lines in the route
+ *
+ * Because a field went missing from those four lines and nothing could see it.
+ * The route mapped `variant_id`, `quantity`, `position`, `note` — and dropped
+ * `quoted_unit_weight_grams`, the weight the MINT was given for a line the
+ * catalogue cannot weigh.
+ *
+ * 🔴 That drop made every DESIGN-led quote unacceptable online. A design is
+ * quoted before its garment exists as a product, so the made-to-order variant
+ * minted for it carries no weight; the operator types one per line instead.
+ * Without it `buildShippingEstimate` fell back to the variant, found nothing,
+ * and refused the WHOLE basket — and the resulting `live_error` reaches
+ * `composeQuoteAcceptance` as `unusable_reason`, which tells the buyer:
+ *
+ *   "This quote is no longer open. Ask for a fresh one and it will be priced
+ *    again."
+ *
+ * on a quote minted minutes earlier and open for a fortnight. Live on
+ * `01M1BPV6TM…` (Oshen, four design lines).
+ *
+ * A mapping that silently omits a pricing input is exactly the shape a test
+ * can hold, so it lives here where one can reach it.
+ */
+
+export type FrozenQuoteLine = {
+  variant_id: string
+  quantity: number
+  position?: number | null
+  note?: string | null
+  quoted_unit_weight_grams?: number | null
+}
+
+export type EffectiveQuoteLine = {
+  variant_id: string
+  quantity: number
+  /**
+   * `undefined`, never `null`, when a line has no position — the view's own
+   * line type declares `position?: number` and a null would not assign to it.
+   */
+  position?: number
+  note: string | null
+  /** The mint's own figure, carried forward. Null means "ask the catalogue". */
+  unit_weight_grams: number | null
+}
+
+/**
+ * @param lines  the quote's frozen rows
+ * @param dial   the `?lines=` query value, or null
+ *
+ * A malformed dial is IGNORED rather than refused: the quoted basket is always
+ * a correct answer, and a link mangled by an email client should not cost the
+ * buyer their price.
+ */
+export function effectiveQuoteLines(
+  lines: FrozenQuoteLine[] | null | undefined,
+  dial?: string | null
+): EffectiveQuoteLine[] {
+  const base: EffectiveQuoteLine[] = (lines ?? []).map((l) => ({
+    variant_id: l.variant_id,
+    quantity: Number(l.quantity),
+    position: l.position ?? undefined,
+    note: l.note ?? null,
+    unit_weight_grams: l.quoted_unit_weight_grams ?? null,
+  }))
+
+  if (!dial) return base
+
+  let byVariant: Map<string, number>
+  try {
+    const parsed = JSON.parse(dial) as Array<{
+      variant_id: string
+      quantity: number
+    }>
+    byVariant = new Map(parsed.map((d) => [d.variant_id, d.quantity]))
+  } catch {
+    return base
+  }
+
+  return base.map((l) => ({
+    ...l,
+    quantity: Number(byVariant.get(l.variant_id) ?? l.quantity),
+  }))
+}

--- a/apps/backend/src/workflows/partner-quote/accept-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/accept-quote.ts
@@ -569,6 +569,11 @@ const assertCartMatchesQuoteStep = createStep(
         lines: (input.lines ?? []).map((l: any) => ({
           variant_id: l.variant_id,
           quantity: Number(l.quantity),
+          // The weight the mint froze on the line. A design-led quote's
+          // made-to-order variant has none of its own, and without this the
+          // estimate refuses the whole basket — the same drop that made the
+          // buyer page report an open quote as closed.
+          unit_weight_grams: l.quoted_unit_weight_grams ?? null,
         })),
         customer_group_id: quote.customer_group_id,
         destination_country_code: quote.destination_country_code,


### PR DESCRIPTION
Sunda's quote page says **"This quote cannot be ordered online"** — *"This quote is no longer open. Ask for a fresh one and it will be priced again."* The quote was minted an hour earlier and stands until 14 September.

## The chain

The buyer route rebuilt the basket as `{ variant_id, quantity, position, note }` and dropped **`quoted_unit_weight_grams`** — the weight the mint was given for a line the catalogue cannot weigh. A design is quoted before its garment exists as a product, so the made-to-order variant has no weight of its own; the operator types one per line, and that column is where the mint froze it (333 g on all four Oshen lines).

Without it the estimate fell back to the variant, found nothing, and refused the whole basket:

```
Variant "Custom Design" has no shipping weight, and neither does its
product, so freight cannot be quoted for it.
```

That becomes `view.live_error`, which the route hands to `composeQuoteAcceptance` as `unusable_reason` — a parameter meaning *revoked, superseded or expired*. A **pricing failure was reported as a lifecycle verdict**, and the one useful action (reply and ask) was hidden behind advice to request a fresh quote that would fail identically.

**Every design-led quote is unacceptable online today.** The mint prices them correctly and freezes a total; the buyer cannot act on it.

## The fix

`effectiveQuoteLines` — pure, and a function precisely *because* a field went missing from an inline `.map()` where no test could hold it. It carries the frozen weight through as `unit_weight_grams`, keeps it when the buyer dials a quantity, and returns the quoted basket unchanged for a mangled dial.

The accept path did the same drop and now passes the same figure, so the cart cannot re-rate the lane differently from the page that offered it.

## Not fixed here

The wrong sentence. `unusable_reason` conflating *"we could not price this"* with *"this quote is closed"* is a second defect, filed separately — this PR removes the cause rather than the mislabelling.

6 new unit tests · 427 quote unit tests green · `check:prod-build` green.

Refs #1439, #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4