### PR TITLE
feat(production-runs): a run's quantity freezes at SETTLEMENT, not when work starts

### DIFF
--- a/apps/backend/integration-tests/http/production-run-quantity-correction.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-quantity-correction.spec.ts
@@ -1,0 +1,352 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(180000)
+
+/**
+ * Correcting a run's agreed quantity after the work is done (#1695).
+ *
+ * The real case: run `prod_run_01M0YVV2M7H7BZWJF5WN4MW4ZR` was sent for 2 and
+ * the partner made 3, with a ₹1,400 DRAFT submission standing against it —
+ * unpaid, unclaimed, uncontested. The correction was impossible from either
+ * end. The run refused because work had begun; `PATCH .../items/:itemId`
+ * refused a claim of 3 against a ceiling of 2. It took an ops job to break the
+ * deadlock, which is the right escape hatch and the wrong daily mechanism.
+ *
+ * 🔑 The freeze point is SETTLEMENT, not the start of work. These exercise the
+ * ROUTE — the unit tests pin the rule, this pins that the route actually asks
+ * it, refuses on it, and cascades the money afterwards.
+ */
+setupSharedTestSuite(() => {
+  describe("Admin: correcting a production run's quantity", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    async function setupTestData() {
+      const container = getContainer()
+      const unique = Date.now()
+      await createAdminUser(container)
+      const adminHeaders = await getAuthHeaders(api)
+      return { adminHeaders, unique }
+    }
+
+    async function createPartner(unique: number) {
+      const email = `qty-correction-${unique}@jyt.test`
+      const password = "supersecret"
+
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      let loginRes = await api.post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${loginRes.data.token}` }
+
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Qty Correction Partner ${unique}`,
+          handle: `qty-correction-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+
+      loginRes = await api.post("/auth/partner/emailpass", { email, password })
+      headers = { Authorization: `Bearer ${loginRes.data.token}` }
+
+      return { partnerId: res.data.partner.id, partnerHeaders: headers }
+    }
+
+    async function createTemplate(adminHeaders: any, unique: number) {
+      const name = `qty-correction-cutting-${unique}`
+      const res = await api.post(
+        "/admin/task-templates",
+        {
+          name,
+          description: "Cutting",
+          priority: "medium",
+          estimated_duration: 60,
+          required_fields: {},
+          eventable: false,
+          notifiable: false,
+          message_template: "",
+          metadata: { workflow_type: "production_run" },
+          category: `Qty Correction ${unique}`,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return name
+    }
+
+    async function createDesign(adminHeaders: any, unique: number) {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name: `Qty Correction Design ${unique}`,
+          description: "Design for quantity correction test",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id
+    }
+
+    /**
+     * A run sent for `quantity`, completed by the partner at `produced` on a
+     * per-unit rate — which is the shape that auto-drafts a payout.
+     */
+    async function completedRun(opts: {
+      adminHeaders: any
+      partnerId: string
+      partnerHeaders: any
+      templateName: string
+      designId: string
+      quantity: number
+      produced: number
+      rate: number
+    }) {
+      const createRes = await api.post(
+        `/admin/designs/${opts.designId}/production-runs`,
+        {
+          quantity: opts.quantity,
+          assignments: [
+            {
+              partner_id: opts.partnerId,
+              quantity: opts.quantity,
+              template_names: [opts.templateName],
+            },
+          ],
+        },
+        opts.adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const runId = createRes.data.children[0].id
+
+      const h = { headers: opts.partnerHeaders }
+      await api.post(`/partners/production-runs/${runId}/accept`, {}, h)
+      await api.post(`/partners/production-runs/${runId}/start`, {}, h)
+      await api.post(`/partners/production-runs/${runId}/finish`, {}, h)
+      const completeRes = await api.post(
+        `/partners/production-runs/${runId}/complete`,
+        {
+          produced_quantity: opts.produced,
+          partner_cost_estimate: opts.rate,
+          cost_type: "per_unit",
+        },
+        h
+      )
+      expect(completeRes.status).toBe(200)
+
+      return runId
+    }
+
+    async function draftForRun(adminHeaders: any, partnerId: string, runId: string) {
+      const res = await api.get(
+        `/admin/payment-submissions?partner_id=${partnerId}&limit=100`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      const submissions: any[] = res.data.payment_submissions ?? res.data.submissions ?? []
+      for (const s of submissions) {
+        const detail = await api.get(`/admin/payment-submissions/${s.id}`, adminHeaders)
+        const items: any[] = detail.data.payment_submission?.items ?? []
+        if (items.some((i) => (i.production_run_ids ?? []).includes(runId))) {
+          return { submission: detail.data.payment_submission, items }
+        }
+      }
+      return { submission: null, items: [] as any[] }
+    }
+
+    /**
+     * ⚠️ The draft is written by the `production_run.completed` SUBSCRIBER, so
+     * it does not exist the instant `complete` returns. Polling rather than
+     * sleeping a fixed amount — a fixed sleep either flakes or wastes time, and
+     * a lookup that raced would leave every claim assertion below vacuous.
+     */
+    async function waitForDraft(adminHeaders: any, partnerId: string, runId: string) {
+      for (let attempt = 0; attempt < 20; attempt++) {
+        const found = await draftForRun(adminHeaders, partnerId, runId)
+        if (found.submission) return found
+        await new Promise((r) => setTimeout(r, 500))
+      }
+      return { submission: null, items: [] as any[] }
+    }
+
+    it("🔴 corrects a COMPLETED run whose only claim is a Draft — the deadlock case", async () => {
+      const { adminHeaders, unique } = await setupTestData()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const templateName = await createTemplate(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique)
+
+      // Sent for 2, the partner made 3, at ₹700 a piece.
+      const runId = await completedRun({
+        adminHeaders,
+        partnerId,
+        partnerHeaders,
+        templateName,
+        designId,
+        quantity: 2,
+        produced: 3,
+        rate: 700,
+      })
+
+      const res = await api.post(
+        `/admin/production-runs/${runId}`,
+        { quantity: 3 },
+        adminHeaders
+      )
+
+      // Before #1695 this was a 4xx: "Cannot edit quantity, role, or run_type
+      // after the run has been accepted or started".
+      expect(res.status).toBe(200)
+      expect(res.data.production_run.quantity).toBe(3)
+
+      // The consequence, stated rather than left to be discovered on a payout.
+      expect(res.data.ceiling).toBeTruthy()
+      expect(res.data.ceiling.before).toBe(2)
+      expect(res.data.ceiling.after).toBe(3)
+      expect(res.data.ceiling.newly_claimable).toBe(1)
+      expect(res.data.ceiling.worth).toBe(700)
+    })
+
+    it("cascades to the Draft payout instead of leaving it at the old number", async () => {
+      const { adminHeaders, unique } = await setupTestData()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const templateName = await createTemplate(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique)
+
+      const runId = await completedRun({
+        adminHeaders,
+        partnerId,
+        partnerHeaders,
+        templateName,
+        designId,
+        quantity: 2,
+        produced: 3,
+        rate: 700,
+      })
+
+      const before = await waitForDraft(adminHeaders, partnerId, runId)
+      expect(before.submission).toBeTruthy()
+      expect(before.submission.status).toBe("Draft")
+
+      const res = await api.post(
+        `/admin/production-runs/${runId}`,
+        { quantity: 3 },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      /**
+       * 🔴 The point of the cascade. `runPayableAmount` bills the ORDERED
+       * quantity, so a draft written at completion against a quantity of 2 is
+       * stale the moment the run says 3. A correction that does not cascade
+       * just moves the disagreement somewhere new.
+       */
+      const after = await draftForRun(adminHeaders, partnerId, runId)
+      expect(after.submission).toBeTruthy()
+      expect(Number(after.submission.total_amount)).toBe(2100)
+      expect(Number(after.submission.total_amount)).toBeGreaterThan(
+        Number(before.submission.total_amount)
+      )
+    })
+
+    it("refuses once the claim is no longer a Draft — that is a reversing entry, not an edit", async () => {
+      const { adminHeaders, unique } = await setupTestData()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const templateName = await createTemplate(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique)
+
+      const runId = await completedRun({
+        adminHeaders,
+        partnerId,
+        partnerHeaders,
+        templateName,
+        designId,
+        quantity: 2,
+        produced: 3,
+        rate: 700,
+      })
+
+      const { submission } = await waitForDraft(adminHeaders, partnerId, runId)
+      expect(submission).toBeTruthy()
+
+      const submitRes = await api.post(
+        `/admin/payment-submissions/${submission.id}/submit`,
+        {},
+        adminHeaders
+      )
+      expect(submitRes.status).toBe(200)
+
+      const res = await api
+        .post(`/admin/production-runs/${runId}`, { quantity: 4 }, adminHeaders)
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message ?? "")).toMatch(/no longer a draft|reversing entry/i)
+
+      // And the run is unchanged — a refusal must not half-apply.
+      const check = await api.get(`/admin/production-runs/${runId}`, adminHeaders)
+      expect(check.data.production_run.quantity).toBe(2)
+    })
+
+    it("refuses a lowering under what a Draft has already claimed", async () => {
+      const { adminHeaders, unique } = await setupTestData()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const templateName = await createTemplate(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique)
+
+      const runId = await completedRun({
+        adminHeaders,
+        partnerId,
+        partnerHeaders,
+        templateName,
+        designId,
+        quantity: 9,
+        produced: 9,
+        rate: 700,
+      })
+
+      // The claim has to EXIST for the refusal to mean anything — without it
+      // there is nothing to overclaim and this passes vacuously.
+      const { submission } = await waitForDraft(adminHeaders, partnerId, runId)
+      expect(submission).toBeTruthy()
+
+      const res = await api
+        .post(`/admin/production-runs/${runId}`, { quantity: 1 }, adminHeaders)
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message ?? "")).toMatch(/retroactive overclaim/i)
+    })
+
+    it("still refuses role and run_type after the partner has accepted", async () => {
+      // The relaxation is deliberately narrow. `role` and `run_type` say WHO is
+      // doing the work and HOW; changing them under an accepted partner
+      // rewrites the assignment, which no money rule makes safe.
+      const { adminHeaders, unique } = await setupTestData()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const templateName = await createTemplate(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique)
+
+      const runId = await completedRun({
+        adminHeaders,
+        partnerId,
+        partnerHeaders,
+        templateName,
+        designId,
+        quantity: 2,
+        produced: 2,
+        rate: 700,
+      })
+
+      const res = await api
+        .post(`/admin/production-runs/${runId}`, { role: "finishing" }, adminHeaders)
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message ?? "")).toMatch(/role or run_type/i)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/route.ts
@@ -101,6 +101,15 @@ import { costTypeGuardMessage } from "../../../../workflows/production-runs/lib/
 import { autoDraftRunPayout } from "../../../../workflows/payment_submissions/lib/auto-draft-run-payout"
 import { refreshUnclaimedDraftPayouts } from "../../../../workflows/payment_submissions/lib/refresh-draft-payouts"
 import { reopenProductionRun } from "../../../../workflows/production-runs/lib/short-close-production-run"
+import {
+  assessRunQuantityCorrection,
+  correctionConsequenceNote,
+} from "../../../../workflows/production-runs/lib/run-quantity-correction"
+import {
+  foldRunClaimTallies,
+  listPartnerPriorLines,
+} from "../../../../workflows/payment_submissions/lib/run-claims"
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const id = req.params.id
@@ -177,16 +186,37 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const body = req.body as Record<string, any>
   const update: Record<string, any> = {}
 
-  const touchesStructural =
-    body.quantity !== undefined ||
-    body.role !== undefined ||
-    body.run_type !== undefined
+  /**
+   * 🔴 QUANTITY NO LONGER FREEZES WITH THE OTHER STRUCTURAL FIELDS (#1695).
+   *
+   * `role` and `run_type` say WHO is doing the work and HOW — changing them
+   * after a partner has accepted rewrites the assignment underneath them, so
+   * they keep the old freeze.
+   *
+   * `quantity` is different: it is the CEILING on what may be billed against
+   * the run, and freezing it at `accepted_at` deadlocked the two halves of a
+   * correction. A run sent for 2 where the partner made 3 could not be fixed
+   * from either end — the run refused because work had begun, and
+   * `assessRunClaims` refused a claim of 3 against a ceiling of 2. Nothing was
+   * paid and nothing was disputed. It took an ops job to break it.
+   *
+   * The freeze point is SETTLEMENT: correctable while every live claim against
+   * the run is a Draft. See `assessRunQuantityCorrection` for the whole rule.
+   */
+  /** Reported back so a ceiling never moves next to money in silence. */
+  let quantityCorrection: ReturnType<typeof assessRunQuantityCorrection> | null =
+    null
 
-  if (touchesStructural) {
+  const touchesAssignment =
+    body.role !== undefined || body.run_type !== undefined
+  const touchesQuantity = body.quantity !== undefined
+  const touchesStructural = touchesAssignment || touchesQuantity
+
+  if (touchesAssignment) {
     if (run.accepted_at || run.started_at) {
       throw new MedusaError(
         MedusaError.Types.NOT_ALLOWED,
-        "Cannot edit quantity, role, or run_type after the run has been accepted or started"
+        "Cannot edit role or run_type after the run has been accepted or started"
       )
     }
     if (run.status === "completed") {
@@ -195,15 +225,19 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         "Cannot edit a completed production run"
       )
     }
+  }
+
+  if (touchesStructural) {
     /**
      * 🔴 `null` CLEARS the agreed quantity (#1676) — an open-ended run, with no
      * ceiling on what may be claimed against it. `Number(null)` is 0, which
      * would have written the opposite: a quantity that IS set and is unusable,
      * which every payment guard refuses outright.
      *
-     * Still gated by the structural check above, so this can only be said
-     * before the partner accepts or starts. Removing the agreed amount after
-     * work began would rewrite the deal retroactively.
+     * ⚠️ This used to be gated on "before the partner accepts or starts". It is
+     * now gated on the money instead (#1695): open-ending a run is a RAISE — it
+     * removes the ceiling — so it is allowed exactly as long as any other raise
+     * is, and refused the moment a non-Draft claim stands against the run.
      */
     if (body.quantity !== undefined) {
       if (body.quantity === null) {
@@ -217,6 +251,47 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
           )
         }
         update.quantity = quantity
+      }
+    }
+
+    /**
+     * The money gate on a quantity change, and the consequence it will have.
+     *
+     * Scoped by PARTNER, which is how every other claim guard in this module
+     * reads prior lines — a run belongs to exactly one partner, and a
+     * design-scoped read cannot see a run-sourced line at all (see
+     * `run-claims`). A run with no partner cannot have been claimed by anyone,
+     * so there is nothing to read.
+     *
+     * 🔴 A failed lookup is NOT "no claims". `claims_readable: false` refuses
+     * the change rather than letting an outage read as headroom.
+     */
+    if (touchesQuantity) {
+      let tally: any = null
+      let claimsReadable = true
+
+      if (run.partner_id) {
+        try {
+          const submissions: any = req.scope.resolve(PAYMENT_SUBMISSIONS_MODULE)
+          const priorLines = await listPartnerPriorLines(submissions, run.partner_id)
+          tally = foldRunClaimTallies(priorLines).get(id) ?? null
+        } catch {
+          claimsReadable = false
+        }
+      }
+
+      quantityCorrection = assessRunQuantityCorrection({
+        run,
+        next_quantity: (update.quantity ?? null) as number | null,
+        tally,
+        claims_readable: claimsReadable,
+      })
+
+      if (!quantityCorrection.allowed) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_ALLOWED,
+          quantityCorrection.refusal as string
+        )
       }
     }
     if (body.role !== undefined) update.role = body.role
@@ -334,7 +409,16 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const touchesMoney =
     update.partner_cost_estimate !== undefined ||
     update.cost_type !== undefined ||
-    update.produced_quantity !== undefined
+    update.produced_quantity !== undefined ||
+    /**
+     * 🔴 The agreed quantity belongs here too (#1695). `runPayableAmount` bills
+     * the ORDERED quantity, so a corrected quantity changes what an existing
+     * Draft is worth — and now that the quantity can be corrected AFTER the
+     * work is done, the draft that was written at completion is exactly the one
+     * left disagreeing with it. A correction that does not cascade just moves
+     * the disagreement somewhere new.
+     */
+    update.quantity !== undefined
   if (touchesMoney) {
     try {
       const outcome = await refreshUnclaimedDraftPayouts(req.scope, id)
@@ -487,5 +571,25 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
      * having to go and check. Empty when nothing needed it.
      */
     ...(refreshedDrafts.length ? { refreshed_draft_submissions: refreshedDrafts } : {}),
+    /**
+     * What the quantity change did to the billing ceiling, in the same shape
+     * the ops job reports (#1694) — before, after, already claimed, newly
+     * claimable and what that is worth.
+     *
+     * 🔑 Always stated when the quantity moved. A number changing next to money
+     * in silence is how a correction becomes a surprise on somebody's payout.
+     */
+    ...(quantityCorrection
+      ? {
+          ceiling: {
+            before: quantityCorrection.ceiling_before,
+            after: quantityCorrection.ceiling_after,
+            already_claimed: quantityCorrection.claimed_quantity,
+            newly_claimable: quantityCorrection.newly_claimable,
+            worth: quantityCorrection.worth,
+            note: correctionConsequenceNote(quantityCorrection),
+          },
+        }
+      : {}),
   })
 }

--- a/apps/backend/src/workflows/production-runs/lib/__tests__/run-quantity-correction.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/lib/__tests__/run-quantity-correction.unit.spec.ts
@@ -1,0 +1,226 @@
+import {
+  assessRunQuantityCorrection,
+  correctionConsequenceNote,
+} from "../run-quantity-correction"
+
+/**
+ * When a run's agreed quantity may still be corrected (#1695).
+ *
+ * The case these exist for: run `prod_run_01M0YVV2M7H7BZWJF5WN4MW4ZR` was sent
+ * for 2 and the partner made 3. A ₹1,400 DRAFT submission stood against it —
+ * unpaid, unclaimed, uncontested — and the correction was impossible from
+ * either end. The run refused because work had begun; the payment refused
+ * because the run said 2. Neither half was wrong on its own terms and together
+ * they deadlocked, so an ops job had to break it.
+ *
+ * 🔑 The freeze point belongs at SETTLEMENT, not at the start of work.
+ */
+
+const run = {
+  quantity: 2,
+  produced_quantity: 3,
+  short_closed_at: null,
+  cost_type: "per_unit",
+  partner_cost_estimate: 700,
+}
+
+const draftClaim = {
+  claimed_quantity: 2,
+  claimed_wholly: false,
+  claims: [{ submission_id: "ps_draft", submission_status: "Draft" }],
+}
+
+describe("assessRunQuantityCorrection — the freeze point", () => {
+  it("🔴 allows the correction that deadlocked: a Draft claim does not freeze the run", () => {
+    const a = assessRunQuantityCorrection({
+      run,
+      next_quantity: 3,
+      tally: draftClaim,
+      claims_readable: true,
+    })
+
+    expect(a.allowed).toBe(true)
+    expect(a.refusal).toBeNull()
+    expect(a.newly_claimable).toBe(1)
+    expect(a.worth).toBe(700)
+  })
+
+  it("allows it when nothing has been claimed at all", () => {
+    const a = assessRunQuantityCorrection({
+      run,
+      next_quantity: 5,
+      tally: null,
+      claims_readable: true,
+    })
+    expect(a.allowed).toBe(true)
+    expect(a.newly_claimable).toBe(3)
+  })
+
+  it.each([
+    ["Pending", "ps_1"],
+    ["Under_Review", "ps_2"],
+    ["Approved", "ps_3"],
+    ["Paid", "ps_4"],
+  ])("refuses once a %s claim stands — that is a reversing entry, not an edit", (status, id) => {
+    const a = assessRunQuantityCorrection({
+      run,
+      next_quantity: 3,
+      tally: {
+        claimed_quantity: 2,
+        claimed_wholly: false,
+        claims: [{ submission_id: id, submission_status: status }],
+      },
+      claims_readable: true,
+    })
+
+    expect(a.allowed).toBe(false)
+    expect(a.refusal).toContain(id)
+    expect(a.frozen_by).toHaveLength(1)
+  })
+
+  it("a Rejected claim does not freeze the run", () => {
+    // `foldRunClaimTallies` already drops Rejected lines upstream — this pins
+    // that a tally arriving without them leaves the run editable, so the two
+    // halves cannot drift into disagreeing about what a live claim is.
+    const a = assessRunQuantityCorrection({
+      run,
+      next_quantity: 3,
+      tally: { claimed_quantity: 0, claimed_wholly: false, claims: [] },
+      claims_readable: true,
+    })
+    expect(a.allowed).toBe(true)
+  })
+})
+
+describe("assessRunQuantityCorrection — lowering is not the mirror of raising", () => {
+  it("refuses a lowering under what has been claimed", () => {
+    const a = assessRunQuantityCorrection({
+      run: { ...run, quantity: 9 },
+      next_quantity: 1,
+      tally: draftClaim,
+      claims_readable: true,
+    })
+    expect(a.allowed).toBe(false)
+    expect(a.refusal).toMatch(/retroactive overclaim/i)
+  })
+
+  it("allows a lowering that stays at or above the claims", () => {
+    const a = assessRunQuantityCorrection({
+      run: { ...run, quantity: 9 },
+      next_quantity: 2,
+      tally: draftClaim,
+      claims_readable: true,
+    })
+    expect(a.allowed).toBe(true)
+    // Nothing becomes newly claimable by lowering — and it must never report a
+    // negative, which downstream would read as room.
+    expect(a.newly_claimable).toBe(0)
+  })
+
+  it("🔴 refuses a lowering when a claim has no attributable quantity", () => {
+    // A line naming several runs carries their SUM. There is no number to
+    // compare against, so the lowering cannot be PROVEN safe — refuse rather
+    // than assume zero.
+    const a = assessRunQuantityCorrection({
+      run: { ...run, quantity: 9 },
+      next_quantity: 2,
+      tally: {
+        claimed_quantity: 0,
+        claimed_wholly: true,
+        claims: [{ submission_id: "ps_multi", submission_status: "Draft" }],
+      },
+      claims_readable: true,
+    })
+    expect(a.allowed).toBe(false)
+    expect(a.refusal).toMatch(/cannot be shown to be safe/i)
+  })
+
+  it("still allows a RAISE when a claim has no attributable quantity", () => {
+    // Raising is additive — it invalidates nothing, whatever was claimed.
+    const a = assessRunQuantityCorrection({
+      run: { ...run, quantity: 2 },
+      next_quantity: 5,
+      tally: {
+        claimed_quantity: 0,
+        claimed_wholly: true,
+        claims: [{ submission_id: "ps_multi", submission_status: "Draft" }],
+      },
+      claims_readable: true,
+    })
+    expect(a.allowed).toBe(true)
+  })
+
+  it("open-ended is never a lowering", () => {
+    const a = assessRunQuantityCorrection({
+      run: { ...run, quantity: 9 },
+      next_quantity: null,
+      tally: draftClaim,
+      claims_readable: true,
+    })
+    expect(a.allowed).toBe(true)
+    expect(a.ceiling_after).toBeNull()
+    expect(correctionConsequenceNote(a)).toMatch(/OPEN-ENDED/)
+  })
+})
+
+describe("assessRunQuantityCorrection — refuse blind", () => {
+  it("🔴 an unreadable claim lookup refuses, and does NOT read as zero", () => {
+    const a = assessRunQuantityCorrection({
+      run,
+      next_quantity: 3,
+      tally: null,
+      claims_readable: false,
+    })
+    expect(a.allowed).toBe(false)
+    expect(a.refusal).toMatch(/blind/i)
+  })
+
+  it("refuses blind even for a raise", () => {
+    // The raise itself is safe, but the ceiling is money-bearing and the
+    // consequence cannot be stated. An outage must not read as headroom.
+    const a = assessRunQuantityCorrection({
+      run,
+      next_quantity: 99,
+      tally: null,
+      claims_readable: false,
+    })
+    expect(a.allowed).toBe(false)
+  })
+})
+
+describe("correctionConsequenceNote", () => {
+  it("always names what becomes claimable and what it is worth", () => {
+    const a = assessRunQuantityCorrection({
+      run,
+      next_quantity: 3,
+      tally: draftClaim,
+      claims_readable: true,
+    })
+    const note = correctionConsequenceNote(a)
+    expect(note).toContain("ceiling 2 → 3")
+    expect(note).toContain("already claimed 2")
+    expect(note).toContain("newly claimable 1")
+    expect(note).toContain("700")
+  })
+
+  it("reads the ceiling of a SHORT-CLOSED run from what was produced", () => {
+    // The ceiling is not the raw quantity field, so the note must come from
+    // `runBillableCeiling` — a run short-closed at 7 of 9 has a ceiling of 7,
+    // and a correction reported against 9 would overstate what it opens up.
+    const a = assessRunQuantityCorrection({
+      run: {
+        quantity: 9,
+        produced_quantity: 7,
+        short_closed_at: "2026-08-20T00:00:00Z",
+        cost_type: "per_unit",
+        partner_cost_estimate: 700,
+      },
+      next_quantity: 12,
+      tally: { claimed_quantity: 0, claimed_wholly: false, claims: [] },
+      claims_readable: true,
+    })
+    expect(a.ceiling_before).toBe(7)
+    expect(a.ceiling_after).toBe(7)
+    expect(a.newly_claimable).toBe(0)
+  })
+})

--- a/apps/backend/src/workflows/production-runs/lib/run-quantity-correction.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-quantity-correction.ts
@@ -1,0 +1,197 @@
+import type { RunClaimTally } from "../../payment_submissions/lib/run-claims"
+import { runBillableCeiling } from "../../payment_submissions/lib/run-billable-ceiling"
+
+/**
+ * May a run's agreed quantity still be corrected — and what does the correction
+ * make claimable? (#1695)
+ *
+ * ## The freeze point was in the wrong place
+ *
+ * `POST /admin/production-runs/:id` froze quantity at `accepted_at` /
+ * `started_at`, inherited from #1676, which was solving a different problem: an
+ * UNBOUNDED first claim. It bounded the claim by freezing the field.
+ *
+ * 🔴 The two halves then deadlock. A run sent for 2 where the partner made 3
+ * cannot be corrected — the run refuses because work began, and
+ * `assessRunClaims` refuses a claim of 3 against a ceiling of 2. Nothing was
+ * paid, nothing was disputed, and the system still could not represent what had
+ * happened. It took an ops job (#1694) to break it, which is the right escape
+ * hatch and the wrong daily mechanism.
+ *
+ * ## The rule this encodes
+ *
+ * **Mutable until the derived money is settled.** Not until work starts, not
+ * until it completes. Payment is the event that turns a number from a current
+ * belief into a historical fact — which is the freeze point the consumption
+ * route already uses (`inventory_applied_at`, #1693) and got right.
+ *
+ * So: correctable while every live claim against the run is a `Draft`. One
+ * `Pending`, `Under_Review`, `Approved` or `Paid` claim and the ceiling is
+ * load-bearing for money somebody is acting on — past that point a correction
+ * is a reversing entry, not an edit.
+ *
+ * `Rejected` never paid anyone and is already dropped upstream by
+ * `foldRunClaimTallies`, so it does not freeze anything.
+ *
+ * ## 🔴 Lowering is not the mirror of raising
+ *
+ * Raising is additive: it makes units newly claimable and invalidates nothing.
+ * Lowering drops the ceiling under claims already made, turning valid
+ * submissions into retroactive overclaims with no mechanism to notice. Same
+ * refusal the ops job makes, for the same reason.
+ *
+ * And when a claim is unattributable — a line naming several runs carries their
+ * SUM — there is no number to compare against, so a lowering cannot be PROVEN
+ * safe. Refuse; do not assume zero. Absence is never permission (#1557, #1565).
+ */
+
+export type CorrectionClaim = {
+  submission_id: string | null
+  submission_status: string | null
+}
+
+export type RunQuantityCorrection = {
+  allowed: boolean
+  /** Written for the caller of the API, not for a log. Null when allowed. */
+  refusal: string | null
+  /** Units already claimed and attributable to this run. */
+  claimed_quantity: number
+  /** A live claim covers the run without an attributable quantity. */
+  claimed_wholly: boolean
+  /** The claims that FREEZE the run — non-Draft. Empty when nothing is frozen. */
+  frozen_by: CorrectionClaim[]
+  /** Ceiling before and after, and what the change opens up. */
+  ceiling_before: number | null
+  ceiling_after: number | null
+  /** Units that become billable that were not. Null when either end is open. */
+  newly_claimable: number | null
+  /** `newly_claimable` at the run's own per-unit rate, when it has one. */
+  worth: number | null
+}
+
+/** Everything except `Draft` is a live claim on money somebody is acting on. */
+const freezesTheRun = (status: string | null | undefined): boolean =>
+  String(status ?? "") !== "Draft"
+
+type RunLike = {
+  quantity?: number | string | null
+  produced_quantity?: number | string | null
+  short_closed_at?: Date | string | null
+  cost_type?: string | null
+  partner_cost_estimate?: number | string | null
+}
+
+/**
+ * PURE.
+ *
+ * `next_quantity` is the requested agreed quantity: a number, or `null` for an
+ * open-ended run (#1676's opt-out — no ceiling at all).
+ *
+ * `claims_readable: false` means the claim lookup FAILED. It is not the same as
+ * "no claims", and it refuses every change rather than letting an outage read
+ * as headroom.
+ */
+export function assessRunQuantityCorrection(input: {
+  run: RunLike
+  next_quantity: number | null
+  tally?: RunClaimTally | null
+  claims_readable: boolean
+}): RunQuantityCorrection {
+  const { run, next_quantity, tally } = input
+
+  const claimed = Number(tally?.claimed_quantity ?? 0)
+  const claimedWholly = Boolean(tally?.claimed_wholly)
+  const frozenBy = (tally?.claims ?? []).filter((c) =>
+    freezesTheRun(c.submission_status)
+  )
+
+  const ceilingBefore = runBillableCeiling(run)
+  const ceilingAfter = runBillableCeiling({ ...run, quantity: next_quantity })
+
+  const newlyClaimable =
+    ceilingBefore === null || ceilingAfter === null
+      ? null
+      : Math.max(0, ceilingAfter - ceilingBefore)
+
+  const rate = Number(run.partner_cost_estimate ?? 0)
+  const perUnit = run.cost_type === "per_unit" && rate > 0 ? rate : null
+
+  const base = {
+    claimed_quantity: claimed,
+    claimed_wholly: claimedWholly,
+    frozen_by: frozenBy,
+    ceiling_before: ceilingBefore,
+    ceiling_after: ceilingAfter,
+    newly_claimable: newlyClaimable,
+    worth: newlyClaimable !== null && perUnit ? newlyClaimable * perUnit : null,
+  }
+
+  const refuse = (refusal: string): RunQuantityCorrection => ({
+    ...base,
+    allowed: false,
+    refusal,
+  })
+
+  if (!input.claims_readable) {
+    return refuse(
+      "Could not read what has already been claimed against this run — refusing to change a billing ceiling blind."
+    )
+  }
+
+  if (frozenBy.length) {
+    const naming = frozenBy
+      .map((c) => `${c.submission_id ?? "unknown"} (${c.submission_status ?? "unknown"})`)
+      .join(", ")
+    return refuse(
+      `Cannot change the quantity: this run is already claimed by a submission that is no longer a draft — ${naming}. Past that point a correction is a reversing entry on the payout, not an edit to the run.`
+    )
+  }
+
+  // A lowering, measured against what has been claimed. `null` is open-ended,
+  // which is never a lowering.
+  if (next_quantity !== null) {
+    if (claimedWholly) {
+      const lowering =
+        ceilingBefore === null || ceilingAfter === null
+          ? true
+          : ceilingAfter < ceilingBefore
+      if (lowering) {
+        return refuse(
+          "Cannot lower the quantity: a draft claim covers this run without an attributable quantity, so a lower ceiling cannot be shown to be safe."
+        )
+      }
+    }
+    if (next_quantity < claimed) {
+      return refuse(
+        `Cannot lower the agreed quantity to ${next_quantity}: ${claimed} has already been claimed against this run, which would become a retroactive overclaim.`
+      )
+    }
+  }
+
+  return { ...base, allowed: true, refusal: null }
+}
+
+/**
+ * The consequence, in one line, ALWAYS stated — the same discipline the ops job
+ * applies. A quantity moving next to money in silence is how a correction
+ * becomes a surprise on somebody's payout.
+ */
+export function correctionConsequenceNote(
+  assessment: RunQuantityCorrection
+): string {
+  if (assessment.ceiling_after === null) {
+    return "run becomes OPEN-ENDED — no ceiling on what may be billed against it"
+  }
+
+  const claimable =
+    assessment.newly_claimable === null
+      ? "unknown"
+      : String(assessment.newly_claimable)
+
+  const worth =
+    assessment.worth !== null && assessment.newly_claimable
+      ? ` (worth ${assessment.worth})`
+      : ""
+
+  return `ceiling ${assessment.ceiling_before ?? "none"} → ${assessment.ceiling_after}; already claimed ${assessment.claimed_quantity}; newly claimable ${claimable}${worth}`
+}


### PR DESCRIPTION
Part of #1695 — the freeze-point half. Cascade tails stay open there.

## The deadlock

Run `prod_run_01M0YVV2M7H7BZWJF5WN4MW4ZR`: sent for 2, the partner made 3, with a ₹1,400 **Draft** submission against it — unpaid, unclaimed, uncontested. Correcting it was impossible from either end.

| door | answer |
|---|---|
| `POST /admin/production-runs/:id` | *"Cannot edit quantity, role, or run_type after the run has been accepted or started"* |
| `PATCH /admin/payment-submissions/:id/items/:itemId` | `assessRunClaims` refuses a claim of 3 against a ceiling of 2 |

🔴 The run refuses because work is recorded; the money refuses because the run says 2. Neither guard is wrong on its own terms, and together they made a true fact unrepresentable. It took an ops job (#1694) to break it.

The old freeze came from #1676, which was solving a different problem — an *unbounded first claim* — and bounded the claim by freezing the field. The consumption route (#1693) got the same question right: it freezes at `inventory_applied_at`, when the stock actually moved.

**Mutable until the derived money is settled.** Payment is what turns a number from a current belief into a historical fact.

## What changed

- `quantity` is correctable while every live claim is a **Draft**; refused once a `Pending` / `Under_Review` / `Approved` / `Paid` claim stands — past there a correction is a reversing entry, not an edit. `Rejected` never paid anyone and freezes nothing.
- **Deliberately narrow.** `role` and `run_type` say who does the work and how; changing them under an accepted partner rewrites the assignment. They keep the old freeze, and a test pins it.
- **Lowering is not the mirror of raising.** Refused under existing claims, and refused when a claim names several runs so carries no attributable quantity — there a lowering cannot be *proven* safe. A failed claim lookup refuses rather than reading as headroom.
- **The correction cascades.** `runPayableAmount` bills the ordered quantity, so the Draft written at completion is stale the moment the run says 3. `quantity` joins the existing `touchesMoney` refresh — an integration test watches a ₹1,400 draft become ₹2,100.
- **The consequence is always stated** — ceiling before/after, already claimed, newly claimable, and what it is worth.

## Verify

```
cd apps/backend
TEST_TYPE=unit npx jest --testPathPattern="run-quantity-correction"        # 16
pnpm test:integration:http:shared ./integration-tests/http/production-run-quantity-correction   # 5
```

**Mutation-checked:** disabling the route guard turns both refusal specs red while the two permissive ones stay green.

## Still open on #1695

Re-deriving `per_piece` consumption resolution and design cost, and the reversing-entry path for a payout that is already Paid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4