### PR TITLE
fix(payments): an order read "INR 0 paid" above INR 20,000 of completed payments

### DIFF
--- a/apps/backend/src/admin/components/inventory-orders/__tests__/inventory-order-payments-section.unit.spec.ts
+++ b/apps/backend/src/admin/components/inventory-orders/__tests__/inventory-order-payments-section.unit.spec.ts
@@ -1,0 +1,92 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+
+/**
+ * The headline over an inventory order's payouts (#1704).
+ *
+ * 🔴 `/admin/inventory-orders/:id/payments` returns `{billed, paid, recorded}`
+ * and this panel rendered two of the three. So an order headlined
+ * "INR 0 paid of INR 28,200 billed" directly above two COMPLETED payments
+ * totalling ₹20,000 — and that reading is what nearly paid a partner twice.
+ * Same shape as #1679: a value computed server-side, sent over the wire, with
+ * no reader.
+ *
+ * There is no component test harness in this package, so this renders the
+ * section to static markup with the data hooks stubbed. It exists to pin one
+ * thing: both numbers reach the screen, and they stay distinguishable.
+ */
+
+jest.mock("react-router-dom", () => ({
+  Link: ({ children }: any) => React.createElement("a", null, children),
+}))
+
+jest.mock("../../../hooks/api/payments", () => ({
+  useUpdatePayment: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}))
+
+const mockPayments = jest.fn()
+jest.mock("../../../hooks/api/inventory-orders", () => ({
+  useInventoryOrderPayments: (...args: any[]) => mockPayments(...args),
+}))
+
+/**
+ * ⚠️ The jest swc transform emits CLASSIC JSX (`React.createElement`) while the
+ * admin sources rely on the automatic runtime and import no React. Putting
+ * React on the global keeps that transform working without changing the shared
+ * jest config for every suite in the repo.
+ */
+;(globalThis as any).React = React
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { InventoryOrderPaymentsSection } = require("../inventory-order-payments-section")
+
+const payout = {
+  line_id: "psi_1",
+  submission_id: "ps_1",
+  submission_status: "Approved",
+  submission_total: 28200,
+  currency: "inr",
+  amount: 28200,
+  source_type: null,
+}
+
+const render = (totals: any, payments: any[] = []) => {
+  mockPayments.mockReturnValue({
+    payouts: [payout],
+    payments,
+    totals,
+    isLoading: false,
+    isError: false,
+  })
+  return renderToStaticMarkup(
+    React.createElement(InventoryOrderPaymentsSection, {
+      inventoryOrder: { id: "inv_order_1" },
+    })
+  )
+}
+
+const text = (html: string) => html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ")
+
+describe("InventoryOrderPaymentsSection — the headline", () => {
+  it("🔴 shows what was RECORDED beside what has settled", () => {
+    const html = text(render({ billed: 28200, paid: 0, recorded: 20000 }))
+
+    expect(html).toContain("INR 28,200 billed")
+    // The number that was missing. Without it the order reads as unpaid.
+    expect(html).toContain("20,000")
+    expect(html).toMatch(/recorded against this order/i)
+  })
+
+  it("does not blend the two — settled stays 0 while 20,000 is recorded", () => {
+    // #1639 exists because collapsing them let a payout read `Paid` for 34
+    // days before the money moved. Both facts, distinctly.
+    const html = text(render({ billed: 28200, paid: 0, recorded: 20000 }))
+    expect(html).toMatch(/INR 0 settled of INR 28,200 billed/)
+  })
+
+  it("says nothing about recorded money when there is none", () => {
+    const html = text(render({ billed: 28200, paid: 0, recorded: 0 }))
+    expect(html).not.toMatch(/recorded against this order/i)
+    expect(html).toMatch(/INR 0 settled of INR 28,200 billed/)
+  })
+})

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-payments-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-payments-section.tsx
@@ -154,6 +154,21 @@ export const InventoryOrderPaymentsSection = ({ inventoryOrder }: InventoryOrder
   const payoutList = payouts || [];
   const total = payoutList.length + payments.length;
 
+  /**
+   * 🔴 `paid` and `recorded` answer DIFFERENT questions and the headline must
+   * carry both (#1704). `paid` is what a submission with status `Paid` covers —
+   * money that has SETTLED — and #1639 made that deliberately strict so an
+   * order cannot claim settlement before the transfer happens. `recorded` is
+   * the internal payments actually booked against this order. Rendering only
+   * `paid` headlined an order "INR 0 paid" above INR 20,000 of completed
+   * payments, and that reading is what nearly paid a partner twice.
+   *
+   * Internal payments carry no currency of their own (see the model), so the
+   * recorded figure is formatted with the INR default rather than the payout's
+   * currency — those are not the same unit and must not be summed.
+   */
+  const recorded = Number(totals?.recorded ?? 0);
+
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
@@ -194,8 +209,14 @@ export const InventoryOrderPaymentsSection = ({ inventoryOrder }: InventoryOrder
               Partner payouts for this order
             </Text>
             <Text size="xsmall" className="text-ui-fg-subtle">
-              {money(totals?.paid, payoutList[0]?.currency)} paid of{" "}
+              {money(totals?.paid, payoutList[0]?.currency)} settled of{" "}
               {money(totals?.billed, payoutList[0]?.currency)} billed
+              {recorded > 0 && (
+                <>
+                  {" · "}
+                  {money(recorded)} recorded against this order
+                </>
+              )}
             </Text>
           </div>
           {payoutList.map((p) => (


### PR DESCRIPTION
Closes #1704

`GET /admin/inventory-orders/:id/payments` returns `{billed, paid, recorded}`. The panel rendered **two of the three**, so `inv_order_01KWAKAZE17CC95XDEY7Q0M8SN` headlined

> Partner payouts for this order — **INR 0 paid of INR 28,200 billed**

directly above two **completed** payments totalling **₹20,000**. Two halves of one screen contradicting each other, with the third value computed server-side, sent over the wire, and read by nobody — the same shape as #1679.

`paid` was not wrong on its own terms: it counts only what a submission with status `Paid` covers, and #1639 made that deliberately strict so an order cannot claim settlement before the transfer happens. But money moves through **two** records here, and "₹0 paid" against a delivered order is the reading that pays a partner twice — very nearly what happened on this one.

**Now:** `INR 0 settled of INR 28,200 billed · INR 20,000 recorded against this order` — both facts, distinctly. Not a blended number; collapsing them is precisely what #1639 exists to prevent.

The recorded figure uses the INR default rather than the payout currency: internal payments carry no currency of their own, and those are not the same unit.

## Verify

```
cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern="inventory-order-payments-section"
```

First render test in this package — the section rendered to static markup with its data hooks stubbed. **Mutation-checked:** reverting the headline to the old two-number form fails all three.

## Deliberately not in this PR

The submission bills the **ordered total** with no knowledge of payments already made against the same order — `01M13T9D9AGDA3QJYCXEZ942W7` billed ₹28,200 while ₹10,000 had been paid on 12 July. Arguably the deeper defect; it needs a decision, not a render change.

Also unchanged: `src/admin/widgets/order-partner-payouts.tsx` carries the same "paid of billed" wording for retail orders, but its route computes no `recorded` — there is no second number to show there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4