### PR TITLE
fix(quotes): a quote that cannot be PRICED told its buyer it was CLOSED

### DIFF
--- a/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
+++ b/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
@@ -162,7 +162,14 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     quote,
     gross_total:
       (view as any)?.live?.gross_total ?? (view as any)?.quoted?.gross_total ?? null,
-    unusable_reason: (view as any)?.live_error ?? null,
+    /**
+     * 🔴 The LIFECYCLE verdict, which is the one this parameter means (#1705).
+     * `live_error` used to be passed here, and it is a PRICING failure — so an
+     * open quote, minted an hour earlier, told its buyer it was no longer open
+     * and to ask for a fresh one that would have failed the same way.
+     */
+    unusable_reason: (view as any)?.unusable_reason ?? null,
+    pricing_error: (view as any)?.live_error ?? null,
   })
 
   res.json({ quote: { ...view, parties, acceptance } })

--- a/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
@@ -621,6 +621,46 @@ describe("buildQuoteView — lifecycle", () => {
     expect(view.compare.state).toBe("dead_link")
   })
 
+  /**
+   * 🔴 The lifecycle verdict must be READABLE off the view (#1705).
+   *
+   * It was not, and the buyer route reached for `live_error` instead — a
+   * PRICING failure — to decide whether to print "this quote is no longer
+   * open". An open quote whose freight could not be rated was told it was
+   * closed. The route now reads this field, so a view that stops carrying it
+   * would silently stop refusing revoked quotes: a missing key is a confident
+   * null.
+   */
+  it("names the lifecycle verdict on the view, separately from live_error", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+
+    const revoked = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({ quote: { status: "revoked", lines: [{ variant_id: "var_a", quantity: 500 }] } })
+    )
+    expect(revoked.unusable_reason).toBe("revoked")
+
+    const expired = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({
+        quote: {
+          status: "active",
+          expires_at: "2026-08-01T00:00:00Z",
+          lines: [{ variant_id: "var_a", quantity: 500 }],
+        },
+      })
+    )
+    expect(expired.unusable_reason).toBe("expired")
+
+    const open = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({ quote: { status: "active", lines: [{ variant_id: "var_a", quantity: 500 }] } })
+    )
+    // The one that mattered: open, and whatever happened to the live half is
+    // NOT allowed to appear here.
+    expect(open.unusable_reason).toBeNull()
+  })
+
   it("never re-prices an expired link, but still names what was quoted", async () => {
     const captured: Captured = { contexts: [], rateWeights: [] }
     const view = await buildQuoteView(

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-acceptance-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-acceptance-view.unit.spec.ts
@@ -90,3 +90,71 @@ describe("composeQuoteAcceptance — the refusal", () => {
     expect(a.blocked_reason).toBeNull()
   })
 })
+
+/**
+ * A quote that cannot be PRICED is not a quote that is CLOSED (#1705).
+ *
+ * 🔴 The buyer route passed the view's `live_error` — a pricing failure — into
+ * `unusable_reason`, which means revoked/superseded/expired. So quote
+ * `01M1BPV6TM…`, minted that morning and valid for a fortnight, told its buyer
+ * "this quote is no longer open, ask for a fresh one" — both halves false, and
+ * the replacement would have failed identically.
+ *
+ * These pin the separation: both inputs still BLOCK, only one may claim the
+ * quote is over, and the pricing sentence must not send the buyer away.
+ */
+describe("composeQuoteAcceptance — priced vs closed", () => {
+  it("🔴 a pricing failure does NOT say the quote is no longer open", () => {
+    const a = composeQuoteAcceptance({
+      quote: { ...base },
+      gross_total: 1000,
+      pricing_error: "freight_unrated",
+    })
+    expect(a.can_accept).toBe(false)
+    expect(a.blocked_reason).not.toMatch(/no longer open/i)
+    // The specific harm: sending them for a replacement that fails the same way.
+    expect(a.blocked_reason).not.toMatch(/fresh one/i)
+    expect(a.blocked_reason).toMatch(/still open/i)
+    expect(a.blocked_reason).toMatch(/reply/i)
+  })
+
+  it("still refuses acceptance — a cart priced off a half we could not compute is worse", () => {
+    const a = composeQuoteAcceptance({
+      quote: { ...base },
+      gross_total: 1000,
+      pricing_error: "freight_unrated",
+    })
+    expect(a.can_accept).toBe(false)
+  })
+
+  it("a revoked quote keeps the lifecycle sentence even when pricing also failed", () => {
+    const a = composeQuoteAcceptance({
+      quote: { ...base },
+      gross_total: 1000,
+      unusable_reason: "revoked",
+      pricing_error: "freight_unrated",
+    })
+    expect(a.blocked_reason).toMatch(/no longer open/i)
+  })
+
+  it("an unrateable DESTINATION is explained as such, not as a pricing hiccup", () => {
+    // The destination gap is structural and permanent; the pricing one is
+    // transient. Telling a buyer to "reply and we will confirm it" about a
+    // route we have no online delivery for promises the wrong thing.
+    const a = composeQuoteAcceptance({
+      quote: { ...base, quoted_shipping_option_id: null },
+      gross_total: 1000,
+      pricing_error: "freight_unrated",
+    })
+    expect(a.blocked_reason).toMatch(/destination|route/i)
+  })
+
+  it("prices normally when nothing failed", () => {
+    const a = composeQuoteAcceptance({
+      quote: { ...base },
+      gross_total: 1000,
+      pricing_error: null,
+    })
+    expect(a.can_accept).toBe(true)
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -448,6 +448,16 @@ export type QuoteView = {
   origin_country_code: string | null
   /** Set when the live half could not be built, so callers can say why. */
   live_error: string | null
+  /**
+   * The LIFECYCLE verdict from `quoteUnusableReason` — revoked, superseded,
+   * expired — or null while the quote still stands.
+   *
+   * 🔴 Exposed because it was not, and the buyer route reached for
+   * `live_error` instead when it needed this (#1705). A pricing failure is not
+   * a closed quote, and one field carrying both meanings printed "no longer
+   * open" on a quote minted an hour earlier.
+   */
+  unusable_reason: "revoked" | "superseded" | "expired" | null
 }
 
 /**
@@ -1647,5 +1657,6 @@ export async function buildQuoteView(
     expires_in_days: input.quote ? daysUntilExpiry(lifecycle, input.now) : null,
     origin_country_code: originCountry,
     live_error: liveError,
+    unusable_reason: unusableReason,
   }
 }

--- a/apps/backend/src/modules/partner-quote/lib/quote-acceptance-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-acceptance-view.ts
@@ -34,6 +34,20 @@ import { splitDeposit } from "../../payment_schedule/lib/split"
  * 🔑 The honest statement is about the DESTINATION, not about who named the
  * number.
  *
+ * ## ⚠️ A quote that cannot be PRICED is not a quote that is CLOSED (#1705)
+ *
+ * `unusable_reason` means one thing — revoked, superseded, expired — and the
+ * sentence it prints ("no longer open, ask for a fresh one") is a statement
+ * about the quote's STANDING. The buyer route used to pass the view's
+ * `live_error` into it, which is a pricing failure, so a quote minted an hour
+ * earlier and valid for a fortnight told its buyer it was closed and sent them
+ * to ask for a replacement that would have failed identically.
+ *
+ * Pricing failures therefore arrive as `pricing_error` and get their own
+ * sentence. Both still block acceptance — a cart priced off a half we could
+ * not compute is worse than a refusal — but only one of them is allowed to
+ * claim the quote is over.
+ *
  * ## The amount shown is the GROSS total
  *
  * 🔑 Not the landed total. The deposit is a share of what the cart will
@@ -63,8 +77,16 @@ export function composeQuoteAcceptance(input: {
   quote: any
   /** The gross total the cart will charge — live if we have it, else frozen. */
   gross_total: number | null | undefined
-  /** Non-null when the quote is revoked or expired. */
+  /**
+   * LIFECYCLE only: revoked, superseded, expired. Nothing else may be passed
+   * here — see the note above on why a pricing failure must not arrive as this.
+   */
   unusable_reason?: string | null
+  /**
+   * The live half could not be priced — the view's `live_error`. Transient and
+   * about US, not about the quote's standing, so it gets its own sentence.
+   */
+  pricing_error?: string | null
 }): QuoteAcceptance {
   const q = input.quote ?? {}
   const accepted = Boolean(q.accepted_cart_id)
@@ -88,6 +110,15 @@ export function composeQuoteAcceptance(input: {
        * without asking the buyer to care why.
        */
       return "We cannot take this order online for your destination yet — there is no online delivery set up for this route. Reply to this quote and we will arrange it for you."
+    }
+    if (input.pricing_error) {
+      /**
+       * 🔴 The quote is OPEN. Only our pricing failed (#1705) — so the one
+       * thing this sentence must not do is send the buyer away for a fresh
+       * quote, which would fail in exactly the same way. Same shape as the
+       * destination copy: what is true, what happens next, whose move it is.
+       */
+      return "We could not work out an up-to-date price for this quote just now. It is still open — reply to this quote and we will confirm it for you."
     }
     if (total === null || !Number.isFinite(total) || total <= 0) {
       return "This quote has no total to charge. Ask for a fresh one."


### PR DESCRIPTION
Closes #1705

Quote `01M1BPV6TMK0SVH32HX6SMQ25Z` — minted 31 Aug, valid to 14 Sep, status `active` — showed its buyer:

> **This quote cannot be ordered online**
> This quote is no longer open. Ask for a fresh one and it will be priced again.

Both halves false. The quote was open, and a fresh one would have failed identically.

## Why

`composeQuoteAcceptance` prints that sentence for `unusable_reason`, whose own type says what it is for — *"non-null when the quote is revoked or expired"*. The buyer route passed `live_error` into it, which is a **pricing** failure (here, freight that could not be rated). One input, two unrelated meanings, and the lifecycle sentence printed for both.

#1703 fixed that particular pricing failure. This is the mislabelling, which outlives its cause: any future live-pricing error — an FX outage, a carrier down, a price list expiring under a live cart — would tell a buyer their open quote is closed and send them for a replacement that fails the same way.

## What changed

- `unusable_reason` carries **lifecycle only**, and `buildQuoteView` finally **exposes** it. It did not before — which is why the route reached for `live_error` in the first place. A missing key is a confident null, so a test pins the field.
- A pricing failure arrives as `pricing_error` with its own sentence, shaped like the destination copy that already works — what is true, what happens next, whose move it is:
  > We could not work out an up-to-date price for this quote just now. It is still open — reply to this quote and we will confirm it for you.
- **Both still block acceptance.** A cart priced off a half we could not compute is worse than a refusal.

## Verify

```
cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern="partner-quote"
```

353 passing. **Mutation-checked:** removing the pricing branch fails 2 of the 5 new assertions; making the view return a null `unusable_reason` fails the lifecycle one. The remaining three are recorded as guards, not proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4