### PR TITLE
feat(mcp): the partner money surface — ledger, payable work/goods, credits, settlement (#1712)

### DIFF
--- a/apps/backend/integration-tests/http/admin-mcp/admin-mcp-partner-money.spec.ts
+++ b/apps/backend/integration-tests/http/admin-mcp/admin-mcp-partner-money.spec.ts
@@ -1,0 +1,279 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user"
+
+jest.setTimeout(120000)
+
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+
+const rpc = (method: string, params: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  params,
+})
+
+/**
+ * The partner-money MCP surface, end to end (#1712).
+ *
+ * ## Why this runs against real routes rather than a dry_run plan
+ *
+ * `partner-money-tools.unit.spec.ts` proves each row plans the right request.
+ * It cannot prove the request WORKS — and that is the gap this whole issue was
+ * born in: `payment_submission ↔ internal_payments` was written correctly and
+ * read back empty for two months, because the read used the wrong query shape.
+ * A fold test, a plan test and a green suite were all silent about it.
+ *
+ * So the assertion that matters here is the round trip: link a payment to a
+ * payout through the tool, and watch `paid` MOVE on the ledger the tool reads.
+ * Then unlink, and watch it move back — which is also the only thing that can
+ * prove the DELETE tool sends `payment_submission_id` where the route looks for
+ * it, since a DELETE that finds no id 400s in a way a `dry_run` never shows.
+ */
+setupSharedTestSuite(() => {
+  describe("Admin MCP — partner money tools (#1710/#1712)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    let auth: { headers: Record<string, string> }
+    let partnerId: string
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      auth = await getAuthHeaders(api)
+
+      const container = getContainer()
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const partnerService: any = container.resolve("partner")
+      const partner = await partnerService.createPartners({
+        name: `Money MCP ${unique}`,
+        handle: `money-mcp-${unique}`,
+      })
+      partnerId = partner.id
+    })
+
+    const mcp = (body: any) =>
+      api.post("/admin/mcp", body, {
+        headers: { ...MCP_HEADERS, ...auth.headers },
+      })
+
+    const parse = (res: any) => JSON.parse(res.data.result.content[0].text)
+
+    const callTool = (name: string, args: Record<string, unknown>) =>
+      mcp(rpc("tools/call", { name, arguments: args }))
+
+    const ledger = async () => {
+      const res = await callTool("get_partner_ledger", { id: partnerId })
+      const payload = parse(res)
+      expect(payload.ok).toBe(true)
+      return payload.data.totals
+    }
+
+    it("tools/list exposes the four reads and both link writes", async () => {
+      const res = await mcp(rpc("tools/list", {}))
+      expect(res.status).toBe(200)
+      const names = (res.data?.result?.tools ?? []).map((t: any) => t.name)
+
+      for (const name of [
+        "get_partner_ledger",
+        "list_payable_runs",
+        "list_payable_inventory_orders",
+        "get_partner_credits",
+        "link_payment_to_payout",
+        "unlink_payment_from_payout",
+      ]) {
+        expect(names).toContain(name)
+      }
+    })
+
+    it("reads a fresh partner as owed nothing rather than erroring", async () => {
+      /**
+       * ⚠️ The figures are nested under `.totals`. A reader that took
+       * `data.billed` would get `undefined` here and report it as "nothing
+       * billed" — a wrong response key is a confident nothing.
+       */
+      const totals = await ledger()
+      expect(totals).toBeDefined()
+      expect(Number(totals.billed)).toBe(0)
+      expect(Number(totals.paid)).toBe(0)
+      expect(Number(totals.outstanding)).toBe(0)
+
+      const credits = parse(
+        await callTool("get_partner_credits", { id: partnerId })
+      )
+      expect(credits.ok).toBe(true)
+      expect(credits.data.open_total).toBe(0)
+
+      const orders = parse(
+        await callTool("list_payable_inventory_orders", {
+          partner_id: partnerId,
+        })
+      )
+      expect(orders.ok).toBe(true)
+      expect(orders.data.count).toBe(0)
+    })
+
+    /**
+     * The tenancy rail. Without `partner_id` the route answers "every completed
+     * run on the platform", so the tool must refuse BEFORE the call — and it
+     * must refuse rather than quietly send an empty filter.
+     */
+    it("refuses payable-runs without a partner_id instead of asking about everyone", async () => {
+      const res = parse(await callTool("list_payable_runs", {}))
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/partner_id/)
+
+      const scoped = parse(
+        await callTool("list_payable_runs", { partner_id: partnerId })
+      )
+      expect(scoped.ok).toBe(true)
+      expect(scoped.data.payable_runs).toEqual([])
+    })
+
+    it("links a payment to a payout, moves `paid`, and unlinks it back", async () => {
+      const container = getContainer()
+      const submissionService: any = container.resolve("payment_submissions")
+      const paymentService: any = container.resolve("internal_payments")
+
+      const submission = await submissionService.createPaymentSubmissions({
+        partner_id: partnerId,
+        status: "Approved",
+        total_amount: 1000,
+        currency: "inr",
+        submitted_at: new Date(),
+      })
+
+      /**
+       * `Completed`, deliberately. Only money that actually moved settles a
+       * payout — two production rows are COMMITMENT rows (the exact ordered
+       * total, filed the day the order was created) and must never advance a
+       * payout's `paid`.
+       */
+      const payment = await paymentService.createPayments({
+        amount: 1000,
+        status: "Completed",
+        payment_type: "Bank",
+        payment_date: new Date(),
+      })
+
+      const before = await ledger()
+      expect(Number(before.billed)).toBe(1000)
+      expect(Number(before.paid)).toBe(0)
+      expect(Number(before.outstanding)).toBe(1000)
+
+      // Without confirm: planned, never executed.
+      const unconfirmed = parse(
+        await callTool("link_payment_to_payout", {
+          id: payment.id,
+          payment_submission_id: submission.id,
+        })
+      )
+      expect(unconfirmed.requires_confirmation).toBe(true)
+      expect(unconfirmed.plan.body).toEqual({
+        payment_submission_id: submission.id,
+      })
+
+      const stillUnpaid = await ledger()
+      expect(Number(stillUnpaid.paid)).toBe(0)
+
+      // With confirm: the fact is recorded, and the ledger reflects it.
+      const linked = parse(
+        await callTool("link_payment_to_payout", {
+          id: payment.id,
+          payment_submission_id: submission.id,
+          confirm: true,
+        })
+      )
+      expect(linked.ok).toBe(true)
+      expect(linked.data.settles).toBe(true)
+
+      const settled = await ledger()
+      expect(Number(settled.paid)).toBe(1000)
+      expect(Number(settled.outstanding)).toBe(0)
+
+      /**
+       * 🔑 The unlink is where a wrong forwarding list shows up. The route reads
+       * `payment_submission_id` from the QUERY first; a tool that sent it in a
+       * body the middleware does not parse would 400, and one that sent it
+       * nowhere at all would 400 too — neither is visible from a dry run.
+       */
+      const unlinked = parse(
+        await callTool("unlink_payment_from_payout", {
+          id: payment.id,
+          payment_submission_id: submission.id,
+          confirm: true,
+        })
+      )
+      expect(unlinked.ok).toBe(true)
+      expect(unlinked.data.settles).toBe(false)
+
+      const reverted = await ledger()
+      expect(Number(reverted.paid)).toBe(0)
+      expect(Number(reverted.outstanding)).toBe(1000)
+    })
+
+    /**
+     * The same-partner guard (#1714) lives on the route, and the tool inherits
+     * it — which is the entire argument for the loopback-proxy design. Asserted
+     * here because "the tool inherits the route's guards" is a claim about this
+     * surface, not about the route.
+     */
+    it("refuses to settle another partner's payout through the tool", async () => {
+      const container = getContainer()
+      const partnerService: any = container.resolve("partner")
+      const submissionService: any = container.resolve("payment_submissions")
+      const paymentService: any = container.resolve("internal_payments")
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const other = await partnerService.createPartners({
+        name: `Other Money MCP ${unique}`,
+        handle: `other-money-mcp-${unique}`,
+      })
+
+      const theirPayout = await submissionService.createPaymentSubmissions({
+        partner_id: other.id,
+        status: "Approved",
+        total_amount: 500,
+        currency: "inr",
+        submitted_at: new Date(),
+      })
+
+      const payment = await paymentService.createPayments({
+        amount: 500,
+        status: "Completed",
+        payment_type: "Bank",
+        payment_date: new Date(),
+      })
+
+      /**
+       * ⚠️ The payment must have a traceable owner for the guard to bite: the
+       * route is deliberately permissive for unattributable money, so a payment
+       * with no partner link would be ALLOWED and this test would pass while
+       * proving nothing.
+       */
+      await remoteLink.create({
+        partner: { partner_id: partnerId },
+        internal_payments: { internal_payments_id: payment.id },
+        data: {
+          partner_id: partnerId,
+          payment_id: payment.id,
+          linked_with: "partner",
+        },
+      })
+
+      const res = parse(
+        await callTool("link_payment_to_payout", {
+          id: payment.id,
+          payment_submission_id: theirPayout.id,
+          confirm: true,
+        })
+      )
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/another partner's payout/i)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/partner-mcp-money.spec.ts
+++ b/apps/backend/integration-tests/http/partner-mcp-money.spec.ts
@@ -1,0 +1,175 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * The partner MCP money reads, CALLED (#1712).
+ *
+ * ## Why a real call, not a plan
+ *
+ * Two failure modes on this surface are invisible to every unit test:
+ *
+ *  - a `/partners/*` route 401s until `middlewares.ts` names it explicitly —
+ *    auth is per-route here, and both tsc and a green suite stay silent about a
+ *    route that answers 401 to every request while looking perfectly correct;
+ *  - a read scoped to the AUTHENTICATED partner is only worth what it refuses.
+ *    "Takes no partner_id" is a property of the tool row; "cannot see another
+ *    partner's money" is a property of the running system, and the second is
+ *    the one that matters.
+ *
+ * So this file authenticates a real partner, has an ADMIN write a credit to
+ * each of two partners, and asks the tool what it can see.
+ */
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+
+const rpc = (method: string, params: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  params,
+})
+
+setupSharedTestSuite(() => {
+  describe("POST /partners/mcp — what a partner may see about their own money", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let partnerHeaders: { Authorization: string }
+    let partnerId: string
+    let otherPartnerId: string
+
+    const registerPartner = async (label: string) => {
+      const { api } = getSharedTestEnv()
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const email = `mcp-money-${label}-${unique}@jyt.test`
+      const password = "supersecret"
+
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      const reg = await api.post("/auth/partner/emailpass", { email, password })
+      const created = await api.post(
+        "/partners",
+        {
+          name: `MCP Money ${label} ${unique}`,
+          handle: `mcp-money-${label}-${unique}`,
+          admin: { email, first_name: "MCP", last_name: "Money" },
+        },
+        { headers: { Authorization: `Bearer ${reg.data.token}` } }
+      )
+      expect(created.status).toBe(200)
+
+      // Re-login: a token minted before the partner existed carries no partner
+      // claim, so every /partners/* call on it is a 401.
+      const login = await api.post("/auth/partner/emailpass", { email, password })
+      return {
+        id: created.data.partner.id as string,
+        headers: { Authorization: `Bearer ${login.data.token}` },
+      }
+    }
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+
+      const mine = await registerPartner("mine")
+      partnerId = mine.id
+      partnerHeaders = mine.headers
+
+      const theirs = await registerPartner("theirs")
+      otherPartnerId = theirs.id
+    })
+
+    const mcp = (body: any) => {
+      const { api } = getSharedTestEnv()
+      return api.post("/partners/mcp", body, {
+        headers: { ...MCP_HEADERS, ...partnerHeaders },
+      })
+    }
+
+    /** The tool envelope, surfaced loudly — a JSON-RPC error hides in `result`. */
+    const call = async (name: string, args: Record<string, unknown> = {}) => {
+      const res = await mcp(rpc("tools/call", { name, arguments: args }))
+      expect(res.status).toBe(200)
+      const text = res.data?.result?.content?.[0]?.text
+      if (typeof text !== "string") {
+        throw new Error(
+          `[${name}] no tool payload — ${JSON.stringify(res.data).slice(0, 600)}`
+        )
+      }
+      return JSON.parse(text)
+    }
+
+    it("advertises the three money reads and no money write", async () => {
+      const res = await mcp(rpc("tools/list", {}))
+      expect(res.status).toBe(200)
+      const tools = res.data?.result?.tools ?? []
+      const names = tools.map((t: any) => t.name)
+
+      for (const name of [
+        "list_payable_runs",
+        "list_payable_inventory_orders",
+        "list_credits",
+      ]) {
+        expect(names).toContain(name)
+      }
+
+      /**
+       * 🔑 The founder's decision, asserted where it is enforced: a partner must
+       * not be able to declare their own payout settled. `tools/list` is what a
+       * third-party MCP client actually enumerates.
+       */
+      expect(names).not.toContain("link_payment_to_payout")
+      expect(names).not.toContain("unlink_payment_from_payout")
+    })
+
+    it("answers the payable reads for the authenticated partner", async () => {
+      const runs = await call("list_payable_runs")
+      expect(runs.ok).toBe(true)
+      expect(runs.data.payable_runs).toEqual([])
+
+      const orders = await call("list_payable_inventory_orders")
+      expect(orders.ok).toBe(true)
+      expect(orders.data.count).toBe(0)
+    })
+
+    it("shows this partner's credit and NOT another partner's", async () => {
+      const { api } = getSharedTestEnv()
+
+      const mine = await api.post(
+        `/admin/partners/${partnerId}/credits`,
+        {
+          amount: 1380,
+          source_type: "overpayment",
+          reason: "Paid beyond the payout; held against a future delivery.",
+        },
+        adminHeaders
+      )
+      expect(mine.status).toBe(201)
+
+      const theirs = await api.post(
+        `/admin/partners/${otherPartnerId}/credits`,
+        {
+          amount: 9999,
+          source_type: "goodwill",
+          reason: "Somebody else's money entirely.",
+        },
+        adminHeaders
+      )
+      expect(theirs.status).toBe(201)
+
+      const payload = await call("list_credits")
+      expect(payload.ok).toBe(true)
+
+      const amounts = (payload.data.credits ?? []).map((c: any) =>
+        Number(c.amount)
+      )
+      expect(amounts).toEqual([1380])
+      expect(Number(payload.data.open_total)).toBe(1380)
+      // The assertion that makes the one above mean something: the other
+      // partner's 9,999 exists and is not visible here.
+      expect(amounts).not.toContain(9999)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -506,6 +506,125 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     inputSchema: obj({ ...PAGINATION }),
   },
 
+  /**
+   * The partner money surface (#1710/#1712).
+   *
+   * These five rows are one question asked five ways — "what does this partner
+   * still have coming, and what has already moved" — and each wraps a route
+   * whose answer is NOT reproducible by reading a table. `list_payments` above
+   * shows rows; none of these do. They show the FOLD, which is where the
+   * double-pay traps live.
+   */
+  {
+    name: "get_partner_ledger",
+    description:
+      "The whole money record for one partner: every payout (billed / paid / outstanding) plus every payment recorded against them, from all THREE homes a payment can live in (the partner link, the inventory-order link, and the payment method's `paid_to`). Read this BEFORE answering 'has this partner been paid' — the payout list alone said `recorded: 0` for a partner holding INR 121,777. 🔑 The figures are nested under `.totals`, not at the top level: a read of `.billed` returns undefined, which is a confident nothing. `recorded_against_open` is money already sitting against a source an UNPAID payout bills — reported BESIDE `outstanding`, never subtracted from it; whether it discharges the payout is a human decision, recorded with link_payment_to_payout.",
+    method: "GET",
+    path: "/admin/payments/partners/:id/ledger",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
+    nextSteps: [
+      "list_payable_runs",
+      "list_payable_inventory_orders",
+      "get_partner_credits",
+      "link_payment_to_payout",
+    ],
+  },
+  {
+    name: "list_payable_runs",
+    description:
+      "The completed production runs this partner can still be billed for — WORK, as opposed to goods. One row per run, carrying its billing status (`clear` / `partly_billed` / `billed` / `unknown`), produced vs ordered quantity, the agreed rate and how much of the run a prior payout already claimed. ⚠️ `unknown` means the run's billing history could not be verified, NOT that it is unbilled: billing it is how the same garments get paid for twice.",
+    method: "GET",
+    path: "/admin/payment-submissions/payable-runs",
+    queryParams: ["partner_id"],
+    inputSchema: obj(
+      {
+        partner_id: STR(
+          "Partner id. REQUIRED — this endpoint answers 'what can I pay THIS partner for', and the route refuses without it rather than returning every completed run on the platform."
+        ),
+      },
+      ["partner_id"]
+    ),
+    nextSteps: ["list_payable_inventory_orders", "get_partner_ledger"],
+  },
+  {
+    name: "list_payable_inventory_orders",
+    description:
+      "The inventory (purchase) orders this partner can still be billed for — GOODS, as opposed to work. Rows carry what the order is worth by RECEIPTS, what earlier payouts already claimed, and the remaining billable amount. 🔑 A `count: 0` here does NOT mean the partner is owed nothing: this route answers only about ORDERS, and their unbilled work may all be in runs (call list_payable_runs too). A partially received order is billable only for what actually arrived.",
+    method: "GET",
+    path: "/admin/payment-submissions/payable-inventory-orders",
+    queryParams: ["partner_id"],
+    inputSchema: obj(
+      {
+        partner_id: STR(
+          "Partner id. REQUIRED — the route refuses without it rather than listing every partner's orders."
+        ),
+      },
+      ["partner_id"]
+    ),
+    nextSteps: ["list_payable_runs", "get_partner_ledger"],
+  },
+  {
+    name: "get_partner_credits",
+    description:
+      "Money this partner ALREADY HOLDS that no payout has consumed — an overpayment, an adjustment or a goodwill credit. Returns the credit rows plus `open_total` (only `Open` credits; an `Applied` one has already reduced a payout). 🔑 Reported beside `outstanding`, never netted against it: applying a credit is a deliberate act, and a partner can hold a credit on one order while being genuinely owed money on another.",
+    method: "GET",
+    path: "/admin/partners/:id/credits",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
+    nextSteps: ["get_partner_ledger"],
+  },
+  {
+    name: "link_payment_to_payout",
+    description:
+      "Record that an existing payment SETTLES a payout — the only way a payout can be settled in PART (the payout keeps its status; `paid` on the ledger moves by the payment's amount). Sensitive: requires confirm:true. 🔴 Never link one payment to TWO payouts to carry a surplus forward: `paid` sums per payout with only a per-payout clamp, so the same money would count in full against both. Record the surplus as a credit instead. 🔴 Only a `Completed` payment settles anything — two production rows are COMMITMENT rows (the exact ordered total, filed the day the order was created) and are not money that moved.",
+    method: "POST",
+    path: "/admin/payments/:id/settles",
+    pathParams: ["id"],
+    bodyParams: ["payment_submission_id"],
+    previewPath: "/admin/payments/:id",
+    write: true,
+    sensitive: true,
+    inputSchema: obj(
+      {
+        id: STR("Payment id (an `internal_payments` row) whose money settles the payout."),
+        payment_submission_id: STR(
+          "The payout (payment submission) this payment settles. Must belong to the SAME partner as the payment — the route refuses otherwise, because a payment discharging another partner's payout pays the wrong person and leaves a link nobody would question."
+        ),
+      },
+      ["id", "payment_submission_id"]
+    ),
+    sideEffects:
+      "Creates the payment↔payout link and moves `paid` / `outstanding` on the partner ledger. Repeating the same link is a no-op, not an error. Writes no payment and changes no payout status.",
+    nextSteps: ["get_partner_ledger"],
+  },
+  {
+    name: "unlink_payment_from_payout",
+    description:
+      "Undo a link_payment_to_payout — the payment no longer settles that payout, and the payout's `paid` falls back by that amount. Sensitive (every DELETE is): requires confirm:true. Use it when a payment was attributed to the wrong payout; it deletes no payment and no payout.",
+    method: "DELETE",
+    path: "/admin/payments/:id/settles",
+    pathParams: ["id"],
+    /**
+     * Query, not body: the route reads `payment_submission_id` from the query
+     * FIRST and its middleware entry registers no body validator. A DELETE body
+     * would work today and is one middleware edit away from being ignored.
+     */
+    queryParams: ["payment_submission_id"],
+    previewPath: "/admin/payments/:id",
+    write: true,
+    inputSchema: obj(
+      {
+        id: STR("Payment id whose settlement link is being removed."),
+        payment_submission_id: STR("The payout the payment should no longer settle."),
+      },
+      ["id", "payment_submission_id"]
+    ),
+    sideEffects:
+      "Removes the payment↔payout link and lowers `paid` on the partner ledger by that payment's amount.",
+    nextSteps: ["get_partner_ledger"],
+  },
+
   // ===== Marketing & analytics ============================================
   {
     name: "list_publishing_campaigns",

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -100,6 +100,16 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   // any conversation, so it lives in the always-present core slice.
   ["/admin/assistant/vision", "core"],
   ["/admin/payments", "money"],
+  // The payout side of money. Without this entry every payable-runs /
+  // payable-inventory-orders tool classifies as undefined and loads in NO
+  // slice — registered, callable in principle, and reachable from no ask.
+  ["/admin/payment-submissions", "money"],
+  /**
+   * A credit is money, not partner administration, so it rides the money slice
+   * rather than inheriting `partners` from the `/admin/partners` prefix above.
+   * Longer prefix wins, and this is the whole reason the match is longest-wins.
+   */
+  ["/admin/partners/:id/credits", "money"],
   ["/admin/publishing-campaigns", "marketing"],
   ["/admin/notifications", "marketing"],
   // Social posts and platform integrations belong to marketing — they are the
@@ -223,6 +233,16 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
   money: [
     "payment", "payments", "payout", "payouts", "invoice", "invoices",
     "revenue", "settle", "settlement", "money", "paid", "unpaid", "balance",
+    // What a partner is still OWED, and what they already hold (#1710/#1712).
+    // An operator asks "what can I pay hrhandloom for?" or "does anyone hold a
+    // credit?" — neither sentence contains a word above, and the ledger is the
+    // one read that prevents paying for the same garments twice.
+    // Bare "pay" is deliberate: "what can I still PAY this partner for?" is the
+    // most natural phrasing of the question these tools exist to answer, and
+    // "paid" below does not match it — word boundaries are exact.
+    "pay", "pays", "paying", "owe", "owed", "owing", "outstanding", "ledger", "bill", "billed",
+    "billable", "payable", "credit", "credits", "overpaid", "overpayment",
+    "advance", "reconcile", "reconciliation", "settled", "unsettled",
   ],
   marketing: [
     "campaign", "campaigns", "newsletter", "email", "emails", "notification",

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -360,6 +360,9 @@ describe("partner-mcp per-ask tool slicing", () => {
       "/partners/payments": "refund this payment",
       "/partners/payment-providers": "which payment providers are available",
       "/partners/payment-submissions": "list my payment submissions",
+      // #1712. A partner asks about a credit in the words of what happened to
+      // them — "was I overpaid" — never "list my partner_credit rows".
+      "/partners/credits": "do I have any credit left over from an overpayment",
       "/partners/payment-collections": "mark this payment collection as paid",
       "/partners/stores/:id/payment-providers":
         "which payment providers are enabled for my store",

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -1160,6 +1160,47 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       ["submissionId"]
     ),
   },
+
+  /**
+   * What this partner may still bill for, and what they already hold (#1712).
+   *
+   * 🔑 READ ONLY, and deliberately so. A partner may see every one of these
+   * numbers; only an admin may declare a payout settled or mint a credit.
+   * Whether money already given discharges the next payout is not a partner's
+   * assertion to make — the admin surface owns link_payment_to_payout.
+   *
+   * ⚠️ None of them take a partner id. They are scoped to the AUTHENTICATED
+   * partner by the route itself; there is no way to ask about somebody else,
+   * which is the property that keeps one partner's payouts off another's
+   * screen.
+   */
+  {
+    name: "list_payable_runs",
+    description:
+      "The completed production runs YOU can still bill for — work, as opposed to goods. One row per run with its billing status (`clear` / `partly_billed` / `billed` / `unknown`), produced vs ordered quantity, the agreed rate, and how much a previous payout already claimed. ⚠️ `unknown` means the run's billing history could not be verified, not that it is unbilled. Scoped to your own runs; it takes no arguments.",
+    method: "GET",
+    path: "/partners/payment-submissions/payable-runs",
+    inputSchema: obj({}),
+    nextSteps: ["list_payable_inventory_orders", "list_payment_submissions"],
+  },
+  {
+    name: "list_payable_inventory_orders",
+    description:
+      "The inventory orders YOU can still bill for — goods, as opposed to work. Each row carries what the order is worth by RECEIPTS (a partially received order is billable only for what actually arrived), what earlier payouts already claimed, and what remains. 🔑 A `count: 0` here does not mean nothing is owed: unbilled WORK lives in list_payable_runs. Takes no arguments.",
+    method: "GET",
+    path: "/partners/payment-submissions/payable-inventory-orders",
+    inputSchema: obj({}),
+    nextSteps: ["list_payable_runs", "list_payment_submissions"],
+  },
+  {
+    name: "list_credits",
+    description:
+      "Money YOU already hold that no payout has consumed — an overpayment, an adjustment or a goodwill credit. Returns the credit rows plus `open_total` (only `Open` credits count; an `Applied` one has already reduced a payout). Read-only: a credit is applied to a payout by an admin, never claimed here. Takes no arguments.",
+    method: "GET",
+    path: "/partners/credits",
+    inputSchema: obj({}),
+    nextSteps: ["list_payment_submissions"],
+  },
   {
     name: "list_returns",
     description: "List returns for the partner's sales channel (optionally filtered by order_id).",

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -143,6 +143,9 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, PartnerToolDomain]> = [
   ["/partners/payments", "money"],
   ["/partners/payment-providers", "money"],
   ["/partners/payment-submissions", "money"],
+  // Money the partner already holds (#1712). Without an entry the tool
+  // classifies as undefined and loads in no slice at all.
+  ["/partners/credits", "money"],
   ["/partners/payment-collections", "money"],
 ]
 
@@ -291,6 +294,13 @@ const DOMAIN_KEYWORDS: Record<Exclude<PartnerToolDomain, "core">, string[]> = {
     "revenue", "settle", "settlement", "money", "paid", "unpaid", "balance",
     "submission", "payment submission", "payment provider", "payment providers",
     "payment collection", "payment collections", "mark as paid", "collect payment",
+    // What the partner may still bill for, and what they already hold. "what
+    // can I invoice for?" / "am I owed anything?" name none of the words above.
+    // Bare "pay" is deliberate: "what can I still PAY this partner for?" is the
+    // most natural phrasing of the question these tools exist to answer, and
+    // "paid" below does not match it — word boundaries are exact.
+    "pay", "pays", "paying", "owe", "owed", "owing", "outstanding", "bill", "billed", "billable",
+    "payable", "credit", "credits", "overpaid", "overpayment", "advance",
   ],
 }
 

--- a/apps/backend/src/lib/mcp-core/__tests__/partner-money-tools.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/partner-money-tools.unit.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * The partner-money MCP surface (#1712): ledger, payable work, payable goods,
+ * credits, and the admin-only settlement link.
+ *
+ * ## Why this file exists rather than trusting the registry invariants
+ *
+ * The generic specs prove a row is WELL-FORMED — classified, tiered, its
+ * bodyParams inside its validator. None of them prove a row does the thing it
+ * was added for, and this domain is the one where a well-formed row that
+ * forwards the wrong field pays the wrong person:
+ *
+ *  - `pick()` is an allowlist walk, so a `payment_submission_id` that reached
+ *    neither `queryParams` nor `bodyParams` would be dropped in SILENCE — the
+ *    route would then read an empty submission id and 400, or worse, a future
+ *    edit to the route's argument source would turn it into a no-op 200.
+ *  - a `partner_id` that stopped being required on `payable-runs` would return
+ *    every completed run on the platform, which is the shape that once made a
+ *    dangling key serve one tenant's rows to another (#1397).
+ *  - the partner surface is READ-ONLY by decision, not by accident: a partner
+ *    must not be able to declare their own payout settled.
+ *
+ * Each test below is written so that deleting the line it guards makes it fail.
+ */
+import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
+import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
+import { dispatchAdminTool } from "../../../api/admin/mcp/lib/dispatch"
+import { dispatchPartnerTool } from "../../../api/partners/mcp/lib/dispatch"
+import { selectAdminToolSlice } from "../../../api/admin/mcp/lib/tool-slice"
+import { selectPartnerToolSlice } from "../../../api/partners/mcp/lib/tool-slice"
+import { isSensitive } from "../schema"
+
+/** Unreachable origin — every assertion here runs on a dry_run or a refusal. */
+const CTX = { baseUrl: "http://localhost:9999" }
+
+const adminTool = (name: string) =>
+  ADMIN_MCP_TOOLS.find((t) => t.name === name)
+const partnerTool = (name: string) =>
+  PARTNER_MCP_TOOLS.find((t) => t.name === name)
+
+describe("admin: the partner money reads", () => {
+  it.each([
+    ["get_partner_ledger", "/admin/payments/partners/:id/ledger"],
+    ["list_payable_runs", "/admin/payment-submissions/payable-runs"],
+    [
+      "list_payable_inventory_orders",
+      "/admin/payment-submissions/payable-inventory-orders",
+    ],
+    ["get_partner_credits", "/admin/partners/:id/credits"],
+  ])("%s wraps %s as a plain read", (name, path) => {
+    const def = adminTool(name)!
+    expect(def).toBeTruthy()
+    expect(def.method ?? "GET").toBe("GET")
+    expect(def.path).toBe(path)
+    expect(def.write).toBeFalsy()
+    expect(isSensitive(def)).toBe(false)
+  })
+
+  it("the ledger read plans the partner's own ledger path", async () => {
+    const res = await dispatchAdminTool(CTX, "get_partner_ledger", {
+      id: "partner_1",
+      dry_run: true,
+    })
+    expect(res.ok).toBe(true)
+    expect(res.plan?.path).toBe("/admin/payments/partners/partner_1/ledger")
+  })
+
+  /**
+   * The tenancy property, asserted as a REFUSAL rather than as a schema shape.
+   *
+   * `partner_id` is required by the route because an unfiltered call returns
+   * every completed run on the platform. A tool that advertised it as optional
+   * would let the model omit it and get exactly that.
+   */
+  it.each(["list_payable_runs", "list_payable_inventory_orders"])(
+    "%s refuses to run without partner_id instead of asking for everyone's",
+    async (name) => {
+      const res = await dispatchAdminTool(CTX, name, { dry_run: true })
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/partner_id/)
+    }
+  )
+
+  it("forwards partner_id as a query param the route will actually read", async () => {
+    const res = await dispatchAdminTool(CTX, "list_payable_runs", {
+      partner_id: "partner_1",
+      dry_run: true,
+    })
+    expect(res.plan?.query).toEqual({ partner_id: "partner_1" })
+    // Nothing silently dropped: a dropped argument is the failure mode this
+    // whole surface is exposed to.
+    expect(res.plan?.dropped_arguments).toBeUndefined()
+  })
+})
+
+describe("admin: linking a payment to the payout it settles", () => {
+  it("is a guarded write, not an ordinary one — money moves on the ledger", () => {
+    const def = adminTool("link_payment_to_payout")!
+    expect(def.method).toBe("POST")
+    expect(def.path).toBe("/admin/payments/:id/settles")
+    expect(def.write).toBe(true)
+    expect(isSensitive(def)).toBe(true)
+  })
+
+  it("refuses to execute without confirm, and shows the plan it would run", async () => {
+    const res = await dispatchAdminTool(CTX, "link_payment_to_payout", {
+      id: "pay_1",
+      payment_submission_id: "sub_1",
+    })
+    expect(res.requires_confirmation).toBe(true)
+    expect(res.plan?.method).toBe("POST")
+    expect(res.plan?.path).toBe("/admin/payments/pay_1/settles")
+    /**
+     * 🔑 The body is the whole point of the row. `payment_submission_id` is the
+     * only field the route's `.strict()` validator accepts, and a version of
+     * this tool that failed to forward it would still return a plan, still
+     * render a confirmation card, and settle nothing.
+     */
+    expect(res.plan?.body).toEqual({ payment_submission_id: "sub_1" })
+  })
+
+  it("cannot be called without naming the payout — half a link is not a link", async () => {
+    const res = await dispatchAdminTool(CTX, "link_payment_to_payout", {
+      id: "pay_1",
+    })
+    expect(res.ok).toBe(false)
+    expect(res.error).toMatch(/payment_submission_id/)
+    expect(res.requires_confirmation).toBeFalsy()
+  })
+
+  it("unlink sends payment_submission_id as QUERY, which is where the route reads it first", async () => {
+    const def = adminTool("unlink_payment_from_payout")!
+    expect(def.method).toBe("DELETE")
+    expect(def.write).toBe(true)
+    // Every DELETE is implicitly sensitive; this one is undoing a money fact.
+    expect(isSensitive(def)).toBe(true)
+
+    const res = await dispatchAdminTool(CTX, "unlink_payment_from_payout", {
+      id: "pay_1",
+      payment_submission_id: "sub_1",
+      dry_run: true,
+    })
+    expect(res.plan?.path).toBe("/admin/payments/pay_1/settles")
+    expect(res.plan?.query).toEqual({ payment_submission_id: "sub_1" })
+    expect(res.plan?.body).toBeUndefined()
+  })
+})
+
+describe("the partner surface stays read-only (founder's decision, #1712)", () => {
+  it.each([
+    ["list_payable_runs", "/partners/payment-submissions/payable-runs"],
+    [
+      "list_payable_inventory_orders",
+      "/partners/payment-submissions/payable-inventory-orders",
+    ],
+    ["list_credits", "/partners/credits"],
+  ])("%s is a GET with no arguments at all", (name, path) => {
+    const def = partnerTool(name)!
+    expect(def).toBeTruthy()
+    expect(def.method ?? "GET").toBe("GET")
+    expect(def.path).toBe(path)
+    expect(def.write).toBeFalsy()
+    expect(def.pathParams ?? []).toEqual([])
+    expect(def.queryParams ?? []).toEqual([])
+    expect(def.bodyParams ?? []).toEqual([])
+  })
+
+  /**
+   * ⚠️ Not merely "takes no partner_id today". A partner-supplied id is how
+   * every storefront once rendered every other partner's quote: these routes
+   * scope themselves to the authenticated partner, and a tool that offered an
+   * id argument would be advertising a parameter the route ignores — or, one
+   * route edit later, one it honours.
+   */
+  it("offers no way to ask about another partner", () => {
+    for (const name of [
+      "list_payable_runs",
+      "list_payable_inventory_orders",
+      "list_credits",
+    ]) {
+      const props = Object.keys(
+        partnerTool(name)!.inputSchema?.properties ?? {}
+      )
+      expect(props).toEqual([])
+    }
+  })
+
+  it("exposes NO tool that settles a payout or mints a credit", () => {
+    const writers = PARTNER_MCP_TOOLS.filter(
+      (t) =>
+        (t.method ?? "GET") !== "GET" &&
+        /\/settles|\/credits/.test(t.path ?? "")
+    ).map((t) => t.name)
+    expect(writers).toEqual([])
+  })
+
+  it("a partner asking about a credit still gets the read", async () => {
+    const res = await dispatchPartnerTool(CTX, "list_credits", {
+      dry_run: true,
+    })
+    expect(res.ok).toBe(true)
+    expect(res.plan?.method).toBe("GET")
+    expect(res.plan?.path).toBe("/partners/credits")
+  })
+})
+
+/**
+ * Slicing. A registered tool the slicer never selects is a tool nobody can
+ * reach — the #1612 shape, where `inventory_order_lines` had a validator, a
+ * guard, tranche folding and zero rows because no screen offered it.
+ */
+describe("the ask an operator actually types reaches these tools", () => {
+  const sliceFor = (ask: string) =>
+    selectAdminToolSlice(ask, ADMIN_MCP_TOOLS).names
+
+  it("'what can I still pay this partner for?' loads both payable reads", () => {
+    const names = sliceFor("what can I still pay this partner for?")
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "list_payable_runs",
+        "list_payable_inventory_orders",
+        "get_partner_ledger",
+      ])
+    )
+  })
+
+  it("'has hrhandloom been paid, and what is outstanding?' loads the ledger", () => {
+    expect(sliceFor("has hrhandloom been paid, and what is outstanding?")).toContain(
+      "get_partner_ledger"
+    )
+  })
+
+  it("'does this partner hold any credit from an overpayment?' loads the credits read", () => {
+    expect(
+      sliceFor("does this partner hold any credit from an overpayment?")
+    ).toContain("get_partner_credits")
+  })
+
+  it("'record that this payment settles the payout' loads the link tool", () => {
+    expect(sliceFor("record that this payment settles the payout")).toContain(
+      "link_payment_to_payout"
+    )
+  })
+
+  it("a partner's own 'am I owed anything?' loads their payable reads", () => {
+    const names = selectPartnerToolSlice("am I owed anything?", PARTNER_MCP_TOOLS)
+      .names
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "list_payable_runs",
+        "list_payable_inventory_orders",
+      ])
+    )
+  })
+})


### PR DESCRIPTION
Nine registry rows over routes that already existed, plus the two tool-slice edits without which they would have been unreachable from any ask. Closes the "MCP tools" item on #1712.

## What this adds

| surface | tools |
|---|---|
| admin reads | `get_partner_ledger`, `list_payable_runs`, `list_payable_inventory_orders`, `get_partner_credits` |
| admin writes | `link_payment_to_payout`, `unlink_payment_from_payout` — `sensitive`, confirm-gated |
| partner reads | `list_payable_runs`, `list_payable_inventory_orders`, `list_credits` |

**The partner surface is read-only, by decision.** A partner must not declare their own payout settled, so no write row wrapping `/settles` or `/credits` exists there at all — and `partner-mcp-money.spec.ts` asserts `tools/list` never advertises one, which is what a third-party MCP client actually enumerates.

No route, validator or workflow changed. Every tool inherits the wrapped route's auth, its `.strict()` validator and #1714's same-partner guard through the loopback proxy.

## Three things a registry row alone would have got wrong

1. **`/admin/payment-submissions` and `/partners/credits` had no tool-slice prefix.** Every tool under them classifies as `undefined` and loads in *no* slice — registered, callable in principle, reachable from nothing. The `inventory_order_lines` shape from #1612.
2. **`pay` was missing from the money keywords.** "what can I still **pay** this partner for?" matched nothing; `paid` does not match it, word boundaries are exact. Caught by a slice test failing on its first run, not by review.
3. **The unlink tool forwards `payment_submission_id` as a QUERY param** — where its route reads it first, and where its middleware entry registers no body validator. `pick()` is an allowlist walk, so getting this wrong is a silent drop.

## What the descriptions carry

The model-facing text states the traps this domain actually has, because a tool that returns the right JSON and is read wrongly is the same defect:

- ledger totals nest under `.totals` — a read of `.billed` is `undefined`, a confident nothing;
- `recorded_against_open` is reported **beside** `outstanding`, never subtracted;
- `payable-inventory-orders` returning `count: 0` does not mean nothing is owed — that route answers about ORDERS, and the work may all be in runs;
- never link one payment to two payouts to carry a surplus forward: `paid` clamps per payout, so the same money counts in full against both. Record a credit instead;
- only a `Completed` payment settles anything — two production rows are commitment rows, not money.

## Verification

**Proven by call, not by plan.**

- `integration-tests/http/admin-mcp/admin-mcp-partner-money.spec.ts` (5 ✓) — links a payment to a payout *through the tool* and watches `paid` move **0 → 1000 → 0** on the ledger the tool reads; the unconfirmed call plans and writes nothing; a cross-partner settle is refused. The unlink round trip is the only thing that can prove the DELETE forwards its id where the route looks for it — a dry run never shows that.
- `integration-tests/http/partner-mcp-money.spec.ts` (3 ✓) — a real authenticated partner sees their own 1,380 credit while another partner's 9,999, actually created, stays invisible.
- `src/lib/mcp-core/__tests__/partner-money-tools.unit.spec.ts` (23 ✓) — plans, refusals, the read-only invariant, slice reachability. **Each assertion was checked by breaking the line it guards** and confirming the intended test failed.
- 528 unit tests green across mcp + assistant-context; `check:prod-build` passed.

## Not in scope

- **No `create_partner_credit` tool.** Minting money from a chat turn is a bigger decision than the reads and the link; recording hrhandloom's 1,380 stays an admin-route POST.
- **No partner ledger tool** — there is no `/partners/.../ledger` route to wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4