### PR TITLE
fix(payments): a fully-settled payout rendered a bare "Pending" badge (#1712)

### DIFF
--- a/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
@@ -14,6 +14,7 @@ import { describePaymentLine } from "../../lib/payment-line-source"
 import {
   paymentSubmissionStatusColor,
   paymentSubmissionStatusLabel,
+  payoutSettlementBadge,
 } from "../../lib/payment-submission-status"
 
 /**
@@ -101,6 +102,8 @@ const PayoutRow = ({ entry }: { entry: PartnerLedgerEntry }) => {
     new Set((entry.lines || []).map((line) => describePaymentLine(line).label))
   )
 
+  const settlement = payoutSettlementBadge(entry)
+
   return (
     <div className="flex items-start justify-between py-3">
       <div className="flex flex-col gap-y-1">
@@ -108,6 +111,17 @@ const PayoutRow = ({ entry }: { entry: PartnerLedgerEntry }) => {
           <StatusBadge color={paymentSubmissionStatusColor(entry.status)}>
             {paymentSubmissionStatusLabel(entry.status)}
           </StatusBadge>
+          {settlement && (
+            /**
+             * 🔴 The money, said next to the approval state (#1712). Without
+             * this a fully-settled payout renders a bare "Pending" directly
+             * above a footer reading "paid", and the row reads as a
+             * double-count to anyone who trusts the badge.
+             */
+            <StatusBadge color={settlement.color}>
+              {settlement.label}
+            </StatusBadge>
+          )}
           <Text size="small" className="text-ui-fg-subtle">
             {labels.length ? labels.join(", ") : "No lines"}
           </Text>

--- a/apps/backend/src/admin/lib/__tests__/payout-settlement-badge.unit.spec.ts
+++ b/apps/backend/src/admin/lib/__tests__/payout-settlement-badge.unit.spec.ts
@@ -1,0 +1,64 @@
+import { payoutSettlementBadge } from "../payment-submission-status"
+
+/**
+ * The real states the 2026-09-01 reconciliation produced on Prince Tailors.
+ */
+describe("payoutSettlementBadge (#1712)", () => {
+  it("says 'settled' for a fully-settled payout still awaiting approval", () => {
+    // The exact row that read a bare "Pending" above a footer saying "paid".
+    expect(
+      payoutSettlementBadge({ status: "Pending", amount: 3250, settled_amount: 3250 })
+    ).toEqual({ label: "settled", color: "green" })
+  })
+
+  it("says 'part settled' when only some of the money has arrived", () => {
+    // Parmar: 28,200 billed, 20,000 linked.
+    expect(
+      payoutSettlementBadge({ status: "Approved", amount: 28200, settled_amount: 20000 })
+    ).toEqual({ label: "part settled", color: "blue" })
+  })
+
+  /** `Paid` already says the money arrived; a second badge is noise. */
+  it("stays silent for a Paid payout", () => {
+    expect(
+      payoutSettlementBadge({ status: "Paid", amount: 1000, settled_amount: 1000 })
+    ).toBeNull()
+  })
+
+  it("stays silent when nothing has been settled", () => {
+    expect(
+      payoutSettlementBadge({ status: "Pending", amount: 1250, settled_amount: 0 })
+    ).toBeNull()
+    expect(
+      payoutSettlementBadge({ status: "Pending", amount: 1250 })
+    ).toBeNull()
+  })
+
+  it("stays silent for a payout with no amount to compare against", () => {
+    expect(
+      payoutSettlementBadge({ status: "Pending", amount: 0, settled_amount: 500 })
+    ).toBeNull()
+  })
+
+  /**
+   * ⚠️ `settled_amount` is a rounded sum of payment rows while the payout total
+   * is stored separately. An exact `>=` would call this "part settled".
+   */
+  it("treats a sub-cent rounding difference as fully settled", () => {
+    expect(
+      payoutSettlementBadge({ status: "Pending", amount: 3250, settled_amount: 3249.999 })
+    ).toEqual({ label: "settled", color: "green" })
+  })
+
+  it("does not round away a real shortfall", () => {
+    expect(
+      payoutSettlementBadge({ status: "Pending", amount: 3250, settled_amount: 3249 })
+    ).toEqual({ label: "part settled", color: "blue" })
+  })
+
+  it("survives non-numeric input rather than rendering NaN", () => {
+    expect(
+      payoutSettlementBadge({ status: "Pending", amount: null, settled_amount: null })
+    ).toBeNull()
+  })
+})

--- a/apps/backend/src/admin/lib/payment-submission-status.ts
+++ b/apps/backend/src/admin/lib/payment-submission-status.ts
@@ -42,3 +42,52 @@ export const paymentSubmissionStatusColor = (
 export const paymentSubmissionStatusLabel = (
   status: string | null | undefined
 ): string => (status ? String(status).replace("_", " ") : "Unknown")
+
+/**
+ * The SECOND thing a payout row has to say: has the money arrived?
+ *
+ * 🔴 A payout's `status` answers "how far through approval is this", and the
+ * ledger's `paid` total answers "has the money moved". They are different
+ * axes, and the row rendered only the first — so a payout reading **Pending**
+ * sat directly above a footer reading *"₹1,000.00 paid"*. The founder read
+ * that as a double-count and asked whether approving it would make the total
+ * 2,000. It would not; but a row that prompts that question is wrong.
+ *
+ * That state is not exotic. It is what recording historical money against work
+ * paid out of band always produces, and the 2026-09-01 reconciliation created
+ * three of them in one afternoon. It will recur every time.
+ *
+ * 🔑 This is the slim survivor of "one payout, three records, three statuses"
+ * (#1636): the records were merged, but two different questions still share one
+ * row. So answer both, side by side, rather than letting the approval state
+ * silently contradict the money.
+ *
+ * ⚠️ Returns null for `Paid` — that status already says the money arrived, and
+ * a second badge beside it is noise.
+ */
+export type PayoutSettlementBadge = {
+  label: string
+  color: PaymentSubmissionStatusColor
+} | null
+
+export const payoutSettlementBadge = (entry: {
+  status?: string | null
+  amount?: number | null
+  settled_amount?: number | null
+}): PayoutSettlementBadge => {
+  const amount = Number(entry.amount ?? 0)
+  const settled = Number(entry.settled_amount ?? 0)
+
+  if (!Number.isFinite(amount) || amount <= 0) return null
+  if (!Number.isFinite(settled) || settled <= 0) return null
+  if (String(entry.status ?? "") === "Paid") return null
+
+  /**
+   * ⚠️ A cent of tolerance. `settled_amount` is a rounded sum of payment rows
+   * and the payout total is stored separately; an exact `>=` would report a
+   * fully-settled payout as merely partial on a rounding difference.
+   */
+  if (settled + 0.005 >= amount) return { label: "settled", color: "green" }
+
+  return { label: "part settled", color: "blue" }
+}


### PR DESCRIPTION
## The problem, as the founder hit it

A payout's `status` answers *"how far through approval is this"*. The ledger's `paid` total answers *"has the money moved"*. Two different axes — and the row rendered only the first.

So a payout reading **Pending** sat directly above a footer reading **"₹1,000.00 paid"**, and the founder asked:

> "If I approve the payment for the 1000 the payment would be shown 1000 on the partner adding 1000 ? =2000 which is wrong ?"

It would not double — `foldPartnerLedger` counts a payout by status **or** by what is linked to it, never both, and that guard is explicit and commented. Verified empirically on production: approving the payout moved it `Pending → Paid` and `paid` stayed at 1,000.

But a row that prompts that question is wrong, and answering it required reading the fold.

## Why this state will recur

It is what recording historical money against work paid out of band always produces. The 2026-09-01 partner reconciliation created three in one afternoon:

| payout | amount | settled | status |
|---|---|---|---|
| Tangaliya Weave Skirt 3 | 3,250 | 3,250 | `Pending` |
| Jacket With Embroidery | 1,250 | 1,250 | `Pending` |
| Flowy Skirt | 1,000 | 1,000 | `Pending` → approved |

🔑 This is the slim survivor of **"one payout, three records, three statuses"** (#1636). The records were merged; two different questions still share one row.

## The change

`payoutSettlementBadge` — pure, added to the lib that already owns payout status colouring, because the moment each screen decides for itself the screens disagree.

- **`settled`** (green) — linked money covers the payout
- **`part settled`** (blue) — some has arrived (Parmar: 20,000 of 28,200)
- **nothing** for `Paid`, which already says the money arrived, and nothing when no money is linked

⚠️ A cent of tolerance: `settled_amount` is a rounded sum of payment rows while the payout total is stored separately, so an exact `>=` would report a fully-settled payout as merely partial on a rounding difference. A real 1-rupee shortfall still reads "part settled".

## Verification

- 8 unit tests over the real states this reconciliation produced, including the rounding boundary in both directions
- 15 green across the ledger section
- `check:prod-build` passed

Display-only — no money logic changes.

Refs #1712, #1636, #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4