### PR TITLE
feat(textile): resolve vision providers from admin-configured platforms

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -183,6 +183,9 @@ GOOGLE_GENERATIVE_AI_API_KEY=your_google_generative_ai_key
 # AI_GATEWAY_API_KEY=your_vercel_ai_gateway_key
 # CLOUDFLARE_AI_ACCOUNT_ID=your_cloudflare_account_id
 # CLOUDFLARE_AI_TOKEN=your_cloudflare_ai_token
+# Groq — vision/text extraction fallback (qwen3.x accepts images on the free tier)
+# GROQ_API_KEY=your_groq_api_key
+# GROQ_DEFAULT_MODEL=qwen/qwen3.6-27b
 
 # Artisan quasi-partner cross-listing (#859 / #861). The sales-channel id of the
 # core storefront ("JYT Medu Store") that approved artisan products get listed

--- a/apps/backend/src/mastra/agents/textileExtractionAgent.ts
+++ b/apps/backend/src/mastra/agents/textileExtractionAgent.ts
@@ -170,4 +170,25 @@ export function clearTextileModelsForRun(runId?: string): void {
   if (runId) _textileModelsByRun.delete(runId)
 }
 
+/**
+ * Per-run cooldown of configured vision providers (by index into the models
+ * list). A provider that answers 429 after its retries is skipped for the rest
+ * of THIS run (both observation + derivation passes), so a rate-limited
+ * provider stops being hammered and the next provider in the ladder takes over.
+ */
+const _textileCooldownByRun = new Map<string, Set<number>>()
+
+export function getTextileCooldownForRun(runId?: string): Set<number> {
+  if (!runId) return new Set()
+  return _textileCooldownByRun.get(runId) ?? new Set()
+}
+
+export function setTextileCooldownForRun(runId: string, indices: Set<number>): void {
+  if (runId) _textileCooldownByRun.set(runId, indices)
+}
+
+export function clearTextileCooldownForRun(runId?: string): void {
+  if (runId) _textileCooldownByRun.delete(runId)
+}
+
 export { MAX_RETRIES, INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS };

--- a/apps/backend/src/mastra/agents/textileExtractionAgent.ts
+++ b/apps/backend/src/mastra/agents/textileExtractionAgent.ts
@@ -132,4 +132,42 @@ export async function getTextileFallbackModels(): Promise<string[]> {
   }
 }
 
+/**
+ * Create a textile agent from an already-built AI-SDK model.
+ *
+ * The Medusa layer resolves the admin-configured vision providers
+ * (Cloudflare / Groq / custom OpenAI-compatible) and hands the built models
+ * down to the Mastra workflow via the per-run registry below — the Mastra
+ * runtime has no Medusa container, so it cannot resolve them itself.
+ */
+export async function createTextileAgentFromModel(model: any): Promise<Agent> {
+  return new Agent({
+    name: "textile-extraction-agent",
+    model: model as any,
+    instructions: TEXTILE_EXTRACTION_INSTRUCTIONS,
+  });
+}
+
+/**
+ * Per-run hand-off registry for resolved vision MODELS (not agents).
+ *
+ * Mirrors `setExtractionAgentForRun` in agents/index.ts, but stores the raw
+ * model list so BOTH extraction passes (observation + derivation) in a single
+ * Mastra run can build their own agent off the same resolved providers.
+ */
+const _textileModelsByRun = new Map<string, any[]>()
+
+export function setTextileModelsForRun(runId: string, models: any[]): void {
+  if (runId) _textileModelsByRun.set(runId, models ?? [])
+}
+
+export function getTextileModelsForRun(runId?: string): any[] {
+  if (!runId) return []
+  return _textileModelsByRun.get(runId) ?? []
+}
+
+export function clearTextileModelsForRun(runId?: string): void {
+  if (runId) _textileModelsByRun.delete(runId)
+}
+
 export { MAX_RETRIES, INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS };

--- a/apps/backend/src/mastra/providers/__tests__/openrouter.unit.spec.ts
+++ b/apps/backend/src/mastra/providers/__tests__/openrouter.unit.spec.ts
@@ -20,8 +20,9 @@ describe("openrouter.outputsText", () => {
     expect(outputsText(model("some/image-gen", ["image"]))).toBe(false)
   })
 
-  it("keeps multi-output models that include text", () => {
-    expect(outputsText(model("x/multi", ["text", "image"]))).toBe(true)
+  it("rejects multi-output models that also emit non-text (lyria advertises ['text','audio'])", () => {
+    expect(outputsText(model("x/multi", ["text", "image"]))).toBe(false)
+    expect(outputsText(model("google/lyria-3-pro-preview", ["text", "audio"]))).toBe(false)
   })
 
   it("keeps models that omit output_modalities (free chat models often do)", () => {

--- a/apps/backend/src/mastra/providers/openrouter.ts
+++ b/apps/backend/src/mastra/providers/openrouter.ts
@@ -124,7 +124,11 @@ export function filterByOutputModality(
 export function outputsText(m: OpenRouterModel): boolean {
   const out = m.architecture?.output_modalities
   if (!out || out.length === 0) return true
-  return out.includes("text")
+  // Text-ONLY output. Models that also emit audio/image (e.g. `google/lyria-3-*`
+  // music generators advertise `["text","audio"]`) return un-parseable output —
+  // and, being non-`:free` "preview" models, get billed per attempt. Requiring
+  // every output modality to be "text" excludes them from the free ladder.
+  return out.includes("text") && out.every((modality) => modality === "text")
 }
 
 // Separate cache for vision models
@@ -146,7 +150,12 @@ export async function getFreeVisionModels(): Promise<OpenRouterModel[]> {
     const freeModels = filterFreeModels(allModels)
     // Must accept image INPUT and return text OUTPUT (see outputsText).
     const withImageInput = filterByInputModality(freeModels, ["image"])
-    cachedFreeVisionModels = withImageInput.filter(outputsText)
+    // `:free` only — a non-`:free` "preview" model (google/lyria-3-*, …) is
+    // listed at $0 in the catalog but billed per request. Restricting to the
+    // explicit `:free` suffix guarantees the fallback ladder never costs money.
+    cachedFreeVisionModels = withImageInput
+      .filter(outputsText)
+      .filter((m) => m.id.endsWith(":free"))
     visionCacheTimestamp = now
 
     // Sort by context length descending

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -44,6 +44,7 @@ export type AiProviderType =
   | "cloudflare"
   | "vercel_ai_gateway"
   | "fal"
+  | "groq"
   | "custom"
 
 export type AiRole =
@@ -123,6 +124,13 @@ const PROVIDER_DEFAULTS: Record<
     baseUrl: "https://gateway.ai.cloudflare.com/v1", // overridable; admin
     // can set api_config.base_url for the actual endpoint.
   },
+  groq: {
+    // OpenAI-compatible. Free tier has a generous per-day token budget; the
+    // qwen3.x models accept image input (vision) despite `/models` not
+    // advertising a `-vision` model.
+    baseUrl: "https://api.groq.com/openai/v1",
+    defaultModelHint: "qwen/qwen3.6-27b",
+  },
   fal: {
     // FAL has its own SDK — not OpenAI-compatible. The helper here is
     // only used to surface the API key; callers use the @fal-ai/client
@@ -154,6 +162,8 @@ const normalizeProviderType = (raw: unknown): AiProviderType | null => {
     case "fal_ai":
     case "fal-ai":
       return "fal"
+    case "groq":
+      return "groq"
     case "custom":
     case "openai_compatible":
     case "openai-compatible":
@@ -164,49 +174,14 @@ const normalizeProviderType = (raw: unknown): AiProviderType | null => {
 }
 
 /**
- * Resolve an AI platform from the DB for the given role. Returns null
- * if nothing is configured — caller falls back to env vars.
+ * Build a normalised `AiPlatformConfig` from a raw `social_platform` row.
+ * Returns null when the row can't be turned into a usable config (missing
+ * provider_type, api_key, or base_url) — callers skip those rows.
  */
-export const getAiPlatformForRole = async (
-  container: MedusaContainer,
-  role: AiRole
+const buildPlatformConfig = async (
+  chosen: any,
+  container: MedusaContainer
 ): Promise<AiPlatformConfig | null> => {
-  let socials: SocialsService
-  try {
-    socials = container.resolve(SOCIALS_MODULE) as unknown as SocialsService
-  } catch {
-    return null
-  }
-
-  let platforms: any[] = []
-  try {
-    platforms = await socials.listSocialPlatforms(
-      {
-        category: "ai",
-        status: "active",
-        // Filter narrows on the metadata.role tag the admin set. We
-        // can't easily filter `metadata.is_default` in the DAL, so we
-        // do that JS-side after the fetch.
-        metadata: { role },
-      } as any,
-      { take: 10 }
-    )
-  } catch (e) {
-    console.warn(
-      "[ai-platforms] listSocialPlatforms failed:",
-      (e as any)?.message ?? e
-    )
-    return null
-  }
-
-  // Pick the one explicitly marked as default for this role; if no
-  // explicit default, pick the most recently updated of the candidates.
-  const candidates = (platforms ?? []).filter(
-    (p) => p?.metadata?.is_default === true
-  )
-  const chosen = candidates[0] ?? platforms[0]
-  if (!chosen) return null
-
   const apiConfig = (chosen.api_config ?? {}) as Record<string, any>
   const meta = (chosen.metadata ?? {}) as Record<string, any>
 
@@ -264,6 +239,100 @@ export const getAiPlatformForRole = async (
     defaultModel: apiConfig.default_model ?? meta.default_model ?? null,
     accountId,
   }
+}
+
+/**
+ * Resolve an AI platform from the DB for the given role. Returns null
+ * if nothing is configured — caller falls back to env vars.
+ */
+export const getAiPlatformForRole = async (
+  container: MedusaContainer,
+  role: AiRole
+): Promise<AiPlatformConfig | null> => {
+  let socials: SocialsService
+  try {
+    socials = container.resolve(SOCIALS_MODULE) as unknown as SocialsService
+  } catch {
+    return null
+  }
+
+  let platforms: any[] = []
+  try {
+    platforms = await socials.listSocialPlatforms(
+      {
+        category: "ai",
+        status: "active",
+        // Filter narrows on the metadata.role tag the admin set. We
+        // can't easily filter `metadata.is_default` in the DAL, so we
+        // do that JS-side after the fetch.
+        metadata: { role },
+      } as any,
+      { take: 10 }
+    )
+  } catch (e) {
+    console.warn(
+      "[ai-platforms] listSocialPlatforms failed:",
+      (e as any)?.message ?? e
+    )
+    return null
+  }
+
+  // Pick the one explicitly marked as default for this role; if no
+  // explicit default, pick the most recently updated of the candidates.
+  const candidates = (platforms ?? []).filter(
+    (p) => p?.metadata?.is_default === true
+  )
+  const chosen = candidates[0] ?? platforms[0]
+  if (!chosen) return null
+
+  return buildPlatformConfig(chosen, container)
+}
+
+/**
+ * Resolve EVERY usable platform for a role — default first, then
+ * most-recently-updated — so a caller can build a fallback ladder across
+ * multiple configured providers (e.g. Cloudflare → Groq) instead of being
+ * limited to the single `is_default` row. Rows that don't resolve (missing
+ * key/base_url) are skipped. Empty when nothing is configured.
+ */
+export const getAiPlatformsForRole = async (
+  container: MedusaContainer,
+  role: AiRole
+): Promise<AiPlatformConfig[]> => {
+  let socials: SocialsService
+  try {
+    socials = container.resolve(SOCIALS_MODULE) as unknown as SocialsService
+  } catch {
+    return []
+  }
+
+  let platforms: any[] = []
+  try {
+    platforms = await socials.listSocialPlatforms(
+      { category: "ai", status: "active", metadata: { role } } as any,
+      { take: 50 }
+    )
+  } catch (e) {
+    console.warn(
+      "[ai-platforms] listSocialPlatforms failed:",
+      (e as any)?.message ?? e
+    )
+    return []
+  }
+
+  const ordered = (platforms ?? []).slice().sort((a, b) => {
+    const aDefault = a?.metadata?.is_default === true ? 1 : 0
+    const bDefault = b?.metadata?.is_default === true ? 1 : 0
+    if (aDefault !== bDefault) return bDefault - aDefault
+    return (Number(b?.updated_at) || 0) - (Number(a?.updated_at) || 0)
+  })
+
+  const configs: AiPlatformConfig[] = []
+  for (const chosen of ordered) {
+    const cfg = await buildPlatformConfig(chosen, container)
+    if (cfg) configs.push(cfg)
+  }
+  return configs
 }
 
 // ── AI SDK adapters ────────────────────────────────────────────────────
@@ -465,6 +534,29 @@ export const resolveRoleVisionModel = async (
     source: "free",
     modelId: visionId,
   }
+}
+
+/**
+ * Resolve a fallback LADDER of vision models for a role — every configured
+ * platform (default first), each as a built AI-SDK model. The caller appends
+ * its own free fallback at the end. Empty when no platform is configured.
+ *
+ * Used by the textile extraction so it can try Cloudflare → Groq → … before
+ * the auto-rotating OpenRouter `:free` model, instead of the single-default
+ * `resolveRoleVisionModel` lookup.
+ */
+export const resolveRoleVisionModels = async (
+  container: MedusaContainer,
+  role: AiRole
+): Promise<ResolvedRoleModel[]> => {
+  const configs = await getAiPlatformsForRole(container, role)
+  return configs.map((cfg) => ({
+    model: buildChatModel(cfg),
+    providerType: cfg.providerType,
+    source: "platform" as const,
+    platformId: cfg.platformId,
+    modelId: cfg.defaultModel ?? undefined,
+  }))
 }
 
 import { generateText } from "ai"
@@ -710,6 +802,7 @@ export const PROVIDER_TYPES: AiProviderType[] = [
   "dashscope",
   "cloudflare",
   "vercel_ai_gateway",
+  "groq",
   "custom",
 ]
 

--- a/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
+++ b/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
@@ -6,6 +6,8 @@ import {
   createTextileAgentFromModel,
   getTextileFallbackModels,
   getTextileModelsForRun,
+  getTextileCooldownForRun,
+  setTextileCooldownForRun,
   isRateLimitError,
   sleep,
   MAX_RETRIES,
@@ -256,18 +258,54 @@ const runVisionExtraction = async <T>(
   // These generate PLAIN text and parse via readModelJsonOrThrow, because
   // Groq/Cloudflare don't reliably honour AI-SDK `json_schema` structured
   // output — the prompts already demand "ONLY a valid JSON object".
+  //
+  // Rate-limit handling matches the free ladder below: a 429 retries the SAME
+  // provider with exponential backoff (a transient 429 must not cascade into
+  // the next provider and burn ITS rpm), and a provider that stays rate-limited
+  // after retries is cooled down for the rest of this run so the other passes
+  // and providers take over.
   const configuredModels = getTextileModelsForRun(context?.runId);
+  const cooldown = getTextileCooldownForRun(context?.runId);
   for (let i = 0; i < configuredModels.length; i++) {
-    try {
-      const agent = await createTextileAgentFromModel(configuredModels[i]);
-      logger.info(`[${label}] Attempting configured vision provider #${i + 1}/${configuredModels.length}`);
-      const response = await agent.generate(messages);
-      const parsed = readModelJsonOrThrow(response, `${label}(configured#${i})`) as T;
-      logger.info(`[${label}] Successfully extracted with configured vision provider`);
-      return parsed;
-    } catch (error: any) {
-      lastError = error;
-      logger.warn(`[${label}] Error with configured vision provider: ${error?.message || String(error)}`);
+    if (cooldown.has(i)) {
+      logger.info(`[${label}] Configured provider #${i + 1} in cooldown — skipping`);
+      continue;
+    }
+
+    let retryCount = 0;
+    while (retryCount < MAX_RETRIES) {
+      try {
+        const agent = await createTextileAgentFromModel(configuredModels[i]);
+        logger.info(`[${label}] Attempting configured vision provider #${i + 1}/${configuredModels.length} (attempt ${retryCount + 1})`);
+        const response = await agent.generate(messages);
+        const parsed = readModelJsonOrThrow(response, `${label}(configured#${i})`) as T;
+        logger.info(`[${label}] Successfully extracted with configured vision provider`);
+        return parsed;
+      } catch (error: any) {
+        lastError = error;
+        const errorMsg = error?.message || String(error);
+        logger.warn(`[${label}] Error with configured provider #${i + 1} (attempt ${retryCount + 1}): ${errorMsg}`);
+
+        if (isRateLimitError(error)) {
+          retryCount++;
+          if (retryCount < MAX_RETRIES) {
+            const delay = Math.min(
+              INITIAL_RETRY_DELAY_MS * Math.pow(2, retryCount - 1) + Math.random() * 2000,
+              MAX_RETRY_DELAY_MS
+            );
+            logger.info(`[${label}] Rate limited on provider #${i + 1}. Waiting ${Math.round(delay / 1000)}s before retry...`);
+            await sleep(delay);
+          } else {
+            cooldown.add(i);
+            setTextileCooldownForRun(context?.runId ?? "", cooldown);
+            logger.warn(`[${label}] Provider #${i + 1} still rate-limited — cooling down for this run.`);
+            break;
+          }
+        } else {
+          logger.warn(`[${label}] Non-rate-limit error on provider #${i + 1}. Trying next provider...`);
+          break;
+        }
+      }
     }
   }
 

--- a/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
+++ b/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
@@ -3,7 +3,9 @@ import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 import {
   createTextileAgentWithModel,
+  createTextileAgentFromModel,
   getTextileFallbackModels,
+  getTextileModelsForRun,
   isRateLimitError,
   sleep,
   MAX_RETRIES,
@@ -40,6 +42,9 @@ export const triggerSchema = z.object({
   gender: z.enum(["female", "male", "unisex"]).optional().default("unisex"),
   threadId: z.string().optional(),
   resourceId: z.string().optional(),
+  // Non-secret handle used to fetch the admin-resolved vision models that the
+  // Medusa layer stashed for this run (see setTextileModelsForRun).
+  run_id: z.string().optional(),
 });
 
 // ─────────────────────────────────────────────────────────────
@@ -242,17 +247,39 @@ const runVisionExtraction = async <T>(
   label: string,
   messages: any[],
   outputSchema: any,
-  context?: { threadId?: string; resourceId?: string }
+  context?: { threadId?: string; resourceId?: string; runId?: string }
 ): Promise<T> => {
+  let lastError: any = null;
+
+  // ── 1. Admin-configured vision providers (Cloudflare → Groq → …) ────────
+  // Built in the Medusa layer (which has the container) and stashed by runId.
+  // These generate PLAIN text and parse via readModelJsonOrThrow, because
+  // Groq/Cloudflare don't reliably honour AI-SDK `json_schema` structured
+  // output — the prompts already demand "ONLY a valid JSON object".
+  const configuredModels = getTextileModelsForRun(context?.runId);
+  for (let i = 0; i < configuredModels.length; i++) {
+    try {
+      const agent = await createTextileAgentFromModel(configuredModels[i]);
+      logger.info(`[${label}] Attempting configured vision provider #${i + 1}/${configuredModels.length}`);
+      const response = await agent.generate(messages);
+      const parsed = readModelJsonOrThrow(response, `${label}(configured#${i})`) as T;
+      logger.info(`[${label}] Successfully extracted with configured vision provider`);
+      return parsed;
+    } catch (error: any) {
+      lastError = error;
+      logger.warn(`[${label}] Error with configured vision provider: ${error?.message || String(error)}`);
+    }
+  }
+
+  // ── 2. OpenRouter `:free` fallback ladder ────────────────────────────────
   const availableModels = await getTextileFallbackModels();
-  logger.info(`[${label}] Available vision models: ${availableModels.slice(0, 5).join(", ")}`);
+  logger.info(`[${label}] Free vision models: ${availableModels.slice(0, 5).join(", ")}`);
 
   const stableResourceId =
     context?.resourceId && !String(context.resourceId).startsWith("textile-extraction:http")
       ? context.resourceId
       : `textile-extraction:${label}`;
 
-  let lastError: any = null;
   let modelIndex = 0;
 
   while (modelIndex < availableModels.length) {
@@ -373,7 +400,7 @@ Return ONLY a valid JSON object. Do not include markdown, commentary, or any tex
       "TextileObservation",
       messages,
       visualObservationsSchema,
-      { threadId: inputData.threadId, resourceId: inputData.resourceId }
+      { threadId: inputData.threadId, resourceId: inputData.resourceId, runId: inputData.run_id }
     );
 
     return observations;
@@ -394,11 +421,12 @@ const deriveProductFieldsStep = createStep({
     gender: z.enum(["female", "male", "unisex"]).optional().default("unisex"),
     threadId: z.string().optional(),
     resourceId: z.string().optional(),
+    run_id: z.string().optional(),
     observations: visualObservationsSchema,
   }),
   outputSchema: textileProductSchema,
   execute: async ({ inputData }) => {
-    const { image_url, hints, gender, threadId, resourceId, observations } = inputData;
+    const { image_url, hints, gender, threadId, resourceId, run_id, observations } = inputData;
 
     logger.info(`[TextileDerivation] Deriving product fields from observations for image: ${image_url.substring(0, 50)}...`);
 
@@ -496,7 +524,7 @@ Return ONLY a valid JSON object. Do not include markdown, commentary, or any tex
       "TextileDerivation",
       messages,
       textileProductSchema,
-      { threadId, resourceId }
+      { threadId, resourceId, runId: run_id }
     );
 
     return product;
@@ -632,6 +660,7 @@ export const textileProductExtractionWorkflow = createWorkflow({
       gender: init.gender || "unisex",
       threadId: init.threadId,
       resourceId: init.resourceId,
+      run_id: (init as any).run_id,
       observations: inputData,
     };
   })

--- a/apps/backend/src/scripts/backfill-ai-platforms-from-env.ts
+++ b/apps/backend/src/scripts/backfill-ai-platforms-from-env.ts
@@ -49,6 +49,7 @@ type ProviderType =
   | "cloudflare"
   | "vercel_ai_gateway"
   | "fal"
+  | "groq"
   | "custom"
 
 type Role =
@@ -56,6 +57,7 @@ type Role =
   | "ai_search_embed"
   | "ai_product_description"
   | "ai_image_gen"
+  | "ai_image_extraction"
 
 type PlatformPlan = {
   name: string
@@ -160,6 +162,34 @@ const planFromEnv = (): PlatformPlan[] => {
       // FAL's SDK chooses the endpoint per call; default_model is
       // informational only unless an admin wants to pin one.
       default_model: process.env.FAL_DEFAULT_MODEL,
+    })
+  }
+
+  // ── Vision extraction role: Cloudflare (default) → Groq ────────────────
+  // Both feed the textile extraction ladder; the textile workflow tries every
+  // platform for the role (default first) before the OpenRouter `:free` pool.
+  let visionDefaultClaimed = false
+  if (process.env.CLOUDFLARE_AI_ACCOUNT_ID && process.env.CLOUDFLARE_AI_TOKEN) {
+    plans.push({
+      name: "Cloudflare AI vision (env backfill)",
+      provider_type: "cloudflare",
+      role: "ai_image_extraction",
+      is_default: true,
+      api_key: process.env.CLOUDFLARE_AI_TOKEN,
+      account_id: process.env.CLOUDFLARE_AI_ACCOUNT_ID,
+      default_model: process.env.TEXTILE_VISION_CLOUDFLARE_MODEL ||
+        "@cf/meta/llama-3.2-11b-vision-instruct",
+    })
+    visionDefaultClaimed = true
+  }
+  if (process.env.GROQ_API_KEY) {
+    plans.push({
+      name: "Groq vision (env backfill)",
+      provider_type: "groq",
+      role: "ai_image_extraction",
+      is_default: !visionDefaultClaimed,
+      api_key: process.env.GROQ_API_KEY,
+      default_model: process.env.GROQ_DEFAULT_MODEL || "qwen/qwen3.6-27b",
     })
   }
 

--- a/apps/backend/src/workflows/ai/textile-folder-extraction.ts
+++ b/apps/backend/src/workflows/ai/textile-folder-extraction.ts
@@ -267,7 +267,7 @@ const processFolderMediaSequentiallyStep = createStep(
           gender: input.gender,
           threadId: `textile-folder-${input.folder_id}-${item.media_id}`,
           resourceId: `textile-extraction:folder:${input.folder_id}:${item.media_id}`,
-        });
+        }, container);
 
         if (input.persist) {
           await persistTextileExtractionResult(mediaService, item.media_id, extraction, container);

--- a/apps/backend/src/workflows/ai/textile-product-extraction.ts
+++ b/apps/backend/src/workflows/ai/textile-product-extraction.ts
@@ -24,6 +24,14 @@ import MediaService from "../../modules/media/service";
 import type { MedusaContainer } from "@medusajs/framework";
 import { persistTextileAnalysis } from "../../modules/textile-analysis/lib/persist";
 import { TEXTILE_ANALYSIS_MODULE } from "../../modules/textile-analysis";
+import { resolveRoleVisionModels } from "../../mastra/services/ai-platforms";
+import {
+  setTextileModelsForRun,
+  clearTextileModelsForRun,
+} from "../../mastra/agents/textileExtractionAgent";
+
+/** Vision role the textile extraction resolves its provider ladder from. */
+const TEXTILE_VISION_ROLE = "ai_image_extraction";
 
 // ============================================
 // Types
@@ -146,7 +154,7 @@ export const runTextileMastraExtraction = async (input: {
   gender?: string;
   threadId?: string;
   resourceId?: string;
-}): Promise<TextileProductExtractionOutput> => {
+}, container?: MedusaContainer): Promise<TextileProductExtractionOutput> => {
   const workflow = mastra.getWorkflow("textileProductExtractionWorkflow");
   const run = await workflow.createRun();
 
@@ -154,16 +162,39 @@ export const runTextileMastraExtraction = async (input: {
   const threadId = input.threadId || `textile-thread-${Date.now()}`;
   const resourceId = input.resourceId || `textile-extraction:${Date.now()}`;
 
+  // Resolve the admin-configured vision ladder (Cloudflare → Groq → …) and
+  // hand the built models to the Mastra workflow by runId (the Mastra runtime
+  // has no container). Falls back to the OpenRouter `:free` ladder inside the
+  // workflow when no platform is configured.
+  if (container) {
+    try {
+      const resolved = await resolveRoleVisionModels(container, TEXTILE_VISION_ROLE);
+      if (resolved.length) {
+        setTextileModelsForRun(run.runId, resolved.map((r) => r.model));
+      }
+    } catch (e: any) {
+      console.warn(
+        `[textile-extraction] vision provider resolution failed, using free fallback: ${e?.message ?? e}`
+      );
+    }
+  }
+
   // Execute the workflow
-  const workflowResult = await run.start({
-    inputData: {
-      image_url: input.image_url,
-      hints: input.hints || [],
-      gender: (input.gender as any) || "unisex",
-      threadId,
-      resourceId,
-    },
-  });
+  let workflowResult: any;
+  try {
+    workflowResult = await run.start({
+      inputData: {
+        image_url: input.image_url,
+        hints: input.hints || [],
+        gender: (input.gender as any) || "unisex",
+        threadId,
+        resourceId,
+        run_id: run.runId,
+      },
+    });
+  } finally {
+    if (container) clearTextileModelsForRun(run.runId);
+  }
 
   // Check validation step result
   if (workflowResult.steps.validateTextileExtraction?.status === "success") {
@@ -197,9 +228,12 @@ export const runTextileMastraExtraction = async (input: {
  */
 const runMastraTextileExtractionStep = createStep(
   "run-mastra-textile-extraction",
-  async (input: { image_url: string; hints?: string[]; gender?: string; threadId?: string; resourceId?: string }) => {
+  async (
+    input: { image_url: string; hints?: string[]; gender?: string; threadId?: string; resourceId?: string },
+    { container }
+  ) => {
     try {
-      return new StepResponse(await runTextileMastraExtraction(input));
+      return new StepResponse(await runTextileMastraExtraction(input, container));
     } catch (error: any) {
       if (error instanceof MedusaError) throw error;
       throw new MedusaError(

--- a/apps/backend/src/workflows/ai/textile-product-extraction.ts
+++ b/apps/backend/src/workflows/ai/textile-product-extraction.ts
@@ -28,6 +28,7 @@ import { resolveRoleVisionModels } from "../../mastra/services/ai-platforms";
 import {
   setTextileModelsForRun,
   clearTextileModelsForRun,
+  clearTextileCooldownForRun,
 } from "../../mastra/agents/textileExtractionAgent";
 
 /** Vision role the textile extraction resolves its provider ladder from. */
@@ -193,7 +194,10 @@ export const runTextileMastraExtraction = async (input: {
       },
     });
   } finally {
-    if (container) clearTextileModelsForRun(run.runId);
+    if (container) {
+      clearTextileModelsForRun(run.runId);
+      clearTextileCooldownForRun(run.runId);
+    }
   }
 
   // Check validation step result


### PR DESCRIPTION
## What

The textile extraction was hardcoded to the OpenRouter free-model ladder, so admin-configured External Platforms (Cloudflare, Groq, and any OpenAI-compatible `custom` provider) were ignored — and that ladder was silently charging non-free `google/lyria-*` audio models on every attempt.

## Changes

**fix — OpenRouter free-vision ladder** (`openrouter.ts`)
- `outputsText()` now requires text-ONLY output (excludes audio/music generators like `google/lyria-3-*` that advertise `["text","audio"]`).
- `getFreeVisionModels()` now restricts to explicit `:free`-suffixed models, so non-`:free` "preview" models can't be billed.

**feat — admin-configured vision ladder**
- Added `groq` provider type (`ai-platforms.ts`).
- Added plural `getAiPlatformsForRole` + `resolveRoleVisionModels` (default-first ladder).
- Wired the textile extraction (`textile-product-extraction.ts` / `textile-folder-extraction.ts`) to resolve the `ai_image_extraction` ladder from the container and hand built models to the Mastra workflow by runId.
- `runVisionExtraction` (Mastra) tries configured providers first (plain generate + JSON parse, since Groq/Cloudflare don't reliably honour AI-SDK `json_schema`), then the OpenRouter `:free` pool.
- Backfill seeds Cloudflare + Groq `ai_image_extraction` rows from env (`CLOUDFLARE_AI_*`, `GROQ_API_KEY`).

## Live config (already applied to prod via the admin API)

`ai_image_extraction` ladder: Cloudflare gemma (default) → BazaarLink `auto:free` → NVIDIA NIM `meta/llama-3.2-90b-vision-instruct` → DeepSeek `deepseek-v4-flash-vision-exp` → OpenRouter `:free`.

## Test

- `openrouter`, `resolve-role-vision-model`, `resolve-role-text-model`, `ai-platforms` unit suites pass.