### PR TITLE
fix(design-chat): a turn that abandons its tool calls now says so (#1725)

### DIFF
--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -228,7 +228,32 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   // Pipe the AI-SDK UI-message stream into the Express response.
   // The SDK handles SSE framing, Content-Type, and flushes — we just
   // hand it the Node ServerResponse Medusa hands us.
-  result.pipeUIMessageStreamToResponse(res as any)
+  //
+  // `onError` here is NOT the same hook as `streamText`'s above. That one is
+  // observability only — it logs and swallows, and the client is left reading
+  // a stream that simply stops. This one decides what the CLIENT is told, so
+  // a mid-turn failure arrives as an `error` part instead of a clean EOF the
+  // browser cannot tell apart from success (#1725). The status line is
+  // already committed by the time anything can go wrong, so an error part is
+  // the only channel left.
+  result.pipeUIMessageStreamToResponse(res as any, {
+    onError: (err: unknown) => {
+      logAiUsage(logger, {
+        feature: "store/ai/chat",
+        role: "ai_search_chat",
+        provider: usage.providerType,
+        source: usage.source,
+        platformId: usage.platformId,
+        model: usage.modelId,
+        ok: false,
+        ms: Date.now() - startedAt,
+        error: err,
+      })
+      // Deliberately generic: this reaches a shopper. The provider's own
+      // message is in the log line above.
+      return "The design assistant's connection dropped mid-turn. Please send that message again."
+    },
+  } as any)
 }
 
 

--- a/apps/storefront/src/modules/products/components/design-chat/index.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/index.tsx
@@ -58,6 +58,10 @@ import {
   type StoredUIMessage,
 } from "./lib/design-conversations"
 import { pickDesignCanvas } from "./lib/design-pick"
+import {
+  countPendingToolParts,
+  sealPendingToolParts,
+} from "./lib/incomplete-turn"
 import { retrieveCustomerFresh } from "@lib/data/customer"
 
 /**
@@ -190,6 +194,49 @@ export default function DesignChat({
   const lenis = useLenis()
 
   const isStreaming = status === "submitted" || status === "streaming"
+
+  // ── Seal abandoned tool calls when a turn ends (#1725) ──
+  //
+  // The provider can end a turn while a tool call's argument JSON is still
+  // streaming. The SDK then never fires `tool-input-available`, so the tool
+  // never runs and the part is stuck at `input-streaming` for the rest of the
+  // session — a chip that spins forever, with no error and no way to retry.
+  //
+  // That silence is the dangerous part: the assistant's prose is written from
+  // its INTENT, so a turn whose `save_brief` was abandoned still says
+  // "Brief locked". Measured on production: one turn ended `finishReason:
+  // "tool-calls"` with zero executed calls, another was cut mid-word with no
+  // `finish` part at all. Neither reached `error`, so `useChat` reported both
+  // as ordinary completions.
+  //
+  // A turn is over once `status` leaves the streaming states. Anything still
+  // pending at that moment did not happen — mark it `output-error` so the
+  // chips in message-parts.tsx render the failure they already know how to
+  // render, and tell the maker to send the message again.
+  const [turnIncomplete, setTurnIncomplete] = React.useState(false)
+  const sealedRef = React.useRef<Set<string>>(new Set())
+
+  React.useEffect(() => {
+    if (isStreaming || messages.length === 0) return
+    const last = messages.at(-1) as any
+    if (!last || last.role !== "assistant") return
+    if (sealedRef.current.has(last.id)) return
+    if (!countPendingToolParts(last)) return
+
+    sealedRef.current.add(last.id)
+    setTurnIncomplete(true)
+    setMessages((prev) =>
+      prev.map((m) =>
+        (m as any).id === last.id ? sealPendingToolParts(m) : m
+      ) as any
+    )
+  }, [messages, isStreaming, setMessages])
+
+  // A fresh turn clears the warning — the maker acted on it.
+  React.useEffect(() => {
+    if (isStreaming) setTurnIncomplete(false)
+  }, [isStreaming])
+
   const isGenerating = messages.some(
     (m) =>
       m.role === "assistant" &&
@@ -267,7 +314,11 @@ export default function DesignChat({
   // ── Persist after each completed turn ──
   React.useEffect(() => {
     if (isStreaming || messages.length === 0) return
-    const signature = `${messages.length}:${(messages as any).at(-1)?.id ?? ""}`
+    // The pending count is part of the signature: sealing an abandoned tool
+    // call (#1725) changes neither the message count nor the id, and without
+    // it the mirror would persist the spinning version forever.
+    const last = (messages as any).at(-1)
+    const signature = `${messages.length}:${last?.id ?? ""}:${countPendingToolParts(last)}`
     if (persistedRef.current === signature) return
     persistedRef.current = signature
 
@@ -569,6 +620,33 @@ export default function DesignChat({
     [isStreaming, uploading, sendMessage]
   )
 
+  /**
+   * Re-send the last user turn after a cut-short stream (#1725).
+   *
+   * Deliberately re-sends rather than "resuming": a turn that ended with an
+   * abandoned tool call left no server-side state to resume from, and the
+   * tools the model was mid-way through calling are the ones that never ran.
+   */
+  const lastUserText = React.useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i] as any
+      if (m.role !== "user") continue
+      const text = ((m.parts ?? []) as any[])
+        .filter((p) => p?.type === "text")
+        .map((p) => p.text)
+        .join("")
+      return text || null
+    }
+    return null
+  }, [messages])
+
+  const handleRetry = React.useCallback(() => {
+    if (!lastUserText || isStreaming || uploading) return
+    setTurnIncomplete(false)
+    setStickToBottom(true)
+    sendMessage({ text: lastUserText })
+  }, [lastUserText, isStreaming, uploading, sendMessage])
+
   const handlePickCanvas = async (canvasId: string) => {
     if (!designId || picking) return
     setPicking(true)
@@ -847,9 +925,22 @@ export default function DesignChat({
           <div className="flex flex-1 flex-col gap-3 px-4 py-4 sm:px-6">
             <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
               {messages.map(renderMessage)}
-              {error && (
-                <div className="rounded-xl border border-ui-tag-red-border bg-ui-tag-red-bg px-3 py-2 text-xs text-ui-tag-red-text">
-                  Something went wrong — try again.
+              {(error || turnIncomplete) && (
+                <div className="flex flex-wrap items-center gap-2 rounded-xl border border-ui-tag-red-border bg-ui-tag-red-bg px-3 py-2 text-xs text-ui-tag-red-text">
+                  <span>
+                    {error
+                      ? "Something went wrong — try again."
+                      : "That turn was cut short — some steps never ran, so anything the reply claims to have saved may not exist. Send it again."}
+                  </span>
+                  {lastUserText && !isStreaming && (
+                    <button
+                      type="button"
+                      onClick={handleRetry}
+                      className="rounded-md border border-ui-tag-red-border px-2 py-0.5 font-medium hover:bg-ui-tag-red-bg-hover"
+                    >
+                      Send again
+                    </button>
+                  )}
                 </div>
               )}
             </div>

--- a/apps/storefront/src/modules/products/components/design-chat/lib/__tests__/incomplete-turn.test.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/__tests__/incomplete-turn.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest"
+import {
+  INCOMPLETE_TOOL_ERROR,
+  countPendingToolParts,
+  sealPendingToolParts,
+} from "../incomplete-turn"
+
+/**
+ * Both fixtures are the real shapes measured on production on 2026-09-02 by
+ * replaying a design turn through cicilabel.com/api/ai-chat and recording the
+ * SSE parts. Kept ugly on purpose: a tidier fixture would certify the wrong
+ * code.
+ */
+
+// Run A — `save_brief` announced at 2.12s and abandoned; `create_design` and
+// `capture_contact` both ran; the stream was then cut mid-word at 10.53s with
+// no `text-end` and no `finish`. The prose still claimed the brief was locked.
+const runA = {
+  id: "msg-a",
+  role: "assistant",
+  parts: [
+    {
+      type: "tool-save_brief",
+      toolCallId: "call_80209fa86fea456d81fe12",
+      state: "input-streaming",
+      input: { product_type: "jumpsuit", concept_theme: "Relaxed indigo" },
+    },
+    {
+      type: "tool-create_design",
+      toolCallId: "call_d6433877c41946ba955ad5",
+      state: "output-available",
+      input: { email: "maker@example.com", name: "Probe 1725" },
+      output: { design_id: "design_01ABC" },
+    },
+    {
+      type: "tool-capture_contact",
+      toolCallId: "call_d0e8333afa4d466b89f6a1",
+      state: "output-available",
+      input: { email: "maker@example.com" },
+      output: { ok: true },
+    },
+    {
+      type: "text",
+      text: "✅ Brief locked and design created!  \nYour design is now live — These will directly",
+    },
+  ],
+}
+
+// Run B — both tool calls announced, neither ever reached
+// `tool-input-available`, and the turn closed with `finishReason: "tool-calls"`
+// and no text at all. Two chips spinning, nothing said.
+const runB = {
+  id: "msg-b",
+  role: "assistant",
+  parts: [
+    {
+      type: "tool-save_brief",
+      toolCallId: "call_dd1f22a953e641348931d4",
+      state: "input-streaming",
+      input: undefined,
+    },
+    {
+      type: "tool-create_design",
+      toolCallId: "call_010ba7f58de646e4b6649d",
+      state: "input-streaming",
+      input: undefined,
+    },
+  ],
+}
+
+const healthy = {
+  id: "msg-ok",
+  role: "assistant",
+  parts: [
+    {
+      type: "tool-save_brief",
+      state: "output-available",
+      output: { ok: true },
+    },
+    { type: "text", text: "Brief locked." },
+  ],
+}
+
+describe("countPendingToolParts", () => {
+  it("counts the abandoned call in a partially-executed turn", () => {
+    expect(countPendingToolParts(runA)).toBe(1)
+  })
+
+  it("counts every call in a turn where none executed", () => {
+    expect(countPendingToolParts(runB)).toBe(2)
+  })
+
+  it("counts nothing in a completed turn", () => {
+    expect(countPendingToolParts(healthy)).toBe(0)
+  })
+
+  it("treats input-available as pending — arguments complete is not a result", () => {
+    expect(
+      countPendingToolParts({
+        parts: [{ type: "tool-save_brief", state: "input-available" }],
+      })
+    ).toBe(1)
+  })
+
+  it("ignores non-tool parts in the same states", () => {
+    expect(
+      countPendingToolParts({
+        parts: [{ type: "text", state: "input-streaming", text: "hi" }],
+      })
+    ).toBe(0)
+  })
+})
+
+describe("sealPendingToolParts", () => {
+  it("marks the abandoned call failed and leaves the executed ones alone", () => {
+    const sealed: any = sealPendingToolParts(runA)
+
+    expect(sealed.parts[0].state).toBe("output-error")
+    expect(sealed.parts[0].errorText).toBe(INCOMPLETE_TOOL_ERROR)
+    // The two that really ran keep their results — sealing is not a reset.
+    expect(sealed.parts[1].state).toBe("output-available")
+    expect(sealed.parts[1].output).toEqual({ design_id: "design_01ABC" })
+    expect(sealed.parts[2].state).toBe("output-available")
+    // The truncated prose is left as the model wrote it; the chip is what
+    // tells the maker it was not true.
+    expect(sealed.parts[3]).toEqual(runA.parts[3])
+    expect(countPendingToolParts(sealed)).toBe(0)
+  })
+
+  it("marks every call failed when none executed", () => {
+    const sealed: any = sealPendingToolParts(runB)
+
+    expect(sealed.parts.map((p: any) => p.state)).toEqual([
+      "output-error",
+      "output-error",
+    ])
+    expect(countPendingToolParts(sealed)).toBe(0)
+  })
+
+  it("does not touch a completed turn", () => {
+    expect(sealPendingToolParts(healthy)).toBe(healthy)
+  })
+
+  it("does not mutate the message it was given", () => {
+    sealPendingToolParts(runB)
+    expect(runB.parts[0].state).toBe("input-streaming")
+  })
+})

--- a/apps/storefront/src/modules/products/components/design-chat/lib/incomplete-turn.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/incomplete-turn.ts
@@ -1,0 +1,54 @@
+/**
+ * Abandoned tool calls — the shape of a turn that stopped without saying so.
+ *
+ * The provider can end a turn while a tool call's argument JSON is still
+ * streaming. The AI SDK then never fires `tool-input-available`, so the tool
+ * never runs and its UI part is stuck at `input-streaming` for the rest of the
+ * session: a chip that spins forever, with no error and nothing to retry.
+ *
+ * The silence is the dangerous part. The assistant's prose is written from its
+ * INTENT, not from what actually happened, so a turn whose `save_brief` was
+ * abandoned still opens with "Brief locked". Measured on production (#1725):
+ * one turn ended `finishReason: "tool-calls"` with zero executed calls, and
+ * another was cut mid-word with no `finish` part at all — neither reached the
+ * `error` channel, so `useChat` reported both as ordinary completions.
+ *
+ * A turn is over once the chat leaves its streaming states. Anything still
+ * pending at that moment did not happen.
+ */
+
+export const INCOMPLETE_TOOL_ERROR =
+  "This step was cut short and never ran — please send your message again."
+
+/**
+ * A tool part the model announced but never finished handing arguments to.
+ *
+ * `input-available` counts as pending too: the arguments are complete but no
+ * result came back, so the tool still may not have run.
+ */
+export const isPendingToolPart = (p: any): boolean =>
+  typeof p?.type === "string" &&
+  p.type.startsWith("tool-") &&
+  (p.state === "input-streaming" || p.state === "input-available")
+
+export const countPendingToolParts = (m: any): number =>
+  ((m?.parts ?? []) as any[]).filter(isPendingToolPart).length
+
+/**
+ * Rewrite every pending tool part to `output-error`.
+ *
+ * `output-error` is not a new state — every chip in message-parts.tsx already
+ * renders it. Sealing just tells them the truth.
+ */
+export const sealPendingToolParts = <T,>(m: T): T => {
+  const anyMsg = m as any
+  if (!countPendingToolParts(anyMsg)) return m
+  return {
+    ...anyMsg,
+    parts: ((anyMsg.parts ?? []) as any[]).map((p) =>
+      isPendingToolPart(p)
+        ? { ...p, state: "output-error", errorText: INCOMPLETE_TOOL_ERROR }
+        : p
+    ),
+  }
+}


### PR DESCRIPTION
Closes the silent half of #1725. The measurement the issue asked for is below — and it **falsifies the `maxDuration` theory**.

## The measurement

Replayed a design turn through production `cicilabel.com/api/ai-chat`, recording every SSE part with its arrival time. (curl can't reach it — the storefront sits behind Vercel's challenge, `x-vercel-mitigated: challenge`, which is why the issue specified a browser.)

**Healthy control**, 7.0 s: `start → start-step → text-start → 51× text-delta → text-end → finish-step → finish{stop} → [DONE] → EOF`.

**Run A** — the dangerous row, reproduced:

| t | event |
|---|---|
| 2.12 s | `tool-input-start save_brief` |
| 4.28 s | `tool-input-start create_design` |
| 6.70 s | `tool-input-available create_design` |
| 6.94 s | `tool-input-start capture_contact` |
| 7.50 s | `tool-input-available capture_contact` |
| 7.52/7.94 s | 2× `tool-output-available` |
| 7.94 s | `finish-step` |
| 8.81 s | `start-step`, `text-start` |
| **10.53 s** | **clean EOF — no `text-end`, no `finish`, no `error`, no `[DONE]`** |

`save_brief` never reached `tool-input-available` and never ran. The text ended `"…These will directly"` and opened with `"✅ Brief locked and design created!"`. `create_design` was true; **`save_brief` was not**.

**Run B** — worse and unambiguous: two `tool-input-start` (`save_brief`, `create_design`), **zero** `tool-input-available`, **zero** `tool-output-available`, then `finish-step` + `finish{finishReason: "tool-calls"}` and **no text at all**. The last `tool-input-delta` is cut mid-JSON at `"code":`. Two chips spinning, nothing said.

## What that rules out

- **Not the function limit.** 10.53 s and 6.82 s are not round numbers, and run B terminated with a proper `finish`. No `maxDuration` change here.
- **Not token exhaustion.** Run B's arguments were a few hundred tokens against `maxOutputTokens: 4096`.

The provider ends the turn while a tool call's argument JSON is still streaming, so the AI SDK never completes the call. Neither run reached the `error` channel, so `useChat` reported both as ordinary completions — hence no banner, no retry, and a part stuck at `input-streaming` for the rest of the session.

## The change

**Client** (`design-chat/index.tsx` + new `lib/incomplete-turn.ts`) — once a turn ends, any tool part still pending is sealed to `output-error`, a state every chip in `message-parts.tsx` already renders. A banner explains that anything the reply claims to have saved may not exist, with a **Send again** button. The pending count joins the persist signature so the server mirror stores the sealed turn rather than the spinning one.

**Backend** (`store/ai/chat/route.ts`) — `pipeUIMessageStreamToResponse` gets its own `onError`. `streamText`'s `onError` is observability only: it logs and swallows, leaving the client reading a stream that just stops. The status line is committed by then, so an error part is the only channel left.

## Verification

- 9 new vitest cases over the two real production shapes above; mutation-checked (neutering the seal fails 2 of 9).
- `pnpm build` green (storefront), `check:prod-build` green (backend).

## Still open on #1725

The **root cause** — why the provider abandons a tool call mid-argument — is not fixed here, only made visible and recoverable. Prod's `ai_search_chat` is DashScope `qwen-plus`, the one model #1689 flagged as never tested. That's a model/config decision, not a code change.

⚠️ Two probe designs named "Probe 1725" were created on production during the measurement and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4