### PR TITLE
fix(ai): a generation minted a duplicate design per image (#1721)

### DIFF
--- a/apps/backend/src/workflows/ai/__tests__/generate-design-image-history.unit.spec.ts
+++ b/apps/backend/src/workflows/ai/__tests__/generate-design-image-history.unit.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * When an AI generation gets its own design record (#1721).
+ *
+ * ## Why this rule is worth a test of its own
+ *
+ * It was a comment that said "Always create a design entry to save AI
+ * generation history", and the code did exactly that — including when the
+ * caller had already named the design the image belongs to. One design-chat
+ * session on production (2026-09-01) produced THREE design records: the real
+ * `Monsoon Kurta`, plus one `AI Design - Sep 1, 12:20 PM` per generated take,
+ * all three linked to the same customer.
+ *
+ * #1698 had already made the chat's `create_design` TOOL idempotent per thread.
+ * This workflow is a second creator that fix never touched, which is the whole
+ * lesson: enumerate every path that creates the record before calling a
+ * duplicate bug closed.
+ */
+import { shouldCreateHistoryDesign } from "../generate-design-image"
+
+const upload = { media_id: "med_1", media_url: "https://cdn/x.jpg" }
+
+describe("shouldCreateHistoryDesign", () => {
+  it("files a standalone generation — nothing else would record it", () => {
+    expect(
+      shouldCreateHistoryDesign({ input: {}, uploadResult: upload })
+    ).toBe(true)
+  })
+
+  /**
+   * 🔴 The regression. The chat's generate tool passes `design_id` with
+   * `mode: "commit"` (see `mastra/agents/tools/storefront-design-flow.ts`), so
+   * the commit step attaches the image to that design — and this used to mint a
+   * second record for the same picture anyway, once per take.
+   */
+  it("files NOTHING when the caller already named a design", () => {
+    expect(
+      shouldCreateHistoryDesign({
+        input: { design_id: "01M1EEFGR1AH949RFREWZ6QKVM" },
+        uploadResult: upload,
+      })
+    ).toBe(false)
+  })
+
+  it("files nothing when no image was actually stored", () => {
+    expect(shouldCreateHistoryDesign({ input: {}, uploadResult: null })).toBe(
+      false
+    )
+    expect(
+      shouldCreateHistoryDesign({ input: {}, uploadResult: { media_id: "" } })
+    ).toBe(false)
+    expect(shouldCreateHistoryDesign({ input: {} })).toBe(false)
+  })
+
+  /**
+   * ⚠️ `""` is not an id. The commit step gates on `!!design_id` as well, so an
+   * empty string attaches the image to nothing — the history record is then the
+   * only trace the generation would leave, and suppressing it would lose the
+   * image entirely. Pinned because the obvious "tighten the guard" edit here
+   * (`design_id === undefined`) would silently do that.
+   */
+  it("treats an empty-string design_id as no design, matching the commit step", () => {
+    expect(
+      shouldCreateHistoryDesign({
+        input: { design_id: "" },
+        uploadResult: upload,
+      })
+    ).toBe(true)
+    expect(
+      shouldCreateHistoryDesign({
+        input: { design_id: null },
+        uploadResult: upload,
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/workflows/ai/generate-design-image.ts
+++ b/apps/backend/src/workflows/ai/generate-design-image.ts
@@ -381,8 +381,31 @@ const updateDesignWithAiMediaStep = createStep(
   }
 );
 
-// Step 4: Create a new design entry for AI generation history
-// Now uses createDesignWorkflow.runAsStep() for proper workflow composition
+/**
+ * Should this generation be filed as its own design record? (#1721)
+ *
+ * Exported and pure so the rule can be asserted directly. It used to be the
+ * word "Always" in a comment, and that is precisely why one design-chat session
+ * produced three designs on production: the real one, plus a row per generated
+ * image named `AI Design - <timestamp>`.
+ *
+ * Two conditions, and they mean different things:
+ *
+ *  - `uploadResult.media_id` — there is an actual stored image to file. No
+ *    image, no record; a failed generation should leave nothing behind.
+ *  - NO `design_id` on the input — nobody has already given this picture a
+ *    home. When the caller names a design, the workflow's commit step attaches
+ *    the image to it, and a second record for the same picture is a duplicate
+ *    that no list can tell apart from a real design.
+ *
+ * ⚠️ An EMPTY-STRING design_id counts as "no design", deliberately: the commit
+ * step gates on `!!design_id` too, so with `""` nothing attaches the image and
+ * the history record is the only trace it would leave.
+ */
+export const shouldCreateHistoryDesign = (data: {
+  input: { design_id?: string | null }
+  uploadResult?: { media_id?: string | null } | null
+}): boolean => !!data.uploadResult?.media_id && !data.input.design_id
 
 // Main workflow
 export const generateDesignAiImageWorkflow = createWorkflow(
@@ -436,9 +459,24 @@ export const generateDesignAiImageWorkflow = createWorkflow(
       return updateDesignWithAiMediaStep(updateDesignInput);
     });
 
-    // Step 4: Always create a design entry to save AI generation history
+    // Step 4: Save the generation as its own design — ONLY when it has no home
     // Uses createDesignWorkflow.runAsStep() for proper workflow composition
-    // This ensures customers can see their AI generations across sessions
+    //
+    // 🔴 This used to run unconditionally, and the comment said so ("Always
+    // create a design entry"). When the caller already supplied a `design_id`,
+    // Step 3 above attached the image to that design and Step 4 then minted a
+    // SECOND record for the same picture — one per image. A design chat asking
+    // for two takes produced three designs: the real one plus two rows named
+    // `AI Design - <timestamp>` (#1721, seen on production 2026-09-01).
+    //
+    // The history intent is right for a standalone generation, which otherwise
+    // leaves no trace a customer can find later. It is wrong the moment a
+    // design_id is given: the history already has a home, and the duplicate is
+    // indistinguishable from a real design in every list.
+    //
+    // ⚠️ #1698 made the chat's `create_design` TOOL idempotent per thread. This
+    // path is a second creator that fix never touched — enumerate every creator
+    // before calling a duplicate-record bug closed.
     const createDesignInput = transform(
       { input, mastraResult, uploadResult },
       (data) => {
@@ -485,8 +523,8 @@ export const generateDesignAiImageWorkflow = createWorkflow(
 
     const createDesignResult = when(
       "create-ai-design-history",
-      { uploadResult },
-      (data) => !!data.uploadResult?.media_id
+      { input, uploadResult },
+      (data) => shouldCreateHistoryDesign(data)
     ).then(() => {
       // Use createDesignWorkflow.runAsStep() for proper workflow composition
       return createDesignWorkflow.runAsStep({
@@ -503,8 +541,13 @@ export const generateDesignAiImageWorkflow = createWorkflow(
         // Always use the uploaded media URL if available
         preview_url: data.uploadResult?.media_url || data.mastraResult.image_url,
         media_id: data.uploadResult?.media_id,
-        // createDesignWorkflow returns the design object directly with an id property
-        design_id: data.createDesignResult?.id,
+        // createDesignWorkflow returns the design object directly with an id
+        // property. ⚠️ Falls back to the design the caller named: Step 4 no
+        // longer runs when one was supplied (#1721), and a response that
+        // dropped `design_id` in that case would look like "no design" to every
+        // caller that reads it — the duplicate would be gone and the answer
+        // would be wrong in a new way.
+        design_id: data.createDesignResult?.id || data.input.design_id,
         prompt_used: data.mastraResult.prompt_used,
         badges: data.input.badges,
         materials_prompt: data.input.materials_prompt,


### PR DESCRIPTION
Closes #1721.

## The bug

`workflows/ai/generate-design-image.ts` ended with a comment that said what the code did:

```ts
// Step 4: Always create a design entry to save AI generation history
```

When the caller supplied a `design_id`, Step 3 attached the generated image to that design — and Step 4 then minted a **second** record for the same picture, once per image.

Production, 2026-09-01, one design-chat session:

| id | name | created |
|---|---|---|
| `01M1EEFGR1AH949RFREWZ6QKVM` | **Monsoon Kurta** | 12:18:07 |
| `01M1EEMCTM8M56NQP5JWQZJZ87` | AI Design - Sep 1, 12:20 PM | 12:20:47 |
| `01M1EEMH1J3KRT26SKHYPZP942` | AI Design - Sep 1, 12:20 PM | 12:20:47 |

Same customer on all three; the junk rows carry the image prompt as their description. Two takes → two duplicates.

## The fix

Gate Step 4 the way Step 3 is gated, on the inverse condition: file a history design only when nothing else has given the image a home. The rule is extracted as an exported pure `shouldCreateHistoryDesign` rather than left as an inline callback inside a workflow, so it can be asserted directly.

The response transform now falls back to the caller's `design_id`, so a caller reading `design_id` off the result still gets the design the image belongs to rather than `undefined`.

## Why this wasn't closed by #1698

#1698 made the chat's `create_design` **tool** idempotent per thread. This workflow is a **second creator** that fix never touched — the duplicates were never created by `create_design` at all. Same shape as "five paths create a product; the fix landed on four": enumerate every creator before calling a duplicate-record bug closed.

That the chat path actually hits this was verified, not assumed — `mastra/agents/tools/storefront-design-flow.ts:780` passes `design_id` with `mode: "commit"`.

## Verification

4 unit tests, **mutation-checked**: restoring the old predicate fails `files NOTHING when the caller already named a design` — and only that one, so the test is not vacuous.

⚠️ One test pins that an **empty-string** `design_id` still files a history record. The commit step gates on `!!design_id` too, so with `""` nothing attaches the image and the history record is its only trace; the obvious tightening (`design_id === undefined`) would silently lose the image.

`check:prod-build` passes.

## Tail

The two junk rows are live on production and should be deleted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
