### PR TITLE
fix(storefront): the client SDK called localhost:9000 in production (#1720)

### DIFF
--- a/apps/storefront/.env.template
+++ b/apps/storefront/.env.template
@@ -1,4 +1,10 @@
 # Your Medusa backend, should be updated to where you are hosting your server. Remember to update CORS settings for your server. See – https://docs.medusajs.com/learn/configurations/medusa-config#httpstorecors
+#
+# 🔴 SET BOTH (#1720). Only the NEXT_PUBLIC_ one reaches the BROWSER — Next
+# inlines nothing else — and the design chat's client-side libs call the backend
+# from there. With only the unprefixed name set, every client-side call goes to
+# http://localhost:9000 in the visitor's browser, silently, on production.
+NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://localhost:9000
 MEDUSA_BACKEND_URL=http://localhost:9000
 
 # Your publishable key that can be attached to sales channels. See - https://docs.medusajs.com/resources/storefront-development/publishable-api-keys

--- a/apps/storefront/src/lib/config.ts
+++ b/apps/storefront/src/lib/config.ts
@@ -1,10 +1,34 @@
 import { getLocaleHeader } from "@lib/util/get-locale-header"
 import Medusa, { FetchArgs, FetchInput } from "@medusajs/js-sdk"
 
-// Defaults to standard port for Medusa server
+/**
+ * The backend origin this SDK talks to (#1720).
+ *
+ * 🔴 `NEXT_PUBLIC_MEDUSA_BACKEND_URL` FIRST, and it is not a style choice.
+ * Next.js inlines only `NEXT_PUBLIC_*` into the client bundle, so reading the
+ * unprefixed name alone left `MEDUSA_BACKEND_URL` undefined in the BROWSER and
+ * every client-side call fell through to `http://localhost:9000` — in the
+ * visitor's own browser, on production, with no error anywhere.
+ *
+ * It stayed invisible for two reasons. This app fetches almost everything in
+ * server components and server actions, where `process.env` works, so the
+ * catalogue, checkout and the AI chat stream were all fine; the design chat's
+ * `"use client"` libs were the first client-side SDK callers. And a developer
+ * running Medusa locally cannot see it at all — the request resolves to their
+ * own :9000 backend.
+ *
+ * The unprefixed name is kept as a fallback: it is what server-only contexts
+ * are configured with, and `provision-storefront.ts` sets BOTH on every
+ * partner project.
+ *
+ * ⚠️ `process.env.NEXT_PUBLIC_*` must be read as a whole static expression for
+ * the inlining to happen — never destructured, never index-accessed.
+ */
 let MEDUSA_BACKEND_URL = "http://localhost:9000"
 
-if (process.env.MEDUSA_BACKEND_URL) {
+if (process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL) {
+  MEDUSA_BACKEND_URL = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL
+} else if (process.env.MEDUSA_BACKEND_URL) {
   MEDUSA_BACKEND_URL = process.env.MEDUSA_BACKEND_URL
 }
 


### PR DESCRIPTION
Closes #1720.

## The bug

`apps/storefront/src/lib/config.ts` read `process.env.MEDUSA_BACKEND_URL`. Next.js inlines only `NEXT_PUBLIC_*` into the client bundle, so in the **browser** that name is `undefined` and the Medusa SDK took its `http://localhost:9000` default. The correctly-prefixed name was already in use three lines below, for the publishable key.

Captured from the live production site during the #1689 re-test:

```
http://localhost:9000/store/custom/design-assistant/conversations
http://localhost:9000/store/custom/design-assistant/designs/01M1EEFGR…?customer_email=…
```

## The fix

Prefer `NEXT_PUBLIC_MEDUSA_BACKEND_URL`; keep the unprefixed name as the server-only fallback. `workflows/stores/provision-storefront.ts:258,264` already sets BOTH on every provisioned partner project, so the 12 partner storefronts are fixed by this commit alone.

## Verification — against the built bundle, with a control

Grepping the source for a nicer variable name proves nothing here, and neither does grepping the bundle for the URL: `design-uploads.ts` **already** read the prefixed name, so the value was in the bundle before this change. Two clean builds (`rm -rf .next/static` each time) with `NEXT_PUBLIC_MEDUSA_BACKEND_URL=https://sentinel-1720.example.com`:

| build | chunks containing the sentinel |
|---|---|
| original code | `27mglz6a2516w.js` — `design-uploads.ts` only |
| with this fix | `27mglz6a2516w.js` **+ `1svz002j2kb7e.js`** — the SDK config |

Reverting the change removes the second chunk. That is the assertion.

## ⚠️ Ops tail — this PR is NOT sufficient on its own for the core store

The core store's Vercel project had `NEXT_PUBLIC_MEDUSA_BACKEND_URL=https://api.jaalyantra.com`, which is **not the backend**:

```
https://api.jaalyantra.com/health  -> 404
https://v3.jaalyantra.com/health   -> 200
```

The founder has corrected the value. The project still needs a **redeploy** — the variable is inlined at build time, and a scan of the live chunks after the env change still shows `api.jaalyantra.com`. After redeploy, re-scan the bundle: `v3.jaalyantra.com` should appear and `localhost:9000` should not.

(I originally reported this variable as *unset*. It was set to the wrong host — my bundle scan searched only for `v3.jaalyantra.com` and `localhost:9000`, so a wrong-but-present value read as absent. #1720 has been corrected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
