### PR TITLE
feat(shipping): register ShipGlobal as a fulfillment provider on prod

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -294,6 +294,23 @@ secrets:
   # reads creds from the `category:shipping` SocialPlatform record, so the
   # password/pickup are intentionally NOT wired as env here.
   SHIPROCKET_EMAIL: /jyt/prod/SHIPROCKET_EMAIL
+  # ShipGlobal fulfillment provider — the SAME arrangement as Shiprocket above,
+  # for the same reason. `medusa-config.prod.ts` registers the provider whenever
+  # SHIPGLOBAL_USERNAME is present IN THE CONTAINER ENV, and only that surfaces
+  # it in Fulfillment Providers.
+  #
+  # 🔴 A working carrier rate was NOT evidence the provider was registered.
+  # Quotes have been rating through ShipGlobal for weeks — a Sunda quote priced
+  # A$44.97 of freight off a live ShipGlobal rate — because
+  # `resolveShippingProvider` reads the `Shipping Global` platform record, which
+  # is a completely separate door. The provider itself was absent from
+  # /admin/fulfillment-providers the whole time, so no shipping option could be
+  # attached to it.
+  #
+  # The password stays OUT of here deliberately: the resolver reads it (and the
+  # service override) from the encrypted `category:shipping` SocialPlatform
+  # record, which is already configured and already working.
+  SHIPGLOBAL_USERNAME: /jyt/prod/SHIPGLOBAL_USERNAME
   STOREFRONT_REVALIDATE_SECRET: /jyt/prod/STOREFRONT_REVALIDATE_SECRET
   STORE_CORS: /jyt/prod/STORE_CORS
   # Enables the Store MCP cart/checkout/PayU *write* tools (POST /mcp + /store/mcp).

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -121,6 +121,10 @@ secrets:
   # env-gated provider block in medusa-config.prod.ts loads in the worker too.
   # Email-only: the API path reads creds from the SocialPlatform record.
   SHIPROCKET_EMAIL: /jyt/prod/SHIPROCKET_EMAIL
+  # ShipGlobal — same parity, same reason as Shiprocket above. A provider block
+  # that loads on the server but not the worker makes the same workflow step
+  # behave differently depending on which task picks it up.
+  SHIPGLOBAL_USERNAME: /jyt/prod/SHIPGLOBAL_USERNAME
   STRIPE_API_KEY: /jyt/prod/STRIPE_API_KEY
   STRIPE_WEBHOOK_SECRET: /jyt/prod/STRIPE_WEBHOOK_SECRET
   VERCEL_STOREFRONT_REPO: /jyt/prod/VERCEL_STOREFRONT_REPO


### PR DESCRIPTION
ShipGlobal is absent from `/admin/fulfillment-providers` on prod (only bluedart, delhivery, manual, shiprocket), so no shipping option can be attached to it — while quotes have been pricing freight through ShipGlobal for weeks.

🔴 **A carrier has two doors, and a working rate is not evidence of registration.** `resolveShippingProvider` reads the `Shipping Global` platform record — that is what rated A$44.97 of freight on the Sunda quote. Registration is a different door: `medusa-config.prod.ts:495` adds the provider only when `SHIPGLOBAL_USERNAME` is present **in the container env**, and the manifest never put it there.

## Username only — deliberately

Exactly how `SHIPROCKET_EMAIL` already runs, for the reason its own manifest comment gives: the env var registers the provider; the API calls take their credentials (and the `service` override) from the encrypted `category:shipping` SocialPlatform record, which is already configured and already working. No new secret is needed, and `/jyt/prod/SHIPGLOBAL_PASSWORD` deliberately stays non-existent.

Both manifests, matching Shiprocket — a provider block that loads on the server but not the worker makes one workflow step behave differently depending on which task picks it up.

## Checked before pushing

`/jyt/prod/SHIPGLOBAL_USERNAME` exists and carries `copilot-application=jyt` + `copilot-environment=prod`, identical to `SHIPROCKET_EMAIL`. A copilot deploy referencing an untagged or missing param fails, so this was verified rather than assumed.

## Verify after deploy

Probe `/admin/fulfillment-providers` for a `shipglobal` row. **Not** the deploy badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4