### PR TITLE
fix(payments): a payment could settle another partner's payout (#1712)

### DIFF
--- a/apps/backend/src/api/admin/payments/[id]/settles/__tests__/same-partner.unit.spec.ts
+++ b/apps/backend/src/api/admin/payments/[id]/settles/__tests__/same-partner.unit.spec.ts
@@ -1,0 +1,181 @@
+import {
+  decideSamePartner,
+  resolvePaymentOwners,
+} from "../same-partner"
+
+describe("decideSamePartner (#1712)", () => {
+  it("refuses a payment demonstrably owned by another partner", () => {
+    const d = decideSamePartner(["partner_A"], "partner_B")
+    expect(d.allowed).toBe(false)
+    expect(d.owners).toEqual(["partner_A"])
+  })
+
+  it("allows when the owner matches", () => {
+    expect(decideSamePartner(["partner_A"], "partner_A").allowed).toBe(true)
+  })
+
+  /**
+   * A payment can be reached through more than one home, and the homes can
+   * legitimately disagree in COUNT while agreeing that this partner is one of
+   * the owners.
+   */
+  it("allows when the submission's partner is one of several owners", () => {
+    expect(
+      decideSamePartner(["partner_A", "partner_B"], "partner_B").allowed
+    ).toBe(true)
+  })
+
+  /**
+   * 🔑 The deliberate hole. Historical rows carry no owner at all and are the
+   * ones reconciliation needs to link; refusing them would block the work.
+   */
+  it("allows an unattributable payment", () => {
+    expect(decideSamePartner([], "partner_B").allowed).toBe(true)
+    expect(decideSamePartner([null, undefined, ""], "partner_B").allowed).toBe(
+      true
+    )
+  })
+
+  it("allows when the submission has no partner to compare against", () => {
+    expect(decideSamePartner(["partner_A"], null).allowed).toBe(true)
+    expect(decideSamePartner(["partner_A"], "").allowed).toBe(true)
+  })
+
+  it("dedupes owners reported by several homes", () => {
+    expect(decideSamePartner(["p", "p", "p"], "q").owners).toEqual(["p"])
+  })
+})
+
+const LINKS = {
+  partnerPayments: { entryPoint: "partner_payments" },
+  orderPayments: { entryPoint: "order_payments" },
+  partnerOrders: { entryPoint: "partner_orders" },
+  partnerMethods: { entryPoint: "partner_methods" },
+}
+
+describe("resolvePaymentOwners — the three homes (#1712)", () => {
+  it("reads the PARTNER link", async () => {
+    const graph = jest.fn(async ({ entity }: any) =>
+      entity === "partner_payments"
+        ? { data: [{ partner_id: "partner_A" }] }
+        : { data: [] }
+    )
+    expect(await resolvePaymentOwners({ graph }, LINKS, "pay_1")).toEqual([
+      "partner_A",
+    ])
+  })
+
+  /**
+   * 🔴 Asserted OUTSIDE the mock, deliberately. Each home is wrapped in a
+   * best-effort `catch {}`, which swallows a failing `expect()` raised inside
+   * the mock and turns the test into a vacuous pass — verified by mutation:
+   * renaming the filter key to `internal_payment_id` kept the suite green.
+   *
+   * The link entry-point convention `<module_model>_id` is not type-checked, so
+   * a wrong name returns no rows, no error, and a guard that never fires.
+   */
+  it("filters each home by the exact link entry-point field name", async () => {
+    const graph = jest.fn(async ({ entity }: any) => {
+      if (entity === "order_payments")
+        return { data: [{ inventory_orders_id: "inv_order_1" }] }
+      return { data: [] }
+    })
+    await resolvePaymentOwners({ graph }, LINKS, "pay_1", "method_1")
+
+    const byEntity = Object.fromEntries(
+      graph.mock.calls.map((c: any) => [c[0].entity, c[0]])
+    )
+    expect(byEntity["partner_payments"].filters).toEqual({
+      internal_payments_id: "pay_1",
+    })
+    expect(byEntity["order_payments"].filters).toEqual({
+      internal_payments_id: "pay_1",
+    })
+    expect(byEntity["partner_orders"].filters).toEqual({
+      inventory_orders_id: ["inv_order_1"],
+    })
+    expect(byEntity["partner_methods"].filters).toEqual({
+      internal_payment_details_id: "method_1",
+    })
+    for (const call of graph.mock.calls) {
+      expect(call[0].fields).toBeDefined()
+    }
+  })
+
+  /**
+   * 🔴 `submit-payment` writes ONLY the order link, so Parmar's two INR 10,000
+   * rows are reachable through nothing else. Two hops: payment → order →
+   * partner.
+   */
+  it("reads the INVENTORY ORDER link, then that order's partner", async () => {
+    const query = {
+      graph: jest.fn(async ({ entity, filters }: any) => {
+        if (entity === "order_payments") {
+          return { data: [{ inventory_orders_id: "inv_order_1" }] }
+        }
+        if (entity === "partner_orders") {
+          return { data: [{ partner_id: "partner_B" }] }
+        }
+        return { data: [] }
+      }),
+    }
+    expect(await resolvePaymentOwners(query, LINKS, "pay_2")).toEqual([
+      "partner_B",
+    ])
+  })
+
+  /** On production this is the ONLY home for 6 of 35 payments. */
+  it("reads the paid_to METHOD link", async () => {
+    const query = {
+      graph: jest.fn(async ({ entity, filters }: any) => {
+        if (entity === "partner_methods") {
+          return { data: [{ partner_id: "partner_C" }] }
+        }
+        return { data: [] }
+      }),
+    }
+    expect(await resolvePaymentOwners(query, LINKS, "pay_3", "method_1")).toEqual(
+      ["partner_C"]
+    )
+  })
+
+  it("skips the method home when the payment has no paid_to", async () => {
+    const graph = jest.fn(async () => ({ data: [] }))
+    await resolvePaymentOwners({ graph }, LINKS, "pay_4", null)
+    const entities = graph.mock.calls.map((c: any) => c[0].entity)
+    expect(entities).not.toContain("partner_methods")
+  })
+
+  /**
+   * ⚠️ Best-effort per home: an understated owner set is permissive, never a
+   * false refusal. One throwing home must not lose the others.
+   */
+  it("survives a throwing home and still reports the others", async () => {
+    const query = {
+      graph: jest.fn(async ({ entity }: any) => {
+        if (entity === "partner_payments") throw new Error("graph hiccup")
+        if (entity === "partner_methods")
+          return { data: [{ partner_id: "partner_D" }] }
+        return { data: [] }
+      }),
+    }
+    expect(await resolvePaymentOwners(query, LINKS, "pay_5", "m")).toEqual([
+      "partner_D",
+    ])
+  })
+
+  it("unions and dedupes across homes", async () => {
+    const query = {
+      graph: jest.fn(async ({ entity }: any) => {
+        if (entity === "partner_payments")
+          return { data: [{ partner_id: "partner_A" }] }
+        if (entity === "partner_methods")
+          return { data: [{ partner_id: "partner_A" }] }
+        return { data: [] }
+      }),
+    }
+    expect(await resolvePaymentOwners(query, LINKS, "pay_6", "m")).toEqual([
+      "partner_A",
+    ])
+  })
+})

--- a/apps/backend/src/api/admin/payments/[id]/settles/route.ts
+++ b/apps/backend/src/api/admin/payments/[id]/settles/route.ts
@@ -5,10 +5,15 @@ import {
 } from "@medusajs/framework/utils"
 import type { Link } from "@medusajs/modules-sdk"
 
+import InventoryOrdersInternalPaymentsLink from "../../../../../links/inventory-orders-internal-payments"
+import PartnerInventoryOrderLink from "../../../../../links/partner-inventory-order"
+import PartnerPaymentMethodsLink from "../../../../../links/partner-payment-methods-link"
+import PartnerPaymentsLink from "../../../../../links/partner-payments-link"
 import { INTERNAL_PAYMENTS_MODULE } from "../../../../../modules/internal_payments"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../modules/payment_submissions"
 import type PaymentSubmissionsService from "../../../../../modules/payment_submissions/service"
 import type InternalPaymentService from "../../../../../modules/internal_payments/service"
+import { decideSamePartner, resolvePaymentOwners } from "./same-partner"
 
 /**
  * POST /admin/payments/:id/settles   { payment_submission_id }
@@ -90,6 +95,47 @@ const resolveBoth = async (
     throw new MedusaError(
       MedusaError.Types.NOT_ALLOWED,
       `Payment submission ${submissionId} was rejected — it is not owed, so no payment can settle it.`
+    )
+  }
+
+  /**
+   * 🔴 BOTH ENDS AGAINST EACH OTHER, not merely both present (#1712).
+   *
+   * Existence checks alone let partner A's money discharge partner B's payout —
+   * this route writes `paid` on the partner ledger, so that mistake pays the
+   * wrong person and leaves a link nobody would think to question. A bulk
+   * reconciliation pass is exactly where an id gets typed one character wrong.
+   *
+   * Permissive when the payment has no traceable owner — see `same-partner.ts`
+   * for why that is deliberate rather than an oversight.
+   */
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  const owners = await resolvePaymentOwners(
+    query,
+    {
+      partnerPayments: PartnerPaymentsLink,
+      orderPayments: InventoryOrdersInternalPaymentsLink,
+      partnerOrders: PartnerInventoryOrderLink,
+      partnerMethods: PartnerPaymentMethodsLink,
+    },
+    String(req.params.id),
+    /**
+     * ⚠️ `paid_to` is a `belongsTo`, so an unexpanded `listPayments` returns the
+     * FK column and NOT the object. Reading only `.paid_to.id` would leave home
+     * 3 permanently unreached — a check that never runs reads as a pass.
+     */
+    (payment as any)?.paid_to?.id ?? (payment as any)?.paid_to_id ?? null
+  )
+
+  const decision = decideSamePartner(owners, (submission as any)?.partner_id)
+  if (!decision.allowed) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Payment ${req.params.id} belongs to partner ${decision.owners.join(
+        ", "
+      )}, but submission ${submissionId} belongs to partner ${
+        (submission as any).partner_id
+      }. A payment cannot settle another partner's payout.`
     )
   }
 }

--- a/apps/backend/src/api/admin/payments/[id]/settles/same-partner.ts
+++ b/apps/backend/src/api/admin/payments/[id]/settles/same-partner.ts
@@ -1,0 +1,157 @@
+/**
+ * May THIS payment settle THAT payout? (#1712)
+ *
+ * ## Why this exists
+ *
+ * `POST /admin/payments/:id/settles` validated that both ids EXIST and that the
+ * payout was not Rejected — and nothing else. Neither end was checked against
+ * the other, so a payment belonging to partner A could be declared to discharge
+ * partner B's payout. The route is the one place a human turns "money moved"
+ * into "this payout is paid", and it decides `paid` on the partner ledger, so an
+ * id typed one character wrong silently pays the wrong person.
+ *
+ * That is the #778 shape — a request naming two ids that checks one — and it
+ * matters more here than for a read, because a bulk reconciliation pass makes
+ * exactly this mistake easy and near-invisible afterwards.
+ *
+ * ## Why it is PERMISSIVE when the payment has no owner
+ *
+ * 🔑 A payment can legitimately belong to nobody the graph can name. The
+ * historical `internal_payments` rows carry no partner link, no order link and
+ * sometimes no payment method — they predate every link this codebase has. On
+ * production, 6 of 35 payments are reachable ONLY through `paid_to`, and older
+ * rows not even that.
+ *
+ * Refusing those would block the reconciliation work this guard exists to make
+ * safe. So the rule is: refuse only when the payment DEMONSTRABLY belongs to
+ * someone else. An unattributable payment is still allowed, because we cannot
+ * prove a mismatch and the operator is asserting the fact deliberately.
+ *
+ * ⚠️ That is a real hole, and a narrow one: it lets an unlinked payment settle
+ * any partner's payout. Closing it needs every payment to carry an owner, which
+ * is a backfill, not a guard.
+ */
+export type SamePartnerDecision = {
+  allowed: boolean
+  /** Every partner the payment can be traced to, deduped. */
+  owners: string[]
+}
+
+/**
+ * PURE, so the rule can be tested without a graph behind it — the resolution
+ * below is best-effort and its failure modes are not the interesting part.
+ */
+export const decideSamePartner = (
+  owners: Array<string | null | undefined>,
+  submissionPartnerId: string | null | undefined
+): SamePartnerDecision => {
+  const set = [
+    ...new Set(
+      (owners || [])
+        .filter((o) => o !== null && o !== undefined && String(o).trim() !== "")
+        .map((o) => String(o))
+    ),
+  ]
+
+  /**
+   * ⚠️ A payout with no partner is not a thing this route can adjudicate, and
+   * `undefined !== "x"` would refuse every such call. Allow and let the
+   * existing checks stand.
+   */
+  if (!submissionPartnerId || String(submissionPartnerId).trim() === "") {
+    return { allowed: true, owners: set }
+  }
+
+  if (set.length === 0) return { allowed: true, owners: set }
+
+  return { allowed: set.includes(String(submissionPartnerId)), owners: set }
+}
+
+/**
+ * Every partner a payment can be traced to, across the homes a payment can
+ * live in. Best-effort per home, for the same reason the ledger is: losing one
+ * home understates ownership, and an understated owner set is PERMISSIVE here
+ * (see `decideSamePartner`) rather than a false refusal.
+ *
+ * 🔴 The homes are the ones #1710 established, plus `paid_to`:
+ *   1. the partner link       — payments recorded against the partner directly
+ *   2. the inventory-order link → that order's partner (`submit-payment` writes
+ *      ONLY this one, so Parmar's two INR 10,000 rows live here and nowhere else)
+ *   3. the paid_to payment METHOD → its partner — on production this is the
+ *      ONLY home for 6 of 35 payments, and the ledger cannot see it at all.
+ *
+ * ⚠️ Field names are the link entry-point convention `<module_model>_id`, which
+ * is not type-checked. A wrong name yields no rows, no error, and a guard that
+ * never fires — so each home is asserted in the unit tests by shape, and the
+ * route is probed cross-partner after deploy.
+ */
+export const resolvePaymentOwners = async (
+  query: any,
+  links: {
+    partnerPayments: any
+    orderPayments: any
+    partnerOrders: any
+    partnerMethods: any
+  },
+  paymentId: string,
+  paidToId?: string | null
+): Promise<string[]> => {
+  const owners: string[] = []
+
+  // ── 1. the PARTNER link ────────────────────────────────────────────────
+  try {
+    const { data } = await query.graph({
+      entity: links.partnerPayments.entryPoint,
+      fields: ["partner_id"],
+      filters: { internal_payments_id: paymentId },
+    })
+    for (const row of data || []) if (row?.partner_id) owners.push(String(row.partner_id))
+  } catch {
+    // best-effort; see above
+  }
+
+  // ── 2. the INVENTORY ORDER link, then that order's partner ─────────────
+  try {
+    const { data: orderRows } = await query.graph({
+      entity: links.orderPayments.entryPoint,
+      fields: ["inventory_orders_id"],
+      filters: { internal_payments_id: paymentId },
+    })
+    const orderIds = [
+      ...new Set(
+        (orderRows || [])
+          .map((r: any) => r?.inventory_orders_id)
+          .filter(Boolean)
+          .map(String)
+      ),
+    ]
+    if (orderIds.length) {
+      const { data: partnerRows } = await query.graph({
+        entity: links.partnerOrders.entryPoint,
+        fields: ["partner_id"],
+        filters: { inventory_orders_id: orderIds },
+      })
+      for (const row of partnerRows || [])
+        if (row?.partner_id) owners.push(String(row.partner_id))
+    }
+  } catch {
+    // best-effort; see above
+  }
+
+  // ── 3. the paid_to METHOD link ─────────────────────────────────────────
+  if (paidToId) {
+    try {
+      const { data } = await query.graph({
+        entity: links.partnerMethods.entryPoint,
+        fields: ["partner_id"],
+        filters: { internal_payment_details_id: String(paidToId) },
+      })
+      for (const row of data || [])
+        if (row?.partner_id) owners.push(String(row.partner_id))
+    } catch {
+      // best-effort; see above
+    }
+  }
+
+  return [...new Set(owners)]
+}


### PR DESCRIPTION
## The defect

`POST /admin/payments/:id/settles` validated that both ids EXIST and that the payout was not Rejected — and nothing else. **Neither end was checked against the other**, so partner A's money could be declared to discharge partner B's payout.

The route writes `paid` on the partner ledger, so that mistake pays the wrong person and leaves a link nobody would think to question afterwards. It is the #778 shape — a request naming two ids that checks one — and it matters most during exactly the work this route exists for: a bulk reconciliation pass, where an id typed one character wrong is easy and near-invisible.

Found while reconciling the partner estate: 5 `/settles` links were written by hand against verified pairs, but nothing in the route would have caught a wrong one.

## The guard

`resolvePaymentOwners` traces a payment to its partner through every home a payment can live in:

| # | home | why it matters |
|---|---|---|
| 1 | the PARTNER link | the common case |
| 2 | the INVENTORY ORDER link → that order's partner | `submit-payment` writes **only** this one — the two INR 10,000 rows that opened #1710 live here and nowhere else |
| 3 | the `paid_to` payment METHOD → its partner | on production the **only** home for 6 of 35 payments (52,974) — the ledger cannot see it at all |

`decideSamePartner` is pure and refuses only when the payment **demonstrably** belongs to someone else.

## Why it is permissive when the payment has no owner

🔑 Historical `internal_payments` rows carry no partner link, no order link and sometimes no method — they predate every link this codebase has. Refusing them would block the reconciliation this guard exists to make safe. So an unattributable payment is still allowed: we cannot prove a mismatch, and the operator is asserting the fact deliberately.

⚠️ That leaves a narrow hole — an unlinked payment can still settle any partner's payout. Closing it needs every payment to carry an owner, which is a backfill, not a guard.

## Verification

🔴 **The first version of the field-name test was vacuous.** Each home is wrapped in a best-effort `catch {}`, which swallowed the `expect()` raised inside the mock — renaming the filter key to `internal_payment_id` kept the suite green. The assertions now run **outside** the mock, and the mutation fails as it should. The link entry-point convention `<module_model>_id` is not type-checked, so a wrong name returns no rows, no error, and a guard that never fires.

- Mutation-checked both halves: forcing `allowed: true` fails the refusal test; a wrong filter key fails the field-name test
- 13 unit tests, 81 green across `payments|payment-submissions`
- `check:prod-build` passed

## Follow-ups (not in this PR)

- Ledger is blind to the `paid_to` → method path — under-reports `recorded` by 47,974
- `paid` double-counts a payment linked to two payouts (the clamp is per-payout)
- Partial orders are re-billable: `amount = min(receipts, ordered − claimed)` never nets receipts already claimed

Refs #1712, #1710, #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4