### PR TITLE
fix(payments): a partial order could be billed for the same receipts again (#1712)

### DIFF
--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/payable-inventory-orders.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/payable-inventory-orders.unit.spec.ts
@@ -1,0 +1,151 @@
+import { listPayableInventoryOrders } from "../payable-inventory-orders"
+import { listPartnerClaims } from "../run-claims"
+
+jest.mock("../run-claims", () => ({
+  listPartnerClaims: jest.fn(),
+}))
+
+/**
+ * The real shape of hrhandloom's `inv_order_01K36TE2WB` as read from production
+ * on 2026-09-01: ordered 88,885, receipts 25,620 across five of ten lines, and
+ * ALREADY CLAIMED at 25,670 by submission `01M13T8NVJ`.
+ *
+ * 🔑 A fixture tidier than reality certifies the wrong code. The awkward parts
+ * are the point: two deltas on one line (10 + 6), a fractional receipt (11.8),
+ * and claims that very slightly EXCEED receipts because the payout was computed
+ * before the #1613 rounding fix moved 12 to 11.8.
+ */
+const PARTIAL_ORDER = {
+  id: "inv_order_01K36TE2WB",
+  status: "Partial",
+  total_price: 88885,
+  currency_code: "inr",
+  orderlines: [
+    { id: "l1", quantity: 16, price: 400, material_name: "Double Black Stripes", line_fulfillments: [{ quantity_delta: 10 }, { quantity_delta: 6 }] },
+    { id: "l2", quantity: 31, price: 430, material_name: "White & Black & Red", line_fulfillments: [{ quantity_delta: 10 }] },
+    { id: "l3", quantity: 22, price: 380, material_name: "Black & Red line", line_fulfillments: [{ quantity_delta: 10.5 }] },
+    { id: "l4", quantity: 21, price: 380, material_name: "Single Black Cheque", line_fulfillments: [{ quantity_delta: 21 }] },
+    { id: "l5", quantity: 50, price: 250, material_name: "Kala cotton white", line_fulfillments: [{ quantity_delta: 11.8 }] },
+    { id: "l6", quantity: 80, price: 380, material_name: "Yellow cheque", line_fulfillments: [] },
+  ],
+  internal_payments: [],
+}
+
+const containerFor = (orders: any[]) => {
+  const query = {
+    graph: jest.fn(async () => ({ data: [{ id: "partner_1", inventory_orders: orders }] })),
+  }
+  return {
+    resolve: (key: string) =>
+      key === "query" || key === "remoteQuery" ? query : ({} as any),
+  } as any
+}
+
+const claimsOf = (map: Record<string, number>) => {
+  ;(listPartnerClaims as jest.Mock).mockResolvedValue({
+    inventoryOrders: new Map(
+      Object.entries(map).map(([id, total]) => [
+        id,
+        { claimed_total: total, claims: [] },
+      ])
+    ),
+  })
+}
+
+beforeEach(() => jest.clearAllMocks())
+
+describe("listPayableInventoryOrders — receipts already claimed (#1712)", () => {
+  /**
+   * 🔴 THE DEFECT. `amount` was `min(receipts, ordered − claimed)`, which nets
+   * against the ORDERED total but never against what was already billed for
+   * those same receipts. On production this offered another 25,620 for goods
+   * billed at 25,670, with ~63,215 of headroom left to repeat it.
+   */
+  it("offers NOTHING when the receipts are already fully claimed", async () => {
+    claimsOf({ "inv_order_01K36TE2WB": 25670 })
+    const [row] = await listPayableInventoryOrders(
+      containerFor([PARTIAL_ORDER]),
+      "partner_1"
+    )
+
+    expect(row.receipts_total).toBe(25620)
+    expect(row.claimed_total).toBe(25670)
+    expect(row.amount).toBe(0)
+    expect(row.payable).toBe(false)
+    // The ceiling has plenty left — it is the CLAIMS that stop this, and the
+    // flag must not blame the ceiling.
+    expect(row.remaining).toBe(63215)
+    expect(row.capped_by_ceiling).toBe(false)
+  })
+
+  it("offers only the receipts not yet claimed", async () => {
+    claimsOf({ "inv_order_01K36TE2WB": 10000 })
+    const [row] = await listPayableInventoryOrders(
+      containerFor([PARTIAL_ORDER]),
+      "partner_1"
+    )
+    expect(row.amount).toBe(15620) // 25,620 − 10,000
+    expect(row.payable).toBe(true)
+  })
+
+  it("offers the full receipts value when nothing is claimed", async () => {
+    claimsOf({})
+    const [row] = await listPayableInventoryOrders(
+      containerFor([PARTIAL_ORDER]),
+      "partner_1"
+    )
+    expect(row.amount).toBe(25620)
+    expect(row.payable).toBe(true)
+  })
+
+  /**
+   * The ordered-total ceiling still binds: receipts can legitimately sit ABOVE
+   * the ordered total (#1617) and `assessInventoryOrderClaims` refuses that.
+   */
+  it("still caps at the ordered-total ceiling, and says so", async () => {
+    const OVER = {
+      ...PARTIAL_ORDER,
+      id: "inv_order_over",
+      total_price: 5000,
+      orderlines: [
+        { id: "x", quantity: 20, price: 400, material_name: "m", line_fulfillments: [{ quantity_delta: 20 }] },
+      ],
+    }
+    claimsOf({})
+    const [row] = await listPayableInventoryOrders(containerFor([OVER]), "partner_1")
+    expect(row.receipts_total).toBe(8000)
+    expect(row.remaining).toBe(5000)
+    expect(row.amount).toBe(5000)
+    expect(row.capped_by_ceiling).toBe(true)
+  })
+
+  it("never offers a negative amount when claims exceed receipts", async () => {
+    claimsOf({ "inv_order_01K36TE2WB": 40000 })
+    const [row] = await listPayableInventoryOrders(
+      containerFor([PARTIAL_ORDER]),
+      "partner_1"
+    )
+    expect(row.amount).toBe(0)
+    expect(row.payable).toBe(false)
+  })
+
+  /**
+   * `recorded_covers_amount` warns that money already moved covers what is
+   * being offered (#1710). With `amount` now netted it must follow the NEW
+   * amount, not the raw receipts.
+   */
+  it("keeps recorded_covers_amount aligned with the netted amount", async () => {
+    claimsOf({ "inv_order_01K36TE2WB": 20000 })
+    const withPayment = {
+      ...PARTIAL_ORDER,
+      internal_payments: [{ id: "p1", amount: 6000, status: "Completed" }],
+    }
+    const [row] = await listPayableInventoryOrders(
+      containerFor([withPayment]),
+      "partner_1"
+    )
+    expect(row.amount).toBe(5620) // 25,620 − 20,000
+    expect(row.recorded_total).toBe(6000)
+    expect(row.recorded_covers_amount).toBe(true)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
@@ -182,18 +182,46 @@ export const listPayableInventoryOrders = async (
           ? null
           : Math.round(Math.max(0, ceiling - claimedTotal) * 100) / 100
 
+      const uncapped = value.total
+
       /**
-       * What this row offers: the receipts value, capped at what is left.
+       * 🔴 The receipts NOT YET CLAIMED — not the receipts figure (#1712).
        *
-       * Capping rather than offering the raw figure is the whole point — but a
-       * silent cap is a reduction nobody decided, so `capped_by_ceiling` says
+       * This offered `min(receipts_total, ordered − claimed)`, which nets what
+       * is billable against the ORDERED total but never against what has
+       * already been billed FOR THOSE SAME RECEIPTS. On a partially-received
+       * order the same goods could therefore be billed again and again until
+       * claims reached the ordered total.
+       *
+       * Live on production: hrhandloom's `inv_order_01K36TE2WB` had receipts
+       * 25,620 already claimed at 25,670, and this route still offered another
+       * 25,620 — roughly 63,215 of re-billable headroom against goods that do
+       * not exist. The operator reading it concluded supply was unpaid.
+       *
+       * 🔑 It never showed on a FULLY claimed order, because there
+       * `remaining` is 0 and the ceiling masked it. Only partially-received
+       * orders were exposed, which is exactly where a partner is mid-delivery
+       * and the screen is consulted most.
+       *
+       * ⚠️ `claimedTotal` counts LIVE claims only — `listPartnerClaims` skips
+       * `Rejected` submissions — so netting against it cannot block a claim
+       * released by a rejection.
+       */
+      const unclaimedReceipts =
+        Math.round(Math.max(0, uncapped - claimedTotal) * 100) / 100
+
+      /**
+       * Still capped at what the ordered-total ceiling leaves, because the
+       * receipts figure can legitimately sit ABOVE the ordered total (#1617)
+       * and `assessInventoryOrderClaims` would refuse it.
+       *
+       * A silent cap is a reduction nobody decided, so `capped_by_ceiling` says
        * it happened and the raw figure stays on the row beside it.
        */
-      const uncapped = value.total
       const amount =
         remaining == null
-          ? uncapped
-          : Math.round(Math.min(uncapped, remaining) * 100) / 100
+          ? unclaimedReceipts
+          : Math.round(Math.min(unclaimedReceipts, remaining) * 100) / 100
 
       /**
        * ⚠️ Computed per order and REPORTED, never folded into `amount`. See
@@ -213,7 +241,13 @@ export const listPayableInventoryOrders = async (
         claimed_total: Math.round(claimedTotal * 100) / 100,
         remaining,
         amount,
-        capped_by_ceiling: remaining != null && uncapped > remaining,
+        /**
+         * ⚠️ Compares the UNCLAIMED receipts, not the raw receipts figure.
+         * Since #1712 `amount` is also reduced by what has already been
+         * claimed, and `uncapped > remaining` would report the ceiling as the
+         * cause whenever prior claims were the real reason.
+         */
+        capped_by_ceiling: remaining != null && unclaimedReceipts > remaining,
         recorded_total: recordedTotal,
         recorded_covers_amount: amount > 0 && recordedTotal >= amount,
         order_date: order.order_date ?? null,


### PR DESCRIPTION
## The defect

`payable-inventory-orders` offered:

```
amount = min(receipts_total, ordered_total − claimed_total)
```

That nets what is billable against the **ordered** total, but never against what has already been billed **for those same receipts**. So on a partially-received order the same goods could be billed again, and again, until claims reached the ordered total.

## Live on production

hrhandloom's `inv_order_01K36TE2WB`:

| | |
|---|---|
| ordered | 88,885 |
| receipts | 25,620 |
| already claimed | 25,670 |
| **still offered** | **another 25,620** |
| headroom to repeat it | ~63,215 |

The operator reading that screen concluded supply was unpaid and asked for it to be paid a second time. It took the full fulfilment history — six deliveries, and two records of them that disagreed — to establish that every receipt was already inside the 28,670 payout.

🔑 **It never showed on a fully-claimed order.** There `remaining` is 0 and the ordered-total ceiling masked it: Parmar's `01KWAKAZE17` (claimed 28,200 of 28,200) correctly reported `payable: false` throughout. Only **partially-received** orders were exposed — exactly where a partner is mid-delivery and the screen is consulted most.

## The fix

```
unclaimedReceipts = max(0, receipts_total − claimed_total)
amount            = min(unclaimedReceipts, remaining)
```

The ordered-total ceiling still binds, because the receipts figure can legitimately sit **above** the ordered total (#1617) and `assessInventoryOrderClaims` refuses that.

⚠️ `capped_by_ceiling` now compares the *unclaimed* receipts — left as it was, it would blame the ceiling whenever prior claims were the real cause.

⚠️ `claimedTotal` counts **live** claims only (`listPartnerClaims` skips `Rejected`), so netting cannot block a claim released by a rejection.

## One home, both surfaces

`listPayableInventoryOrders` is shared — the admin route and `/partners/payment-submissions/payable-inventory-orders` both call it, and `apps/partner-ui` only mirrors the response type. No second copy to drift, and `amount` keeps its shape so no client type changes are needed.

Checked deliberately, given this repo's history of the same logic living in two homes (the partner DataGrid fork, the private `foldPartnerBilling` copy).

## Verification

- **Reverting the fix fails 4 of the 6 new tests**; the 2 that survive cover behaviour that did not change
- Fixture is the real production shape of `01K36TE2WB` — two deltas on one line, a fractional 11.8 receipt, and claims that slightly *exceed* receipts because the payout was computed before the #1613 rounding fix moved 12 to 11.8
- 278 green across `payment_submissions|payable`
- `check:prod-build` passed

## Not in this PR

- Ledger blind to the `paid_to` → method path (under-reports `recorded` by 47,974)
- `paid` double-counts a payment linked to two payouts
- A settled-but-unapproved payout renders a plain `Pending` badge beside a total that counts it as paid

Refs #1712, #1710, #1617, #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4