### PR TITLE
fix(payments): an already-paid order was offered as billable, and the submission link shipped inert (#1710)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -4727,6 +4727,198 @@ setupSharedTestSuite(() => {
         expect(row.amount).toBe(clean.amount)
       })
 
+      /**
+       * #1710 — stating that an EXISTING payment settles a payout, which is
+       * what makes a PARTIAL payout expressible.
+       *
+       * Parmar's payout is INR 28,200 with INR 20,000 moved. `Approved` reports
+       * 0 paid and 28,200 outstanding — the reading that pays someone twice;
+       * `Paid` would claim 28,200 moved when 8,200 is still owed. Neither is
+       * true, and linking is how a human says which.
+       */
+      describe("POST /admin/payments/:id/settles (#1710)", () => {
+        const recordPayment = async (orderId: string, amount: number) => {
+          const res = await api
+            .post(
+              "/admin/payments/link",
+              {
+                payment: {
+                  amount,
+                  status: "Completed",
+                  payment_type: "Bank",
+                  payment_date: new Date().toISOString(),
+                },
+                inventoryOrderIds: [orderId],
+              },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(res.status).toBe(201)
+          return res.data.payment.id as string
+        }
+
+        const billOrder = async (partnerHeaders: any, orderId: string, amount: number) => {
+          const res = await api
+            .post(
+              "/partners/payment-submissions",
+              {
+                inventory_order_lines: [
+                  { inventory_order_id: orderId, amount },
+                ],
+              },
+              { headers: partnerHeaders }
+            )
+            .catch((e: any) => e.response)
+          expect(res.status).toBe(201)
+          return res.data.payment_submission.id as string
+        }
+
+        const ledger = async (partnerId: string) => {
+          const res = await api.get(
+            `/admin/payments/partners/${partnerId}/ledger`,
+            adminHeaders
+          )
+          expect(res.status).toBe(200)
+          return res.data.totals
+        }
+
+        it("settles a payout in PART — the reading neither status could give", async () => {
+          const stamp = Date.now() + 70
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `psettle-${stamp}`)
+
+          const submissionId = await billOrder(owner.partnerHeaders, orderId, 1000)
+          const paymentId = await recordPayment(orderId, 400)
+
+          // Before linking: the money is visible but settles nothing.
+          const before = await ledger(owner.partnerId)
+          expect(before.billed).toBe(1000)
+          expect(before.paid).toBe(0)
+          expect(before.outstanding).toBe(1000)
+          expect(before.recorded).toBe(400)
+          // …and it WARNS, because a payout still bills that order.
+          expect(before.recorded_against_open).toBe(400)
+
+          const link = await api
+            .post(
+              `/admin/payments/${paymentId}/settles`,
+              { payment_submission_id: submissionId },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(link.status).toBe(200)
+
+          // After: 400 of 1,000 is settled and only 600 is owed.
+          const after = await ledger(owner.partnerId)
+          expect(after.billed).toBe(1000)
+          expect(after.paid).toBe(400)
+          expect(after.outstanding).toBe(600)
+          /**
+           * 🔑 And it stops warning: the money is no longer unmatched, it is
+           * accounted for. Reporting it as both settled AND a double-pay risk
+           * would contradict itself.
+           */
+          expect(after.recorded_against_open).toBe(0)
+        })
+
+        it("is idempotent — re-stating the same fact is not a 500", async () => {
+          /**
+           * ⚠️ `link.create` raises on the composite primary key, so a repeated
+           * call would 500 without the dismiss-first (#1710).
+           */
+          const stamp = Date.now() + 80
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `pidem-${stamp}`)
+          const submissionId = await billOrder(owner.partnerHeaders, orderId, 1000)
+          const paymentId = await recordPayment(orderId, 400)
+
+          for (const _ of [1, 2]) {
+            const res = await api
+              .post(
+                `/admin/payments/${paymentId}/settles`,
+                { payment_submission_id: submissionId },
+                adminHeaders
+              )
+              .catch((e: any) => e.response)
+            expect(res.status).toBe(200)
+          }
+
+          // Linked once, counted once.
+          expect((await ledger(owner.partnerId)).paid).toBe(400)
+        })
+
+        it("takes the statement back, and the money returns to unmatched", async () => {
+          const stamp = Date.now() + 90
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `punlink-${stamp}`)
+          const submissionId = await billOrder(owner.partnerHeaders, orderId, 1000)
+          const paymentId = await recordPayment(orderId, 400)
+
+          await api.post(
+            `/admin/payments/${paymentId}/settles`,
+            { payment_submission_id: submissionId },
+            adminHeaders
+          )
+          expect((await ledger(owner.partnerId)).paid).toBe(400)
+
+          const res = await api
+            .delete(
+              `/admin/payments/${paymentId}/settles?payment_submission_id=${submissionId}`,
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(res.status).toBe(200)
+
+          const after = await ledger(owner.partnerId)
+          expect(after.paid).toBe(0)
+          expect(after.outstanding).toBe(1000)
+          expect(after.recorded_against_open).toBe(400)
+        })
+
+        it("refuses a payout that does not exist, rather than linking to nothing", async () => {
+          const stamp = Date.now() + 100
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `pnosub-${stamp}`)
+          const paymentId = await recordPayment(orderId, 400)
+
+          const res = await api
+            .post(
+              `/admin/payments/${paymentId}/settles`,
+              { payment_submission_id: "ps_does_not_exist" },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(404)
+        })
+
+        it("accepts payment_submission_id at all — the route ordering trap", async () => {
+          /**
+           * 🔴 `/admin/payments/:id` POST carries a `.strict()` validator and
+           * matching is prefix-based, so if the settles entry were registered
+           * AFTER it, this body would be rejected as an unrecognised field —
+           * a 400 that reads like a bad request rather than a mis-ordered
+           * route. This case exists to fail loudly if the order is disturbed.
+           */
+          const stamp = Date.now() + 110
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `porder-${stamp}`)
+          const submissionId = await billOrder(owner.partnerHeaders, orderId, 1000)
+          const paymentId = await recordPayment(orderId, 400)
+
+          const res = await api
+            .post(
+              `/admin/payments/${paymentId}/settles`,
+              { payment_submission_id: submissionId },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).not.toBe(400)
+          expect(res.status).toBe(200)
+        })
+      })
+
       it("still refuses a submission naming nothing at all", async () => {
         const res = await api
           .post(

--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -4659,6 +4659,74 @@ setupSharedTestSuite(() => {
         expect(line.inventory_order_id).toBe(orderId)
       })
 
+      /**
+       * 🔴 The prod shape this warning exists for.
+       *
+       * `inv_order_01KKB850WN…` (Parmar): ordered 9,800, receipts 5,800,
+       * claimed **0**, and INR 9,800 PAID since March 2026. The billable
+       * ceiling measures claims against the ordered total and has no term for
+       * payments, so the route offered 5,800 of an order already settled in
+       * full — on a screen a partner can now reach.
+       */
+      it("reports money already PAID against an order it still offers to bill", async () => {
+        const stamp = Date.now() + 60
+        const owner = await createPartnerWithAuth(stamp)
+        const orderId = await seedOrderForPartner(
+          owner.partnerId,
+          `precorded-${stamp}`
+        )
+
+        const before = await api.get(
+          "/partners/payment-submissions/payable-inventory-orders",
+          { headers: owner.partnerHeaders }
+        )
+        const clean = before.data.payable_inventory_orders.find(
+          (o: any) => o.inventory_order_id === orderId
+        )
+        // The control: nothing paid yet, so nothing to warn about.
+        expect(clean.recorded_total).toBe(0)
+        expect(clean.recorded_covers_amount).toBe(false)
+
+        // Record a payment against the order — the exact call the inventory
+        // order's "Add payment" form makes, and the one that made #1710.
+        const paid = await api
+          .post(
+            "/admin/payments/link",
+            {
+              payment: {
+                amount: 1000,
+                status: "Completed",
+                payment_type: "Bank",
+                payment_date: new Date().toISOString(),
+              },
+              inventoryOrderIds: [orderId],
+            },
+            adminHeaders
+          )
+          .catch((e: any) => e.response)
+        expect(paid.status).toBe(201)
+
+        const after = await api.get(
+          "/partners/payment-submissions/payable-inventory-orders",
+          { headers: owner.partnerHeaders }
+        )
+        const row = after.data.payable_inventory_orders.find(
+          (o: any) => o.inventory_order_id === orderId
+        )
+
+        expect(row.recorded_total).toBe(1000)
+
+        /**
+         * ⚠️ And the offer is UNCHANGED. The warning is reported, never netted:
+         * a payment on an order is not necessarily an advance against a payout,
+         * and silently reducing what a partner may bill is the underpayment
+         * this codebase keeps producing (#1596, #1616, #1679).
+         */
+        expect(row.ordered_total).toBe(clean.ordered_total)
+        expect(row.remaining).toBe(clean.remaining)
+        expect(row.amount).toBe(clean.amount)
+      })
+
       it("still refuses a submission naming nothing at all", async () => {
         const res = await api
           .post(

--- a/apps/backend/src/admin/components/creates/payable-inventory-orders-grid.tsx
+++ b/apps/backend/src/admin/components/creates/payable-inventory-orders-grid.tsx
@@ -300,9 +300,24 @@ export const PayableInventoryOrdersGrid = ({
                   ? order.receipts_total > 0
                     ? "already claimed in full"
                     : "no receipts recorded"
-                  : order.capped_by_ceiling
-                    ? "capped at the ordered total"
-                    : "what was delivered"}
+                  : /**
+                     * 🔴 #1710 — the warning that outranks the basis.
+                     *
+                     * The ceiling measures CLAIMS against the ordered total and
+                     * has no term for payments, so an order already paid in
+                     * full but never billed is offered as freshly payable. That
+                     * is live on prod: INR 9,800 recorded since March, INR 0
+                     * claimed, and this grid offered INR 5,800 of it.
+                     *
+                     * ⚠️ Warned, not blocked and not netted. A payment on an
+                     * order is not necessarily an advance against a payout —
+                     * whether it discharges this claim is the operator's call.
+                     */
+                    order.recorded_covers_amount
+                    ? `⚠ ${order.recorded_total.toLocaleString()} already paid on this order`
+                    : order.capped_by_ceiling
+                      ? "capped at the ordered total"
+                      : "what was delivered"}
               </Text>
             </DataGridReadOnlyCell>
           )

--- a/apps/backend/src/admin/components/partners/__tests__/partner-ledger-section.unit.spec.ts
+++ b/apps/backend/src/admin/components/partners/__tests__/partner-ledger-section.unit.spec.ts
@@ -23,6 +23,7 @@ const mockLedger = jest.fn()
 jest.mock("../../../hooks/api/payments", () => ({
   usePartnerLedger: (...args: any[]) => mockLedger(...args),
   useUpdatePayment: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useSetPaymentSettles: () => ({ mutateAsync: jest.fn(), isPending: false }),
 }))
 
 /**
@@ -168,5 +169,32 @@ describe("PartnerLedgerSection — the double-pay warning (#1710)", () => {
 
     expect(html).toMatch(/recorded against Parmar cotton/i)
     expect(html).toMatch(/no payout attached/i)
+  })
+})
+
+describe("PartnerLedgerSection — acting on the warning (#1710)", () => {
+  it("🔑 offers a way to SETTLE each payment the warning names", () => {
+    /**
+     * A warning with no action beside it becomes wallpaper. The route
+     * (`POST /admin/payments/:id/settles`) is the human statement the ledger
+     * refuses to infer — and a capability with no screen is no capability
+     * (#1612).
+     */
+    const html = text(render([payout()], totals()))
+
+    expect(html).toMatch(/Mark .* as settling this payout/i)
+    // One per payment named in the warning, not one for the row.
+    expect(html.match(/as settling this payout/gi)).toHaveLength(2)
+  })
+
+  it("offers nothing to settle when nothing is recorded against the payout", () => {
+    const html = text(
+      render(
+        [payout({ recorded_against: [], recorded_against_total: 0 })],
+        totals({ recorded: 0, recorded_against_open: 0 })
+      )
+    )
+
+    expect(html).not.toMatch(/as settling this payout/i)
   })
 })

--- a/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom"
 import { ActionMenu } from "../common/action-menu"
 import {
   usePartnerLedger,
+  useSetPaymentSettles,
   useUpdatePayment,
   type PartnerLedgerEntry,
 } from "../../hooks/api/payments"
@@ -41,6 +42,54 @@ const money = (amount: number | null | undefined, currency?: string | null) =>
 
 const day = (value: string | null | undefined) =>
   value ? new Date(value).toLocaleDateString() : null
+
+/**
+ * "This payment settles this payout" — one click, no picker (#1710).
+ *
+ * ⚠️ Deliberately NOT a free-form link builder. The only payments offered are
+ * the ones already sitting against an order this payout bills, which is the
+ * only case where the answer is likely to be yes. Anything else is a judgement
+ * that wants more context than a button.
+ */
+const SettlesButton = ({
+  paymentId,
+  submissionId,
+  amount,
+  currency,
+}: {
+  paymentId: string
+  submissionId: string
+  amount: number
+  currency: string
+}) => {
+  const { mutateAsync, isPending } = useSetPaymentSettles(paymentId)
+
+  return (
+    <button
+      type="button"
+      disabled={isPending}
+      data-testid={`settles-${paymentId}`}
+      className="text-ui-fg-interactive txt-compact-xsmall w-fit hover:underline disabled:opacity-50"
+      onClick={() => {
+        void (async () => {
+          try {
+            await mutateAsync({
+              payment_submission_id: submissionId,
+              settles: true,
+            })
+            toast.success(
+              `${money(amount, currency)} now counts against this payout`
+            )
+          } catch (e: any) {
+            toast.error(e?.message || "Could not link this payment")
+          }
+        })()
+      }}
+    >
+      Mark {money(amount, currency)} as settling this payout
+    </button>
+  )
+}
 
 /** A payout: a submission, with the work it bills named. */
 const PayoutRow = ({ entry }: { entry: PartnerLedgerEntry }) => {
@@ -95,15 +144,35 @@ const PayoutRow = ({ entry }: { entry: PartnerLedgerEntry }) => {
            * payout can legitimately coexist; only a human linking the payment
            * to this submission settles that question.
            */
-          <Text size="xsmall" className="text-ui-tag-orange-text">
-            ⚠ {money(entry.recorded_against_total!, entry.currency)} already
-            recorded against{" "}
-            {entry.recorded_against!.length === 1
-              ? entry.recorded_against![0].inventory_order_name ||
-                "the order this bills"
-              : `${entry.recorded_against!.length} payments on the order this bills`}{" "}
-            — check before paying
-          </Text>
+          <div className="flex flex-col gap-y-1">
+            <Text size="xsmall" className="text-ui-tag-orange-text">
+              ⚠ {money(entry.recorded_against_total!, entry.currency)} already
+              recorded against{" "}
+              {entry.recorded_against!.length === 1
+                ? entry.recorded_against![0].inventory_order_name ||
+                  "the order this bills"
+                : `${entry.recorded_against!.length} payments on the order this bills`}{" "}
+              — check before paying
+            </Text>
+            {/**
+             * 🔑 The action beside the warning (#1710).
+             *
+             * A warning with no way to act on it leaves the operator to go and
+             * do something elsewhere, which mostly means nothing happens — the
+             * warning becomes wallpaper. One click per payment turns "money is
+             * sitting here" into "this money settles this payout", which is
+             * the human statement the ledger refuses to infer.
+             */}
+            {entry.recorded_against!.map((r) => (
+              <SettlesButton
+                key={r.payment_id}
+                paymentId={r.payment_id}
+                submissionId={entry.submission_id!}
+                amount={r.amount}
+                currency={entry.currency}
+              />
+            ))}
+          </div>
         )}
       </div>
       <div className="flex flex-col items-end">

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -444,6 +444,17 @@ export interface PayableInventoryOrder {
    * offer match what the guard accepts (#1617).
    */
   capped_by_ceiling: boolean
+  /**
+   * Money already PAID against this order (#1710).
+   *
+   * 🔴 Declare it or the grid cannot read it. The route computes it, and a
+   * value sent over the wire with no entry in the client type has ZERO readers
+   * — the shape that let an order headline "INR 0 paid" over INR 20,000 of
+   * completed payments (#1704), and a flag ship for months unread (#1679).
+   */
+  recorded_total: number
+  /** Whether what has already been paid meets or exceeds what this row bills. */
+  recorded_covers_amount: boolean
   order_date: string | null
   expected_delivery_date: string | null
   payable: boolean

--- a/apps/backend/src/admin/hooks/api/payments.ts
+++ b/apps/backend/src/admin/hooks/api/payments.ts
@@ -190,3 +190,43 @@ export const usePartnerLedger = (
   });
   return { ...data, ...rest };
 };
+
+/**
+ * State that a payment settles a payout — or take it back (#1710).
+ *
+ * 🔑 The human act the ledger refuses to perform on its own. The panel WARNS
+ * that money sits against an order an unpaid payout bills; it will not decide
+ * that the money discharges the payout, because a payment on an order may be an
+ * advance, a deposit, or money for a different delivery. This is where a person
+ * says which — after which it counts toward `paid` and the payout is settled in
+ * PART.
+ */
+export const useSetPaymentSettles = (paymentId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      payment_submission_id,
+      settles,
+    }: {
+      payment_submission_id: string;
+      settles: boolean;
+    }) =>
+      settles
+        ? sdk.client.fetch(`/admin/payments/${paymentId}/settles`, {
+            method: "POST",
+            body: { payment_submission_id },
+          })
+        : sdk.client.fetch(
+            `/admin/payments/${paymentId}/settles?payment_submission_id=${payment_submission_id}`,
+            { method: "DELETE" },
+          ),
+    onSuccess: () => {
+      // The ledger's totals move with this — `paid` and `outstanding` both
+      // change — so a stale panel would show the old figures beside the new
+      // state and read as if nothing happened.
+      queryClient.invalidateQueries({ queryKey: [PARTNER_LEDGER_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: adminPartnersQueryKeys.details() });
+    },
+  });
+};

--- a/apps/backend/src/api/admin/payments/[id]/settles/route.ts
+++ b/apps/backend/src/api/admin/payments/[id]/settles/route.ts
@@ -1,0 +1,154 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/modules-sdk"
+
+import { INTERNAL_PAYMENTS_MODULE } from "../../../../../modules/internal_payments"
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../../modules/payment_submissions/service"
+import type InternalPaymentService from "../../../../../modules/internal_payments/service"
+
+/**
+ * POST /admin/payments/:id/settles   { payment_submission_id }
+ * DELETE /admin/payments/:id/settles { payment_submission_id }
+ *
+ * State that an EXISTING payment discharges a payout — or take it back.
+ *
+ * ## Why this exists (#1710)
+ *
+ * `paymentSubmissionIds` on `POST /admin/payments/link` only writes the link at
+ * CREATION. Every payment already in the system — including the two INR 10,000
+ * rows that opened #1710, made months before the payout they pay off — had no
+ * way to say what they settle. A capability reachable only for rows that do not
+ * exist yet is a capability nobody has (#1612's lesson).
+ *
+ * ## Why it is a deliberate action and not an inference
+ *
+ * 🔴 The ledger will NOT decide this on its own, and that is the whole design.
+ * A payment sitting on the same inventory order as a payout may be an advance,
+ * a deposit, or money for a different delivery — Parmar's other order carries
+ * INR 9,800 with no payout in existence at all. So the ledger WARNS
+ * (`recorded_against_open`) and refuses to net. This route is where a human
+ * turns that warning into a fact, after which the money counts toward `paid`
+ * and the payout can be settled in PART.
+ *
+ * ⚠️ Linking does not change the payment's own `status`. A `Pending` payment
+ * that is linked still reports as not-yet-moved, and `foldPartnerLedger`
+ * excludes `Failed`/`Cancelled` from settlement entirely. Saying which payout a
+ * payment belongs to is a different assertion from saying the money left.
+ */
+const resolveBoth = async (
+  req: MedusaRequest,
+  submissionId: string
+): Promise<void> => {
+  if (!submissionId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "payment_submission_id is required"
+    )
+  }
+
+  /**
+   * 🔴 BOTH ends validated, not just the one in the URL. A request that names
+   * two ids and checks one is the shape that let body ids through unexamined
+   * (#778) — and here the unchecked id decides whose money is discharged.
+   */
+  const paymentService: InternalPaymentService = req.scope.resolve(
+    INTERNAL_PAYMENTS_MODULE
+  )
+  const [payment] = (await paymentService.listPayments({
+    id: [req.params.id],
+  })) as any[]
+  if (!payment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Payment ${req.params.id} not found`
+    )
+  }
+
+  const submissionService: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+  const [submission] = (await submissionService.listPaymentSubmissions({
+    id: [submissionId],
+  })) as any[]
+  if (!submission) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Payment submission ${submissionId} not found`
+    )
+  }
+
+  /**
+   * ⚠️ A Rejected payout was never owed, so nothing can settle it. Allowing the
+   * link would put money against a claim we refused and make `billed` and
+   * `paid` disagree about whether the payout exists at all.
+   */
+  if (String(submission.status) === "Rejected") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Payment submission ${submissionId} was rejected — it is not owed, so no payment can settle it.`
+    )
+  }
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const submissionId = String(
+    (req.validatedBody as any)?.payment_submission_id ??
+      (req.body as any)?.payment_submission_id ??
+      ""
+  ).trim()
+
+  await resolveBoth(req, submissionId)
+
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link
+
+  /**
+   * ⚠️ `link.create` is NOT idempotent here — a repeated call would raise on the
+   * composite primary key. Dismiss first so re-stating the same fact is a
+   * no-op rather than a 500.
+   */
+  const definition = {
+    [PAYMENT_SUBMISSIONS_MODULE]: { payment_submission_id: submissionId },
+    [INTERNAL_PAYMENTS_MODULE]: { internal_payments_id: req.params.id },
+  }
+  await remoteLink.dismiss(definition).catch(() => undefined)
+  await remoteLink.create({
+    ...definition,
+    data: {
+      payment_submission_id: submissionId,
+      payment_id: req.params.id,
+      linked_with: "payment_submission",
+    },
+  } as any)
+
+  return res.status(200).json({
+    payment_id: req.params.id,
+    payment_submission_id: submissionId,
+    settles: true,
+  })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const submissionId = String(
+    (req.query as any)?.payment_submission_id ??
+      (req.body as any)?.payment_submission_id ??
+      ""
+  ).trim()
+
+  await resolveBoth(req, submissionId)
+
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link
+  await remoteLink.dismiss({
+    [PAYMENT_SUBMISSIONS_MODULE]: { payment_submission_id: submissionId },
+    [INTERNAL_PAYMENTS_MODULE]: { internal_payments_id: req.params.id },
+  })
+
+  return res.status(200).json({
+    payment_id: req.params.id,
+    payment_submission_id: submissionId,
+    settles: false,
+  })
+}

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/__tests__/fold.unit.spec.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/__tests__/fold.unit.spec.ts
@@ -439,3 +439,166 @@ describe("mergePaymentSources", () => {
     expect(merged).toEqual([])
   })
 })
+
+/**
+ * PARTIAL settlement (#1710) — the reading the founder asked for.
+ *
+ * Parmar's payout is INR 28,200 and INR 20,000 has demonstrably moved. Before
+ * this, the model had no honest way to say so: `Approved` reports 0 paid and
+ * 28,200 outstanding — the reading that pays someone twice — while flipping it
+ * to `Paid` would claim 28,200 moved when 8,200 is still owed.
+ *
+ * 🔑 Linking a payment to the payout it settles is the human statement that
+ * makes the partial expressible. It is not inference: nothing here derives it
+ * from a shared order id.
+ */
+describe("foldPartnerLedger — a payout settled in PART (#1710)", () => {
+  const sub = {
+    id: "sub_28200",
+    status: "Approved",
+    total_amount: 28200,
+    currency: "inr",
+    submitted_at: "2026-08-28T10:00:00.000Z",
+  }
+
+  const linked = (over: Record<string, any> = {}) => ({
+    id: "pay_jul",
+    amount: 10000,
+    status: "Completed",
+    submission_id: "sub_28200",
+    ...over,
+  })
+
+  const fold = (payments: any[]) =>
+    foldPartnerLedger({
+      submissions: [sub],
+      items: [],
+      payments,
+      reconciliations: [],
+    })
+
+  it("counts linked money as paid, and owes only the remainder", () => {
+    const { totals } = fold([linked(), linked({ id: "pay_aug" })])
+
+    expect(totals.billed).toBe(28200)
+    expect(totals.paid).toBe(20000)
+    expect(totals.outstanding).toBe(8200)
+  })
+
+  it("leaves an UNLINKED payment out of paid — that is the whole distinction", () => {
+    // Same money, same order, no statement that it settles this payout.
+    const { totals } = fold([
+      { id: "pay_jul", amount: 10000, status: "Completed" },
+      { id: "pay_aug", amount: 10000, status: "Completed" },
+    ])
+
+    expect(totals.paid).toBe(0)
+    expect(totals.outstanding).toBe(28200)
+    expect(totals.recorded).toBe(20000)
+  })
+
+  it("does not let a bounced payment settle anything", () => {
+    const { totals } = fold([
+      linked({ id: "pay_failed", status: "Failed" }),
+      linked({ id: "pay_cancelled", status: "Cancelled" }),
+      linked({ id: "pay_real" }),
+    ])
+
+    // Only the one that moved.
+    expect(totals.paid).toBe(10000)
+    expect(totals.outstanding).toBe(18200)
+  })
+
+  it("🔴 does not let a PENDING payment settle anything either", () => {
+    /**
+     * The status a partner's own submission is written with. If Pending
+     * settled, a partner could move their own `paid` figure by asserting they
+     * had been paid — the admin marking it `Completed` is the only control on
+     * that, and it is deliberately a human act (#1639's rule, applied to the
+     * link).
+     */
+    const { totals, entries } = fold([
+      linked({ id: "pay_pending", status: "Pending" }),
+    ])
+
+    expect(entries.find((e) => e.kind === "payout")!.settled_amount).toBe(0)
+    expect(totals.paid).toBe(0)
+    expect(totals.outstanding).toBe(28200)
+  })
+
+  it("warns on a Pending payment even though it cannot settle — warn wide, settle narrow", () => {
+    /**
+     * ⚠️ The two rules are deliberately different. `recorded_against_open`
+     * counts Pending because a warning should over-fire; `paid` refuses it
+     * because a settlement must not.
+     */
+    const { totals } = foldPartnerLedger({
+      submissions: [sub],
+      items: [{ id: "i1", submission_id: "sub_28200", source_type: "inventory_order", inventory_order_id: "o1" }],
+      payments: [
+        { id: "pay_pending", amount: 10000, status: "Pending", inventory_order_id: "o1" },
+      ],
+      reconciliations: [],
+    })
+
+    expect(totals.paid).toBe(0)
+    expect(totals.recorded_against_open).toBe(10000)
+  })
+
+  it("caps settlement at the payout's own amount", () => {
+    // A INR 30,000 payment cannot make a INR 28,200 payout overpaid; the
+    // surplus belongs to something else.
+    const { totals, entries } = fold([linked({ amount: 30000 })])
+
+    expect(entries.find((e) => e.kind === "payout")!.settled_amount).toBe(28200)
+    expect(totals.paid).toBe(28200)
+    expect(totals.outstanding).toBe(0)
+  })
+
+  it("does NOT double-count a Paid payout that also carries a link", () => {
+    /**
+     * 🔴 The regression this guards. If status and links both contributed, a
+     * settled payout with its payment linked would report 38,200 paid against
+     * 28,200 billed and a NEGATIVE outstanding.
+     */
+    const { totals } = foldPartnerLedger({
+      submissions: [{ ...sub, status: "Paid", paid_at: "2026-08-31T00:00:00.000Z" }],
+      items: [],
+      payments: [linked()],
+      reconciliations: [],
+    })
+
+    expect(totals.paid).toBe(28200)
+    expect(totals.outstanding).toBe(0)
+  })
+
+  it("keeps a RECONCILIATION-derived association out of paid", () => {
+    /**
+     * ⚠️ Provenance, not a statement of how much is discharged. Letting it move
+     * `paid` would silently restate historical numbers nobody re-examined.
+     */
+    const { totals } = foldPartnerLedger({
+      submissions: [sub],
+      items: [],
+      payments: [{ id: "pay_hist", amount: 10000, status: "Pending" }],
+      reconciliations: [
+        { reference_type: "payment_submission", reference_id: "sub_28200", payment_id: "pay_hist" },
+      ],
+    })
+
+    expect(totals.paid).toBe(0)
+    expect(totals.outstanding).toBe(28200)
+  })
+
+  it("still reports a Rejected payout as neither billed nor paid", () => {
+    const { totals } = foldPartnerLedger({
+      submissions: [{ ...sub, status: "Rejected" }],
+      items: [],
+      payments: [linked()],
+      reconciliations: [],
+    })
+
+    expect(totals.billed).toBe(0)
+    expect(totals.paid).toBe(0)
+  })
+})

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/fold.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/fold.ts
@@ -166,6 +166,15 @@ export type LedgerEntry = {
   recorded_against?: RecordedAgainst[]
   /** Sum of `recorded_against`. Advisory, for the same reason. */
   recorded_against_total?: number
+  /**
+   * What has been SETTLED against this payout — money a human linked to it
+   * (#1710). Unlike `recorded_against` this is not advisory: it enters `paid`.
+   *
+   * Capped at the payout's own amount. A INR 30,000 payment linked to a INR
+   * 28,200 payout settles 28,200 of it; the surplus belongs somewhere else and
+   * must not make the partner look overpaid on this row.
+   */
+  settled_amount?: number
 
   // ── payment only ───────────────────────────────────────────────────────
   payment_type?: string | null
@@ -180,7 +189,24 @@ export type LedgerEntry = {
 export type LedgerTotals = {
   /** Everything claimed and not rejected, at any status. */
   billed: number
-  /** Of that, what a `Paid` submission covers. */
+  /**
+   * Of that, what has actually been settled.
+   *
+   * Two ways a payout counts here, and they never double up:
+   *
+   *   1. its status is `Paid` — the whole amount, as before; or
+   *   2. payments have been LINKED to it, which settles it in PART.
+   *
+   * 🔴 (2) is what makes a partial payout expressible at all (#1710). A payout
+   * of INR 28,200 against which INR 20,000 has moved had no honest reading
+   * before: `Paid` claims 28,200 moved, and `Approved` claims nothing did. Both
+   * are wrong, and the second is the one that pays a partner twice.
+   *
+   * ⚠️ Only the DIRECT link counts — a human naming the payout a payment
+   * settles. A reconciliation-derived association is provenance, not a
+   * statement about how much is discharged, and letting it move `paid` would
+   * silently restate historical numbers nobody re-examined.
+   */
   paid: number
   /** Still owed. `billed - paid`. */
   outstanding: number
@@ -394,6 +420,31 @@ export const foldPartnerLedger = (input: {
       }
     }
 
+    /**
+     * Money a human LINKED to this payout, and so a statement that it is
+     * discharged in part (#1710).
+     *
+     * 🔴 ONLY `Completed` settles. This is the same rule as `PAID_STATUSES`
+     * above and it is load-bearing for the same reason (#1639): a payout must
+     * not read as settled before the transfer happened. `Pending` is the status
+     * the partner portal writes on a payment a partner records themselves — so
+     * counting it here would let a partner move their own `paid` figure by
+     * asserting they had been paid. The admin marking it `Completed` is the
+     * only control on that assertion, and it is deliberately a human act.
+     *
+     * ⚠️ Deliberately STRICTER than `recorded_against_open`, which counts
+     * Pending on purpose. A warning should over-fire; a settlement must not.
+     */
+    const SETTLES = new Set(["Completed"])
+    const settledRaw = payments
+      .filter((p) => p.submission_id === submission.id)
+      .filter((p) => SETTLES.has(String(p.status ?? "")))
+      .reduce((acc, p) => acc + num(p.amount), 0)
+
+    const submissionAmount = num(submission.total_amount)
+    const settledAmount =
+      Math.round(Math.min(settledRaw, submissionAmount) * 100) / 100
+
     return {
       id: `payout:${submission.id}`,
       kind: "payout",
@@ -432,6 +483,7 @@ export const foldPartnerLedger = (input: {
         (acc, r) => acc + r.amount,
         0
       ),
+      settled_amount: settledAmount,
     }
   })
 
@@ -471,9 +523,18 @@ export const foldPartnerLedger = (input: {
    */
   const live = payoutEntries.filter((e) => e.status !== "Rejected")
   const billed = live.reduce((acc, e) => acc + e.amount, 0)
-  const paid = live
-    .filter((e) => PAID_STATUSES.has(String(e.status)))
-    .reduce((acc, e) => acc + e.amount, 0)
+  /**
+   * 🔴 A payout counts as paid EITHER by status OR by what has been linked to
+   * it — never both, or a `Paid` payout with a linked payment would be counted
+   * twice and report a partner as overpaid.
+   *
+   * The status wins outright where it is set: `Paid` means the whole payout
+   * settled, whatever subset of payments happens to carry the link.
+   */
+  const paid = live.reduce((acc, e) => {
+    if (PAID_STATUSES.has(String(e.status))) return acc + e.amount
+    return acc + (e.settled_amount ?? 0)
+  }, 0)
 
   const currencies = new Set(live.map((e) => e.currency))
   for (const e of paymentEntries) currencies.add(e.currency)

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/route.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/route.ts
@@ -47,6 +47,7 @@ import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 import PartnerPaymentsLink from "../../../../../../links/partner-payments-link"
+import SubmissionPaymentLink from "../../../../../../links/submission-payment-link"
 import { PAYMENT_REPORTS_MODULE } from "../../../../../../modules/payment_reports"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../../modules/payment_submissions"
 import type PaymentSubmissionsService from "../../../../../../modules/payment_submissions/service"
@@ -160,6 +161,63 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   /**
+   * ── 2b. the SAME orders, reached in ONE hop ──────────────────────────────
+   *
+   * 🔴 Belt and braces, and not paranoia. 2a traverses
+   * `partner → inventory_orders → internal_payments` — TWO link hops across
+   * three modules — and that resolved nothing in the integration environment
+   * while working on production. A traversal that returns no rows is
+   * indistinguishable from an order with no payments, so the failure is silent
+   * and the panel reports INR 0 recorded: the exact defect this route exists to
+   * fix, reintroduced by the query shape used to fix it.
+   *
+   * This is the query `/admin/inventory-orders/:id/payments` has always used —
+   * `inventory_orders` filtered by id, ONE hop to `internal_payments` — over
+   * the orders the submission LINES name. Those are precisely the orders a
+   * payout bills, so it covers every case that can raise a double-pay warning.
+   *
+   * ⚠️ It does NOT replace 2a: an order with no payout names no line, so only
+   * the partner traversal can find money sitting on it (Parmar's INR 9,800).
+   * The union dedupes by payment id, so running both costs nothing.
+   */
+  const linedOrderIds = [...orderNames.keys()]
+  const claimedOrderIds = Array.from(
+    new Set([
+      ...linedOrderIds,
+      ...items.map((i) => i.inventory_order_id).filter(Boolean).map(String),
+    ])
+  )
+
+  if (claimedOrderIds.length) {
+    try {
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        fields: [
+          "id",
+          "internal_payments.*",
+          "internal_payments.paid_to.*",
+          "internal_payments.attachments.*",
+        ],
+        filters: { id: claimedOrderIds },
+      })
+      for (const order of (data || []) as any[]) {
+        if (!order?.id) continue
+        const raw = order.internal_payments
+        const rows = !raw ? [] : Array.isArray(raw) ? raw : [raw]
+        sources.push({
+          rows: rows.filter(Boolean),
+          attribution: {
+            inventory_order_id: String(order.id),
+            inventory_order_name: orderNames.get(String(order.id)) ?? null,
+          },
+        })
+      }
+    } catch {
+      // Same reason again.
+    }
+  }
+
+  /**
    * ── 3. through the SUBMISSION link ─────────────────────────────────────
    *
    * The payout a payment explicitly settles. Empty until
@@ -168,27 +226,40 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
    */
   if (submissionIds.length) {
     try {
+      /**
+       * 🔴 Read through the LINK'S ENTRY POINT, not by traversing from
+       * `payment_submission`.
+       *
+       * `entity: "payment_submission", fields: ["payments.*"]` returns the
+       * submissions with NO `payments` key — silently, with no error. Two
+       * successful link writes and a 200 from `/settles` still read back as
+       * `paid: 0`, which is the same class of silent-absence this whole issue
+       * is about, and it is what made the link look unwritable for months.
+       *
+       * The entry-point form is what source 1 above uses (`PartnerPaymentsLink`)
+       * and what every working link read in this codebase uses. Same shape,
+       * same direction: filter on one side's id, select the other side.
+       */
       const { data } = await query.graph({
-        entity: "payment_submission",
+        entity: SubmissionPaymentLink.entryPoint,
         fields: [
-          "id",
-          "payments.*",
-          "payments.paid_to.*",
-          "payments.attachments.*",
+          "payment_submission_id",
+          "internal_payments.*",
+          "internal_payments.paid_to.*",
+          "internal_payments.attachments.*",
         ],
-        filters: { id: submissionIds },
+        filters: { payment_submission_id: submissionIds },
       })
-      for (const sub of (data || []) as any[]) {
-        const raw = sub?.payments
+      for (const row of (data || []) as any[]) {
+        const raw = row?.internal_payments
         const rows = !raw ? [] : Array.isArray(raw) ? raw : [raw]
         sources.push({
           rows: rows.filter(Boolean),
-          attribution: { submission_id: String(sub.id) },
+          attribution: { submission_id: String(row.payment_submission_id) },
         })
       }
     } catch {
-      // The link may not be traversable in every environment; the other two
-      // homes still answer.
+      // The other two homes still answer.
     }
   }
 

--- a/apps/backend/src/api/admin/payments/validators.ts
+++ b/apps/backend/src/api/admin/payments/validators.ts
@@ -36,3 +36,18 @@ export const ListPaymentsQuerySchema = z.object({
 export type ListPaymentsQuery = z.infer<typeof ListPaymentsQuerySchema>;
 
 export const ListPaymentsQuery = ListPaymentsQuerySchema;
+
+/**
+ * Which payout an existing payment settles (#1710).
+ *
+ * ⚠️ Its middleware entry MUST precede `/admin/payments/:id`. Matching is
+ * prefix-based and `UpdatePaymentSchema` is `.strict()`, so the update entry
+ * would otherwise claim this path and reject `payment_submission_id` as an
+ * unrecognised field — a 400 that looks like a bad request rather than a
+ * mis-ordered route.
+ */
+export const PaymentSettlesSchema = z.object({
+  payment_submission_id: z.string().min(1),
+})
+
+export type PaymentSettles = z.infer<typeof PaymentSettlesSchema>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -246,7 +246,7 @@ import {
   AdminUpdateFormSchema,
 } from "./admin/forms/validators";
 // Payments: schemas
-import { PaymentSchema, ListPaymentsQuerySchema, UpdatePaymentSchema } from "./admin/payments/validators";
+import { PaymentSchema, ListPaymentsQuerySchema, UpdatePaymentSchema, PaymentSettlesSchema } from "./admin/payments/validators";
 import { CreatePaymentAndLinkSchema } from "./admin/payments/link/validators";
 import { ListPaymentsByPersonQuerySchema } from "./admin/payments/persons/[id]/validators";
 import { ListPaymentsByPartnerQuerySchema } from "./admin/payments/partners/[id]/validators";
@@ -3572,6 +3572,23 @@ export default defineMiddlewares({
       middlewares: [validateAndTransformBody(wrapSchema(PaymentSchema))],
     },
 
+    {
+      /**
+       * 🔴 MUST precede `/admin/payments/:id` below (#1710). Matching is
+       * prefix-based and `UpdatePaymentSchema` is `.strict()`, so the update
+       * entry would otherwise claim this path and reject
+       * `payment_submission_id` as an unrecognised field — a 400 that reads
+       * like a bad request rather than a mis-ordered route.
+       */
+      matcher: "/admin/payments/:id/settles",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(PaymentSettlesSchema))],
+    },
+    {
+      matcher: "/admin/payments/:id/settles",
+      method: "DELETE",
+      middlewares: [],
+    },
     {
       matcher: "/admin/payments/:id",
       method: "POST",

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/recorded-payments.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/recorded-payments.unit.spec.ts
@@ -1,0 +1,78 @@
+import { sumRecordedPayments } from "../payable-inventory-orders"
+
+/**
+ * "Have we already paid for this order?" (#1710)
+ *
+ * 🔴 The billable ceiling asks how much of an order has been BILLED. It has no
+ * term for `internal_payments` at all, so an order paid in full and never
+ * billed is offered as freshly payable. That is live on prod:
+ *
+ *   inv_order_01KKB850WN…  ordered 9,800 · receipts 5,800 · claimed 0
+ *                          · RECORDED 9,800 (paid March 2026)
+ *
+ * …and `payable-inventory-orders` offered 5,800 of it, on a screen a partner
+ * can now reach. This is the number that makes the row say so.
+ */
+describe("sumRecordedPayments", () => {
+  it("sums the payments recorded against an order", () => {
+    // The other prod order: two Completed INR 10,000 rows.
+    expect(
+      sumRecordedPayments([
+        { id: "p1", amount: 10000, status: "Completed" },
+        { id: "p2", amount: 10000, status: "Completed" },
+      ])
+    ).toBe(20000)
+  })
+
+  it("counts a Pending payment — that is what the partner portal writes", () => {
+    /**
+     * 🔑 Over-warning costs a glance. Under-warning is the double-pay this
+     * exists to prevent, so the doubt resolves toward saying something.
+     */
+    expect(sumRecordedPayments([{ amount: 9800, status: "Pending" }])).toBe(9800)
+  })
+
+  it("ignores money that never moved", () => {
+    expect(
+      sumRecordedPayments([
+        { amount: 5000, status: "Failed" },
+        { amount: 5000, status: "Cancelled" },
+        { amount: 1000, status: "Completed" },
+      ])
+    ).toBe(1000)
+  })
+
+  it("survives the to-many arriving as a bare object", () => {
+    // ⚠️ `query.graph` returns a single-row to-many as an object, not an array.
+    // Treating that as an array reads `undefined` and warns about nothing.
+    expect(sumRecordedPayments({ amount: 9800, status: "Completed" })).toBe(9800)
+  })
+
+  it("is zero for an order with no payments at all", () => {
+    expect(sumRecordedPayments(null)).toBe(0)
+    expect(sumRecordedPayments([])).toBe(0)
+    expect(sumRecordedPayments(undefined)).toBe(0)
+  })
+
+  it("does not let a junk amount poison the sum", () => {
+    // `Number(undefined)` is NaN, and one NaN turns the whole total into NaN —
+    // which renders as "NaN already paid" and warns about nothing legible.
+    expect(
+      sumRecordedPayments([
+        { amount: "not a number", status: "Completed" },
+        { amount: 500, status: "Completed" },
+      ])
+    ).toBe(500)
+  })
+
+  it("keeps a fractional receipt intact rather than rounding it away", () => {
+    // #1613: an integer column rounded 11.8 to 12 and cost INR 646.50 across
+    // seven rows. Money keeps two decimals here.
+    expect(
+      sumRecordedPayments([
+        { amount: 10.5, status: "Completed" },
+        { amount: 0.25, status: "Completed" },
+      ])
+    ).toBe(10.75)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
@@ -42,10 +42,58 @@ export type PayableInventoryOrder = {
   amount: number
   /** Whether `amount` is below `receipts_total` because the ceiling bit. */
   capped_by_ceiling: boolean
+  /**
+   * Money already PAID against this order, from `internal_payments` (#1710).
+   *
+   * 🔴 The ceiling above measures claims against the ordered total. It has no
+   * term for payments at all — so an order we have already paid in full, but
+   * never billed, is offered as freshly payable. That is real on prod:
+   * `inv_order_01KKB850WN…` has INR 9,800 recorded since March, INR 0 claimed,
+   * and this route offered INR 5,800 of it.
+   *
+   * ⚠️ Reported, never subtracted. A payment on an order is not necessarily an
+   * advance against a payout — on that same order it is a full prepayment with
+   * no payout in existence. Whether it discharges a claim is a human's call,
+   * stated by linking the payment to the submission. Netting it here would
+   * silently underpay, which is this codebase's recurring failure mode.
+   */
+  recorded_total: number
+  /**
+   * Whether what has already been paid meets or exceeds what this row offers to
+   * bill. The signal a screen must not stay quiet about.
+   */
+  recorded_covers_amount: boolean
   order_date: string | null
   expected_delivery_date: string | null
   payable: boolean
   claims: Array<{ submission_id: string | null; status: string | null }>
+}
+
+/**
+ * What has actually been paid against one order.
+ *
+ * 🔑 `Failed` and `Cancelled` never moved money and must not warn. Everything
+ * else counts — including `Pending`, which is the status the partner portal
+ * writes. Over-warning costs a glance; under-warning is the double-pay this
+ * exists to prevent, so the doubt resolves toward saying something.
+ *
+ * PURE, so "have we already paid for this" can be tested without a graph.
+ */
+export const sumRecordedPayments = (payments: any): number => {
+  const rows = !payments ? [] : Array.isArray(payments) ? payments : [payments]
+  const DID_NOT_MOVE = new Set(["Failed", "Cancelled"])
+
+  return (
+    Math.round(
+      rows
+        .filter(Boolean)
+        .filter((p: any) => !DID_NOT_MOVE.has(String(p?.status ?? "")))
+        .reduce((acc: number, p: any) => {
+          const n = Number(p?.amount ?? 0)
+          return acc + (Number.isFinite(n) ? n : 0)
+        }, 0) * 100
+    ) / 100
+  )
 }
 
 export const listPayableInventoryOrders = async (
@@ -78,6 +126,15 @@ export const listPayableInventoryOrders = async (
       // — the two disagree by INR 4,050 on a real order and these are what the
       // concurrency guard reads (#1613).
       "inventory_orders.orderlines.line_fulfillments.quantity_delta",
+      /**
+       * 🔴 What has already been PAID against each order (#1710). Without this
+       * the route offers an order we have settled in full as if nothing had
+       * moved — a guard reading a field the query never fetched is dead, and a
+       * field never fetched at all cannot warn.
+       */
+      "inventory_orders.internal_payments.id",
+      "inventory_orders.internal_payments.amount",
+      "inventory_orders.internal_payments.status",
     ],
     filters: { id: partnerId },
   })
@@ -138,6 +195,12 @@ export const listPayableInventoryOrders = async (
           ? uncapped
           : Math.round(Math.min(uncapped, remaining) * 100) / 100
 
+      /**
+       * ⚠️ Computed per order and REPORTED, never folded into `amount`. See
+       * `recorded_total` on the type for why netting is refused here.
+       */
+      const recordedTotal = sumRecordedPayments(order.internal_payments)
+
       return {
         inventory_order_id: String(order.id),
         status: order.status ?? null,
@@ -151,6 +214,8 @@ export const listPayableInventoryOrders = async (
         remaining,
         amount,
         capped_by_ceiling: remaining != null && uncapped > remaining,
+        recorded_total: recordedTotal,
+        recorded_covers_amount: amount > 0 && recordedTotal >= amount,
         order_date: order.order_date ?? null,
         expected_delivery_date: order.expected_delivery_date ?? null,
         /**

--- a/apps/docs/docs/guides/partner-portal/getting-paid.md
+++ b/apps/docs/docs/guides/partner-portal/getting-paid.md
@@ -172,13 +172,33 @@ that an **unpaid** payout also bills:
 > ⚠ *INR 20,000 of that sits against orders an unpaid payout still bills —
 > settle or link it before paying again*
 
+:::tip Acting on it — "Mark N as settling this payout"
+Beside the warning, each recorded payment now carries a one-click action. Using
+it states that **this payment discharges this payout** — after which:
+
+- the money counts toward **paid**, so a payout of INR 28,200 with INR 20,000
+  linked reads *paid 20,000 · outstanding 8,200*
+- it stops being "recorded separately" and stops raising the warning
+- the payout stays **Approved**, which is now honest: partly settled, not
+  fully
+
+🔑 This is the only way a payout can be settled in **part**. Before it existed
+the model could only say `Approved` (0 paid, the reading that pays twice) or
+`Paid` (the whole amount, when only some of it moved). Neither was true.
+
+⚠️ Only a **Completed** payment settles anything. A `Pending` one — the status
+the partner portal writes — still raises the warning but contributes nothing to
+`paid`, because a partner must not be able to move their own paid figure by
+asserting they were paid. Marking it Completed is a separate, deliberate act.
+:::
+
 :::danger Do not pay past this line without checking
 The system deliberately **does not** subtract that money from `outstanding`. An
 advance and a payout can legitimately coexist, and no screen may quietly decide
 that one discharges the other. Only a human can say so — by linking the payment
-to the submission it settles (`paymentSubmissionIds` on
-`POST /admin/payments/link`). Once linked, it shows on the payout as
-"settled by" and drops out of "recorded separately".
+to the submission it settles (the "Mark … as settling this payout" action, or
+`POST /admin/payments/:id/settles`). Once linked, the money counts toward
+`paid` and drops out of "recorded separately".
 :::
 
 ### Where the ledger reads from

--- a/apps/docs/docs/guides/partner-portal/getting-paid.md
+++ b/apps/docs/docs/guides/partner-portal/getting-paid.md
@@ -74,6 +74,21 @@ wrong, that is a conversation to have before billing — the cap is not
 negotiable through this screen.
 :::
 
+:::danger "⚠ N already paid on this order"
+Someone has already recorded a payment against this order — possibly for these
+very goods. The row is **still tickable**, deliberately: a payment on an order
+is not always payment for the claim you are about to make (it may be an advance,
+a deposit, or money for a different delivery on the same order). But billing
+again for goods already settled is the mistake this row can cause, so check
+before you submit.
+
+This is not hypothetical. One live order shows **INR 9,800 paid since March
+against INR 0 ever billed** — so the screen was offering INR 5,800 of an order
+that had already been settled in full. The billable ceiling measures what has
+been *billed* against what was *ordered*; it has no knowledge of what has been
+*paid*. That is why the warning exists and why it is only a warning.
+:::
+
 :::warning Rows you cannot tick
 A greyed row says why underneath:
 
@@ -180,6 +195,23 @@ different questions. The order page is scoped to one order; the ledger is
 scoped to one partner. They should agree on any payment they can both see — if
 they do not, say so rather than trusting the larger number.
 :::
+
+## Quick reference
+
+## Why "paid" and "billed" are tracked separately
+
+A recurring source of confusion, worth stating plainly:
+
+- **Recording a payment never creates a payout.** The three places you can
+  record one — the partner page, the inventory order page, and the partner
+  portal's Submit Payment — all write a payment row and nothing else. No claim
+  is raised, nothing enters review.
+- **Approving a payout never records a payment.** Since #1638 approval writes no
+  payment row at all; `Paid` is set when the reconciliation is settled.
+
+So the two records are joined only when a human joins them. Everything above —
+the ledger warning, the "already paid on this order" note — exists because
+nothing does it automatically, and the system deliberately refuses to guess.
 
 ## Quick reference
 

--- a/apps/partner-ui/src/hooks/api/partner-payable-inventory-orders.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payable-inventory-orders.tsx
@@ -39,6 +39,17 @@ export interface PayableInventoryOrder {
   amount: number
   /** Whether `amount` is below `receipts_total` because the ceiling bit. */
   capped_by_ceiling: boolean
+  /**
+   * Money already PAID against this order (#1710).
+   *
+   * 🔴 The billable ceiling measures CLAIMS against the ordered total and has
+   * no term for payments, so an order already settled but never billed is
+   * offered here as freshly payable. Live on prod: INR 9,800 recorded since
+   * March against INR 0 claimed, and this list offered INR 5,800 of it.
+   */
+  recorded_total: number
+  /** Whether what has already been paid meets or exceeds what this row bills. */
+  recorded_covers_amount: boolean
   order_date: string | null
   expected_delivery_date: string | null
   /**

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -1360,6 +1360,22 @@ const InventoryOrderRow = ({
             </Text>
           </Tooltip>
         )}
+        {!blocked && order.recorded_covers_amount && (
+          /**
+           * 🔴 #1710 — money already paid against this order.
+           *
+           * Not a block: a payment on an order is not necessarily payment for
+           * THIS claim, and refusing would stop a legitimate bill. But billing
+           * again for goods already settled is the mistake this row can cause,
+           * so it must not be silent.
+           */
+          <Tooltip content="Someone has already recorded a payment against this order. If that payment was for these goods, you may have been paid already — check before billing.">
+            <Text size="xsmall" className="mt-1 text-ui-tag-orange-text">
+              ⚠ {order.recorded_total.toLocaleString()} already paid on this
+              order
+            </Text>
+          </Tooltip>
+        )}
         {!blocked && order.claimed_total > 0 && !order.capped_by_ceiling && (
           <Text size="xsmall" className="mt-1 text-ui-fg-muted">
             {order.claimed_total.toLocaleString()} already claimed on this order


### PR DESCRIPTION
Two defects found by the founder in the data #1711 surfaced. Both are follow-ups to `fa2c13e17`.

---

# 1. The payable-orders screen offered an order that was already paid for

## 🔴 Live on prod

```
inv_order_01KKB850WN…   ordered 9,800 · receipts 5,800 · claimed 0
                        · RECORDED 9,800 (since March 2026)
```

`payable-inventory-orders` offered **INR 5,800 of an order already settled in full.** The billable ceiling is `ordered_total − claimed_total` — it measures what has been **BILLED** against what was **ORDERED** and has **no term for `internal_payments` at all**.

This got sharper with `fa2c13e17`, which gave partners a **Goods** tab — the first screen from which a partner could act on that row.

## The fix — report, never net

`recorded_total` + `recorded_covers_amount` on every row, rendered as `⚠ 9,800 already paid on this order` in both the admin grid and the partner Goods row. **The offer is unchanged** — the test asserts `ordered_total`, `remaining` and `amount` are identical before and after a payment is recorded. Not blocked either: refusing would stop a legitimate claim on evidence that does not exist.

`sumRecordedPayments` is pure and covers `Failed`/`Cancelled` exclusion, `Pending` **inclusion** (what the partner portal writes — over-warn), the bare-object to-many, `NaN` poisoning, and two-decimal money.

---

# 2. 🔴 The submission↔payment link shipped INERT in #1711

`paymentSubmissionIds` wrote its link row correctly and the ledger could not see a single one. Two successful `remoteLink.create` calls and a 200 from the route still read back `paid: 0` — with **no error anywhere**.

The cause was the READ, and the working example was three sources above the broken one **in the same file**:

```ts
// ❌ returns the rows with NO `payments` key. Silent.
query.graph({ entity: "payment_submission", fields: ["payments.*"] })

// ✅ what source 1 (PartnerPaymentsLink) already did
query.graph({ entity: SubmissionPaymentLink.entryPoint,
              filters: { payment_submission_id: ids },
              fields: ["internal_payments.*"] })
```

🔑 **A link that writes fine and reads empty is indistinguishable from a link that cannot be written.** That is almost certainly why nobody built the writer for two months — and why the table's emptiness attracted two separate wrong explanations, both mine: first *"the 73-char name was never created"* (false — Medusa abbreviates and hashes), then *"the two-hop traversal fails"* (false — I shipped a fix for it and nothing changed).

⚠️ My #1711 unit tests passed on a fixture with `submission_id` already populated. **A fold test cannot prove a query works.** Only a container round-trip could; this adds one.

## A payout settled in PART

Parmar's payout is INR 28,200 with INR 20,000 moved. The model had no honest reading — `Approved` says 0 paid and 28,200 outstanding (the reading that pays twice), `Paid` claims 28,200 moved when 8,200 is owed.

`paid` now counts money a human **linked** to the payout, capped at its amount:

> **billed 28,200 · paid 20,000 · outstanding 8,200** — and the payout stays `Approved`, which is the truth.

- Status and links never both count — a `Paid` payout with a linked payment would otherwise report a **negative** outstanding.
- A reconciliation-derived association is provenance, not settlement; historical numbers stay byte-identical.

### 🔴 Only `Completed` settles

`Pending` is what the partner portal writes on a payment a partner records themselves. Counting it would let a partner move their own `paid` figure by asserting they had been paid.

| | counts `Pending`? | why |
|---|---|---|
| `recorded_against_open` (warning) | **yes** | a warning should over-fire |
| `settled_amount` → `paid` | **no** | a settlement must not |

## `POST /admin/payments/:id/settles` (+ `DELETE`)

`paymentSubmissionIds` only worked at **creation** — every payment already in the system, including the two INR 10,000 rows that opened #1710, had no way to state what it settles.

- Both ends validated (#778): the URL id **and** the body id.
- A `Rejected` payout refuses — never owed, so nothing settles it.
- Idempotent: `link.create` raises on the composite PK, so dismiss-first makes re-stating the same fact a no-op rather than a 500.
- ⚠️ Its middleware entry **must precede** `/admin/payments/:id`, whose validator is `.strict()` and whose matcher is a prefix. A test fails loudly if that order is disturbed.

## And a screen for it

**"Mark INR 10,000 as settling this payout"** — one click per payment, directly under the warning naming it. A warning with no action beside it becomes wallpaper, and a capability with no screen is no capability (#1612).

---

## Also answered

**Creating a payment never creates a payment submission.** All three paths write an `internal_payments` row and nothing else:

| UI | sends | creates a submission? |
|---|---|---|
| Partner page → Add payment | `partnerIds` | no |
| Inventory order → Add payment | `inventoryOrderIds` **only** | no |
| Partner portal → Submit Payment | `inventoryOrderIds` **only** | no |

Only the two submission routes and `auto-draft-run-payout` create a payout. The middle row sends no `partnerIds` — that is how #1710's invisible money was made. Now stated plainly in the guide.

## Verify

```
TEST_TYPE=unit npx jest --testPathPattern="payment|ledger"
pnpm test:integration:http:shared ./integration-tests/http/payment-submissions-api.spec.ts
```

- **135 integration** (6 new) and **500 unit** (18 new) green
- tsc at the **50-error baseline**, `check:prod-build` passed, partner-ui and docs build
- The payable-orders test was verified to FAIL on the old code (`Expected: 1000, Received: 0`); the settles tests failed on the entity-traversal read and pass on the entry-point read

## After merge

Two calls make the Parmar correction real:

```
POST /admin/payments/01KXBCRTFZB7P4G70XMYMKBWT1/settles {"payment_submission_id":"01M13T9D9AGDA3QJYCXEZ942W7"}
POST /admin/payments/01M1BQGVGCTVVB7BKSMBK39G3Q/settles {"payment_submission_id":"01M13T9D9AGDA3QJYCXEZ942W7"}
```

Both payments are `Completed`. Expected after: `paid: 20000`, `outstanding: 8200`, `recorded_against_open: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4