### PR TITLE
fix(textile): diagnose failures, transcode HEIC images, retry failed folder extraction

### DIFF
--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/retry/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/retry/route.ts
@@ -1,0 +1,82 @@
+/**
+ * Retry the media files that FAILED a previous folder-wide extraction.
+ *
+ *   POST /admin/medias/folder/:id/extract-features/retry
+ *
+ * Reads the failed media ids recorded in `folder.metadata.folder_extraction.errors`
+ * and re-runs the folder extraction workflow scoped to just those files
+ * (`media_ids`), auto-confirming so processing starts immediately — one call,
+ * no separate confirm step.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { Modules, TransactionHandlerType } from "@medusajs/framework/utils"
+import { IWorkflowEngineService } from "@medusajs/framework/types"
+import { StepResponse } from "@medusajs/framework/workflows-sdk"
+import MediaService from "../../../../../../../modules/media/service"
+import { MEDIA_MODULE } from "../../../../../../../modules/media"
+import {
+  textileFolderExtractionMedusaWorkflow,
+  textileFolderExtractionWorkflowId,
+  waitConfirmationTextileFolderExtractionStepId,
+  FolderExtractionProgress,
+} from "../../../../../../../workflows/ai/textile-folder-extraction"
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const folder_id = req.params.id
+
+  const mediaService = req.scope.resolve(MEDIA_MODULE) as MediaService
+  const folder = await mediaService.retrieveFolder(folder_id).catch(() => null)
+  if (!folder) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Folder not found: ${folder_id}`)
+  }
+
+  const progress = (folder.metadata?.folder_extraction as FolderExtractionProgress) || null
+  const failedMediaIds = (progress?.errors ?? [])
+    .map((e) => e?.media_id)
+    .filter(Boolean)
+
+  if (!failedMediaIds.length) {
+    return res.json({
+      message: "No failed extractions to retry.",
+      folder_id,
+      retried: 0,
+    })
+  }
+
+  // Re-run the folder extraction scoped to the failed files only.
+  const { transaction } = await textileFolderExtractionMedusaWorkflow(req.scope).run({
+    input: {
+      folder_id,
+      media_ids: failedMediaIds,
+      persist: true,
+      interval_ms: progress?.interval_ms,
+    },
+  })
+
+  // Auto-confirm so processing starts immediately (one call for the caller).
+  const workflowEngineService: IWorkflowEngineService = req.scope.resolve(
+    Modules.WORKFLOW_ENGINE
+  )
+  await workflowEngineService.setStepSuccess({
+    idempotencyKey: {
+      action: TransactionHandlerType.INVOKE,
+      transactionId: transaction.transactionId,
+      stepId: waitConfirmationTextileFolderExtractionStepId,
+      workflowId: textileFolderExtractionWorkflowId,
+    },
+    stepResponse: new StepResponse(true),
+  })
+
+  logger.info(
+    `[FolderExtractFeatures/Retry] Retrying ${failedMediaIds.length} failed file(s) in folder ${folder_id}`
+  )
+
+  return res.status(202).json({
+    message: `Retrying ${failedMediaIds.length} failed extraction(s).`,
+    transaction_id: transaction.transactionId,
+    folder_id,
+    retried: failedMediaIds.length,
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -4179,6 +4179,11 @@ export default defineMiddlewares({
       method: "GET",
       middlewares: [],
     },
+    {
+      matcher: "/admin/medias/folder/:id/extract-features/retry",
+      method: "POST",
+      middlewares: [],
+    },
     // Person Types
     {
       matcher: "/admin/persontypes",

--- a/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
+++ b/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
@@ -16,8 +16,13 @@ import {
 } from "../../agents/textileExtractionAgent";
 import { PinoLogger } from "@mastra/loggers";
 import { readModelJsonOrThrow } from "../../../lib/ai/model-json";
+import sharp from "sharp";
 
 const logger = new PinoLogger();
+
+/** Longest-side cap for images sent to vision models — keeps the base64 body
+ * under Cloudflare's request-size ceiling and matches typical "high detail". */
+const MAX_IMAGE_DIM = 1024;
 
 // Input schema for the workflow
 export const triggerSchema = z.object({
@@ -213,7 +218,7 @@ const prepareImageForAgent = async (image_url: string): Promise<{ image: string;
   if (image_url.startsWith("http")) {
     try {
       const resp = await fetch(image_url);
-      const buf = Buffer.from(await resp.arrayBuffer());
+      let buf = Buffer.from(await resp.arrayBuffer());
 
       const isPng = buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47;
       const isJpeg = buf[0] === 0xff && buf[1] === 0xd8;
@@ -228,6 +233,34 @@ const prepareImageForAgent = async (image_url: string): Promise<{ image: string;
       else {
         const ct = resp.headers.get("content-type") || "";
         if (ct.startsWith("image/")) mimeType = ct.split(";")[0].trim();
+      }
+
+      // 🔑 Normalise through sharp → JPEG. HEIC (iPhone) and other phone
+      // formats are rejected by almost every vision model (Cloudflare:
+      // "unrecognized image format", Minimax: "image/heic not supported"), and
+      // an oversized base64 body trips Cloudflare's request-size limit. Anything
+      // that isn't already JPEG/PNG/WebP is re-encoded, and everything is capped
+      // to MAX_IMAGE_DIM so the body stays small.
+      const needsReencode = !isJpeg && !isPng && !isWebp; // HEIC, GIF, TIFF, …
+      try {
+        const meta = await sharp(buf, { failOn: "none" }).metadata();
+        const tooBig =
+          (meta.width ?? 0) > MAX_IMAGE_DIM || (meta.height ?? 0) > MAX_IMAGE_DIM;
+        if (needsReencode || tooBig) {
+          buf = await sharp(buf, { failOn: "none" })
+            .rotate() // apply EXIF orientation
+            .resize({
+              width: MAX_IMAGE_DIM,
+              height: MAX_IMAGE_DIM,
+              fit: "inside",
+              withoutEnlargement: true,
+            })
+            .jpeg({ quality: 82 })
+            .toBuffer();
+          mimeType = "image/jpeg";
+        }
+      } catch (err) {
+        logger.warn(`[TextileExtraction] sharp re-encode failed, using original bytes: ${err}`);
       }
 
       const b64 = buf.toString("base64");
@@ -367,7 +400,14 @@ const runVisionExtraction = async <T>(
     }
   }
 
-  throw new Error(`[${label}] All vision models exhausted. Last error: ${lastError?.message || String(lastError)}`);
+  // Surface the provider's REAL reason, not just a wrapped "Provider returned
+  // error". The AI SDK buries the detail in `responseBody` (e.g. Cloudflare
+  // "unrecognized image format", Minimax "image/heic not supported"), which is
+  // the difference between a diagnosable failure and "[object Object]".
+  const lastDetail = lastError?.responseBody
+    ? `${lastError?.message ?? "error"} — ${String(lastError.responseBody).slice(0, 300)}`
+    : lastError?.message || String(lastError)
+  throw new Error(`[${label}] All vision models exhausted. Last error: ${lastDetail}`);
 };
 
 // ─────────────────────────────────────────────────────────────

--- a/apps/backend/src/workflows/ai/textile-folder-extraction.ts
+++ b/apps/backend/src/workflows/ai/textile-folder-extraction.ts
@@ -43,6 +43,12 @@ export type TextileFolderExtractionInput = {
   persist?: boolean;
   /** Milliseconds to wait between photos. Default 60000 (1 photo/minute). */
   interval_ms?: number;
+  /**
+   * When set, only these media files are extracted (instead of every image in
+   * the folder). Used by the "retry failed" endpoint to re-run just the files
+   * that failed a previous folder extraction.
+   */
+  media_ids?: string[];
 };
 
 export type FolderMediaItem = {
@@ -148,7 +154,13 @@ const listFolderMediaStep = createStep(
       { select: ["id", "file_path", "file_type"], order: { created_at: "ASC" } } as any
     );
 
-    const images = (mediaFiles || []).filter((f: any) => f.file_type === "image" && f.file_path);
+    let images = (mediaFiles || []).filter((f: any) => f.file_type === "image" && f.file_path);
+
+    // Scope to an explicit subset (the "retry failed" path) when requested.
+    if (input.media_ids?.length) {
+      const wanted = new Set(input.media_ids);
+      images = images.filter((f: any) => wanted.has(f.id));
+    }
 
     if (images.length === 0) {
       throw new MedusaError(
@@ -441,6 +453,7 @@ export const textileFolderExtractionMedusaWorkflow = createWorkflow(
       gender: data.input.gender,
       persist: data.input.persist ?? false,
       interval_ms: data.input.interval_ms,
+      media_ids: data.input.media_ids,
     }));
 
     // Use runAsStep with backgroundExecution for the long rate-limited run

--- a/apps/backend/src/workflows/ai/textile-product-extraction.ts
+++ b/apps/backend/src/workflows/ai/textile-product-extraction.ts
@@ -30,6 +30,7 @@ import {
   clearTextileModelsForRun,
   clearTextileCooldownForRun,
 } from "../../mastra/agents/textileExtractionAgent";
+import { summarizeAiStepError } from "./image-extraction";
 
 /** Vision role the textile extraction resolves its provider ladder from. */
 const TEXTILE_VISION_ROLE = "ai_image_extraction";
@@ -215,9 +216,14 @@ export const runTextileMastraExtraction = async (input: {
   // Check for errors
   const failedStep = Object.entries(workflowResult.steps).find(([, step]) => (step as any).status === "failed");
   if (failedStep) {
+    // ⚠️ The step VALUE here is a `{ status, output, error }` object — printing
+    // it directly yields "[object Object]" and buries the reason the operator
+    // needs (which model/format/size actually failed). `summarizeAiStepError`
+    // digs the provider's real message out of the AI SDK error shape.
+    const detail = summarizeAiStepError((failedStep[1] as any)?.error)
     throw new MedusaError(
       MedusaError.Types.UNEXPECTED_STATE,
-      `Textile extraction failed at step ${failedStep[0]}: ${failedStep[1] || "Unknown error"}`
+      `Textile extraction failed at step ${failedStep[0]}: ${detail}`
     );
   }
 


### PR DESCRIPTION
## What

Follow-up to #1719 (vision providers) and #1724 (folder UI) — fixes the failures behind `Textile extraction failed at step deriveProductFields: [object Object]`, diagnosed from prod CloudWatch logs.

## Root cause (from logs)

Every derivation pass walked 6 broken models before reaching the one that works (`dots-studio`), and iPhone **HEIC** photos were rejected by every provider: Cloudflare `unrecognized image format`, Minimax `image/heic not supported (2013)`, NVIDIA `Internal Server Error`, BazaarLink `vision tier disabled`.

## Changes

1. **Surface the real error.** `runTextileMastraExtraction` printed the failed step object (`[object Object]`); `runVisionExtraction`'s final throw dropped `responseBody`. Both now report the provider's actual reason via `summarizeAiStepError`.
2. **Transcode HEIC → JPEG.** `prepareImageForAgent` now runs every image through `sharp`, re-encodes non-JPEG/PNG/WebP formats, applies EXIF rotation, and caps to 1024px so the base64 body stays under Cloudflare's size limit.
3. **Retry failed folder extractions.** The folder workflow accepts `media_ids`, and `POST /admin/medias/folder/:id/extract-features/retry` re-runs only the files in `folder_extraction.errors` (auto-confirmed). The UI half (`useRetryFolderExtraction` + "Retry Failed" button) already landed via #1724.

## Test

- `tsc --noEmit` — no errors in the changed files.