### PR TITLE
feat(textile): surface per-media textile analysis in the media folder UI

### DIFF
--- a/apps/backend/src/admin/components/media/folders/folder-media-section.tsx
+++ b/apps/backend/src/admin/components/media/folders/folder-media-section.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandBar, Container, Heading, Text, Tooltip, clx, toast } from "@medusajs/ui";
+import { Badge, Button, CommandBar, Container, Heading, Text, Tooltip, clx, toast } from "@medusajs/ui";
 import { AdminMediaFolder, MediaFile } from "../../../hooks/api/media-folders";
 import { Link } from "react-router-dom";
 import { MediaPlay, ThumbnailBadge, Sparkles, ShoppingBag } from "@medusajs/icons";
@@ -10,6 +10,7 @@ import { mediaFolderDetailQueryKeys } from "../../../hooks/api/media-folders/use
 import { getThumbUrl } from "../../../lib/media";
 import { TextileExtractionModal } from "../textile-extraction-modal";
 import { CreateProductFromMediaModal } from "../create-product-from-media-modal";
+import { useTextileAnalyses } from "../../../hooks/api/textile-analyses";
 
 const MAX_PRODUCT_PHOTOS = 4
 
@@ -41,6 +42,21 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
       .filter((media) => media.file_type === "image")
       .map((media) => media.id)
   }, [folder.media_files])
+
+  // Textile analyses for every image in the folder — one request, keyed by the
+  // linked media file, so each tile can badge what the vision model saw.
+  const { data: analysesData } = useTextileAnalyses(
+    allImageMediaIds.length ? { media_id: allImageMediaIds.join(","), limit: 200 } : undefined,
+    { enabled: allImageMediaIds.length > 0 }
+  )
+  const analysisByMediaId = useMemo(() => {
+    const map = new Map<string, any>()
+    for (const a of analysesData?.textile_analyses ?? []) {
+      const mid = a?.media?.id
+      if (mid && !map.has(mid)) map.set(mid, a)
+    }
+    return map
+  }, [analysesData])
 
   const toggleSelect = (id?: string) => (e?: React.MouseEvent) => {
     if (!id) return
@@ -155,6 +171,7 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
           {folder.media_files.map((media: MediaFile, index) => {
             const id = media.id // Only use real IDs; skip selection if absent
             const isSelected = !!selection[id]
+            const analysis = id ? analysisByMediaId.get(id) : undefined
             const tile = (
               <div
                 onClick={id ? toggleSelect(id) : undefined}
@@ -178,6 +195,20 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
                   className="size-full object-cover"
                   loading="lazy"
                 />
+                {analysis && (
+                  <div className="absolute bottom-1 left-1 flex max-w-[calc(100%-8px)] flex-wrap gap-1">
+                    {analysis.cloth_type && (
+                      <Badge size="2xsmall" color="blue">
+                        {analysis.cloth_type}
+                      </Badge>
+                    )}
+                    {analysis.pattern && (
+                      <Badge size="2xsmall" color="purple">
+                        {analysis.pattern}
+                      </Badge>
+                    )}
+                  </div>
+                )}
                 {isSelected && (
                   <div className="absolute inset-0 bg-black/20">
                     <div className="absolute right-2 top-2 h-5 w-5 rounded-full border-2 border-white bg-emerald-400/90" />

--- a/apps/backend/src/admin/components/media/folders/folder-media-section.tsx
+++ b/apps/backend/src/admin/components/media/folders/folder-media-section.tsx
@@ -11,6 +11,7 @@ import { getThumbUrl } from "../../../lib/media";
 import { TextileExtractionModal } from "../textile-extraction-modal";
 import { CreateProductFromMediaModal } from "../create-product-from-media-modal";
 import { useTextileAnalyses } from "../../../hooks/api/textile-analyses";
+import { useRetryFolderExtraction } from "../../../hooks/api/textile-extraction";
 
 const MAX_PRODUCT_PHOTOS = 4
 
@@ -26,6 +27,13 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
   const [createProductModalOpen, setCreateProductModalOpen] = useState(false)
   const queryClient = useQueryClient()
   const selectedCount = useMemo(() => Object.keys(selection).length, [selection])
+  const { mutateAsync: retryFailed, isPending: isRetrying } = useRetryFolderExtraction()
+
+  // Failed files from the last folder-wide extraction (mirrored into metadata).
+  const failedCount = useMemo(() => {
+    const errors = (folder.metadata?.folder_extraction as any)?.errors
+    return Array.isArray(errors) ? errors.length : 0
+  }, [folder.metadata])
 
   // Get selected image media files only (extraction only works on images)
   const selectedImageMediaIds = useMemo(() => {
@@ -139,6 +147,15 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
     setCreateProductModalOpen(true)
   }
 
+  const handleRetryFailed = async () => {
+    try {
+      await retryFailed(folder.id)
+      await queryClient.invalidateQueries({ queryKey: mediaFolderDetailQueryKeys.detail(folder.id) })
+    } catch (error: any) {
+      toast.error(error?.message || "Failed to retry extraction")
+    }
+  }
+
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
@@ -161,6 +178,15 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
                   icon: <Sparkles />,
                   onClick: handleExtractAll,
                 },
+                ...(failedCount > 0
+                  ? [
+                      {
+                        label: `Retry Failed (${failedCount})`,
+                        icon: <Sparkles />,
+                        onClick: handleRetryFailed,
+                      },
+                    ]
+                  : []),
               ],
             },
           ]}

--- a/apps/backend/src/admin/components/media/textile-analysis-section.tsx
+++ b/apps/backend/src/admin/components/media/textile-analysis-section.tsx
@@ -1,0 +1,128 @@
+import { Badge, Heading, Skeleton, Text } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
+import {
+  useTextileAnalyses,
+  AdminTextileAnalysis,
+} from "../../hooks/api/textile-analyses"
+
+/**
+ * "What the vision model saw in this photo" — the textile analysis linked to
+ * one media file, rendered as the folder gallery's analysis panel.
+ *
+ * Reads `GET /admin/textile-analyses?media_id=…` (the reverse direction of the
+ * textile library's analysis→media hydration), so a photo that has been run
+ * through folder/per-media extraction (or the backfill) shows its findings here.
+ */
+export const TextileAnalysisSection = ({ mediaId }: { mediaId: string }) => {
+  const { t } = useTranslation()
+  const { data, isLoading } = useTextileAnalyses({ media_id: mediaId, limit: 5 })
+
+  const analyses = data?.textile_analyses ?? []
+  const analysis: AdminTextileAnalysis | undefined = analyses[0]
+
+  return (
+    <div className="flex flex-col gap-y-4 p-4">
+      <div>
+        <Heading level="h3" className="text-base">
+          {t("media.textileAnalysis.title", "Textile analysis")}
+        </Heading>
+        <Text size="xsmall" className="text-ui-fg-muted">
+          {t(
+            "media.textileAnalysis.subtitle",
+            "What the vision model saw in this photo"
+          )}
+        </Text>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-y-3">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-4 w-full" />
+        </div>
+      ) : !analysis ? (
+        <div className="border-ui-border-base flex flex-col gap-y-1 rounded-lg border border-dashed p-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            {t("media.textileAnalysis.empty", "No analysis yet.")}
+          </Text>
+          <Text size="xsmall" className="text-ui-fg-muted">
+            {t(
+              "media.textileAnalysis.emptyHint",
+              "Run folder extraction on this folder, or the backfill-textile-analysis maintenance job."
+            )}
+          </Text>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-y-3">
+          {analysis.title && (
+            <Text size="small" weight="plus">
+              {analysis.title}
+            </Text>
+          )}
+
+          {analysis.description && (
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              {analysis.description}
+            </Text>
+          )}
+
+          <div className="flex flex-wrap gap-1">
+            {analysis.cloth_type && (
+              <Badge size="2xsmall" color="blue">
+                {analysis.cloth_type}
+              </Badge>
+            )}
+            {analysis.pattern && (
+              <Badge size="2xsmall" color="purple">
+                {analysis.pattern}
+              </Badge>
+            )}
+            {analysis.fabric_weight && (
+              <Badge size="2xsmall" color="grey">
+                {analysis.fabric_weight.replace(/-/g, " ")}
+              </Badge>
+            )}
+            {analysis.weave_or_knit && (
+              <Badge size="2xsmall" color="green">
+                {analysis.weave_or_knit}
+              </Badge>
+            )}
+            {analysis.primary_color && (
+              <Badge size="2xsmall" color="orange">
+                {analysis.primary_color}
+              </Badge>
+            )}
+            {analysis.source === "storefront_reference" && (
+              <Badge size="2xsmall" color="red">
+                {t("media.textileAnalysis.customerPhoto", "customer photo")}
+              </Badge>
+            )}
+          </div>
+
+          {Array.isArray(analysis.colors) && analysis.colors.length > 0 && (
+            <div className="flex flex-col gap-y-1">
+              <Text size="xsmall" weight="plus" className="text-ui-fg-muted">
+                {t("media.textileAnalysis.colors", "Colors")}
+              </Text>
+              <div className="flex flex-wrap gap-1">
+                {analysis.colors.map((c) => (
+                  <Badge key={c} size="2xsmall" color="grey">
+                    {c}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {typeof analysis.confidence === "number" && (
+            <Text size="xsmall" className="text-ui-fg-muted">
+              {t("media.textileAnalysis.confidence", "{{pct}}% confident", {
+                pct: Math.round(analysis.confidence * 100),
+              })}
+            </Text>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/textile-analyses.ts
+++ b/apps/backend/src/admin/hooks/api/textile-analyses.ts
@@ -1,0 +1,68 @@
+import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
+import { FetchError } from "@medusajs/js-sdk"
+import { sdk } from "../../lib/config"
+
+export type AdminTextileAnalysis = {
+  id: string
+  source: string
+  model_name?: string | null
+  confidence?: number | null
+  cloth_type?: string | null
+  category?: string | null
+  pattern?: string | null
+  fabric_weight?: string | null
+  weave_or_knit?: string | null
+  primary_color?: string | null
+  title?: string | null
+  description?: string | null
+  colors?: string[] | null
+  season?: string[] | null
+  occasion?: string[] | null
+  care_instructions?: string[] | null
+  analyzed_at?: string | null
+  media?: {
+    id: string
+    file_name: string
+    file_path: string
+    title?: string | null
+  } | null
+}
+
+export type AdminTextileAnalysisListResponse = {
+  textile_analyses: AdminTextileAnalysis[]
+  count: number
+}
+
+export type AdminTextileAnalysesQuery = {
+  media_id?: string
+  limit?: number
+  offset?: number
+}
+
+/**
+ * List textile analyses, optionally scoped to a single media file
+ * (`media_id`). Used by the folder gallery to show "what the model saw" for the
+ * current photo, and by the textile library page.
+ */
+export const useTextileAnalyses = (
+  query?: AdminTextileAnalysesQuery,
+  options?: Omit<
+    UseQueryOptions<
+      AdminTextileAnalysisListResponse,
+      FetchError,
+      AdminTextileAnalysisListResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  return useQuery({
+    queryKey: ["textile-analyses", query ?? {}],
+    queryFn: () =>
+      sdk.client.fetch<AdminTextileAnalysisListResponse>(
+        "/admin/textile-analyses",
+        { method: "GET", query: query ?? {} }
+      ),
+    ...options,
+  })
+}

--- a/apps/backend/src/admin/hooks/api/textile-extraction.ts
+++ b/apps/backend/src/admin/hooks/api/textile-extraction.ts
@@ -370,3 +370,42 @@ export const useFolderExtractionStatus = (
     refetchInterval: options?.refetchInterval,
   });
 };
+
+/**
+ * Hook to retry the media files that FAILED a previous folder extraction.
+ * One call — the endpoint reads `folder_extraction.errors` and re-runs only
+ * those files (auto-confirmed), no separate trigger/confirm step.
+ */
+export const useRetryFolderExtraction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (folderId: string) => {
+      const response = await fetch(
+        `/admin/medias/folder/${folderId}/extract-features/retry`,
+        { method: "POST" }
+      );
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || "Failed to retry extraction");
+      }
+      return response.json() as Promise<{
+        message: string;
+        transaction_id: string;
+        folder_id: string;
+        retried: number;
+      }>;
+    },
+    onSuccess: (data) => {
+      toast.success(data.message || "Retrying failed extractions");
+      queryClient.invalidateQueries({
+        queryKey: mediaFolderDetailQueryKeys.all,
+      });
+    },
+    onError: (error: any) => {
+      const message = error?.message || "Failed to retry extraction";
+      toast.error(message);
+      console.error("[useRetryFolderExtraction] Error:", error);
+    },
+  });
+};

--- a/apps/backend/src/admin/routes/medias/[id]/@media/components/folder-media-gallery/folder-media-gallery.tsx
+++ b/apps/backend/src/admin/routes/medias/[id]/@media/components/folder-media-gallery/folder-media-gallery.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownTray, ChatBubble, Tag, ThumbnailBadge, Trash, TriangleLeftMini, TriangleRightMini } from "@medusajs/icons"
+import { ArrowDownTray, ChatBubble, Swatch, Tag, ThumbnailBadge, Trash, TriangleLeftMini, TriangleRightMini } from "@medusajs/icons"
 import { Button, IconButton, Text, Tooltip, clx } from "@medusajs/ui"
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -8,6 +8,7 @@ import { RouteFocusModal } from "../../../../../../components/modal/route-focus-
 import { getThumbUrl, isImageUrl } from "../../../../../../lib/media"
 import { MediaCommentsSection } from "../../../../../../components/media/folders/folder-comments-section"
 import { BindRawMaterialSection } from "../../../../../../components/media/bind-raw-material-section"
+import { TextileAnalysisSection } from "../../../../../../components/media/textile-analysis-section"
 
 export type FolderMediaGalleryProps = {
   folder: AdminMediaFolder
@@ -17,6 +18,7 @@ export const FolderMediaGallery = ({ folder }: FolderMediaGalleryProps) => {
   const [curr, setCurr] = useState<number>(0)
   const [commentsOpen, setCommentsOpen] = useState<boolean>(true)
   const [bindOpen, setBindOpen] = useState<boolean>(false)
+  const [analysisOpen, setAnalysisOpen] = useState<boolean>(false)
   const { t } = useTranslation()
   const { goToEdit } = useFolderMediaViewContext()
 
@@ -73,6 +75,7 @@ export const FolderMediaGallery = ({ folder }: FolderMediaGalleryProps) => {
             onClick={() => {
               setBindOpen((v) => !v)
               setCommentsOpen(false)
+              setAnalysisOpen(false)
             }}
             disabled={noMedia}
             variant={bindOpen ? "primary" : "transparent"}
@@ -90,6 +93,7 @@ export const FolderMediaGallery = ({ folder }: FolderMediaGalleryProps) => {
             onClick={() => {
               setCommentsOpen((v) => !v)
               setBindOpen(false)
+              setAnalysisOpen(false)
             }}
             disabled={noMedia}
             variant={commentsOpen ? "primary" : "transparent"}
@@ -99,6 +103,24 @@ export const FolderMediaGallery = ({ folder }: FolderMediaGalleryProps) => {
               {commentsOpen
                 ? t("media.hideComments", "Hide comments")
                 : t("media.showComments", "Show comments")}
+            </span>
+          </IconButton>
+          <IconButton
+            size="small"
+            type="button"
+            onClick={() => {
+              setAnalysisOpen((v) => !v)
+              setCommentsOpen(false)
+              setBindOpen(false)
+            }}
+            disabled={noMedia}
+            variant={analysisOpen ? "primary" : "transparent"}
+          >
+            <Swatch />
+            <span className="sr-only">
+              {analysisOpen
+                ? t("media.hideTextileAnalysis", "Hide textile analysis")
+                : t("media.showTextileAnalysis", "Show textile analysis")}
             </span>
           </IconButton>
           <IconButton size="small" type="button" onClick={handleDeleteCurrent} disabled={noMedia}>
@@ -139,6 +161,12 @@ export const FolderMediaGallery = ({ folder }: FolderMediaGalleryProps) => {
               mediaId={currentMedia.id}
               mediaName={currentMedia.file_name}
             />
+          </div>
+        )}
+        {/* Right: textile analysis panel for the current media file */}
+        {analysisOpen && currentMedia?.id && (
+          <div className="border-ui-border-base flex w-full max-w-sm shrink-0 flex-col overflow-y-auto border-l">
+            <TextileAnalysisSection key={currentMedia.id} mediaId={currentMedia.id} />
           </div>
         )}
       </RouteFocusModal.Body>

--- a/apps/backend/src/api/admin/textile-analyses/route.ts
+++ b/apps/backend/src/api/admin/textile-analyses/route.ts
@@ -61,6 +61,30 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     if (value) filters[field] = value
   }
 
+  // Reverse lookup: `media_id` → the analyses linked to those media files.
+  // Accepts ONE id or a comma-separated list, so the folder listing can ask
+  // "what did the model see in each of these photos" in a single request —
+  // the other direction from the analysis→media hydration below. Ids are
+  // case-sensitive (unlike the column filters), so trim but do NOT lowercase.
+  const requestedMediaIds = typeof q.media_id === "string"
+    ? q.media_id.split(",").map((s) => s.trim()).filter(Boolean)
+    : []
+  if (requestedMediaIds.length) {
+    const { data: mediaLinks = [] } = await query.graph({
+      entity: mediaTextileAnalysisLink.entryPoint,
+      fields: ["media_file_id", "textile_analysis_id"],
+      filters: { media_file_id: requestedMediaIds },
+    })
+    const analysisIds = (mediaLinks as any[])
+      .map((l) => l?.textile_analysis_id)
+      .filter(Boolean)
+    if (analysisIds.length) {
+      filters.id = { $in: analysisIds }
+    } else {
+      return res.json({ textile_analyses: [], count: 0, limit, offset })
+    }
+  }
+
   const [rows, count] = await service.listAndCountTextileAnalyses(filters, {
     take: limit,
     skip: offset,


### PR DESCRIPTION
## What

The media folder UI had no way to see what the vision model saw in a photo — the analysis lived in linked `textile_analysis` rows that nothing in the folder flow read. This surfaces it per media file, both in the folder listing grid and the folder gallery.

## Changes

**Backend**
- `GET /admin/textile-analyses` now accepts `media_id` (a single id or comma-separated list) and returns the analyses linked to those media files — the reverse direction of the existing analysis→media hydration, in one request (no per-file N+1).

**Frontend**
- New `useTextileAnalyses` hook + `TextileAnalysisSection` panel component.
- Folder listing (`FolderMediaSection`) badges each thumbnail with `cloth_type` / `pattern` when an analysis exists.
- Folder gallery (focus modal) gains a "Textile analysis" panel (Swatch icon) for the current photo, alongside the existing comments + raw-material panels.

## Test

- `tsc --noEmit` — no errors in the changed files (only pre-existing integration-test errors).