### PR TITLE
fix(payments): a partner ledger reported INR 0 recorded against INR 20,000 that had moved (#1710)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -4446,5 +4446,230 @@ setupSharedTestSuite(() => {
       expect(row.amount).toBe(0)
       expect(row.payable).toBe(false)
     })
+
+    /**
+     * #1710 — the PARTNER's own door to the same question.
+     *
+     * The admin has been able to bill goods since #1612; a partner never
+     * could. Their create validator accepted `design_ids` and `task_ids` and
+     * nothing else, and no partner screen listed an inventory order — so the
+     * one party who knows what they delivered had to ask an admin. The only
+     * self-serve path left, `submit-payment` on the order, writes an
+     * `internal_payments` row that is NOT a claim and that no payout accounts
+     * for. That is where the two orphaned INR 10,000 rows came from.
+     */
+    describe("GET /partners/payment-submissions/payable-inventory-orders (#1710)", () => {
+      it("401s without partner auth, rather than listing everyone's goods", async () => {
+        const res = await api
+          .get("/partners/payment-submissions/payable-inventory-orders")
+          .catch((e: any) => e.response)
+
+        expect(res.status).toBe(401)
+      })
+
+      /**
+       * 🔴 Non-vacuously. An order really exists and really belongs to A, and
+       * B is asked for it with B's own token. There is no `partner_id`
+       * parameter on this route at all — the scope comes from the auth
+       * context, which is the whole of the security boundary.
+       */
+      it("shows the owner their order and withholds it from another partner", async () => {
+        const stamp = Date.now() + 10
+        const owner = await createPartnerWithAuth(stamp)
+        const other = await createPartnerWithAuth(stamp + 1)
+
+        const orderId = await seedOrderForPartner(
+          owner.partnerId,
+          `pown-${stamp}`
+        )
+
+        const mine = await api.get(
+          "/partners/payment-submissions/payable-inventory-orders",
+          { headers: owner.partnerHeaders }
+        )
+        expect(mine.status).toBe(200)
+        expect(
+          mine.data.payable_inventory_orders.map(
+            (o: any) => o.inventory_order_id
+          )
+        ).toContain(orderId)
+
+        const theirs = await api.get(
+          "/partners/payment-submissions/payable-inventory-orders",
+          { headers: other.partnerHeaders }
+        )
+        expect(theirs.status).toBe(200)
+        expect(
+          theirs.data.payable_inventory_orders.map(
+            (o: any) => o.inventory_order_id
+          )
+        ).not.toContain(orderId)
+      })
+
+      /**
+       * 🔑 One question, one answer. The admin and partner routes read the
+       * same lib, so the receipts rule, the ordered-total ceiling and the cap
+       * flag cannot drift apart between them — which is exactly what happened
+       * when `apps/partner-ui` kept a private copy of `foldPartnerBilling`.
+       */
+      it("answers identically to the admin route for the same partner", async () => {
+        const stamp = Date.now() + 20
+        const owner = await createPartnerWithAuth(stamp)
+        const orderId = await seedOrderForPartner(
+          owner.partnerId,
+          `psame-${stamp}`
+        )
+
+        const asPartner = await api.get(
+          "/partners/payment-submissions/payable-inventory-orders",
+          { headers: owner.partnerHeaders }
+        )
+        const asAdmin = await api.get(
+          `/admin/payment-submissions/payable-inventory-orders?partner_id=${owner.partnerId}`,
+          adminHeaders
+        )
+
+        const pick = (data: any) =>
+          data.payable_inventory_orders.find(
+            (o: any) => o.inventory_order_id === orderId
+          )
+
+        expect(pick(asPartner.data)).toEqual(pick(asAdmin.data))
+      })
+    })
+
+    /**
+     * #1710 — a partner BILLING for goods, which the create route refused
+     * outright until now ("At least one design or task is required").
+     */
+    describe("POST /partners/payment-submissions — inventory_order_lines (#1710)", () => {
+      it("refuses an order that belongs to ANOTHER partner", async () => {
+        const stamp = Date.now() + 30
+        const owner = await createPartnerWithAuth(stamp)
+        const thief = await createPartnerWithAuth(stamp + 1)
+
+        const orderId = await seedOrderForPartner(
+          owner.partnerId,
+          `pthief-${stamp}`
+        )
+
+        const res = await api
+          .post(
+            "/partners/payment-submissions",
+            {
+              inventory_order_lines: [
+                { inventory_order_id: orderId, amount: 500 },
+              ],
+            },
+            { headers: thief.partnerHeaders }
+          )
+          .catch((e: any) => e.response)
+
+        expect(res.status).toBe(400)
+        expect(res.data.message).toContain("does not belong to this partner")
+      })
+
+      /**
+       * 🔴 The hole this route would have opened.
+       *
+       * The ownership guard read `if (ownerId && ownerId !== partner_id)`, so
+       * an order with NO partner link satisfied it by having nothing to
+       * compare — and 8 of 16 orders in a dev database have no link. That was
+       * survivable while only an admin naming an explicit `partner_id` could
+       * reach the step. It stopped being survivable the moment a partner
+       * could. A missing id is not permission; it is a missing answer.
+       */
+      it("refuses an order linked to NO partner at all", async () => {
+        const stamp = Date.now() + 40
+        const partner = await createPartnerWithAuth(stamp)
+
+        // Deliberately NOT sent to any partner.
+        const inventoryItemId = await seedInventoryItem(`orphan-${stamp}`)
+        const stockLocationId = await seedStockLocation()
+        const created = await api.post(
+          "/admin/inventory-orders",
+          {
+            order_lines: [
+              { inventory_item_id: inventoryItemId, quantity: 4, price: 250 },
+            ],
+            quantity: 4,
+            total_price: 1000,
+            status: "Pending",
+            expected_delivery_date: new Date().toISOString(),
+            order_date: new Date().toISOString(),
+            shipping_address: {},
+            stock_location_id: stockLocationId,
+          },
+          adminHeaders
+        )
+        const orphanId = created.data.inventoryOrder.id
+
+        const res = await api
+          .post(
+            "/partners/payment-submissions",
+            {
+              inventory_order_lines: [
+                { inventory_order_id: orphanId, amount: 500 },
+              ],
+            },
+            { headers: partner.partnerHeaders }
+          )
+          .catch((e: any) => e.response)
+
+        expect(res.status).toBe(400)
+        expect(res.data.message).toContain("not linked to any partner")
+      })
+
+      it("creates a goods-sourced submission a partner can see on their own list", async () => {
+        const stamp = Date.now() + 50
+        const owner = await createPartnerWithAuth(stamp)
+        const orderId = await seedOrderForPartner(
+          owner.partnerId,
+          `pbill-${stamp}`
+        )
+
+        const res = await api
+          .post(
+            "/partners/payment-submissions",
+            {
+              // An explicit amount: this order has no receipts recorded, and
+              // an amountless line is correctly refused there.
+              inventory_order_lines: [
+                { inventory_order_id: orderId, amount: 600 },
+              ],
+              notes: "Cotton delivered in July",
+            },
+            { headers: owner.partnerHeaders }
+          )
+          .catch((e: any) => e.response)
+
+        expect(res.status).toBe(201)
+
+        const submission = res.data.payment_submission
+        expect(Number(submission.total_amount)).toBe(600)
+
+        /**
+         * 🔑 The LINE carries the order, at `source_type: "inventory_order"`.
+         * Without that the partner detail screen has nothing to render and the
+         * ledger cannot tell which order the payout bills — which is the join
+         * #1710 needs to warn on money already recorded against it.
+         */
+        const line = (submission.items || [])[0]
+        expect(line.source_type).toBe("inventory_order")
+        expect(line.inventory_order_id).toBe(orderId)
+      })
+
+      it("still refuses a submission naming nothing at all", async () => {
+        const res = await api
+          .post(
+            "/partners/payment-submissions",
+            { notes: "pay me" },
+            { headers: partnerHeaders }
+          )
+          .catch((e: any) => e.response)
+
+        expect(res.status).toBe(400)
+      })
+    })
   })
 })

--- a/apps/backend/src/admin/components/partners/__tests__/partner-ledger-section.unit.spec.ts
+++ b/apps/backend/src/admin/components/partners/__tests__/partner-ledger-section.unit.spec.ts
@@ -1,0 +1,172 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+
+/**
+ * The partner ledger's double-pay warning (#1710).
+ *
+ * 🔴 The route now computes `recorded_against_open` and attaches
+ * `recorded_against` to each payout. A value computed server-side with no
+ * reader on the screen is worth nothing — that is #1679's shape, and #1704's,
+ * and it is why an order headlined "INR 0 paid" over INR 20,000 of completed
+ * payments. So this pins the one thing: the warning REACHES THE SCREEN.
+ *
+ * There is no component test harness in this package; this renders the section
+ * to static markup with its data hooks stubbed, the same shape
+ * `inventory-order-payments-section.unit.spec.ts` established in #1706.
+ */
+
+jest.mock("react-router-dom", () => ({
+  Link: ({ children }: any) => React.createElement("a", null, children),
+}))
+
+const mockLedger = jest.fn()
+jest.mock("../../../hooks/api/payments", () => ({
+  usePartnerLedger: (...args: any[]) => mockLedger(...args),
+  useUpdatePayment: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}))
+
+/**
+ * ⚠️ The jest swc transform emits CLASSIC JSX while the admin sources rely on
+ * the automatic runtime and import no React.
+ */
+;(globalThis as any).React = React
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PartnerLedgerSection } = require("../partner-ledger-section")
+
+/** The prod shape from #1710: Parmar, INR 28,200 Approved, INR 20,000 moved. */
+const payout = (over: Record<string, any> = {}) => ({
+  id: "payout:01M13T9D9A",
+  kind: "payout" as const,
+  status: "Approved",
+  amount: 28200,
+  currency: "inr",
+  occurred_at: "2026-08-28T10:00:00.000Z",
+  submission_id: "01M13T9D9A",
+  lines: [],
+  submitted_at: "2026-08-28T10:00:00.000Z",
+  settled_by: null,
+  recorded_against: [
+    {
+      payment_id: "pay_jul",
+      amount: 10000,
+      status: "Completed",
+      payment_type: "Bank",
+      payment_date: "2026-07-11T00:00:00.000Z",
+      via: "inventory_order",
+      inventory_order_id: "inv_order_01KWAKAZE1",
+      inventory_order_name: "Parmar cotton",
+    },
+    {
+      payment_id: "pay_aug",
+      amount: 10000,
+      status: "Completed",
+      payment_type: "Bank",
+      payment_date: "2026-08-30T00:00:00.000Z",
+      via: "inventory_order",
+      inventory_order_id: "inv_order_01KWAKAZE1",
+      inventory_order_name: "Parmar cotton",
+    },
+  ],
+  recorded_against_total: 20000,
+  ...over,
+})
+
+const totals = (over: Record<string, any> = {}) => ({
+  billed: 28200,
+  paid: 0,
+  outstanding: 28200,
+  recorded: 20000,
+  recorded_against_open: 20000,
+  currency: "inr",
+  ...over,
+})
+
+const render = (entries: any[], t: any) => {
+  mockLedger.mockReturnValue({
+    entries,
+    totals: t,
+    isLoading: false,
+    isError: false,
+  })
+  return renderToStaticMarkup(
+    React.createElement(PartnerLedgerSection, { partnerId: "partner_1" })
+  )
+}
+
+const text = (html: string) =>
+  html.replace(/<[^>]*>/g, " ").replace(/&#x27;/g, "'").replace(/\s+/g, " ")
+
+describe("PartnerLedgerSection — the double-pay warning (#1710)", () => {
+  it("🔴 warns on the totals line that money sits against an unpaid payout", () => {
+    const html = text(render([payout()], totals()))
+
+    // The reading that pays someone twice, still present and still honest…
+    expect(html).toMatch(/outstanding/i)
+    // …and the number that stops it.
+    expect(html).toContain("20,000")
+    expect(html).toMatch(/an unpaid payout still bills/i)
+  })
+
+  it("warns on the payout ROW, naming the order the money sits against", () => {
+    const html = text(render([payout()], totals()))
+
+    expect(html).toMatch(/already\s+recorded against/i)
+    expect(html).toMatch(/check before paying/i)
+  })
+
+  it("stays silent when nothing is recorded against an open payout", () => {
+    const html = text(
+      render(
+        [payout({ recorded_against: [], recorded_against_total: 0 })],
+        totals({ recorded: 0, recorded_against_open: 0 })
+      )
+    )
+
+    expect(html).not.toMatch(/check before paying/i)
+    expect(html).not.toMatch(/an unpaid payout still bills/i)
+  })
+
+  it("stops warning on the row once the payout is Paid", () => {
+    // Money against a settled payout is history, not a double-pay risk.
+    const html = text(
+      render(
+        [payout({ status: "Paid", paid_at: "2026-08-31T00:00:00.000Z" })],
+        totals({ paid: 28200, outstanding: 0, recorded_against_open: 0 })
+      )
+    )
+
+    expect(html).not.toMatch(/check before paying/i)
+  })
+
+  it("says which ORDER a recorded payment belongs to, not just that it exists", () => {
+    /**
+     * 🔴 Before #1710 this row could not appear at all: the ledger read
+     * payments through the partner link only, and this one is attached to the
+     * inventory order.
+     */
+    const html = text(
+      render(
+        [
+          {
+            id: "payment:pay_jul",
+            kind: "payment" as const,
+            status: "Completed",
+            amount: 10000,
+            currency: "inr",
+            occurred_at: "2026-07-11T00:00:00.000Z",
+            payment_type: "Bank",
+            payment_date: "2026-07-11T00:00:00.000Z",
+            attachments: [],
+            inventory_order_id: "inv_order_01KWAKAZE1",
+            inventory_order_name: "Parmar cotton",
+          },
+        ],
+        totals({ billed: 0, outstanding: 0, recorded_against_open: 0 })
+      )
+    )
+
+    expect(html).toMatch(/recorded against Parmar cotton/i)
+    expect(html).toMatch(/no payout attached/i)
+  })
+})

--- a/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
@@ -82,6 +82,29 @@ const PayoutRow = ({ entry }: { entry: PartnerLedgerEntry }) => {
               : ""}
           </Text>
         )}
+        {entry.status !== "Paid" && (entry.recorded_against_total ?? 0) > 0 && (
+          /**
+           * 🔴 #1710 — the line that stops someone being paid twice.
+           *
+           * This payout claims money is owed; these payments say money has
+           * already moved against the same order. Neither record knows about
+           * the other, so the reconciliation has to happen in the reader's
+           * head — and it can only happen if the reader is TOLD.
+           *
+           * ⚠️ Not subtracted from the amount beside it. An advance and a
+           * payout can legitimately coexist; only a human linking the payment
+           * to this submission settles that question.
+           */
+          <Text size="xsmall" className="text-ui-tag-orange-text">
+            ⚠ {money(entry.recorded_against_total!, entry.currency)} already
+            recorded against{" "}
+            {entry.recorded_against!.length === 1
+              ? entry.recorded_against![0].inventory_order_name ||
+                "the order this bills"
+              : `${entry.recorded_against!.length} payments on the order this bills`}{" "}
+            — check before paying
+          </Text>
+        )}
       </div>
       <div className="flex flex-col items-end">
         <Text size="small" weight="plus">
@@ -137,7 +160,12 @@ const PaymentRow = ({ entry }: { entry: PartnerLedgerEntry }) => {
           {/* No lines exist for these. Saying so beats an empty space that
               reads as "nothing was billed". */}
           <Text size="xsmall" className="text-ui-fg-muted">
-            recorded payment — no payout attached
+            {entry.inventory_order_id
+              ? /* #1710 — this row reached the ledger through the ORDER link.
+                   Before, it reached it through nothing at all and the panel
+                   reported the partner as owed the full amount. */
+                `recorded against ${entry.inventory_order_name || "an inventory order"} — no payout attached`
+              : "recorded payment — no payout attached"}
           </Text>
         </div>
         <div className="flex items-center gap-x-3">
@@ -239,6 +267,16 @@ export const PartnerLedgerSection = ({ partnerId }: { partnerId: string }) => {
               </>
             )}
           </Text>
+          {totals!.recorded_against_open > 0 && (
+            /* #1710 — the headline figure for the double-pay risk. Its own
+               line, not appended to the run-on above, because it is the one
+               number here that should stop an action. */
+            <Text size="xsmall" className="text-ui-tag-orange-text mt-1">
+              ⚠ {money(totals!.recorded_against_open, totals!.currency)} of that
+              sits against orders an unpaid payout still bills — settle or link
+              it before paying again
+            </Text>
+          )}
         </div>
       )}
 

--- a/apps/backend/src/admin/hooks/api/payments.ts
+++ b/apps/backend/src/admin/hooks/api/payments.ts
@@ -120,11 +120,33 @@ export type PartnerLedgerEntry = {
     payment_date: string | null;
     status: string | null;
   } | null;
+  /**
+   * Money already recorded against a source this payout ALSO bills (#1710).
+   *
+   * 🔴 Declare it here or the panel cannot read it. A flag the server sends for
+   * months with no entry in the client TYPE has zero readers (#1679) — the same
+   * shape that let an order headline "INR 0 paid" over INR 20,000 of completed
+   * payments.
+   */
+  recorded_against?: Array<{
+    payment_id: string;
+    amount: number;
+    status: string | null;
+    payment_type: string | null;
+    payment_date: string | null;
+    via: "submission" | "inventory_order";
+    inventory_order_id: string | null;
+    inventory_order_name: string | null;
+  }>;
+  recorded_against_total?: number;
   // payment
   payment_type?: string | null;
   payment_date?: string | null;
   attachments?: any[];
   paid_to?: any;
+  /** Which inventory order this money was recorded against (#1710). */
+  inventory_order_id?: string | null;
+  inventory_order_name?: string | null;
 };
 
 export type PartnerLedgerResponse = {
@@ -134,6 +156,8 @@ export type PartnerLedgerResponse = {
     paid: number;
     outstanding: number;
     recorded: number;
+    /** Of `recorded`, what sits against a source an UNPAID payout bills (#1710). */
+    recorded_against_open: number;
     currency: string | null;
   };
   count: number;

--- a/apps/backend/src/api/admin/payment-submissions/payable-inventory-orders/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-inventory-orders/route.ts
@@ -1,13 +1,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import {
-  ContainerRegistrationKeys,
-  MedusaError,
-} from "@medusajs/framework/utils"
+import { MedusaError } from "@medusajs/framework/utils"
 
-import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
-import type PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
-import { listPartnerClaims } from "../../../../workflows/payment_submissions/lib/run-claims"
-import { valueInventoryOrderByReceipts } from "../../../../workflows/payment_submissions/lib/inventory-order-value"
+import { listPayableInventoryOrders } from "../../../../workflows/payment_submissions/lib/payable-inventory-orders"
 
 /**
  * GET /admin/payment-submissions/payable-inventory-orders?partner_id=…
@@ -23,21 +17,13 @@ import { valueInventoryOrderByReceipts } from "../../../../workflows/payment_sub
  * offered them: on production, NO payment carries an `inventory_order_id`. A
  * capability with no way to reach it is a capability nobody has.
  *
- * ## What it offers, and what it refuses to invent
+ * ## Where the answer lives
  *
- * The value is derived from RECEIPTS, never from `total_price`. An order placed
- * for ₹88,885 with ₹28,670 actually delivered is owed ₹28,670 — billing the
- * ordered total there overpays by ₹60,215, and asking an operator to work it
- * out by hand invites it to be got wrong once per order (#1612).
- *
- * An order with no receipts is listed and marked `payable: false` rather than
- * hidden. "Why isn't this order here" is the question an operator arrives with,
- * and a delivered order that recorded no receipt is a gap in the record — not a
- * statement that the goods were free.
- *
- * 🔑 Already-claimed orders come from `listPartnerClaims`, the same fold the
- * write guard refuses on. A screen offering what the guard will reject teaches
- * an operator about the rule through a 400.
+ * 🔑 In `lib/payable-inventory-orders`, not here. The partner portal asks the
+ * same question of its own orders (#1710) and a second copy of "what is this
+ * order worth, and how much of it is already claimed" is a second place for the
+ * receipts rule, the ordered-total ceiling and the cap flag to drift apart.
+ * This route is now just the admin DOOR: read `partner_id`, refuse without it.
  */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const partnerId = String(
@@ -53,123 +39,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     )
   }
 
-  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-
-  /**
-   * ⚠️ Reached through the PARTNER, not by filtering inventory orders on a
-   * partner column — there is no such column. `partner-inventory-order` is a
-   * list link, so the orders arrive nested.
-   */
-  const { data: partners } = await query.graph({
-    entity: "partner",
-    fields: [
-      "id",
-      "inventory_orders.id",
-      "inventory_orders.status",
-      "inventory_orders.total_price",
-      "inventory_orders.currency_code",
-      "inventory_orders.expected_delivery_date",
-      "inventory_orders.order_date",
-      "inventory_orders.is_sample",
-      "inventory_orders.orderlines.id",
-      "inventory_orders.orderlines.quantity",
-      "inventory_orders.orderlines.price",
-      "inventory_orders.orderlines.material_name",
-      // 🔴 The receipts. The typed rows, never `metadata.partner_delivery_history`
-      // — the two disagree by ₹4,050 on a real order and these are what the
-      // concurrency guard reads (#1613).
-      "inventory_orders.orderlines.line_fulfillments.quantity_delta",
-    ],
-    filters: { id: partnerId },
-  })
-
-  const partner = ((partners || []) as any[])[0]
-  const orders = (partner?.inventory_orders || []) as any[]
-
-  const submissionService: PaymentSubmissionsService = req.scope.resolve(
-    PAYMENT_SUBMISSIONS_MODULE
-  )
-  const { inventoryOrders: claims } = await listPartnerClaims(
-    submissionService as any,
+  const payable_inventory_orders = await listPayableInventoryOrders(
+    req.scope,
     partnerId
   )
-
-  const payable_inventory_orders = orders
-    /**
-     * A cancelled order is not a debt. Everything else is listed — including
-     * Pending and Processing, because a receipt can legitimately be recorded
-     * before the status catches up, and an order with goods in it is payable
-     * whatever the workflow calls it.
-     */
-    .filter((order) => String(order?.status || "") !== "Cancelled")
-    .map((order) => {
-      const value = valueInventoryOrderByReceipts(order.orderlines || [])
-      const claim = claims.get(String(order.id)) ?? null
-      const claimedTotal = claim?.claimed_total ?? 0
-
-      /**
-       * 🔴 The CEILING is the ordered total, not the receipts value.
-       *
-       * `assessInventoryOrderClaims` refuses anything that would take an order
-       * past `total_price`, and the receipts figure can legitimately sit ABOVE
-       * it — ₹64,274 derived against ₹63,375.75 ordered on the order that
-       * opened #1617. An amountless line defaults to the receipts figure and is
-       * refused there. So the screen has to know BOTH numbers, or it offers a
-       * figure the guard rejects and the operator learns the rule from a 400.
-       */
-      const ordered = Number(order.total_price ?? 0)
-      const ceiling = Number.isFinite(ordered) && ordered > 0 ? ordered : null
-
-      const remaining =
-        ceiling == null
-          ? null
-          : Math.round(Math.max(0, ceiling - claimedTotal) * 100) / 100
-
-      /**
-       * What this row offers: the receipts value, capped at what is left.
-       *
-       * Capping rather than offering the raw figure is the whole point — but a
-       * silent cap is a reduction nobody decided, so `capped_by_ceiling` says
-       * it happened and the raw figure stays on the row beside it.
-       */
-      const uncapped = value.total
-      const amount =
-        remaining == null ? uncapped : Math.round(Math.min(uncapped, remaining) * 100) / 100
-
-      return {
-        inventory_order_id: String(order.id),
-        status: order.status ?? null,
-        is_sample: !!order.is_sample,
-        currency_code: order.currency_code ?? null,
-        /** What was ORDERED. This is the guard's ceiling. */
-        ordered_total: ceiling,
-        /** What the RECEIPTS are worth, before any cap. */
-        receipts_total: uncapped,
-        received_quantity: value.received_quantity,
-        lines: value.lines,
-        /** Already billed across every live submission. */
-        claimed_total: Math.round(claimedTotal * 100) / 100,
-        /** What may still be billed — `null` when the order has no readable price. */
-        remaining,
-        /** What this row bills if selected. */
-        amount,
-        /** Whether `amount` is below `receipts_total` because the ceiling bit. */
-        capped_by_ceiling: remaining != null && uncapped > remaining,
-        order_date: order.order_date ?? null,
-        expected_delivery_date: order.expected_delivery_date ?? null,
-        /**
-         * Whether there is anything to bill. False means either no receipt has
-         * been recorded — a gap in the record, not a price of zero — or the
-         * order is fully claimed already.
-         */
-        payable: amount > 0,
-        /** Who holds the live claims on this order, earliest first. */
-        claims: (claim?.claims || []).map((c) => ({
-          submission_id: c.submission_id,
-          status: c.submission_status,
-        })),
-      }
-    })
 
   return res.status(200).json({
     payable_inventory_orders,

--- a/apps/backend/src/api/admin/payments/link/validators.ts
+++ b/apps/backend/src/api/admin/payments/link/validators.ts
@@ -25,6 +25,20 @@ export const CreatePaymentAndLinkSchema = z.object({
   personIds: z.array(z.string()).optional(),
   partnerIds: z.array(z.string()).optional(),
   inventoryOrderIds: z.array(z.string()).optional(),
+  /**
+   * The payout(s) this payment settles (#1710).
+   *
+   * 🔑 The fact a human states. Everything else on this request says who the
+   * money is ABOUT — a person, a partner, an order — and none of it says what
+   * it pays OFF, which is why the partner ledger could read `recorded: 0`
+   * beside `outstanding: 28,200` on an order that had already seen INR 20,000.
+   *
+   * Naming a submission here attaches the payment to that payout on the ledger
+   * and takes it out of "recorded separately". Leaving it absent is still
+   * correct for an advance or an unrelated payment — the ledger will show the
+   * money against the order and warn, rather than assume.
+   */
+  paymentSubmissionIds: z.array(z.string()).optional(),
   attachments: z.array(PaymentAttachmentSchema).optional(),
 })
 

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/__tests__/fold.unit.spec.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/__tests__/fold.unit.spec.ts
@@ -1,4 +1,4 @@
-import { foldPartnerLedger } from "../fold"
+import { foldPartnerLedger, mergePaymentSources } from "../fold"
 
 /**
  * The merged partner ledger (#1612). Every case here is a shape that exists on
@@ -187,5 +187,255 @@ describe("foldPartnerLedger", () => {
     })
 
     expect(new Set(entries.map((e) => e.id)).size).toBe(2)
+  })
+})
+
+/**
+ * #1710 — one fact, two homes, no reconciliation.
+ *
+ * The exact prod shape: partner `01KKB7C2FY…` (Parmar), inventory order
+ * `inv_order_01KWAKAZE1…`, submission `01M13T9D9A…` (Approved, INR 28,200 —
+ * the ordered total), and two Completed INR 10,000 payments that linked to the
+ * ORDER and never to the partner. The order page read `recorded: 20000`; the
+ * partner ledger read `recorded: 0, outstanding: 28200`. That second reading is
+ * the one that pays someone twice.
+ */
+describe("foldPartnerLedger — money recorded against an order a payout bills (#1710)", () => {
+  const ORDER = "inv_order_01KWAKAZE17CC95XDEY7Q0M8SN"
+
+  const parmarSubmission = {
+    id: "01M13T9D9AGDA3QJYCXEZ942W7",
+    status: "Approved",
+    total_amount: 28200,
+    currency: "inr",
+    submitted_at: "2026-08-28T10:00:00.000Z",
+  }
+
+  const parmarLine = {
+    id: "item_1",
+    submission_id: "01M13T9D9AGDA3QJYCXEZ942W7",
+    source_type: "inventory_order",
+    inventory_order_id: ORDER,
+    inventory_order_name: "Parmar cotton",
+  }
+
+  /** Both real rows: 11 Jul and 30 Aug, INR 10,000 each, Completed. */
+  const orderPayments = [
+    {
+      id: "pay_jul",
+      amount: 10000,
+      status: "Completed",
+      payment_type: "Bank",
+      payment_date: "2026-07-11T00:00:00.000Z",
+      inventory_order_id: ORDER,
+      inventory_order_name: "Parmar cotton",
+    },
+    {
+      id: "pay_aug",
+      amount: 10000,
+      status: "Completed",
+      payment_type: "Bank",
+      payment_date: "2026-08-30T00:00:00.000Z",
+      inventory_order_id: ORDER,
+      inventory_order_name: "Parmar cotton",
+    },
+  ]
+
+  const parmar = (over: Record<string, any> = {}) =>
+    foldPartnerLedger({
+      submissions: [parmarSubmission],
+      items: [parmarLine],
+      payments: orderPayments,
+      reconciliations: [],
+      ...over,
+    })
+
+  it("SEES money that reached the ledger only through the inventory order", () => {
+    /**
+     * ⚠️ The union that makes these rows VISIBLE is `mergePaymentSources`, not
+     * this fold — handing the fold a payments array asserts nothing about where
+     * it came from. So drive it the way the route does: a partner link that
+     * returns NOTHING, and the order link that returns both rows.
+     */
+    const payments = mergePaymentSources([
+      { rows: [] },
+      {
+        rows: [{ id: "pay_jul", amount: 10000, status: "Completed" }],
+        attribution: { inventory_order_id: ORDER, inventory_order_name: "Parmar cotton" },
+      },
+      {
+        rows: [{ id: "pay_aug", amount: 10000, status: "Completed" }],
+        attribution: { inventory_order_id: ORDER, inventory_order_name: "Parmar cotton" },
+      },
+    ])
+
+    const { totals } = parmar({ payments })
+
+    // Before #1710 the route read the partner link ALONE, which returns [] for
+    // both of these — so this was 0 while the order page said 20,000.
+    expect(totals.recorded).toBe(20000)
+    expect(totals.recorded_against_open).toBe(20000)
+  })
+
+  it("warns on the payout that INR 20,000 already sits against the order it bills", () => {
+    const { entries } = parmar()
+
+    const payout = entries.find((e) => e.kind === "payout")!
+    expect(payout.recorded_against_total).toBe(20000)
+    expect(payout.recorded_against).toHaveLength(2)
+    expect(payout.recorded_against!.map((r) => r.payment_id).sort()).toEqual([
+      "pay_aug",
+      "pay_jul",
+    ])
+    expect(payout.recorded_against![0].via).toBe("inventory_order")
+    expect(payout.recorded_against![0].inventory_order_name).toBe(
+      "Parmar cotton"
+    )
+  })
+
+  it("does NOT net that money off `outstanding` — an advance and a payout can coexist", () => {
+    const { totals } = parmar()
+
+    // The founder decides whether these INR 20,000 discharge the payout, by
+    // linking the payment to the submission. This fold must not infer it from a
+    // shared order id.
+    expect(totals.billed).toBe(28200)
+    expect(totals.paid).toBe(0)
+    expect(totals.outstanding).toBe(28200)
+    // …but it must say so, right beside it.
+    expect(totals.recorded_against_open).toBe(20000)
+  })
+
+  it("counts a payment ONCE when two open payouts bill the same order", () => {
+    const second = {
+      ...parmarSubmission,
+      id: "sub_2",
+      total_amount: 5000,
+    }
+    const { totals } = parmar({
+      submissions: [parmarSubmission, second],
+      items: [parmarLine, { ...parmarLine, id: "item_2", submission_id: "sub_2" }],
+    })
+
+    // Two payouts mention the order; the money moved once.
+    expect(totals.recorded_against_open).toBe(20000)
+  })
+
+  it("stops warning once the payout is Paid — settled money is history, not risk", () => {
+    // The control: while it is Approved the warning is loud.
+    expect(parmar().totals.recorded_against_open).toBe(20000)
+
+    const { totals } = parmar({
+      submissions: [{ ...parmarSubmission, status: "Paid", paid_at: "2026-08-31T00:00:00.000Z" }],
+    })
+
+    expect(totals.paid).toBe(28200)
+    expect(totals.recorded_against_open).toBe(0)
+    // Still visible as recorded money — it did move.
+    expect(totals.recorded).toBe(20000)
+  })
+
+  it("keeps the order on the payment entry, so a reader can see WHY it is there", () => {
+    const { entries } = parmar()
+
+    const payment = entries.find((e) => e.id === "payment:pay_jul")!
+    expect(payment.inventory_order_id).toBe(ORDER)
+    expect(payment.inventory_order_name).toBe("Parmar cotton")
+
+    // The control: a payment with no order stays null rather than inheriting
+    // the order of whichever row was folded beside it.
+    const { entries: bare } = parmar({
+      payments: [{ id: "pay_bare", amount: 500, status: "Completed" }],
+    })
+    expect(bare.find((e) => e.id === "payment:pay_bare")!.inventory_order_id).toBeNull()
+  })
+
+  it("attaches a payment that NAMES its payout, and drops it from `recorded`", () => {
+    // The direct link — the fact a human states. Same money, now matched.
+    const { entries, totals } = parmar({
+      payments: [
+        { ...orderPayments[0], submission_id: "01M13T9D9AGDA3QJYCXEZ942W7" },
+        orderPayments[1],
+      ],
+    })
+
+    const payout = entries.find((e) => e.kind === "payout")!
+    expect(payout.settled_by?.payment_id).toBe("pay_jul")
+
+    // It is described on its payout, so it is no longer "recorded separately"…
+    expect(totals.recorded).toBe(10000)
+    // …nor is it double-reported as unmatched money against the same order.
+    expect(payout.recorded_against!.map((r) => r.payment_id)).toEqual(["pay_aug"])
+    expect(totals.recorded_against_open).toBe(10000)
+  })
+
+  it("ignores a direct link that names a submission belonging to someone else", () => {
+    // The control: the SAME row, naming THIS partner's payout, does attach.
+    const attached = parmar({
+      payments: [{ ...orderPayments[0], submission_id: parmarSubmission.id }],
+    })
+    expect(
+      attached.entries.find((e) => e.kind === "payout")!.settled_by?.payment_id
+    ).toBe("pay_jul")
+
+    const { entries, totals } = parmar({
+      payments: [{ ...orderPayments[0], submission_id: "sub_of_another_partner" }],
+    })
+
+    const payout = entries.find((e) => e.kind === "payout")!
+    expect(payout.settled_by).toBeNull()
+    // Still this partner's money, still visible.
+    expect(totals.recorded).toBe(10000)
+  })
+})
+
+/**
+ * The union itself (#1710) — which decides whether money is VISIBLE at all,
+ * before any arithmetic runs on it.
+ */
+describe("mergePaymentSources", () => {
+  it("returns a row that only ONE source knows about", () => {
+    const merged = mergePaymentSources([
+      { rows: [] },
+      { rows: [{ id: "p1", amount: 10000 }], attribution: { inventory_order_id: "o1" } },
+    ])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].inventory_order_id).toBe("o1")
+  })
+
+  it("counts a row present in TWO sources once", () => {
+    const merged = mergePaymentSources([
+      { rows: [{ id: "p1", amount: 10000 }] },
+      { rows: [{ id: "p1", amount: 10000 }], attribution: { inventory_order_id: "o1" } },
+    ])
+
+    expect(merged).toHaveLength(1)
+    // …and the later source still teaches it which order it was recorded against.
+    expect(merged[0].inventory_order_id).toBe("o1")
+  })
+
+  it("lets a later source FILL IN a missing field but never OVERWRITE one", () => {
+    const merged = mergePaymentSources([
+      { rows: [{ id: "p1" }], attribution: { inventory_order_id: "o_first" } },
+      { rows: [{ id: "p1" }], attribution: { inventory_order_id: "o_second", submission_id: "s1" } },
+    ])
+
+    expect(merged[0].inventory_order_id).toBe("o_first")
+    expect(merged[0].submission_id).toBe("s1")
+  })
+
+  it("does not let a null attribution erase a value already present", () => {
+    const merged = mergePaymentSources([
+      { rows: [{ id: "p1", inventory_order_name: "Parmar cotton" }] },
+      { rows: [{ id: "p1" }], attribution: { inventory_order_name: null } },
+    ])
+
+    expect(merged[0].inventory_order_name).toBe("Parmar cotton")
+  })
+
+  it("skips rows with no id rather than collapsing them into one", () => {
+    const merged = mergePaymentSources([{ rows: [{ amount: 1 }, null, undefined] as any }])
+    expect(merged).toEqual([])
   })
 })

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/fold.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/fold.ts
@@ -54,13 +54,63 @@ export type PaymentLike = {
   paid_to?: any
   attachments?: any[] | null
   metadata?: any
+  /**
+   * The inventory order this payment was recorded against, when it was reached
+   * through the order rather than through the partner (#1710).
+   *
+   * 🔴 The whole defect. `POST /partners/inventory-orders/:id/submit-payment`
+   * writes ONLY the order link, so two Completed INR 10,000 payments were
+   * invisible to a ledger that reads exclusively through the partner link —
+   * `recorded: 0` beside `outstanding: 28,200` on the very order they paid.
+   * Reading both homes needs no backfill, so historical rows are covered too.
+   */
+  inventory_order_id?: string | null
+  inventory_order_name?: string | null
+  /** The payout this payment settles, via the direct link (#1710). */
+  submission_id?: string | null
 }
 
 /**
- * A reconciliation is the only thing that says an `internal_payments` row came
- * from a submission — there is no link between the two and there never was.
- * The generated link table name is 73 characters, past PostgreSQL's 63-byte
- * identifier limit, so `defineLink` skipped it in silence.
+ * A payment recorded against something a payout ALSO bills.
+ *
+ * 🔑 Advisory, never arithmetic. It is attached to the payout so the operator
+ * reading "INR 28,200 outstanding" sees, on the same row, that INR 20,000 has
+ * already moved against the order that payout bills. It is deliberately not
+ * subtracted from `outstanding`: whether an order-linked payment discharges a
+ * payout is a money decision a human makes by linking it (`submission_id`),
+ * not one this fold may infer from a shared order id.
+ */
+export type RecordedAgainst = {
+  payment_id: string
+  amount: number
+  status: string | null
+  payment_type: string | null
+  payment_date: string | null
+  /** How this payment was tied to the payout. */
+  via: "submission" | "inventory_order"
+  inventory_order_id: string | null
+  inventory_order_name: string | null
+}
+
+/**
+ * A reconciliation says an `internal_payments` row came from a submission.
+ *
+ * 🔴 CORRECTED (#1710). This file used to assert it was the ONLY such thing,
+ * because `defineLink(paymentSubmission, internalPayments)` generates a
+ * 73-character table name and Postgres truncates identifiers at 63 bytes — so
+ * the table "was never created, in either environment". That is wrong. Medusa
+ * abbreviates each segment of an over-long link name to four characters and
+ * appends a hash; the table exists, migrated, in both environments:
+ *
+ *     paym_subm_paym_subm_inte_paym_inte_paym-9812b09f
+ *
+ * It read as absent because it held ZERO ROWS — nothing ever wrote it. A
+ * capability declared dead on a mechanism that was never the mechanism, so
+ * nobody built the writer. `linkPaymentToSubmissionsStep` is that writer now,
+ * and `PaymentLike.submission_id` below is how a linked row arrives here.
+ *
+ * The reconciliation path stays: it resolves the 5 historical rows, and it is
+ * correctly null for everything written since #1638.
  */
 export type ReconciliationLike = {
   reference_type?: string | null
@@ -104,12 +154,27 @@ export type LedgerEntry = {
     payment_date: string | null
     status: string | null
   } | null
+  /**
+   * Money already recorded against something THIS payout bills (#1710).
+   *
+   * 🔴 The reading that pays someone twice is "INR 28,200 outstanding" printed
+   * with no hint that INR 20,000 has moved against the same order. This is that
+   * hint, attached to the row that makes the claim.
+   *
+   * ⚠️ Advisory. It never enters `paid` or `outstanding` — see `RecordedAgainst`.
+   */
+  recorded_against?: RecordedAgainst[]
+  /** Sum of `recorded_against`. Advisory, for the same reason. */
+  recorded_against_total?: number
 
   // ── payment only ───────────────────────────────────────────────────────
   payment_type?: string | null
   payment_date?: string | null
   attachments?: any[]
   paid_to?: any
+  /** Which inventory order this money was recorded against, if any (#1710). */
+  inventory_order_id?: string | null
+  inventory_order_name?: string | null
 }
 
 export type LedgerTotals = {
@@ -127,10 +192,70 @@ export type LedgerTotals = {
    */
   recorded: number
   /**
+   * Of `recorded`, what was recorded against a source an UNPAID payout bills
+   * (#1710).
+   *
+   * 🔑 The anti-double-pay figure. `outstanding` says what the payouts still
+   * claim; this says how much of that has money already sitting against it,
+   * unmatched. On the order that opened #1710 it is INR 20,000 against INR
+   * 28,200 outstanding.
+   *
+   * ⚠️ NOT subtracted from `outstanding`. Two Completed payments touching the
+   * same order as a payout is evidence a human should look, not proof the
+   * payout is discharged — an advance and a payout can legitimately coexist.
+   * Linking the payment to the submission is how a human states that it does.
+   */
+  recorded_against_open: number
+  /**
    * The currency all live submissions agree on, or null when they do not. A
    * caller must not render an aggregate against a null currency.
    */
   currency: string | null
+}
+
+/**
+ * Union the payment rows a partner's money can arrive through, deduped by id
+ * (#1710).
+ *
+ * 🔴 THE FIX. One payment has up to three homes — the partner link, the
+ * inventory-order link, the submission link — and until this existed the ledger
+ * read exactly one of them. Two Completed INR 10,000 rows lived only in the
+ * order home, so the screen that answers "what do we owe this partner" reported
+ * `recorded: 0` against `outstanding: 28,200` on the very order they paid.
+ *
+ * 🔑 Order matters, and it is the caller's: the FIRST source to supply a row
+ * owns its provenance, and later sources may only FILL IN fields that are still
+ * absent. A payment reached through the partner link keeps that identity while
+ * still learning which order it was recorded against.
+ *
+ * PURE, so the union that decides whether money is visible at all can be tested
+ * without a graph behind it.
+ */
+export const mergePaymentSources = (
+  sources: Array<{
+    rows: any[]
+    /** Fields this source knows that the row itself does not carry. */
+    attribution?: Record<string, any>
+  }>
+): PaymentLike[] => {
+  const byId = new Map<string, any>()
+
+  for (const source of sources) {
+    for (const row of source.rows || []) {
+      if (!row?.id) continue
+      const extra = source.attribution || {}
+      const existing = byId.get(row.id)
+      if (existing) {
+        for (const [k, v] of Object.entries(extra)) {
+          if (v != null && existing[k] == null) existing[k] = v
+        }
+        continue
+      }
+      byId.set(row.id, { ...row, ...extra })
+    }
+  }
+
+  return [...byId.values()]
 }
 
 const num = (v: unknown): number => {
@@ -189,7 +314,50 @@ export const foldPartnerLedger = (input: {
     paymentBySubmission.set(rec.reference_id, rec.payment_id)
   }
 
+  /**
+   * The DIRECT link (#1710): a payment that names the submission it settles.
+   *
+   * 🔑 Applied ON TOP of the reconciliations, never instead — the 5 historical
+   * rows have only a reconciliation, and this must not take their settlement
+   * away. Every directly-linked payment is marked settled, so none of them can
+   * also be reported as unmatched money against the same order.
+   *
+   * ⚠️ Where BOTH exist for one submission the reconciliation keeps the
+   * `settled_by` slot, which is why the guard below is `!has` rather than an
+   * overwrite. It is one display slot, not an arithmetic precedence: both
+   * payments are attached either way, so neither total moves.
+   */
+  for (const p of payments) {
+    if (!p.submission_id) continue
+    if (!submissionIds.has(p.submission_id)) continue
+    settlementByPayment.set(p.id, {
+      reference_type: "payment_submission",
+      reference_id: p.submission_id,
+      payment_id: p.id,
+    })
+    if (!paymentBySubmission.has(p.submission_id)) {
+      paymentBySubmission.set(p.submission_id, p.id)
+    }
+  }
+
   const paymentsById = new Map(payments.map((p) => [p.id, p]))
+
+  /**
+   * inventory order id → the payments recorded against it, for payments that no
+   * payout already accounts for (#1710).
+   *
+   * A payment already attached as `settled_by` is excluded: it is described on
+   * its payout as the money that settled it, and describing it a second time as
+   * "unmatched money against the same order" would contradict that.
+   */
+  const paymentsByOrder = new Map<string, PaymentLike[]>()
+  for (const p of payments) {
+    if (!p.inventory_order_id) continue
+    if (settlementByPayment.has(p.id)) continue
+    const list = paymentsByOrder.get(p.inventory_order_id) || []
+    list.push(p)
+    paymentsByOrder.set(p.inventory_order_id, list)
+  }
 
   const payoutEntries: LedgerEntry[] = submissions.map((submission) => {
     const settlingPaymentId = paymentBySubmission.get(submission.id)
@@ -200,6 +368,32 @@ export const foldPartnerLedger = (input: {
     const submitted = iso(submission.submitted_at)
     const paid = iso(submission.paid_at)
 
+    /**
+     * Money sitting against the orders THIS payout bills (#1710). Deduped by
+     * payment id: one payout may bill several lines of the same order, and a
+     * mixed payout may bill several orders that share a payment.
+     */
+    const lines = itemsBySubmission.get(submission.id) || []
+    const seenPayment = new Set<string>()
+    const recordedAgainst: RecordedAgainst[] = []
+    for (const line of lines) {
+      if (!line.inventory_order_id) continue
+      for (const p of paymentsByOrder.get(line.inventory_order_id) || []) {
+        if (seenPayment.has(p.id)) continue
+        seenPayment.add(p.id)
+        recordedAgainst.push({
+          payment_id: p.id,
+          amount: num(p.amount),
+          status: p.status ?? null,
+          payment_type: p.payment_type ?? null,
+          payment_date: iso(p.payment_date),
+          via: "inventory_order",
+          inventory_order_id: line.inventory_order_id ?? null,
+          inventory_order_name: line.inventory_order_name ?? null,
+        })
+      }
+    }
+
     return {
       id: `payout:${submission.id}`,
       kind: "payout",
@@ -208,7 +402,7 @@ export const foldPartnerLedger = (input: {
       currency: (submission.currency || "inr").toLowerCase(),
       occurred_at: paid || submitted || iso(submission.created_at),
       submission_id: submission.id,
-      lines: (itemsBySubmission.get(submission.id) || []).map((item) => ({
+      lines: lines.map((item) => ({
         id: item.id,
         submission_id: item.submission_id ?? null,
         source_type: item.source_type ?? null,
@@ -233,6 +427,11 @@ export const foldPartnerLedger = (input: {
             status: settlingPayment.status ?? null,
           }
         : null,
+      recorded_against: recordedAgainst,
+      recorded_against_total: recordedAgainst.reduce(
+        (acc, r) => acc + r.amount,
+        0
+      ),
     }
   })
 
@@ -257,6 +456,8 @@ export const foldPartnerLedger = (input: {
     payment_date: iso(p.payment_date),
     attachments: Array.isArray(p.attachments) ? p.attachments : [],
     paid_to: p.paid_to ?? null,
+    inventory_order_id: p.inventory_order_id ?? null,
+    inventory_order_name: p.inventory_order_name ?? null,
   }))
 
   const entries = [...payoutEntries, ...paymentEntries].sort((a, b) =>
@@ -284,6 +485,25 @@ export const foldPartnerLedger = (input: {
       paid,
       outstanding: billed - paid,
       recorded: paymentEntries.reduce((acc, e) => acc + e.amount, 0),
+      /**
+       * Counted once per PAYMENT, not once per payout that mentions it — two
+       * open payouts billing the same order must not double the warning.
+       * Only payouts that are not already Paid contribute: money against a
+       * settled payout is history, not a double-pay risk.
+       */
+      recorded_against_open: (() => {
+        const seen = new Set<string>()
+        let total = 0
+        for (const entry of live) {
+          if (PAID_STATUSES.has(String(entry.status))) continue
+          for (const r of entry.recorded_against || []) {
+            if (seen.has(r.payment_id)) continue
+            seen.add(r.payment_id)
+            total += r.amount
+          }
+        }
+        return total
+      })(),
       currency: currencies.size === 1 ? [...currencies][0] : null,
     },
   }

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/route.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/route.ts
@@ -11,14 +11,35 @@
  * quietly turned into a history list that a reader had no way to know was
  * partial — the #1621 shape.
  *
- * ⚠️ The two are joined through the RECONCILIATION, never through a link.
- * `defineLink(paymentSubmission, internalPayments)` exists in `src/links`, but
- * its generated table name is 73 characters — past PostgreSQL's 63-byte
- * identifier limit — so the table was never created, in either environment,
- * with no error raised. `query.graph` therefore returns submissions with no
- * `payments` key at all. `payment_reconciliation.payment_id` resolves the 5
- * historical submission-derived rows and is correctly null for everything
- * since.
+ * 🔴 CORRECTED (#1710) — this route used to say the two could only be joined
+ * through the RECONCILIATION, because `defineLink(paymentSubmission,
+ * internalPayments)` generates a 73-character table name and "the table was
+ * never created, in either environment, with no error raised". That is wrong.
+ * Medusa abbreviates each segment of an over-long link name to four characters
+ * and appends a hash, and the table exists and is migrated in both:
+ *
+ *     paym_subm_paym_subm_inte_paym_inte_paym-9812b09f
+ *
+ * `query.graph` returned no `payments` key because the table held ZERO ROWS.
+ * Nothing wrote it — a capability declared dead on a mechanism that was never
+ * the mechanism. `linkPaymentToSubmissionsStep` writes it now.
+ *
+ * ## Where a partner's payments are read from (#1710)
+ *
+ * THREE homes, unioned and deduped by payment id — because one payment may sit
+ * in any of them and a reader that knows only one reports the others as zero:
+ *
+ *   1. the PARTNER link          — how a payment recorded on the partner arrives
+ *   2. the INVENTORY ORDER link  — how `POST /partners/inventory-orders/:id/
+ *                                  submit-payment` records one. Two Completed
+ *                                  INR 10,000 payments lived only here, so the
+ *                                  ledger said `recorded: 0` while the order
+ *                                  page said `recorded: 20000`.
+ *   3. the SUBMISSION link       — a payment that names the payout it settles.
+ *
+ * ⚠️ Reading by order needs no backfill, which is why it is a read-side union
+ * rather than a data migration: every historical row is covered the moment this
+ * ships, and nothing has to be rewritten to be seen.
  *
  * Response: { entries, totals, count }
  */
@@ -29,7 +50,7 @@ import PartnerPaymentsLink from "../../../../../../links/partner-payments-link"
 import { PAYMENT_REPORTS_MODULE } from "../../../../../../modules/payment_reports"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../../modules/payment_submissions"
 import type PaymentSubmissionsService from "../../../../../../modules/payment_submissions/service"
-import { foldPartnerLedger } from "./fold"
+import { foldPartnerLedger, mergePaymentSources } from "./fold"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id: partner_id } = req.params
@@ -51,14 +72,25 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     : []
 
   /**
-   * The partner's `internal_payments`. Best-effort: a partner with no link rows
-   * at all is the normal case for anyone onboarded after #1638, and a graph
-   * hiccup must not turn a panel that CAN answer the payout question into an
-   * error.
+   * The partner's `internal_payments`, from every home they can live in.
+   *
+   * Each pass is best-effort: a partner with no link rows of a given kind is
+   * the normal case, and a graph hiccup on one source must not turn a panel
+   * that CAN answer the payout question into an error. Losing one source
+   * understates `recorded`; throwing loses the whole ledger.
    */
-  let payments: any[] = []
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  /**
+   * The three homes, collected here and unioned by `mergePaymentSources` below.
+   * The partner source is listed FIRST so a payment recorded on the partner
+   * keeps that provenance; the order and submission sources only fill in
+   * `inventory_order_id` / `submission_id` on a row already present.
+   */
+  const sources: Array<{ rows: any[]; attribution?: Record<string, any> }> = []
+
+  // ── 1. through the PARTNER link ──────────────────────────────────────────
   try {
-    const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
     const { data } = await query.graph({
       entity: PartnerPaymentsLink.entryPoint,
       fields: [
@@ -68,10 +100,99 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       ],
       filters: { partner_id },
     })
-    payments = (data || []).map((r: any) => r.internal_payments).filter(Boolean)
+    sources.push({
+      rows: (data || []).map((r: any) => r?.internal_payments).filter(Boolean),
+    })
   } catch {
-    payments = []
+    // A graph hiccup must not turn a panel that CAN answer the payout question
+    // into an error.
   }
+
+  /**
+   * ⚠️ The order's display name comes from the submission ITEMS, not from the
+   * order: `inventory_orders` has no name or number column at all. A field the
+   * query cannot fetch would have read `null` forever without erroring.
+   */
+  const orderNames = new Map<string, string>()
+  for (const item of items) {
+    if (item.inventory_order_id && item.inventory_order_name) {
+      orderNames.set(String(item.inventory_order_id), item.inventory_order_name)
+    }
+  }
+
+  /**
+   * ── 2. through the INVENTORY ORDER link ────────────────────────────────
+   *
+   * 🔴 The #1710 defect. Scoped to the orders this PARTNER owns — reached
+   * through the partner, since `inventory_orders` has no partner column.
+   *
+   * ⚠️ `partner.inventory_orders` is a LIST link, so the orders arrive nested,
+   * and `internal_payments` on each is itself a to-many that can arrive as a
+   * bare object rather than an array when a single row matches.
+   */
+  try {
+    const { data } = await query.graph({
+      entity: "partner",
+      fields: [
+        "id",
+        "inventory_orders.id",
+        "inventory_orders.internal_payments.*",
+        "inventory_orders.internal_payments.paid_to.*",
+        "inventory_orders.internal_payments.attachments.*",
+      ],
+      filters: { id: partner_id },
+    })
+    const orders = ((data || [])[0]?.inventory_orders || []) as any[]
+    for (const order of Array.isArray(orders) ? orders : [orders]) {
+      if (!order?.id) continue
+      const raw = order.internal_payments
+      const rows = !raw ? [] : Array.isArray(raw) ? raw : [raw]
+      sources.push({
+        rows: rows.filter(Boolean),
+        attribution: {
+          inventory_order_id: String(order.id),
+          inventory_order_name: orderNames.get(String(order.id)) ?? null,
+        },
+      })
+    }
+  } catch {
+    // Same reason as above: an incomplete panel beats a broken one.
+  }
+
+  /**
+   * ── 3. through the SUBMISSION link ─────────────────────────────────────
+   *
+   * The payout a payment explicitly settles. Empty until
+   * `linkPaymentToSubmissionsStep` has run for a payment, which is the point:
+   * it is the fact a human states, not one this route infers.
+   */
+  if (submissionIds.length) {
+    try {
+      const { data } = await query.graph({
+        entity: "payment_submission",
+        fields: [
+          "id",
+          "payments.*",
+          "payments.paid_to.*",
+          "payments.attachments.*",
+        ],
+        filters: { id: submissionIds },
+      })
+      for (const sub of (data || []) as any[]) {
+        const raw = sub?.payments
+        const rows = !raw ? [] : Array.isArray(raw) ? raw : [raw]
+        sources.push({
+          rows: rows.filter(Boolean),
+          attribution: { submission_id: String(sub.id) },
+        })
+      }
+    } catch {
+      // The link may not be traversable in every environment; the other two
+      // homes still answer.
+    }
+  }
+
+  const payments = mergePaymentSources(sources)
 
   /**
    * The reconciliations for THESE submissions.

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3817,6 +3817,16 @@ export default defineMiddlewares({
       middlewares: [authenticate("partner", ["session", "bearer"])],
     },
     {
+      /**
+       * #1710 — the goods half of what a partner may bill for. Same placement
+       * rule as `payable-runs` above: before the list entry, whose query
+       * validator would otherwise claim this path.
+       */
+      matcher: "/partners/payment-submissions/payable-inventory-orders",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
       matcher: "/partners/payment-submissions",
       method: "GET",
       middlewares: [

--- a/apps/backend/src/api/partners/payment-submissions/payable-inventory-orders/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/payable-inventory-orders/route.ts
@@ -1,0 +1,56 @@
+import type { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { getPartnerFromAuthContext } from "../../helpers"
+import { listPayableInventoryOrders } from "../../../../workflows/payment_submissions/lib/payable-inventory-orders"
+
+/**
+ * GET /partners/payment-submissions/payable-inventory-orders
+ *
+ * The inventory orders this authenticated partner can bill us for — material
+ * we bought FROM them, as opposed to work they did for us.
+ *
+ * ## Why this exists (#1710)
+ *
+ * The admin has offered these since #1612. A partner never could: the partner
+ * create validator accepts `design_ids` and `task_ids` and nothing else, and no
+ * partner screen listed an inventory order at all. So the one party who knows
+ * what they delivered had to ask an admin to bill on their behalf — and the
+ * only self-serve path, `POST /partners/inventory-orders/:id/submit-payment`,
+ * writes an `internal_payments` row that is not a claim and that no payout ever
+ * accounts for. That is where the two INR 10,000 rows behind #1710 came from.
+ *
+ * 🔑 Identical answer to the admin route, from the same lib. The partner id
+ * comes from the AUTH CONTEXT rather than the query string, which is the whole
+ * of the difference and also the whole of the security boundary: there is no
+ * `partner_id` parameter here to tamper with.
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest<never>,
+  res: MedusaResponse
+) => {
+  if (!req.auth_context?.actor_id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required - no actor ID"
+    )
+  }
+
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required - no partner found"
+    )
+  }
+
+  const payable_inventory_orders = await listPayableInventoryOrders(
+    req.scope,
+    partner.id
+  )
+
+  return res.status(200).json({
+    payable_inventory_orders,
+    count: payable_inventory_orders.length,
+  })
+}

--- a/apps/backend/src/api/partners/payment-submissions/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/route.ts
@@ -83,6 +83,12 @@ export const POST = async (
       partner_id: partner.id,
       design_ids: body.design_ids || [],
       task_ids: body.task_ids || [],
+      /**
+       * Goods this partner delivered (#1710). The workflow values an amountless
+       * line from the typed receipts and refuses any order this partner does
+       * not own — see `assessInventoryOrderClaims`.
+       */
+      inventory_order_lines: body.inventory_order_lines,
       notes: body.notes,
       documents: body.documents,
       // Typed input, not folded into metadata — see the field's docs.

--- a/apps/backend/src/api/partners/payment-submissions/validators.ts
+++ b/apps/backend/src/api/partners/payment-submissions/validators.ts
@@ -31,12 +31,48 @@ export const CreatePaymentSubmissionSchema = z
      * may not waive the design-eligibility gate on it.
      */
     ...paymentSubmissionMoneyFields,
+    /**
+     * Payout lines sourced from INVENTORY ORDERS — material we bought from this
+     * partner (#1710).
+     *
+     * 🔴 Until this existed a partner could bill only for WORK. The goods half
+     * of what they are owed had no partner-facing expression at all: the admin
+     * route has accepted `inventory_order_lines` since #1612, this one accepted
+     * `design_ids` and `task_ids` and nothing else, and no partner screen
+     * listed an order. The only self-serve path left was
+     * `POST /partners/inventory-orders/:id/submit-payment`, which records an
+     * `internal_payments` row that is NOT a claim and that no payout accounts
+     * for — the two orphaned INR 10,000 rows behind #1710.
+     *
+     * ⚠️ `amount` is an OVERRIDE, and the same one the admin route documents:
+     * left absent the workflow derives what is owed from the typed
+     * `line_fulfillments` receipts, because `total_price` is what was ORDERED.
+     * One `Partial` order is ordered at INR 88,885 with INR 25,670 received.
+     *
+     * ⚠️ Deliberately NOT accepting a `partner_id` anywhere on this schema. The
+     * route takes it from the auth context, and the workflow re-checks that
+     * every order named here belongs to that partner — both ends, because a
+     * request that names an id must be validated at both (#778).
+     */
+    inventory_order_lines: z
+      .array(
+        z.object({
+          inventory_order_id: z.string().min(1),
+          amount: z.coerce.number().positive().optional(),
+          currency: z.string().min(1).optional(),
+        })
+      )
+      .optional(),
     metadata: z.record(z.string(), z.any()).optional(),
   })
   .refine(
-    (data) => (data.design_ids?.length || 0) + (data.task_ids?.length || 0) > 0,
+    (data) =>
+      (data.design_ids?.length || 0) +
+        (data.task_ids?.length || 0) +
+        (data.inventory_order_lines?.length || 0) >
+      0,
     {
-      message: "At least one design or task is required",
+      message: "At least one design, task or inventory order is required",
       path: ["design_ids"],
     }
   )

--- a/apps/backend/src/workflows/internal_payments/create-payment-and-link.ts
+++ b/apps/backend/src/workflows/internal_payments/create-payment-and-link.ts
@@ -14,6 +14,7 @@ import { INTERNAL_PAYMENTS_MODULE } from "../../modules/internal_payments"
 import { PERSON_MODULE } from "../../modules/person"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../modules/payment_submissions"
 import InternalPaymentService from "../../modules/internal_payments/service"
 import {
   normalizePaymentAttachments,
@@ -32,6 +33,24 @@ export type CreatePaymentAndLinkInput = {
   personIds?: string[]
   partnerIds?: string[]
   inventoryOrderIds?: string[]
+  /**
+   * The payout(s) this payment SETTLES (#1710).
+   *
+   * 🔴 The fact that ends the "one fact, two homes" class. Until this existed a
+   * payment could name a person, a partner or an inventory order — never the
+   * submission it was actually paying off — so the partner ledger read
+   * `recorded: 0` beside `outstanding: 28,200` on an order against which
+   * INR 20,000 had demonstrably moved. That is the reading that pays someone
+   * twice.
+   *
+   * ⚠️ The link it writes is `paym_subm_paym_subm_inte_paym_inte_paym-9812b09f`.
+   * It has existed and been migrated since the link was declared — the belief
+   * that Postgres's 63-byte identifier limit stopped it from being created was
+   * wrong (Medusa abbreviates each segment to four characters and appends a
+   * hash). The table was empty because nothing wrote it, not because it was
+   * missing.
+   */
+  paymentSubmissionIds?: string[]
   // #496 — file attachments (receipts/invoices) persisted to the link table.
   attachments?: PaymentAttachmentInput[]
 }
@@ -154,6 +173,51 @@ export const linkPaymentToInventoryOrdersStep = createStep(
   }
 )
 
+/**
+ * Link a payment to the payout(s) it settles (#1710).
+ *
+ * 🔑 This is the only relationship in the system that says a given rupee of
+ * `internal_payments` discharges a given `payment_submission`. Everything else
+ * — the reconciliation's vestigial `payment_id`, the order link, the partner
+ * link — says who or what the money is ABOUT, never what it pays OFF.
+ */
+export const linkPaymentToSubmissionsStep = createStep(
+  "link-payment-to-submissions-step",
+  async (
+    input: { payment_id: string; submission_ids: string[] },
+    { container }
+  ) => {
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+
+    const links: LinkDefinition[] = input.submission_ids.map(
+      (payment_submission_id) => ({
+        [PAYMENT_SUBMISSIONS_MODULE]: {
+          payment_submission_id,
+        },
+        [INTERNAL_PAYMENTS_MODULE]: {
+          internal_payments_id: input.payment_id,
+        },
+        data: {
+          payment_submission_id,
+          payment_id: input.payment_id,
+          linked_with: "payment_submission",
+        },
+      })
+    )
+
+    if (links.length) {
+      await remoteLink.create(links)
+    }
+
+    return new StepResponse(links, links)
+  },
+  async (rollbackLinks: LinkDefinition[], { container }) => {
+    if (!rollbackLinks?.length) return
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    await remoteLink.dismiss(rollbackLinks)
+  }
+)
+
 export const createPaymentAttachmentsStep = createStep(
   "create-payment-attachments-step",
   async (
@@ -208,6 +272,13 @@ export const createPaymentAndLinkWorkflow = createWorkflow(
       })
     )
 
+    const submissionLinks = when(input, (i) => Boolean(i.paymentSubmissionIds && i.paymentSubmissionIds.length)).then(() =>
+      linkPaymentToSubmissionsStep({
+        payment_id: payment.id,
+        submission_ids: input.paymentSubmissionIds as string[],
+      })
+    )
+
     const attachments = when(input, (i) => Boolean(i.attachments && i.attachments.length)).then(() =>
       createPaymentAttachmentsStep({
         payment_id: payment.id,
@@ -215,6 +286,6 @@ export const createPaymentAndLinkWorkflow = createWorkflow(
       })
     )
 
-    return new WorkflowResponse({ payment, personLinks, partnerLinks, inventoryOrderLinks, attachments })
+    return new WorkflowResponse({ payment, personLinks, partnerLinks, inventoryOrderLinks, submissionLinks, attachments })
   }
 )

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -1399,8 +1399,33 @@ const validateInventoryOrderLinesStep = createStep(
     const validated: ValidatedInventoryLine[] = lines.map((line) => {
       const order = orderById.get(line.inventory_order_id)!
 
+      /**
+       * 🔴 The order must be OWNED by the partner being paid — and an order
+       * with no owner at all is refused, not waved through (#1710).
+       *
+       * This guard used to read `if (ownerId && ownerId !== partner_id)`, so a
+       * dangling link — an inventory order with no `partner` row, which is 8 of
+       * 16 orders in a dev database — satisfied it by having nothing to
+       * compare. That was survivable while only an admin naming an explicit
+       * `partner_id` could reach this step. It stopped being survivable when
+       * the partner portal gained `inventory_order_lines` (#1710): a partner
+       * could then bill for any unowned order in the system, and the callee is
+       * the one that has to refuse.
+       *
+       * ⚠️ Same shape as the dangling publishable key that made a tenant filter
+       * evaluate to "no filter" and rendered every storefront's data to
+       * everyone. A missing id is not permission; it is a missing answer.
+       */
       const ownerId = order.partner?.id ?? order.partner?.[0]?.id ?? null
-      if (ownerId && String(ownerId) !== input.partner_id) {
+      if (!ownerId) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_ALLOWED,
+          `Inventory order ${line.inventory_order_id} is not linked to any partner, ` +
+            `so it cannot be billed as this partner's goods. Link the order to its ` +
+            `supplier first.`
+        )
+      }
+      if (String(ownerId) !== input.partner_id) {
         throw new MedusaError(
           MedusaError.Types.NOT_ALLOWED,
           `Inventory order ${line.inventory_order_id} does not belong to this partner`

--- a/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
@@ -1,0 +1,169 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../modules/payment_submissions/service"
+import { listPartnerClaims } from "./run-claims"
+import { valueInventoryOrderByReceipts } from "./inventory-order-value"
+
+/**
+ * What a partner is owed for GOODS, as opposed to for work (#1612, #1710).
+ *
+ * ## Why this is a lib and not a route body
+ *
+ * There are two callers — `GET /admin/payment-submissions/payable-inventory-orders`
+ * and `GET /partners/payment-submissions/payable-inventory-orders` — and this is
+ * one question with one answer. The partner-facing copy of `foldPartnerBilling`
+ * that `apps/partner-ui` kept privately is the warning: a fix landed in one home
+ * and the other silently kept the old rule. One owner, two importers.
+ *
+ * 🔑 Everything below (receipts-derived value, the ordered-total ceiling, the
+ * explicit `capped_by_ceiling` flag, listing unpayable orders rather than
+ * hiding them) is the admin route's behaviour unchanged. The ONLY difference
+ * between the callers is where `partnerId` comes from — the query string for an
+ * admin, the auth context for a partner.
+ */
+export type PayableInventoryOrder = {
+  inventory_order_id: string
+  status: string | null
+  is_sample: boolean
+  currency_code: string | null
+  /** What was ORDERED. This is the guard's ceiling. */
+  ordered_total: number | null
+  /** What the RECEIPTS are worth, before any cap. */
+  receipts_total: number
+  received_quantity: number
+  lines: any[]
+  /** Already billed across every live submission. */
+  claimed_total: number
+  /** What may still be billed — `null` when the order has no readable price. */
+  remaining: number | null
+  /** What this row bills if selected. */
+  amount: number
+  /** Whether `amount` is below `receipts_total` because the ceiling bit. */
+  capped_by_ceiling: boolean
+  order_date: string | null
+  expected_delivery_date: string | null
+  payable: boolean
+  claims: Array<{ submission_id: string | null; status: string | null }>
+}
+
+export const listPayableInventoryOrders = async (
+  container: MedusaContainer,
+  partnerId: string
+): Promise<PayableInventoryOrder[]> => {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  /**
+   * ⚠️ Reached through the PARTNER, not by filtering inventory orders on a
+   * partner column — there is no such column. `partner-inventory-order` is a
+   * list link, so the orders arrive nested.
+   */
+  const { data: partners } = await query.graph({
+    entity: "partner",
+    fields: [
+      "id",
+      "inventory_orders.id",
+      "inventory_orders.status",
+      "inventory_orders.total_price",
+      "inventory_orders.currency_code",
+      "inventory_orders.expected_delivery_date",
+      "inventory_orders.order_date",
+      "inventory_orders.is_sample",
+      "inventory_orders.orderlines.id",
+      "inventory_orders.orderlines.quantity",
+      "inventory_orders.orderlines.price",
+      "inventory_orders.orderlines.material_name",
+      // 🔴 The receipts. The typed rows, never `metadata.partner_delivery_history`
+      // — the two disagree by INR 4,050 on a real order and these are what the
+      // concurrency guard reads (#1613).
+      "inventory_orders.orderlines.line_fulfillments.quantity_delta",
+    ],
+    filters: { id: partnerId },
+  })
+
+  const partner = ((partners || []) as any[])[0]
+  const orders = (partner?.inventory_orders || []) as any[]
+
+  const submissionService: PaymentSubmissionsService = container.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+  const { inventoryOrders: claims } = await listPartnerClaims(
+    submissionService as any,
+    partnerId
+  )
+
+  return (Array.isArray(orders) ? orders : [orders])
+    .filter(Boolean)
+    /**
+     * A cancelled order is not a debt. Everything else is listed — including
+     * Pending and Processing, because a receipt can legitimately be recorded
+     * before the status catches up, and an order with goods in it is payable
+     * whatever the workflow calls it.
+     */
+    .filter((order) => String(order?.status || "") !== "Cancelled")
+    .map((order) => {
+      const value = valueInventoryOrderByReceipts(order.orderlines || [])
+      const claim = claims.get(String(order.id)) ?? null
+      const claimedTotal = claim?.claimed_total ?? 0
+
+      /**
+       * 🔴 The CEILING is the ordered total, not the receipts value.
+       *
+       * `assessInventoryOrderClaims` refuses anything that would take an order
+       * past `total_price`, and the receipts figure can legitimately sit ABOVE
+       * it — INR 64,274 derived against INR 63,375.75 ordered on the order that
+       * opened #1617. An amountless line defaults to the receipts figure and is
+       * refused there. So the screen has to know BOTH numbers, or it offers a
+       * figure the guard rejects and the operator learns the rule from a 400.
+       */
+      const ordered = Number(order.total_price ?? 0)
+      const ceiling = Number.isFinite(ordered) && ordered > 0 ? ordered : null
+
+      const remaining =
+        ceiling == null
+          ? null
+          : Math.round(Math.max(0, ceiling - claimedTotal) * 100) / 100
+
+      /**
+       * What this row offers: the receipts value, capped at what is left.
+       *
+       * Capping rather than offering the raw figure is the whole point — but a
+       * silent cap is a reduction nobody decided, so `capped_by_ceiling` says
+       * it happened and the raw figure stays on the row beside it.
+       */
+      const uncapped = value.total
+      const amount =
+        remaining == null
+          ? uncapped
+          : Math.round(Math.min(uncapped, remaining) * 100) / 100
+
+      return {
+        inventory_order_id: String(order.id),
+        status: order.status ?? null,
+        is_sample: !!order.is_sample,
+        currency_code: order.currency_code ?? null,
+        ordered_total: ceiling,
+        receipts_total: uncapped,
+        received_quantity: value.received_quantity,
+        lines: value.lines,
+        claimed_total: Math.round(claimedTotal * 100) / 100,
+        remaining,
+        amount,
+        capped_by_ceiling: remaining != null && uncapped > remaining,
+        order_date: order.order_date ?? null,
+        expected_delivery_date: order.expected_delivery_date ?? null,
+        /**
+         * Whether there is anything to bill. False means either no receipt has
+         * been recorded — a gap in the record, not a price of zero — or the
+         * order is fully claimed already.
+         */
+        payable: amount > 0,
+        /** Who holds the live claims on this order, earliest first. */
+        claims: (claim?.claims || []).map((c) => ({
+          submission_id: c.submission_id,
+          status: c.submission_status,
+        })),
+      }
+    })
+}

--- a/apps/docs/docs/guides/partner-portal/getting-paid.md
+++ b/apps/docs/docs/guides/partner-portal/getting-paid.md
@@ -1,0 +1,192 @@
+---
+title: "Getting Paid: payouts, payments and the ledger"
+sidebar_label: "Getting Paid"
+sidebar_position: 2
+---
+
+# Getting Paid
+
+There are **two different records of money** in this system, they look alike on
+screen, and mixing them up is how a partner gets paid twice or not at all. This
+guide is the map: what each screen means, which one to use, and the places the
+screens have historically misled people.
+
+Read this before using **Payment Submissions** or **Submit Payment**.
+
+## The one distinction that matters
+
+| | A **payout** (payment submission) | A **payment** (internal payment) |
+|---|---|---|
+| What it is | A **claim**: "you owe me this" | A **record**: "this money moved" |
+| Who creates it | The partner, or an admin on their behalf | Whoever recorded the transfer |
+| Where | **Payment Submissions → Create** | **Submit Payment** on an inventory order |
+| Goes through review | Yes — Draft → Pending → Approved → Paid | No |
+| Shows on the partner ledger as owed | Yes | No |
+
+:::danger The mistake this guide exists to prevent
+**"Submit Payment" on an inventory order does not bill anyone.** It records
+that money *already moved*. If you are asking to be paid, you want **Payment
+Submissions → Create**, not Submit Payment.
+
+Two INR 10,000 rows created through Submit Payment sat against an order that
+also had an unpaid INR 28,200 payout on it. The order page said INR 20,000 had
+been recorded; the partner ledger said INR 0. Nothing joined the two, so the
+screen that answers *"what do we owe this partner"* answered **INR 28,200
+outstanding** against money that had already gone out.
+:::
+
+## Claiming what you are owed
+
+**Payment Submissions → Create** is one table of everything billable, with a
+filter above it. Three kinds of thing can appear:
+
+- **Runs** — production runs you have completed. Work.
+- **Tasks** — completed tasks not attached to a run. Work.
+- **Goods** — inventory orders: material we bought *from* you.
+
+Tick the rows, check the amounts, press **Submit for payment**. The running
+total in the bar at the bottom is the claim.
+
+### What the numbers mean
+
+- The **Amount** column is what that row bills. It is filled in for you.
+- On a **run**, the rate box may be blank. That is deliberate — see the
+  watch-out below.
+- On a **goods** row, the amount is derived from **deliveries actually
+  recorded**, not from what was ordered. An order placed for INR 88,885 with
+  INR 28,670 delivered bills INR 28,670.
+
+### Watch-outs when claiming
+
+:::warning A blank rate on a run is not a bug
+Most runs are priced as an agreed **total**, not per piece. When a run has
+already been partly billed, the box is left empty on purpose: re-billing the
+total would double-pay, and dividing it would re-price work at a rate nobody
+agreed. **Type what the remaining pieces are worth.** The row will not submit
+at zero.
+:::
+
+:::warning "Capped at what is left on the order"
+On a goods row this means the deliveries recorded are worth more than the order
+has headroom for. You are being offered the remainder, not the full value of
+the receipts. Hover the note to see both figures. If the ordered total is
+wrong, that is a conversation to have before billing — the cap is not
+negotiable through this screen.
+:::
+
+:::warning Rows you cannot tick
+A greyed row says why underneath:
+
+- **"Already paid"** / **"Already fully billed"** — a live claim covers it.
+- **"This design is already in an open submission"** — a payment line is keyed
+  by *design*, so a second run of the same design waits until the first
+  submission is resolved.
+- **"No delivery recorded against this order yet"** — this is a **gap in the
+  record**, not a statement that the goods were free. Get the delivery recorded
+  and the row becomes billable.
+
+Tick **Show already submitted** to see them.
+:::
+
+:::tip One order is claimed whole
+An inventory order may appear only once per submission. If you need to bill it
+in stages, submit them as separate claims — each is checked against what is
+left of the ordered total.
+:::
+
+## Reading a submission
+
+Open a submission and the **What this bills for** table lists every line with a
+badge: Design, Task, Run, or Goods.
+
+:::info Why every line is in one table
+It used to be two tables — "Design Items" and "Task Items". Lines sourced from
+a *run* or an *inventory order* matched neither and rendered **nowhere**, while
+still counting toward the total in the header. A submission could show a
+five-figure total above an empty list. If you ever see a total with no lines
+under it, that is a bug worth reporting, not an empty claim.
+:::
+
+Statuses mean:
+
+| Status | What it means |
+|---|---|
+| **Draft** | Prepared, not yet claimed. Press **Submit for review** to claim it. |
+| **Pending** / **Under review** | With us. |
+| **Approved** | Agreed — but **the money has not moved yet.** |
+| **Paid** | The transfer was recorded. |
+| **Rejected** | Not owed. The reason is on the page. |
+
+:::danger Approved is not Paid
+Approval agrees the amount. **Paid** is written separately, when the
+reconciliation is settled. On production that gap has run to **34 days**. A
+partner chasing a transfer on an Approved payout is asking a reasonable
+question.
+:::
+
+## Recording money that has already moved
+
+Use **Submit Payment** on an inventory order (see
+[Submitting Payments on Inventory Orders](./submit-payment-guide.md)) only to
+record a transfer that has happened.
+
+:::warning A recorded payment is not a claim
+It creates no payout, enters no review queue, and does not reduce what a payout
+says is outstanding. If an unpaid payout bills the same order, both records now
+exist side by side and **a human has to reconcile them.**
+:::
+
+## For admins: the partner ledger
+
+**Partners → a partner → Payments** merges both records into one list. Every
+row says which kind it is.
+
+The totals line reads:
+
+> *X paid · Y outstanding · Z recorded separately*
+
+- **paid** — covered by a payout at status **Paid**. Approved does not count.
+- **outstanding** — billed minus paid.
+- **recorded separately** — money that moved with no payout accounting for it.
+
+### The warning to stop before you act
+
+An orange line appears when money has already been recorded against an order
+that an **unpaid** payout also bills:
+
+> ⚠ *INR 20,000 of that sits against orders an unpaid payout still bills —
+> settle or link it before paying again*
+
+:::danger Do not pay past this line without checking
+The system deliberately **does not** subtract that money from `outstanding`. An
+advance and a payout can legitimately coexist, and no screen may quietly decide
+that one discharges the other. Only a human can say so — by linking the payment
+to the submission it settles (`paymentSubmissionIds` on
+`POST /admin/payments/link`). Once linked, it shows on the payout as
+"settled by" and drops out of "recorded separately".
+:::
+
+### Where the ledger reads from
+
+A payment can be attached to a **partner**, an **inventory order**, or a
+**payout** — and one payment may have only one of the three. The ledger reads
+**all three and deduplicates**. Before it did, a payment recorded through the
+partner portal was attached only to the order and was invisible here, which is
+the defect above.
+
+:::tip If a number here disagrees with another screen
+The order page (**Inventory order → Payments**) and this ledger answer
+different questions. The order page is scoped to one order; the ledger is
+scoped to one partner. They should agree on any payment they can both see — if
+they do not, say so rather than trusting the larger number.
+:::
+
+## Quick reference
+
+| I want to… | Screen |
+|---|---|
+| Ask to be paid for work | Payment Submissions → Create → **Runs** / **Tasks** |
+| Ask to be paid for material I supplied | Payment Submissions → Create → **Goods** |
+| Record a transfer that already happened | Inventory order → **Submit Payment** |
+| See what a partner is owed overall | Partners → *partner* → **Payments** |
+| See what one order has cost | Inventory order → **Payments** |

--- a/apps/docs/docs/guides/partner-portal/submit-payment-guide.md
+++ b/apps/docs/docs/guides/partner-portal/submit-payment-guide.md
@@ -1,12 +1,24 @@
 ---
 title: "Submitting Payments on Inventory Orders"
 sidebar_label: "Submit Payment"
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Submitting Payments on Inventory Orders
 
-This guide walks through how partners submit payments against their inventory orders from the partner portal.
+This guide walks through how partners **record a payment that has already
+happened** against an inventory order.
+
+:::danger This is not how you ask to be paid
+Submit Payment creates a **record that money moved**. It is not a claim: it
+creates no payout, enters no review queue, and does not reduce what a payout
+says is outstanding.
+
+**If you are asking to be paid for material you supplied, use Payment
+Submissions → Create → Goods instead.** See
+[Getting Paid](./getting-paid.md), which explains the difference and why it
+matters.
+:::
 
 ## Prerequisites
 
@@ -42,8 +54,18 @@ A success toast confirms the submission, and the drawer closes automatically.
 ## What Happens Next
 
 - The payment appears in the admin's inventory order detail view under the payments section
+- It also appears on the partner ledger (**Partners → *partner* → Payments**),
+  listed as *"recorded against &lt;order&gt; — no payout attached"*
 - Admin can review and update the payment status (approve, mark as completed, etc.)
 - Partners can submit multiple payments against the same order (e.g., partial payments)
+
+:::warning If a payout also bills this order
+Both records now exist and neither knows about the other. The partner ledger
+raises an orange warning on the payout — *"already recorded against the order
+this bills — check before paying"* — but it deliberately does **not** subtract
+one from the other. An advance and a payout can legitimately coexist, so a
+human decides, by linking the payment to the submission it settles.
+:::
 
 ## Troubleshooting
 

--- a/apps/partner-ui/src/hooks/api/partner-payable-inventory-orders.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payable-inventory-orders.tsx
@@ -1,0 +1,92 @@
+import { useQuery } from "@tanstack/react-query"
+import type { UseQueryOptions } from "@tanstack/react-query"
+import { FetchError } from "@medusajs/js-sdk"
+import { sdk } from "../../lib/client"
+
+/**
+ * An inventory order this partner can bill us for — material we bought FROM
+ * them, as opposed to work they did for us (#1710).
+ *
+ * 🔴 Every field the server sends is declared here. A flag the server has sent
+ * for months with no entry in the client type has ZERO readers and reads as
+ * absent forever (#1679) — which is how a screen ends up re-deriving a number
+ * the route already computed correctly.
+ */
+export interface PayableInventoryOrder {
+  inventory_order_id: string
+  status: string | null
+  is_sample: boolean
+  currency_code: string | null
+  /**
+   * What was ORDERED. This is the write guard's ceiling — not the receipts
+   * figure, which can legitimately sit above it.
+   */
+  ordered_total: number | null
+  /** What the recorded RECEIPTS are worth, before any cap. */
+  receipts_total: number
+  received_quantity: number
+  lines: Array<{
+    material_name?: string | null
+    received_quantity?: number
+    price?: number
+    total?: number
+  }>
+  /** Already billed across every live submission of this partner's. */
+  claimed_total: number
+  /** What may still be billed — `null` when the order has no readable price. */
+  remaining: number | null
+  /** What this row bills if selected. Read THIS for the money. */
+  amount: number
+  /** Whether `amount` is below `receipts_total` because the ceiling bit. */
+  capped_by_ceiling: boolean
+  order_date: string | null
+  expected_delivery_date: string | null
+  /**
+   * Whether there is anything to bill. False means either no receipt has been
+   * recorded — a gap in the record, not a price of zero — or the order is
+   * already fully claimed.
+   */
+  payable: boolean
+  claims: Array<{ submission_id: string | null; status: string | null }>
+}
+
+export interface PayableInventoryOrdersListResponse {
+  payable_inventory_orders: PayableInventoryOrder[]
+  count: number
+}
+
+export const usePartnerPayableInventoryOrders = (
+  options?: Omit<
+    UseQueryOptions<
+      PayableInventoryOrdersListResponse,
+      FetchError,
+      PayableInventoryOrdersListResponse,
+      ["partner-payable-inventory-orders"]
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ["partner-payable-inventory-orders"] as const,
+    queryFn: async () => {
+      return await sdk.client.fetch<PayableInventoryOrdersListResponse>(
+        "/partners/payment-submissions/payable-inventory-orders",
+        { method: "GET" }
+      )
+    },
+    ...options,
+  })
+
+  /**
+   * 🔴 Spread the payload, for the same reason `usePartnerPayableRuns` does:
+   * returning the raw `useQuery` result gives the caller `{ data, … }`, so
+   * destructuring `payable_inventory_orders` finds nothing, falls back to `[]`,
+   * and the screen renders "no inventory orders to bill" forever — with a 200
+   * and a full payload sitting in `data`.
+   */
+  return {
+    ...data,
+    payable_inventory_orders: data?.payable_inventory_orders ?? [],
+    ...rest,
+  }
+}

--- a/apps/partner-ui/src/hooks/api/partner-payment-submissions.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payment-submissions.tsx
@@ -103,6 +103,25 @@ export type CreatePaymentSubmissionPayload = {
    * refused, and the bands already carry the total.
    */
   rate_breakdown?: Record<string, Array<{ quantity: number; unit_amount: number }>>
+  /**
+   * Payout lines sourced from INVENTORY ORDERS — goods we bought from this
+   * partner, as opposed to work they did for us (#1710).
+   *
+   * 🔴 Declared here or the screen cannot send it. The mutation passes the body
+   * straight through, so an undeclared field type-errors at the call site while
+   * the request would have worked — and the reverse (a field the client sends
+   * that no type declares) is how a flag shipped for months with zero readers
+   * (#1679). One order per entry; the workflow refuses a repeated order id.
+   *
+   * ⚠️ Send `amount` ONLY when a human typed one. Absent means "value it from
+   * the recorded receipts", which is the server's job and the one place that
+   * arithmetic lives.
+   */
+  inventory_order_lines?: Array<{
+    inventory_order_id: string
+    amount?: number
+    currency?: string
+  }>
   metadata?: Record<string, any>
 }
 

--- a/apps/partner-ui/src/lib/__tests__/payment-submission-money.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/payment-submission-money.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  describeLine,
   groupIntoRateBands,
   money,
   perUnit,
@@ -8,6 +9,7 @@ import {
   runBillsVerbatimTotal,
   runLineAmount,
   runNeedsTypedPrice,
+  summariseItems,
 } from "../payment-submission-money"
 
 /**
@@ -363,5 +365,94 @@ describe("runLineAmount — a total is the agreed price (#1679)", () => {
         alreadyPartlyBilled: true,
       })
     ).toBe(7000)
+  })
+})
+
+/**
+ * #1710 — a submission line must RENDER, whatever it is sourced from.
+ *
+ * The partner detail screen partitioned `items` into `designItems` and
+ * `taskItems` and drew a table for each. `source_type` has four values, so a
+ * `run` or `inventory_order` line matched neither filter and appeared nowhere
+ * — while still counting toward the total in the header. A partner billing for
+ * goods saw a five-figure total above an empty item list.
+ */
+describe("describeLine", () => {
+  it("labels an inventory-order line as goods, with the order on it", () => {
+    const line = describeLine({
+      source_type: "inventory_order",
+      inventory_order_id: "inv_order_01KWAKAZE17CC95XDEY7Q0M8SN",
+      inventory_order_name: "Parmar cotton",
+    })
+
+    expect(line.badge).toBe("Goods")
+    expect(line.title).toBe("Parmar cotton")
+    expect(line.subtitle).toBe("inv_order_01KWAKAZE17CC95XDEY7Q0M8SN")
+  })
+
+  it("labels a run line, which the two old tables could not render either", () => {
+    const line = describeLine({
+      source_type: "run",
+      design_name: "Kala kurta",
+      production_run_ids: ["run_1", "run_2"],
+    })
+
+    expect(line.badge).toBe("Run")
+    expect(line.title).toBe("Kala kurta")
+    expect(line.subtitle).toBe("run_1, run_2")
+  })
+
+  it("still renders a source type this build has never heard of", () => {
+    /**
+     * 🔑 The whole point. Adding a fourth branch to a filter fixes the two
+     * types we know about today and loses the fifth one the same way — so the
+     * unknown case must produce a row, not nothing.
+     */
+    const line = describeLine({ source_type: "commission", amount: 500 })
+
+    expect(line.badge).toBe("Item")
+    expect(line.title).toBe("Payment line")
+    expect(line.subtitle).toBe("source: commission")
+  })
+
+  it("treats a line with NO source_type as a design, like every other reader", () => {
+    const line = describeLine({ design_name: "Old row", design_id: "d1" })
+    expect(line.badge).toBe("Design")
+    expect(line.title).toBe("Old row")
+  })
+})
+
+describe("summariseItems", () => {
+  it("counts goods lines, which the old summary omitted entirely", () => {
+    const summary = summariseItems([
+      { source_type: "inventory_order" },
+      { source_type: "inventory_order" },
+      { source_type: "design" },
+    ])
+
+    expect(summary).toContain("2 goods lines")
+    expect(summary).toContain("1 design")
+  })
+
+  it("reads an item with no source_type as a design", () => {
+    expect(summariseItems([{ design_id: "d1" }])).toBe("1 design")
+  })
+
+  it("reads an item with no source_type but a task id as a task", () => {
+    expect(summariseItems([{ task_id: "t1" }])).toBe("1 task")
+  })
+
+  it("names an unknown source type rather than dropping it from the count", () => {
+    // Singular for one, and an "s" appended for more — an unknown label has no
+    // plural we can know, so the fallback must at least not read as a count of
+    // zero.
+    expect(summariseItems([{ source_type: "commission" }])).toBe("1 commission")
+    expect(
+      summariseItems([{ source_type: "commission" }, { source_type: "commission" }])
+    ).toBe("2 commissions")
+  })
+
+  it("is empty for no items, so the caller can print its own zero", () => {
+    expect(summariseItems([])).toBe("")
   })
 })

--- a/apps/partner-ui/src/lib/payment-submission-money.ts
+++ b/apps/partner-ui/src/lib/payment-submission-money.ts
@@ -261,3 +261,112 @@ export const runLineAmount = (input: RunLinePricingInput): number => {
   }
   return Math.round(quantity * rate * 100) / 100
 }
+
+/**
+ * How to label ONE submission line, whatever it is sourced from (#1710).
+ *
+ * 🔑 The `default` branch is load-bearing: a source type this build has never
+ * heard of still gets a row, a readable title and its amount. The previous
+ * design — one table per known type — made an unknown type vanish silently,
+ * which is how `run` and `inventory_order` lines came to render nowhere on
+ * this screen while still counting toward the total.
+ */
+export const describeLine = (
+  item: any
+): {
+  title: string
+  subtitle: string | null
+  badge: string
+  badgeColor: "blue" | "purple" | "orange" | "green" | "grey"
+  billedFor: string
+} => {
+  /**
+   * ⚠️ Normalise FIRST. `source_type` defaults to `design` on the model, but
+   * rows written before the discriminator existed carry null, and every other
+   * reader in the codebase resolves those by asking which id is populated. A
+   * switch on the raw field sent them to the unknown branch and badged a
+   * perfectly ordinary design line "Item".
+   */
+  const sourceType =
+    item.source_type || (item.task_id ? "task" : item.design_id ? "design" : null)
+
+  switch (sourceType) {
+    case "task":
+      return {
+        title: item.task_name || "Untitled task",
+        subtitle: item.task_id ?? null,
+        badge: "Task",
+        badgeColor: "purple",
+        billedFor: "One task",
+      }
+    case "run":
+      return {
+        title: item.design_name || "Production run",
+        subtitle: (item.production_run_ids || []).join(", ") || null,
+        badge: "Run",
+        badgeColor: "green",
+        billedFor: "Production run",
+      }
+    case "inventory_order":
+      return {
+        title: item.inventory_order_name || "Inventory order",
+        subtitle: item.inventory_order_id ?? null,
+        badge: "Goods",
+        badgeColor: "orange",
+        billedFor: "Material delivered",
+      }
+    case "design":
+      return {
+        title: item.design_name || "Unnamed design",
+        subtitle: null,
+        badge: "Design",
+        badgeColor: "blue",
+        billedFor: "One line, no rate given",
+      }
+    default:
+      /**
+       * ⚠️ Not an error state — a line whose type this build does not know is
+       * still money this partner is owed, and hiding it is strictly worse than
+       * labelling it plainly.
+       */
+      return {
+        title:
+          item.design_name ||
+          item.task_name ||
+          item.inventory_order_name ||
+          "Payment line",
+        subtitle: sourceType ? `source: ${sourceType}` : null,
+        badge: "Item",
+        badgeColor: "grey",
+        billedFor: "One line, no rate given",
+      }
+  }
+}
+
+/**
+ * "2 designs · 1 task · 3 goods" — counted off `source_type` rather than off a
+ * fixed list of the two types this screen used to know about (#1710).
+ */
+export const summariseItems = (items: any[]): string => {
+  const LABELS: Record<string, [string, string]> = {
+    design: ["design", "designs"],
+    task: ["task", "tasks"],
+    run: ["run", "runs"],
+    inventory_order: ["goods line", "goods lines"],
+  }
+
+  const counts = new Map<string, number>()
+  for (const item of items) {
+    // An item with no `source_type` at all predates the discriminator and is a
+    // design line by the same rule every other reader uses.
+    const key = item.source_type || (item.task_id ? "task" : "design")
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  return [...counts.entries()]
+    .map(([key, n]) => {
+      const [one, many] = LABELS[key] ?? [key, `${key}s`]
+      return `${n} ${n === 1 ? one : many}`
+    })
+    .join(" · ")
+}

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -24,6 +24,10 @@ import {
   type PayableRun,
 } from "../../../hooks/api/partner-payable-runs"
 import {
+  usePartnerPayableInventoryOrders,
+  type PayableInventoryOrder,
+} from "../../../hooks/api/partner-payable-inventory-orders"
+import {
   groupIntoRateBands,
   runBillsVerbatimTotal,
   runLineAmount,
@@ -51,7 +55,9 @@ export const PaymentSubmissionCreate = () => {
    * Tasks are NOT redundant with runs. Most hang off a run, but a partner can
    * hold standalone ones, and this screen is the only place they can be billed.
    */
-  const [typeFilter, setTypeFilter] = useState<"all" | "runs" | "tasks">("all")
+  const [typeFilter, setTypeFilter] = useState<
+    "all" | "runs" | "tasks" | "orders"
+  >("all")
   /** Reveal the rows that cannot be submitted, greyed out, with the reason. */
   const [showSubmitted, setShowSubmitted] = useState(false)
   const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(
@@ -65,11 +71,30 @@ export const PaymentSubmissionCreate = () => {
   const [taskCostOverrides, setTaskCostOverrides] = useState<
     Record<string, number>
   >({})
+  /**
+   * GOODS this partner delivered (#1710) — material we bought FROM them, as
+   * opposed to work they did for us.
+   *
+   * 🔴 Until now a partner could bill only for work. The one self-serve path
+   * for goods was "Submit Payment" on the inventory order, which records an
+   * `internal_payments` row that is NOT a claim and that no payout accounts
+   * for — money that then sat invisible to the partner ledger entirely.
+   */
+  const [selectedOrderIds, setSelectedOrderIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [orderAmountOverrides, setOrderAmountOverrides] = useState<
+    Record<string, number>
+  >({})
   const [notes, setNotes] = useState("")
 
-  // Fetch payable runs and tasks in parallel
+  // Fetch payable runs, tasks and inventory orders in parallel
   const { payable_runs = [], isPending: runsLoading } = usePartnerPayableRuns()
   const { tasks = [], isPending: tasksLoading } = usePartnerAssignedTasks()
+  const {
+    payable_inventory_orders = [],
+    isPending: ordersLoading,
+  } = usePartnerPayableInventoryOrders()
 
   /**
    * Why a run cannot be submitted right now, or null when it can.
@@ -134,6 +159,49 @@ export const PaymentSubmissionCreate = () => {
     [tasks]
   )
 
+  /**
+   * Why an inventory order cannot be billed right now, or null when it can.
+   *
+   * 🔑 The server already decided this — `payable` is false when there is
+   * nothing left, and `remaining` says how much headroom is left against the
+   * ORDERED total. The screen must not re-derive it: a screen that computes its
+   * own answer offers figures the write guard then refuses, and the partner
+   * learns the rule from a 400 (#1617).
+   */
+  const orderBlockedReason = useCallback(
+    (o: PayableInventoryOrder): string | null => {
+      if (o.payable) return null
+      if (o.remaining != null && o.remaining <= 0) {
+        return o.claims.length
+          ? `Already billed · ${o.claims[0].submission_id ?? "open submission"}`
+          : "Already fully billed"
+      }
+      /**
+       * ⚠️ No receipts is a GAP IN THE RECORD, not a price of zero. Saying so
+       * is the difference between a partner chasing the delivery note and a
+       * partner concluding we think the goods were free.
+       */
+      return "No delivery recorded against this order yet"
+    },
+    []
+  )
+
+  const eligibleOrders = useMemo(
+    () =>
+      payable_inventory_orders.filter(
+        (o: PayableInventoryOrder) => !orderBlockedReason(o)
+      ),
+    [payable_inventory_orders, orderBlockedReason]
+  )
+
+  const blockedOrders = useMemo(
+    () =>
+      payable_inventory_orders.filter(
+        (o: PayableInventoryOrder) => !!orderBlockedReason(o)
+      ),
+    [payable_inventory_orders, orderBlockedReason]
+  )
+
   const { mutateAsync: createSubmission, isPending: isCreating } =
     useCreatePartnerPaymentSubmission()
 
@@ -154,6 +222,14 @@ export const PaymentSubmissionCreate = () => {
     })
   }, [])
 
+  const toggleOrder = useCallback((id: string) => {
+    setSelectedOrderIds((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }, [])
+
   /**
    * Select-all acts on what is ON SCREEN, not on everything selectable.
    *
@@ -162,26 +238,46 @@ export const PaymentSubmissionCreate = () => {
    * would bill work the partner never looked at, and the command bar total is
    * the only place they would notice.
    */
+  /**
+   * ⚠️ Each of these names the filter it BELONGS to, rather than excluding the
+   * one filter it does not. Under the old exclusion form
+   * (`typeFilter === "tasks" ? [] : eligibleRuns`) adding a third tab silently
+   * made every run selectable from it — pressing select-all on Goods would
+   * have billed work the partner never looked at, and the command-bar total is
+   * the only place they would have noticed.
+   */
   const visibleSelectableRuns = useMemo(
-    () => (typeFilter === "tasks" ? [] : eligibleRuns),
+    () => (typeFilter === "all" || typeFilter === "runs" ? eligibleRuns : []),
     [typeFilter, eligibleRuns]
   )
   const visibleSelectableTasks = useMemo(
-    () => (typeFilter === "runs" ? [] : eligibleTasks),
+    () => (typeFilter === "all" || typeFilter === "tasks" ? eligibleTasks : []),
     [typeFilter, eligibleTasks]
+  )
+  const visibleSelectableOrders = useMemo(
+    () =>
+      typeFilter === "all" || typeFilter === "orders" ? eligibleOrders : [],
+    [typeFilter, eligibleOrders]
   )
 
   const allVisibleSelected =
-    visibleSelectableRuns.length + visibleSelectableTasks.length > 0 &&
+    visibleSelectableRuns.length +
+      visibleSelectableTasks.length +
+      visibleSelectableOrders.length >
+      0 &&
     visibleSelectableRuns.every((r: PayableRun) => selectedRunIds.has(r.run_id)) &&
     visibleSelectableTasks.every((t: PartnerAssignedTask) =>
       selectedTaskIds.has(t.id)
+    ) &&
+    visibleSelectableOrders.every((o: PayableInventoryOrder) =>
+      selectedOrderIds.has(o.inventory_order_id)
     )
 
   const toggleSelectAllVisible = useCallback(() => {
     if (allVisibleSelected) {
       setSelectedRunIds(new Set())
       setSelectedTaskIds(new Set())
+      setSelectedOrderIds(new Set())
       return
     }
     setSelectedRunIds(
@@ -190,7 +286,19 @@ export const PaymentSubmissionCreate = () => {
     setSelectedTaskIds(
       new Set(visibleSelectableTasks.map((t: PartnerAssignedTask) => t.id))
     )
-  }, [allVisibleSelected, visibleSelectableRuns, visibleSelectableTasks])
+    setSelectedOrderIds(
+      new Set(
+        visibleSelectableOrders.map(
+          (o: PayableInventoryOrder) => o.inventory_order_id
+        )
+      )
+    )
+  }, [
+    allVisibleSelected,
+    visibleSelectableRuns,
+    visibleSelectableTasks,
+    visibleSelectableOrders,
+  ])
 
   // ─── Cost helpers ───────────────────────────────────────────────────
   const getEffectiveRunQuantity = useCallback(
@@ -280,6 +388,37 @@ export const PaymentSubmissionCreate = () => {
     [taskCostOverrides]
   )
 
+  /**
+   * What this order bills.
+   *
+   * 🔑 `o.amount` is the SERVER's answer — the receipts value, already capped
+   * at what is left against the ordered total. The screen offers it as a
+   * default and lets a partner state a different figure, but it never computes
+   * one: re-deriving a total is how a ₹10,000 job got re-priced to ₹12,857
+   * (#1679) and how a partner was underpaid by 22% (#1596).
+   */
+  const getEffectiveOrderAmount = useCallback(
+    (order: PayableInventoryOrder): number => {
+      const typed = orderAmountOverrides[order.inventory_order_id]
+      if (typed != null) return typed
+      return order.amount
+    },
+    [orderAmountOverrides]
+  )
+
+  const handleOrderAmountChange = (orderId: string, value: string) => {
+    const num = parseFloat(value)
+    if (value === "" || isNaN(num)) {
+      setOrderAmountOverrides((prev) => {
+        const next = { ...prev }
+        delete next[orderId]
+        return next
+      })
+    } else {
+      setOrderAmountOverrides((prev) => ({ ...prev, [orderId]: num }))
+    }
+  }
+
   const handleRunQuantityChange = (runId: string, value: string) => {
     const num = parseFloat(value)
     if (value === "" || isNaN(num)) {
@@ -320,7 +459,8 @@ export const PaymentSubmissionCreate = () => {
   }
 
   // ─── Totals ─────────────────────────────────────────────────────────
-  const totalSelected = selectedRunIds.size + selectedTaskIds.size
+  const totalSelected =
+    selectedRunIds.size + selectedTaskIds.size + selectedOrderIds.size
 
   const totalAmount = useMemo(() => {
     const runTotal = eligibleRuns
@@ -329,7 +469,16 @@ export const PaymentSubmissionCreate = () => {
     const taskTotal = eligibleTasks
       .filter((t) => selectedTaskIds.has(t.id))
       .reduce((sum, t) => sum + getEffectiveTaskCost(t), 0)
-    return runTotal + taskTotal
+    const orderTotal = eligibleOrders
+      .filter((o: PayableInventoryOrder) =>
+        selectedOrderIds.has(o.inventory_order_id)
+      )
+      .reduce(
+        (sum: number, o: PayableInventoryOrder) =>
+          sum + getEffectiveOrderAmount(o),
+        0
+      )
+    return runTotal + taskTotal + orderTotal
   }, [
     eligibleRuns,
     selectedRunIds,
@@ -337,15 +486,19 @@ export const PaymentSubmissionCreate = () => {
     eligibleTasks,
     selectedTaskIds,
     getEffectiveTaskCost,
+    eligibleOrders,
+    selectedOrderIds,
+    getEffectiveOrderAmount,
   ])
 
   const clearSelection = useCallback(() => {
     setSelectedRunIds(new Set())
     setSelectedTaskIds(new Set())
+    setSelectedOrderIds(new Set())
   }, [])
 
   // ─── Rows ───────────────────────────────────────────────────────────
-  const isLoading = runsLoading || tasksLoading
+  const isLoading = runsLoading || tasksLoading || ordersLoading
 
   /**
    * One list, runs and tasks together, in the order a partner reads them.
@@ -357,13 +510,22 @@ export const PaymentSubmissionCreate = () => {
   type Row =
     | { kind: "run"; run: PayableRun }
     | { kind: "task"; task: PartnerAssignedTask }
+    | { kind: "order"; order: PayableInventoryOrder }
 
+  /**
+   * ⚠️ Each filter names the kinds it INCLUDES, rather than excluding the ones
+   * it is not. The exclusion form (`typeFilter !== "tasks"`) silently drops
+   * every kind added later — adding "orders" under that rule would have shown
+   * runs on the Orders tab. A filter that enumerates known values and drops
+   * the rest is exactly how two of four payout source types rendered nowhere
+   * at all (#1621).
+   */
   const visibleRows = useMemo((): Row[] => {
     const rows: Row[] = []
-    if (typeFilter !== "tasks") {
+    if (typeFilter === "all" || typeFilter === "runs") {
       rows.push(...eligibleRuns.map((run: PayableRun) => ({ kind: "run" as const, run })))
     }
-    if (typeFilter !== "runs") {
+    if (typeFilter === "all" || typeFilter === "tasks") {
       rows.push(
         ...eligibleTasks.map((task: PartnerAssignedTask) => ({
           kind: "task" as const,
@@ -371,11 +533,37 @@ export const PaymentSubmissionCreate = () => {
         }))
       )
     }
-    if (showSubmitted && typeFilter !== "tasks") {
-      rows.push(...blockedRuns.map((run: PayableRun) => ({ kind: "run" as const, run })))
+    if (typeFilter === "all" || typeFilter === "orders") {
+      rows.push(
+        ...eligibleOrders.map((order: PayableInventoryOrder) => ({
+          kind: "order" as const,
+          order,
+        }))
+      )
+    }
+    if (showSubmitted) {
+      if (typeFilter === "all" || typeFilter === "runs") {
+        rows.push(...blockedRuns.map((run: PayableRun) => ({ kind: "run" as const, run })))
+      }
+      if (typeFilter === "all" || typeFilter === "orders") {
+        rows.push(
+          ...blockedOrders.map((order: PayableInventoryOrder) => ({
+            kind: "order" as const,
+            order,
+          }))
+        )
+      }
     }
     return rows
-  }, [typeFilter, eligibleRuns, eligibleTasks, showSubmitted, blockedRuns])
+  }, [
+    typeFilter,
+    eligibleRuns,
+    eligibleTasks,
+    eligibleOrders,
+    showSubmitted,
+    blockedRuns,
+    blockedOrders,
+  ])
 
   /**
    * 🔑 An empty table must say WHICH kind of empty it is. "Nothing to bill" and
@@ -384,6 +572,7 @@ export const PaymentSubmissionCreate = () => {
    * finished runs have vanished.
    */
   const emptyMessage = useMemo(() => {
+    const hiddenCount = blockedRuns.length + blockedOrders.length
     if (typeFilter === "runs") {
       return blockedRuns.length && !showSubmitted
         ? `No runs left to bill — ${blockedRuns.length} are already submitted. Tick "Show already submitted" to see them.`
@@ -392,15 +581,20 @@ export const PaymentSubmissionCreate = () => {
     if (typeFilter === "tasks") {
       return "No payable tasks. Completed tasks that are not part of a run appear here."
     }
-    return blockedRuns.length && !showSubmitted
-      ? `Nothing left to bill — ${blockedRuns.length} item(s) are already submitted. Tick "Show already submitted" to see them.`
-      : "Nothing to bill yet. Completed runs and tasks appear here."
-  }, [typeFilter, blockedRuns.length, showSubmitted])
+    if (typeFilter === "orders") {
+      return blockedOrders.length && !showSubmitted
+        ? `No inventory orders left to bill — ${blockedOrders.length} are already billed or have no delivery recorded. Tick "Show already submitted" to see them.`
+        : "No inventory orders to bill. Orders appear here once a delivery is recorded against them."
+    }
+    return hiddenCount && !showSubmitted
+      ? `Nothing left to bill — ${hiddenCount} item(s) are already submitted. Tick "Show already submitted" to see them.`
+      : "Nothing to bill yet. Completed runs, tasks and delivered inventory orders appear here."
+  }, [typeFilter, blockedRuns.length, blockedOrders.length, showSubmitted])
 
   // ─── Submit ─────────────────────────────────────────────────────────
   const handleSubmit = async () => {
     if (totalSelected === 0) {
-      toast.error("Select at least one run or task")
+      toast.error("Select at least one run, task or inventory order")
       return
     }
 
@@ -419,12 +613,23 @@ export const PaymentSubmissionCreate = () => {
     const invalidTasks = eligibleTasks.filter(
       (t) => selectedTaskIds.has(t.id) && getEffectiveTaskCost(t) <= 0
     )
-    if (invalidRuns.length || invalidTasks.length) {
+    /**
+     * ⚠️ An order line whose amount is zero would be REFUSED by the workflow
+     * ("has no recorded receipts to bill"), so catch it here where the partner
+     * can see which row it was. A 400 naming an order id teaches nothing.
+     */
+    const invalidOrders = eligibleOrders.filter(
+      (o: PayableInventoryOrder) =>
+        selectedOrderIds.has(o.inventory_order_id) &&
+        getEffectiveOrderAmount(o) <= 0
+    )
+    if (invalidRuns.length || invalidTasks.length || invalidOrders.length) {
       const names = [
         ...invalidRuns.map((r: PayableRun) => r.design_name || r.run_id),
         ...invalidTasks.map((t) => t.title || t.id),
+        ...invalidOrders.map((o: PayableInventoryOrder) => o.inventory_order_id),
       ]
-      toast.error(`Enter valid quantity and unit amount for: ${names.join(", ")}`)
+      toast.error(`Enter a valid amount for: ${names.join(", ")}`)
       return
     }
 
@@ -540,9 +745,33 @@ export const PaymentSubmissionCreate = () => {
        */
       const designIds = Object.keys(productionRunIds)
 
+      /**
+       * Goods lines (#1710). One entry per order, claimed whole — the workflow
+       * refuses a repeated order id, and sums per order across the submission
+       * so splitting a line cannot defeat the ceiling.
+       *
+       * 🔑 `amount` is sent ONLY when a human typed one. Leaving it absent lets
+       * the server value the order from its typed `line_fulfillments` receipts,
+       * which is the one place that arithmetic lives. Echoing the server's own
+       * default back at it would make this screen a second pricer.
+       */
+      const inventoryOrderLines = eligibleOrders
+        .filter((o: PayableInventoryOrder) =>
+          selectedOrderIds.has(o.inventory_order_id)
+        )
+        .map((o: PayableInventoryOrder) => {
+          const typed = orderAmountOverrides[o.inventory_order_id]
+          return typed != null
+            ? { inventory_order_id: o.inventory_order_id, amount: typed }
+            : { inventory_order_id: o.inventory_order_id }
+        })
+
       await createSubmission({
         design_ids: designIds,
         task_ids: Array.from(selectedTaskIds),
+        inventory_order_lines: inventoryOrderLines.length
+          ? inventoryOrderLines
+          : undefined,
         notes: notes || undefined,
         production_run_ids: designIds.length ? productionRunIds : undefined,
         // Per-piece prices, when this selection has any (#1596).
@@ -572,7 +801,7 @@ export const PaymentSubmissionCreate = () => {
           <div>
             <RouteFocusModal.Title>New Payment Submission</RouteFocusModal.Title>
             <RouteFocusModal.Description>
-              Pick the runs and tasks you want paid for
+              Pick the work and goods you want paid for
             </RouteFocusModal.Description>
           </div>
         </div>
@@ -617,9 +846,16 @@ export const PaymentSubmissionCreate = () => {
             <div className="flex items-center gap-1 rounded-lg bg-ui-bg-subtle p-1">
               {(
                 [
-                  ["all", "All", eligibleRuns.length + eligibleTasks.length],
+                  [
+                    "all",
+                    "All",
+                    eligibleRuns.length +
+                      eligibleTasks.length +
+                      eligibleOrders.length,
+                  ],
                   ["runs", "Runs", eligibleRuns.length],
                   ["tasks", "Tasks", eligibleTasks.length],
+                  ["orders", "Goods", eligibleOrders.length],
                 ] as const
               ).map(([value, label, count]) => (
                 <button
@@ -649,14 +885,15 @@ export const PaymentSubmissionCreate = () => {
               ))}
             </div>
 
-            {blockedRuns.length > 0 && (
+            {blockedRuns.length + blockedOrders.length > 0 && (
               <label className="flex items-center gap-2 text-ui-fg-subtle txt-compact-small">
                 <Checkbox
                   checked={showSubmitted}
                   onCheckedChange={(v) => setShowSubmitted(!!v)}
                   aria-label="Show already submitted"
                 />
-                Show already submitted ({blockedRuns.length})
+                Show already submitted (
+                {blockedRuns.length + blockedOrders.length})
               </label>
             )}
           </div>
@@ -690,7 +927,7 @@ export const PaymentSubmissionCreate = () => {
                       aria-label="Select all shown"
                     />
                   </Table.HeaderCell>
-                  <Table.HeaderCell>Work</Table.HeaderCell>
+                  <Table.HeaderCell>Work / goods</Table.HeaderCell>
                   <Table.HeaderCell className="text-right">Qty</Table.HeaderCell>
                   <Table.HeaderCell className="text-right">Rate</Table.HeaderCell>
                   <Table.HeaderCell className="text-right">Amount</Table.HeaderCell>
@@ -698,7 +935,19 @@ export const PaymentSubmissionCreate = () => {
               </Table.Header>
               <Table.Body>
                 {visibleRows.map((row) =>
-                  row.kind === "run" ? (
+                  row.kind === "order" ? (
+                    <InventoryOrderRow
+                      key={row.order.inventory_order_id}
+                      order={row.order}
+                      blockedReason={orderBlockedReason(row.order)}
+                      selected={selectedOrderIds.has(
+                        row.order.inventory_order_id
+                      )}
+                      onToggle={toggleOrder}
+                      amount={getEffectiveOrderAmount(row.order)}
+                      onAmountChange={handleOrderAmountChange}
+                    />
+                  ) : row.kind === "run" ? (
                     <RunRow
                       key={row.run.run_id}
                       run={row.run}
@@ -1025,5 +1274,131 @@ const TaskRow = ({
     </Table.Cell>
   </Table.Row>
 )
+
+/**
+ * One inventory order this partner may bill for (#1710) — GOODS, not work.
+ *
+ * 🔴 The amount box is pre-filled from the server's `amount`, which is the
+ * receipts value already capped at what is left against the ORDERED total. It
+ * is the only figure on this row that may be sent as money. `receipts_total`
+ * and `ordered_total` are shown beside it as explanation, never re-multiplied
+ * into a new one — every time a screen has re-derived a payout total on this
+ * codebase it has got it wrong (#1596 by 22%, #1679 by 28%).
+ */
+const InventoryOrderRow = ({
+  order,
+  blockedReason,
+  selected,
+  onToggle,
+  amount,
+  onAmountChange,
+}: {
+  order: PayableInventoryOrder
+  blockedReason: string | null
+  selected: boolean
+  onToggle: (id: string) => void
+  amount: number
+  onAmountChange: (id: string, value: string) => void
+}) => {
+  const blocked = !!blockedReason
+
+  return (
+    <Table.Row
+      data-inventory-order-id={order.inventory_order_id}
+      data-testid="payable-inventory-order-row"
+      className={blocked ? "opacity-60" : undefined}
+    >
+      <Table.Cell>
+        <Checkbox
+          checked={selected}
+          disabled={blocked}
+          onCheckedChange={() => onToggle(order.inventory_order_id)}
+          aria-label={`Select inventory order ${order.inventory_order_id}`}
+        />
+      </Table.Cell>
+
+      <Table.Cell>
+        <div className="flex items-center gap-2">
+          <Text weight="plus" className="truncate font-mono text-xs">
+            {order.inventory_order_id}
+          </Text>
+          <Badge color="orange" size="2xsmall">
+            Goods
+          </Badge>
+          {order.is_sample && (
+            <Badge color="grey" size="2xsmall">
+              Sample
+            </Badge>
+          )}
+        </div>
+        <Text size="small" className="mt-1 text-ui-fg-subtle">
+          {order.status || "Unknown"}
+          {order.lines?.length
+            ? ` · ${order.lines
+                .map((l) => l.material_name)
+                .filter(Boolean)
+                .slice(0, 2)
+                .join(", ")}`
+            : ""}
+        </Text>
+        {blockedReason && (
+          <Text size="xsmall" className="mt-1 text-ui-fg-muted">
+            {blockedReason}
+          </Text>
+        )}
+        {!blocked && order.capped_by_ceiling && (
+          /**
+           * ⚠️ A silent cap is a reduction nobody decided. The receipts are
+           * worth more than the order has headroom for, so this row offers
+           * less than the goods came to — say so, with both figures.
+           */
+          <Tooltip
+            content={`Receipts are worth ${order.receipts_total.toLocaleString()}, but only ${(order.remaining ?? 0).toLocaleString()} is left against the ordered total of ${(order.ordered_total ?? 0).toLocaleString()}.`}
+          >
+            <Text size="xsmall" className="mt-1 text-ui-tag-orange-text">
+              capped at what is left on the order
+            </Text>
+          </Tooltip>
+        )}
+        {!blocked && order.claimed_total > 0 && !order.capped_by_ceiling && (
+          <Text size="xsmall" className="mt-1 text-ui-fg-muted">
+            {order.claimed_total.toLocaleString()} already claimed on this order
+          </Text>
+        )}
+      </Table.Cell>
+
+      {/* Units RECEIVED, which is what the amount is derived from — not the
+          quantity ordered. The two differ on every partially-delivered order. */}
+      <Table.Cell className="text-right">
+        <Text size="small" className="text-ui-fg-muted">
+          {order.received_quantity?.toLocaleString() ?? "—"}
+        </Text>
+      </Table.Cell>
+
+      {/* No rate. An order is priced per line by material, and inventing a
+          single blended rate here would be a number nobody agreed. */}
+      <Table.Cell className="text-right">
+        <Text size="small" className="text-ui-fg-muted">
+          —
+        </Text>
+      </Table.Cell>
+
+      <Table.Cell className="text-right">
+        {blocked ? (
+          <Text size="small" className="text-ui-fg-muted">
+            —
+          </Text>
+        ) : (
+          <NumberCell
+            label={`Amount for inventory order ${order.inventory_order_id}`}
+            placeholder="0"
+            value={amount || undefined}
+            onChange={(v) => onAmountChange(order.inventory_order_id, v)}
+          />
+        )}
+      </Table.Cell>
+    </Table.Row>
+  )
+}
 
 export const Component = PaymentSubmissionCreate

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-detail/payment-submission-detail.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-detail/payment-submission-detail.tsx
@@ -17,9 +17,11 @@ import {
   useSubmitPartnerPaymentSubmission,
 } from "../../../hooks/api/partner-payment-submissions"
 import {
+  describeLine,
   money,
   perUnit,
   provenanceLabel,
+  summariseItems,
 } from "../../../lib/payment-submission-money"
 
 /** The provenance note, rendered. The decision itself lives in `src/lib`. */
@@ -72,12 +74,30 @@ export const PaymentSubmissionDetail = () => {
   }
 
   const items: any[] = submission.items || []
+
+  /**
+   * 🔴 ONE list of lines, not a table per source type (#1710, #1621).
+   *
+   * This screen used to partition `items` into `designItems` and `taskItems`
+   * and render a table for each. `source_type` has FOUR values — `design`,
+   * `task`, `run`, `inventory_order` — so a line sourced from a production run
+   * or from an inventory order matched neither filter and rendered NOWHERE. It
+   * still counted toward `total_amount` in the header, so the page showed a
+   * total with no lines adding up to it, and a partner billing for goods saw
+   * an empty submission.
+   *
+   * 🔑 The fix for a filter that enumerates known values is to REMOVE the
+   * partitioning, not to add a fourth branch — the next source type would
+   * disappear the same way. `describeLine` below labels whatever arrives, and
+   * an unrecognised type still gets a row.
+   */
   const designItems = items.filter(
     (i) => i.source_type === "design" || (!i.source_type && i.design_id)
   )
   const taskItems = items.filter(
     (i) => i.source_type === "task" || (!i.source_type && i.task_id)
   )
+  const goodsItems = items.filter((i) => i.source_type === "inventory_order")
   const documents: any[] = submission.documents || []
   const currency: string | undefined = (submission as any).currency
 
@@ -142,12 +162,13 @@ export const PaymentSubmissionDetail = () => {
                 <Text size="small" className="text-ui-fg-subtle">
                   Items
                 </Text>
-                <Text>
-                  {designItems.length ? `${designItems.length} design${designItems.length !== 1 ? "s" : ""}` : ""}
-                  {designItems.length && taskItems.length ? " · " : ""}
-                  {taskItems.length ? `${taskItems.length} task${taskItems.length !== 1 ? "s" : ""}` : ""}
-                  {!items.length ? 0 : ""}
-                </Text>
+                {/*
+                  ⚠️ Counts every line, including the ones this summary used to
+                  omit. It listed designs and tasks only, so a submission of
+                  three inventory-order lines read as an empty item count while
+                  the total beside it was in five figures (#1710).
+                */}
+                <Text>{summariseItems(items) || 0}</Text>
               </div>
               <div>
                 <Text size="small" className="text-ui-fg-subtle">
@@ -199,7 +220,7 @@ export const PaymentSubmissionDetail = () => {
         )}
 
         {/* Stat Cards */}
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-6">
           <Container className="p-4">
             <Text size="small" className="text-ui-fg-subtle">
               Total Amount
@@ -222,6 +243,12 @@ export const PaymentSubmissionDetail = () => {
           </Container>
           <Container className="p-4">
             <Text size="small" className="text-ui-fg-subtle">
+              Goods
+            </Text>
+            <Heading>{goodsItems.length}</Heading>
+          </Container>
+          <Container className="p-4">
+            <Text size="small" className="text-ui-fg-subtle">
               Currency
             </Text>
             <Heading>
@@ -236,82 +263,65 @@ export const PaymentSubmissionDetail = () => {
           </Container>
         </div>
 
-        {/* Design Items */}
-        {designItems.length > 0 && (
+        {/*
+          Every line, whatever its source (#1710).
+
+          🔴 Replaces the "Design Items" and "Task Items" tables. Those two
+          between them could render `design` and `task` lines only, so a `run`
+          or `inventory_order` line was invisible while still counting toward
+          the total in the header above.
+        */}
+        {items.length > 0 && (
           <Container className="p-0">
             <div className="border-b border-ui-border-base px-4 py-3">
-              <Heading level="h3">Design Items</Heading>
+              <Heading level="h3">What this bills for</Heading>
             </div>
             <Table>
               <Table.Header>
                 <Table.Row>
-                  <Table.HeaderCell>Design</Table.HeaderCell>
+                  <Table.HeaderCell>Item</Table.HeaderCell>
                   <Table.HeaderCell>Billed for</Table.HeaderCell>
                   <Table.HeaderCell>Amount</Table.HeaderCell>
                 </Table.Row>
               </Table.Header>
               <Table.Body>
-                {designItems.map((item: any) => (
-                  <Table.Row key={item.id}>
-                    <Table.Cell>
-                      {item.design_name || "Unnamed design"}
-                    </Table.Cell>
-                    {/*
-                      The design id used to sit here. It answers a question
-                      nobody asks on a payment screen; "what am I being paid
-                      for, and at what rate" is the question, and the create
-                      screen has answered it since #1579 while this one did
-                      not — the two money screens disagreed about what a
-                      submission even was.
-                    */}
-                    <Table.Cell>
-                      <div className="flex flex-col">
-                        <Text size="small">
-                          {perUnit(item, currency) ?? "One line, no rate given"}
-                        </Text>
-                        <ProvenanceNote item={item} />
-                      </div>
-                    </Table.Cell>
-                    <Table.Cell>
-                      {money(item.amount, currency)}
-                    </Table.Cell>
-                  </Table.Row>
-                ))}
-              </Table.Body>
-            </Table>
-          </Container>
-        )}
-
-        {/* Task Items */}
-        {taskItems.length > 0 && (
-          <Container className="p-0">
-            <div className="border-b border-ui-border-base px-4 py-3">
-              <Heading level="h3">Task Items</Heading>
-            </div>
-            <Table>
-              <Table.Header>
-                <Table.Row>
-                  <Table.HeaderCell>Task</Table.HeaderCell>
-                  <Table.HeaderCell>Task ID</Table.HeaderCell>
-                  <Table.HeaderCell>Amount</Table.HeaderCell>
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {taskItems.map((item: any) => (
-                  <Table.Row key={item.id}>
-                    <Table.Cell>
-                      {item.task_name || "Untitled task"}
-                    </Table.Cell>
-                    <Table.Cell>
-                      <span className="font-mono text-xs">
-                        {item.task_id}
-                      </span>
-                    </Table.Cell>
-                    <Table.Cell>
-                      {money(item.amount, currency)}
-                    </Table.Cell>
-                  </Table.Row>
-                ))}
+                {items.map((item: any) => {
+                  const line = describeLine(item)
+                  return (
+                    <Table.Row key={item.id}>
+                      <Table.Cell>
+                        <div className="flex items-center gap-2">
+                          <Text size="small">{line.title}</Text>
+                          <Badge color={line.badgeColor} size="2xsmall">
+                            {line.badge}
+                          </Badge>
+                        </div>
+                        {line.subtitle && (
+                          <Text size="xsmall" className="mt-1 text-ui-fg-muted font-mono">
+                            {line.subtitle}
+                          </Text>
+                        )}
+                      </Table.Cell>
+                      {/*
+                        The design id used to sit here. It answers a question
+                        nobody asks on a payment screen; "what am I being paid
+                        for, and at what rate" is the question, and the create
+                        screen has answered it since #1579 while this one did
+                        not — the two money screens disagreed about what a
+                        submission even was.
+                      */}
+                      <Table.Cell>
+                        <div className="flex flex-col">
+                          <Text size="small">
+                            {perUnit(item, currency) ?? line.billedFor}
+                          </Text>
+                          <ProvenanceNote item={item} />
+                        </div>
+                      </Table.Cell>
+                      <Table.Cell>{money(item.amount, currency)}</Table.Cell>
+                    </Table.Row>
+                  )
+                })}
               </Table.Body>
             </Table>
           </Container>


### PR DESCRIPTION
Closes #1710. Also gives a partner the goods half of what they may bill for, which is where the orphaned rows came from.

## 🔴 The correction that unlocked this

The ledger route and `fold.ts` both asserted that `defineLink(paymentSubmission, internalPayments)` was **never created** — 73-character table name, past Postgres's 63-byte identifier limit, "in either environment, with no error raised".

That is wrong. Medusa abbreviates each segment of an over-long link name to four characters and appends a hash. The table exists, migrated and indexed:

```
paym_subm_paym_subm_inte_paym_inte_paym-9812b09f   0 rows
inve_orde_inve_orde_inte_paym_inte_paym-441a29a2c  4 rows
```

`query.graph` returned no `payments` key because it held **zero rows**. Nothing ever wrote it. A capability declared dead on a mechanism that was never the mechanism — so nobody built the writer, and option 3 sat available the whole time. Both comments are corrected in place rather than deleted.

## The defect

| reader | the same two Completed INR 10,000 payments |
|---|---|
| `GET /admin/inventory-orders/:id/payments` | `recorded: 20000` |
| `GET /admin/payments/partners/:id/ledger` | `recorded: 0`, `outstanding: 28200` |

They link to the ORDER and never to the partner; the ledger read the partner link alone. The screen that answers *"what do we owe this partner"* said **INR 28,200 outstanding** against money that had gone out.

## The fix

- **Read all three homes** — `mergePaymentSources` (pure, tested) unions partner / inventory-order / submission links, deduped by payment id, first source owning provenance. **No backfill**: every historical row is covered the moment this ships.
- **Write the missing one** — `linkPaymentToSubmissionsStep` and `paymentSubmissionIds` on `POST /admin/payments/link` let a human state which payout a payment settles.
- **Warn, never net off** — `recorded_against` per payout, `recorded_against_open` in the totals, rendered on the partner page.

> ⚠ INR 20,000 of that sits against orders an unpaid payout still bills — settle or link it before paying again

Deliberately **not** subtracted from `outstanding`. An advance and a payout can legitimately coexist; only a human may say one discharges the other, by linking it.

## A partner could not bill for goods at all

The admin has offered `inventory_order_lines` since #1612. The partner validator accepted `design_ids` / `task_ids` only and no partner screen listed an order — so the one party who knows what they delivered had to ask an admin, and the only self-serve path (`submit-payment`) writes a payment that is **not a claim**. That is exactly where the two orphaned rows came from.

- `GET /partners/payment-submissions/payable-inventory-orders`, off the **same lib** as the admin route so the receipts rule, the ordered-total ceiling and the cap flag cannot drift. Registered in `middlewares.ts`.
- Create screen: a **Goods** filter and rows. Detail screen: every line type renders.

## 🔴 A security hole this would have opened

The ownership guard read `if (ownerId && ownerId !== partner_id)` — an order with **no** partner link satisfied it by having nothing to compare. 8 of 16 orders in a dev database have no link. Survivable while only an admin naming an explicit `partner_id` could reach the step; not survivable once a partner could. Now refused outright, with an integration test that fails against the old guard.

## Two bugs the new tests caught

- `describeLine` sent a legacy row with null `source_type` to the unknown branch and badged an ordinary design line "Item".
- Select-all used the exclusion form (`typeFilter !== "tasks"`), so pressing it on the new Goods tab would have ticked **every run**.

The detail screen's `designItems`/`taskItems` partitioning is **removed**, not extended — `source_type` has four values, so `run` and `inventory_order` lines rendered nowhere while still counting toward the header total. A fourth branch loses the fifth type the same way (#1621).

## Docs

`apps/docs/docs/guides/partner-portal/getting-paid.md` — the money flow from the UI, with the watch-outs: Submit Payment is not a claim, **Approved is not Paid** (34 days on prod), a blank rate is deliberate, a capped goods row, greyed rows, and the admin warning line. `submit-payment-guide.md` now leads with what it is *not*.

## Verify

```
TEST_TYPE=unit npx jest --testPathPattern="ledger/__tests__|partner-ledger-section"
pnpm test:integration:http:shared ./integration-tests/http/payment-submissions-api.spec.ts
```

- 129 integration passed (7 new), 442 unit passed (13 new + 5 render)
- tsc at the **50-error baseline** (unchanged), `check:prod-build` passed, partner-ui builds, docs build
- **Every new assertion was verified to FAIL with the fix reverted** — including 4 that initially passed on the old code and were rewritten

## ⚠️ Post-deploy

Probe that `paym_subm_paym_subm_inte_paym_inte_paym-9812b09f` exists on prod before relying on the direct link. The read is in a `try/catch`, so a missing table degrades to "no submission-linked payments" rather than breaking the ledger — but the writer would then silently do nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4