### PR TITLE
feat(payments): a credit can be applied to a payout, and its earmark can be read (#1712)

### DIFF
--- a/apps/backend/integration-tests/http/partner-credit-apply.spec.ts
+++ b/apps/backend/integration-tests/http/partner-credit-apply.spec.ts
@@ -1,0 +1,333 @@
+/**
+ * Applying a partner credit to a payout, and reading its earmark (#1712).
+ *
+ *   GET  /admin/partners/:id/credits
+ *   POST /admin/partners/:id/credits/:creditId/apply
+ *
+ * ## Why these are integration tests and not more unit tests
+ *
+ * `checkCreditApplicable` and `foldPartnerLedger` are unit-tested against
+ * prod-shaped rows. What those cannot show is the part that actually bites:
+ *
+ *  - `partner_credit` has NO partner column. Both the read and the apply reach
+ *    it through a link, and a link that writes fine and reads empty is this
+ *    codebase's most expensive recurring bug. A guard that silently sees no
+ *    rows refuses nothing.
+ *  - the earmark is a SECOND link, written by the create route and — until
+ *    this change — exposed by no read at all. `partner_credit.*` selects
+ *    columns, so the field was simply absent rather than null.
+ *  - the ledger's `credited` has to move after the write. A fold that computes
+ *    it from credits the route never fetched is dead code, and the apply would
+ *    stamp a decision no screen honours.
+ *
+ * ⚠️ The shared-DB runner restores a snapshot before every test, so each case
+ * builds its own partner. Do not thread state between them.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(120000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  let adminHeaders: any
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    adminHeaders = await getAuthHeaders(api)
+  })
+
+  // ─── fixtures ─────────────────────────────────────────────────────────────
+
+  async function createPartner(label: string) {
+    const unique = `${label}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    const email = `credit-${unique}@jyt.test`
+    const password = "supersecret"
+
+    await api.post("/auth/partner/emailpass/register", { email, password })
+    const login = await api.post("/auth/partner/emailpass", { email, password })
+    const partnerHeaders = { Authorization: `Bearer ${login.data.token}` }
+
+    const res = await api.post(
+      "/partners",
+      {
+        name: `Credit ${unique}`,
+        handle: `credit-${unique}`,
+        admin: { email, first_name: "Credit", last_name: "Partner" },
+      },
+      { headers: partnerHeaders }
+    )
+    expect(res.status).toBe(200)
+    return res.data.partner.id as string
+  }
+
+  async function createDesign(name: string, partnerId: string) {
+    const res = await api.post(
+      "/admin/designs",
+      {
+        name,
+        description: `Credit design ${name}`,
+        design_type: "Original",
+        status: "Commerce_Ready",
+        priority: "Medium",
+        estimated_cost: 1000,
+        cost_currency: "inr",
+      },
+      adminHeaders
+    )
+    expect(res.status).toBe(201)
+    const designId = res.data.design.id as string
+
+    const remoteLink = getContainer().resolve(
+      ContainerRegistrationKeys.LINK
+    ) as any
+    await remoteLink.create({
+      design: { design_id: designId },
+      partner: { partner_id: partnerId },
+    })
+    return designId
+  }
+
+  /** A payout worth `amount`, as an admin-created submission for one design. */
+  async function createSubmission(
+    partnerId: string,
+    designId: string,
+    amount = 1000
+  ) {
+    const res = await api.post(
+      "/admin/payment-submissions",
+      {
+        partner_id: partnerId,
+        design_ids: [designId],
+        cost_overrides: { [designId]: amount },
+      },
+      adminHeaders
+    )
+    expect(res.status).toBe(201)
+    return res.data.payment_submission
+  }
+
+  async function createCredit(
+    partnerId: string,
+    body: Record<string, any>
+  ) {
+    const res = await api.post(
+      `/admin/partners/${partnerId}/credits`,
+      {
+        amount: 380,
+        reason: "Overpaid against an earlier payout",
+        ...body,
+      },
+      adminHeaders
+    )
+    expect(res.status).toBe(201)
+    return res.data.credit
+  }
+
+  const listCredits = async (partnerId: string) => {
+    const res = await api.get(
+      `/admin/partners/${partnerId}/credits`,
+      adminHeaders
+    )
+    expect(res.status).toBe(200)
+    return res.data
+  }
+
+  const ledger = async (partnerId: string) => {
+    const res = await api.get(
+      `/admin/payments/partners/${partnerId}/ledger`,
+      adminHeaders
+    )
+    expect(res.status).toBe(200)
+    return res.data
+  }
+
+  const apply = (partnerId: string, creditId: string, body: any) =>
+    api
+      .post(
+        `/admin/partners/${partnerId}/credits/${creditId}/apply`,
+        body,
+        adminHeaders
+      )
+      .catch((e: any) => e.response)
+
+  // ─── the earmark ──────────────────────────────────────────────────────────
+
+  /**
+   * 🔴 The gap this closes. The create route writes TWO links and the read
+   * exposed only one, so "this credit is earmarked against order X" was a fact
+   * the database held and no surface showed.
+   */
+  it("exposes the order a credit is earmarked against", async () => {
+    const partnerId = await createPartner("earmark")
+
+    /**
+     * ⚠️ A synthetic order id on purpose. The earmark is a LINK ROW and the
+     * read never joins through to the order, so building a real inventory
+     * order (which needs an inventory item and two stock locations) would test
+     * the order fixture rather than the thing that was broken — that the second
+     * link the create route writes is exposed by a read at all.
+     */
+    const orderId = `ord_earmark_${Date.now()}`
+
+    const credit = await createCredit(partnerId, {
+      amount: 1380,
+      reason: "Paid 30,000 against a 28,620 payout",
+      inventory_order_id: orderId,
+    })
+
+    const { credits, open_total } = await listCredits(partnerId)
+    const row = credits.find((c: any) => c.id === credit.id)
+
+    expect(row.inventory_order_id).toBe(orderId)
+    expect(open_total).toBe(1380)
+  })
+
+  /** A partner-wide credit reads as null, never as a missing field. */
+  it("reports no earmark as null rather than omitting the field", async () => {
+    const partnerId = await createPartner("no-earmark")
+    await createCredit(partnerId, { amount: 500 })
+
+    const { credits } = await listCredits(partnerId)
+    expect(credits).toHaveLength(1)
+    expect(credits[0]).toHaveProperty("inventory_order_id")
+    expect(credits[0].inventory_order_id).toBeNull()
+  })
+
+  // ─── applying ─────────────────────────────────────────────────────────────
+
+  it("applies a credit and moves the ledger's outstanding, not its paid", async () => {
+    const partnerId = await createPartner("apply")
+    const designId = await createDesign(`Credit apply ${Date.now()}`, partnerId)
+    const submission = await createSubmission(partnerId, designId, 1000)
+    const credit = await createCredit(partnerId, { amount: 380 })
+
+    const before = await ledger(partnerId)
+    expect(before.totals.outstanding).toBe(1000)
+    expect(before.totals.credited).toBe(0)
+
+    const res = await apply(partnerId, credit.id, {
+      submission_id: submission.id,
+    })
+    expect(res.status).toBe(200)
+    expect(res.data.remaining_before).toBe(1000)
+    expect(res.data.remaining_after).toBe(620)
+    expect(res.data.credit.status).toBe("Applied")
+    expect(res.data.credit.applied_to_submission_id).toBe(submission.id)
+    expect(res.data.credit.applied_at).toBeTruthy()
+
+    const after = await ledger(partnerId)
+    expect(after.totals.credited).toBe(380)
+    expect(after.totals.outstanding).toBe(620)
+    /**
+     * 🔑 `paid` means money that TRANSFERRED. A founder reconciling this screen
+     * against a bank statement must not find a figure no statement explains.
+     */
+    expect(after.totals.paid).toBe(0)
+
+    const payout = after.entries.find((e: any) => e.kind === "payout")
+    expect(payout.credited_amount).toBe(380)
+    expect(payout.credits_applied[0].credit_id).toBe(credit.id)
+  })
+
+  /** An Applied credit has been consumed — offering it again offers it twice. */
+  it("drops an applied credit out of open_total", async () => {
+    const partnerId = await createPartner("open-total")
+    const designId = await createDesign(`Credit open ${Date.now()}`, partnerId)
+    const submission = await createSubmission(partnerId, designId, 1000)
+    const credit = await createCredit(partnerId, { amount: 380 })
+
+    expect((await listCredits(partnerId)).open_total).toBe(380)
+    expect((await apply(partnerId, credit.id, { submission_id: submission.id })).status).toBe(200)
+
+    const after = await listCredits(partnerId)
+    expect(after.open_total).toBe(0)
+    expect(after.count).toBe(1)
+  })
+
+  it("refuses to apply the same credit twice", async () => {
+    const partnerId = await createPartner("twice")
+    const designId = await createDesign(`Credit twice ${Date.now()}`, partnerId)
+    const first = await createSubmission(partnerId, designId, 1000)
+    const credit = await createCredit(partnerId, { amount: 380 })
+
+    expect((await apply(partnerId, credit.id, { submission_id: first.id })).status).toBe(200)
+
+    const second = await apply(partnerId, credit.id, {
+      submission_id: first.id,
+    })
+    expect(second.status).toBe(400)
+    expect(String(second.data.message)).toContain("Applied")
+  })
+
+  /**
+   * 🔴 A silent clamp is what hid the 1,380 in the first place. A credit
+   * applies whole, so one larger than the remaining claim is refused with both
+   * numbers named — not quietly consumed down to the remainder.
+   */
+  it("refuses a credit larger than what the payout still claims, naming both numbers", async () => {
+    const partnerId = await createPartner("too-big")
+    const designId = await createDesign(`Credit big ${Date.now()}`, partnerId)
+    const submission = await createSubmission(partnerId, designId, 1000)
+    const credit = await createCredit(partnerId, { amount: 5000 })
+
+    const res = await apply(partnerId, credit.id, {
+      submission_id: submission.id,
+    })
+    expect(res.status).toBe(400)
+    expect(String(res.data.message)).toContain("5000")
+    expect(String(res.data.message)).toContain("1000")
+
+    // And nothing moved.
+    expect((await ledger(partnerId)).totals.outstanding).toBe(1000)
+    expect((await listCredits(partnerId)).open_total).toBe(5000)
+  })
+
+  /**
+   * 🔴 Both ends of the request are checked. `partner_credit` has no partner
+   * column, so an id alone would happily apply another partner's money — the
+   * shape that rendered every partner's quote on every storefront.
+   */
+  it("refuses a credit that belongs to a DIFFERENT partner", async () => {
+    const owner = await createPartner("owner")
+    const stranger = await createPartner("stranger")
+    const designId = await createDesign(`Credit cross ${Date.now()}`, stranger)
+    const submission = await createSubmission(stranger, designId, 1000)
+    const credit = await createCredit(owner, { amount: 380 })
+
+    const res = await apply(stranger, credit.id, {
+      submission_id: submission.id,
+    })
+    expect(res.status).toBe(404)
+
+    // The owner still holds it, untouched.
+    expect((await listCredits(owner)).open_total).toBe(380)
+  })
+
+  /** The other end: a payout belonging to someone else is a 404, not a discharge. */
+  it("refuses a payout that belongs to a DIFFERENT partner", async () => {
+    const holder = await createPartner("holder")
+    const other = await createPartner("other")
+    const designId = await createDesign(`Credit other ${Date.now()}`, other)
+    const submission = await createSubmission(other, designId, 1000)
+    const credit = await createCredit(holder, { amount: 380 })
+
+    const res = await apply(holder, credit.id, {
+      submission_id: submission.id,
+    })
+    expect(res.status).toBe(404)
+    expect((await listCredits(holder)).open_total).toBe(380)
+  })
+
+  it("requires a submission_id — a credit applied to nobody's payout reduces nothing", async () => {
+    const partnerId = await createPartner("no-submission")
+    const credit = await createCredit(partnerId, { amount: 380 })
+
+    const res = await apply(partnerId, credit.id, {})
+    expect(res.status).toBe(400)
+  })
+})

--- a/apps/backend/src/admin/components/partners/__tests__/partner-credits-section.unit.spec.ts
+++ b/apps/backend/src/admin/components/partners/__tests__/partner-credits-section.unit.spec.ts
@@ -1,0 +1,181 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+
+/**
+ * The partner credits panel (#1712).
+ *
+ * 🔴 What this pins is that the facts REACH THE SCREEN. A credit was
+ * recordable and readable and nothing more — `status` starts `Open`, is
+ * displayed beside `outstanding` and never netted against it, and there was no
+ * screen on which a human could make the decision to apply it. A capability
+ * with no screen is no capability (#1612). And the earmark, a second link the
+ * create route writes, was exposed by no read at all.
+ *
+ * Same harness as `partner-ledger-section.unit.spec.ts`: render to static
+ * markup with the data hooks stubbed. There is no component test harness here.
+ */
+
+jest.mock("react-router-dom", () => ({
+  Link: ({ children }: any) => React.createElement("a", null, children),
+}))
+
+const mockCredits = jest.fn()
+const mockLedger = jest.fn()
+jest.mock("../../../hooks/api/payments", () => ({
+  usePartnerCredits: (...args: any[]) => mockCredits(...args),
+  usePartnerLedger: (...args: any[]) => mockLedger(...args),
+  useApplyPartnerCredit: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}))
+
+/**
+ * ⚠️ The jest swc transform emits CLASSIC JSX while the admin sources rely on
+ * the automatic runtime and import no React.
+ */
+;(globalThis as any).React = React
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PartnerCreditsSection } = require("../partner-credits-section")
+
+/** hrhandloom's real credit: 1,380 from being paid 30,000 on a 28,620 payout. */
+const credit = (over: Record<string, any> = {}) => ({
+  id: "01M1EA29VR9H1466JJ0F4FWEPN",
+  amount: 1380,
+  currency_code: "inr",
+  status: "Open",
+  source_type: "overpayment",
+  reason: "Paid 30,000 against a 28,620 payout",
+  source_submission_id: null,
+  applied_to_submission_id: null,
+  applied_at: null,
+  inventory_order_id: null,
+  ...over,
+})
+
+const payout = (over: Record<string, any> = {}) => ({
+  id: "payout:01M13T9D9A",
+  kind: "payout" as const,
+  status: "Approved",
+  amount: 10000,
+  currency: "inr",
+  occurred_at: "2026-09-01T00:00:00.000Z",
+  submission_id: "01M13T9D9A",
+  settled_amount: 0,
+  credited_amount: 0,
+  ...over,
+})
+
+const render = (
+  credits: any[],
+  entries: any[] = [payout()],
+  over: Record<string, any> = {}
+) => {
+  mockCredits.mockReturnValue({
+    credits,
+    count: credits.length,
+    open_total: credits
+      .filter((c) => c.status === "Open")
+      .reduce((a, c) => a + c.amount, 0),
+    currency: "inr",
+    isLoading: false,
+    isError: false,
+    ...over,
+  })
+  mockLedger.mockReturnValue({ entries, isLoading: false, isError: false })
+  return renderToStaticMarkup(
+    React.createElement(PartnerCreditsSection, { partnerId: "partner_1" })
+  )
+}
+
+describe("PartnerCreditsSection (#1712)", () => {
+  it("shows what the partner holds", () => {
+    const html = render([credit()])
+    expect(html).toContain("1,380")
+    expect(html).toContain("held")
+    expect(html).toContain("Open")
+  })
+
+  /**
+   * 🔑 A bare amount with no statement of origin is the shape that let
+   * `metadata` blobs decide payouts (#1557).
+   */
+  it("always states why the credit exists", () => {
+    expect(render([credit()])).toContain(
+      "Paid 30,000 against a 28,620 payout"
+    )
+  })
+
+  /**
+   * 🔴 The gap this closes. The earmark is a link the create route writes and
+   * no read exposed — a fact the database held and no surface showed.
+   */
+  it("renders the earmarked order", () => {
+    const html = render([credit({ inventory_order_id: "01K36TE2WB" })])
+    expect(html).toContain("earmarked against order")
+    expect(html).toContain("01K36TE2WB")
+  })
+
+  it("says nothing about an earmark when there is none", () => {
+    expect(render([credit()])).not.toContain("earmarked against order")
+  })
+
+  it("shows the payout an applied credit discharged, and when", () => {
+    const html = render([
+      credit({
+        status: "Applied",
+        applied_to_submission_id: "01M13T9D9A",
+        applied_at: "2026-09-02T00:00:00.000Z",
+      }),
+    ])
+    expect(html).toContain("applied to")
+    expect(html).toContain("01M13T9D9A")
+    expect(html).toContain("Applied")
+  })
+
+  /** An Applied credit has been consumed — no picker, nothing left to decide. */
+  it("offers no apply control on a credit that is not Open", () => {
+    const html = render([credit({ status: "Applied" })])
+    expect(html).not.toContain("Apply to a payout")
+  })
+
+  it("offers the open payouts a credit can be applied to", () => {
+    const html = render([credit()])
+    expect(html).toContain("still claimed")
+  })
+
+  /**
+   * ⚠️ Offered and DISABLED with the reason, never hidden. A credit applies
+   * whole, and hiding the payout leaves an operator wondering where it went.
+   */
+  it("offers a payout too small for the credit, saying why it cannot take it", () => {
+    const html = render([credit({ amount: 50000 })], [payout()])
+    expect(html).toContain("credit is larger than this")
+  })
+
+  it("marks a payout with nothing left to claim", () => {
+    const html = render([credit()], [payout({ settled_amount: 10000 })])
+    expect(html).toContain("nothing left to claim")
+  })
+
+  /** Paid and Rejected payouts are not candidates at all. */
+  it("does not offer a Paid or Rejected payout", () => {
+    const html = render(
+      [credit()],
+      [payout({ status: "Paid" }), payout({ id: "p2", status: "Rejected" })]
+    )
+    expect(html).toContain("No payout is open to apply this against")
+  })
+
+  /**
+   * 🔴 An error must never render as "they hold nothing". That reading is
+   * exactly the one that lets a credit be paid out a second time.
+   */
+  it("does not report an unreadable list as an empty one", () => {
+    const html = render([], [], { isError: true })
+    expect(html).toContain("could not be read")
+    expect(html).not.toContain("holds no credit")
+  })
+
+  it("says plainly when a partner genuinely holds nothing", () => {
+    expect(render([])).toContain("holds no credit")
+  })
+})

--- a/apps/backend/src/admin/components/partners/__tests__/partner-ledger-section.unit.spec.ts
+++ b/apps/backend/src/admin/components/partners/__tests__/partner-ledger-section.unit.spec.ts
@@ -198,3 +198,55 @@ describe("PartnerLedgerSection — acting on the warning (#1710)", () => {
     expect(html).not.toMatch(/as settling this payout/i)
   })
 })
+
+/**
+ * Applied credits on the ledger (#1712).
+ *
+ * 🔴 An applied credit has ALREADY reduced `outstanding`. If it does not reach
+ * the screen the footer shows a smaller amount owed than the payouts above add
+ * up to, with nothing explaining the difference — a reader either distrusts the
+ * panel or, worse, trusts the larger figure and pays it.
+ */
+describe("PartnerLedgerSection — applied credits (#1712)", () => {
+  it("names the credit that discharged part of a payout", () => {
+    const html = render(
+      [
+        payout({
+          recorded_against: [],
+          recorded_against_total: 0,
+          credited_amount: 1380,
+          credits_applied: [
+            {
+              credit_id: "cred_1",
+              amount: 1380,
+              reason: "Paid 30,000 against a 28,620 payout",
+              applied_at: "2026-09-02T00:00:00.000Z",
+            },
+          ],
+        }),
+      ],
+      totals({ credited: 1380, outstanding: 26820 })
+    )
+
+    expect(html).toContain("discharged by")
+    expect(html).toContain("Paid 30,000 against a 28,620 payout")
+  })
+
+  it("puts credited in the footer, beside paid and outstanding", () => {
+    const html = render(
+      [payout({ recorded_against: [], recorded_against_total: 0 })],
+      totals({ credited: 1380, outstanding: 26820 })
+    )
+    expect(html).toContain("credited")
+  })
+
+  /** Silent when there is nothing to say — a "₹0 credited" is noise. */
+  it("says nothing about credits when none were applied", () => {
+    const html = render(
+      [payout({ recorded_against: [], recorded_against_total: 0 })],
+      totals({ credited: 0 })
+    )
+    expect(html).not.toContain("credited")
+    expect(html).not.toContain("discharged by")
+  })
+})

--- a/apps/backend/src/admin/components/partners/partner-credits-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-credits-section.tsx
@@ -1,0 +1,323 @@
+import { Badge, Button, Container, Heading, StatusBadge, Text, toast } from "@medusajs/ui"
+import { Link } from "react-router-dom"
+
+import {
+  usePartnerCredits,
+  usePartnerLedger,
+  useApplyPartnerCredit,
+  type PartnerCredit,
+  type PartnerLedgerEntry,
+} from "../../hooks/api/payments"
+import { remainingClaim } from "../../../modules/internal_payments/lib/apply-credit"
+
+/**
+ * Money this partner already holds, and the one thing you can do with it (#1712).
+ *
+ * 🔴 Why this panel has to exist. A credit was recordable and readable and
+ * nothing more: `status` starts `Open`, is DISPLAYED beside `outstanding` and
+ * never netted against it, because whether money already given discharges the
+ * next payout is a decision a human makes. There was no screen on which a
+ * human could make it — a capability with no screen is no capability (#1612,
+ * where `inventory_order_lines` had a validator, a guard, tranche folding and
+ * zero rows).
+ *
+ * 🔑 And the earmark. The create route writes TWO links — partner→credit and
+ * inventory_order→credit — and until #1712's follow-up no read exposed the
+ * second, so "this 1,380 is earmarked against order 01K36TE2WB" was a fact the
+ * database held and no surface showed.
+ */
+
+const money = (amount: number | null | undefined, currency?: string | null) =>
+  new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: (currency || "inr").toUpperCase(),
+    maximumFractionDigits: 2,
+  }).format(Number(amount ?? 0))
+
+const day = (value: string | null | undefined) =>
+  value ? new Date(value).toLocaleDateString() : null
+
+const statusColor = (status: string) =>
+  status === "Applied" ? "green" : status === "Cancelled" ? "red" : "orange"
+
+/**
+ * How much of a payout a credit could still discharge.
+ *
+ * 🔑 Imported from the module lib the ROUTE checks with, never re-derived here.
+ * A screen that computes a money figure its own way is how a derived rate
+ * outranked the server's pricer and re-priced a ₹10,000 job to ₹12,857 (#1679).
+ *
+ * ⚠️ Advisory even so. This decides what the picker DISABLES; the server
+ * decides what is allowed, and refuses with both numbers named. If the two ever
+ * disagree the operator sees the server's message, not a silent no-op.
+ */
+const remainingFor = (entry: PartnerLedgerEntry) =>
+  remainingClaim({
+    submissionAmount: entry.amount,
+    settledAmount: entry.settled_amount ?? 0,
+    appliedCreditsTotal: entry.credited_amount ?? 0,
+  })
+
+/** A payout a credit could be applied to, with why it can or cannot be. */
+type Candidate = {
+  entry: PartnerLedgerEntry
+  remaining: number
+  blocked: string | null
+}
+
+const ApplyControl = ({
+  partnerId,
+  credit,
+  candidates,
+}: {
+  partnerId: string
+  credit: PartnerCredit
+  candidates: Candidate[]
+}) => {
+  const { mutateAsync, isPending } = useApplyPartnerCredit(partnerId, credit.id)
+
+  if (!candidates.length) {
+    /**
+     * ⚠️ Says WHY, never renders an empty picker. An empty control reads as
+     * "this is broken"; the real answer is usually that every payout is
+     * already settled.
+     */
+    return (
+      <Text size="xsmall" className="text-ui-fg-muted">
+        No payout is open to apply this against — every claim is Paid, Rejected,
+        or already fully covered.
+      </Text>
+    )
+  }
+
+  const handleApply = (chosen: Candidate) => {
+    if (chosen.blocked || isPending) return
+    /**
+     * 🔴 Confirmed because it is FORWARD-ONLY. There is no unapply: reversing a
+     * settled money decision is a new decision with its own reason. A one-click
+     * irreversible money write with no confirmation is how the wrong payout
+     * gets discharged at 11pm.
+     */
+    const ok = window.confirm(
+      `Apply ${money(credit.amount, credit.currency_code)} to payout ${chosen.entry.submission_id}?\n\n` +
+        `That payout still claims ${money(chosen.remaining, chosen.entry.currency)}, and will claim ` +
+        `${money(chosen.remaining - Number(credit.amount ?? 0), chosen.entry.currency)} after.\n\n` +
+        `This cannot be undone.`
+    )
+    if (!ok) return
+
+    void (async () => {
+      try {
+        const res = await mutateAsync({
+          submission_id: chosen.entry.submission_id!,
+        })
+        toast.success(
+          `Applied — that payout now claims ${money(res.remaining_after, chosen.entry.currency)}`
+        )
+      } catch (e: any) {
+        /**
+         * The server's refusal names both numbers. Surfacing it verbatim beats
+         * "Could not apply", which sends an operator to the database to find
+         * out why — and gets worked around by editing rows directly.
+         */
+        toast.error(e?.message || "Could not apply this credit")
+      }
+    })()
+  }
+
+  /**
+   * 🔴 A visible list, deliberately NOT a dropdown.
+   *
+   * A `Select` renders its options only when opened, so every reason a payout
+   * cannot take this credit — "credit is larger than this", "nothing left to
+   * claim" — would be hidden behind a click, and invisible to any test that
+   * renders the screen. On a money decision the reasons ARE the screen.
+   */
+  return (
+    <div className="flex flex-col gap-y-1 rounded-md bg-ui-bg-subtle px-3 py-2">
+      <Text size="xsmall" className="text-ui-fg-muted">
+        Apply to a payout
+      </Text>
+      {candidates.map((c) => (
+        <div
+          key={c.entry.submission_id}
+          className="flex items-center justify-between gap-x-3"
+        >
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            <span className="font-mono">{c.entry.submission_id}</span> ·{" "}
+            {money(c.remaining, c.entry.currency)} still claimed
+            {c.blocked ? ` — ${c.blocked}` : ""}
+          </Text>
+          <Button
+            size="small"
+            variant="secondary"
+            disabled={!!c.blocked || isPending}
+            onClick={() => handleApply(c)}
+            data-testid={`apply-credit-${credit.id}-${c.entry.submission_id}`}
+          >
+            Apply
+          </Button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const CreditRow = ({
+  partnerId,
+  credit,
+  candidates,
+}: {
+  partnerId: string
+  credit: PartnerCredit
+  candidates: Candidate[]
+}) => {
+  const isOpen = credit.status === "Open"
+
+  return (
+    <div className="flex flex-col gap-y-2 py-3">
+      <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-y-1">
+          <div className="flex items-center gap-x-2">
+            <StatusBadge color={statusColor(credit.status)}>
+              {credit.status}
+            </StatusBadge>
+            <Text size="small" className="text-ui-fg-subtle">
+              {credit.source_type || "credit"}
+            </Text>
+          </div>
+          {/**
+           * 🔑 The reason, always. A bare amount with no statement of origin is
+           * the shape that let `metadata` blobs decide payouts (#1557) — the
+           * next reader has to be able to audit it without this session's
+           * transcript.
+           */}
+          <Text size="xsmall" className="text-ui-fg-muted">
+            {credit.reason || "No reason recorded"}
+          </Text>
+          {credit.inventory_order_id && (
+            /* The earmark — where the founder decided it should be consumed.
+               Advisory: it does not restrict which payout it may be applied to. */
+            <Text size="xsmall" className="text-ui-fg-muted">
+              earmarked against order{" "}
+              <span className="font-mono">{credit.inventory_order_id}</span>
+            </Text>
+          )}
+          {credit.applied_to_submission_id && (
+            <Text size="xsmall" className="text-ui-fg-muted">
+              applied to{" "}
+              <Link
+                to={`/payment-submissions/${credit.applied_to_submission_id}`}
+                className="text-ui-fg-interactive font-mono hover:underline"
+              >
+                {credit.applied_to_submission_id}
+              </Link>
+              {credit.applied_at ? ` on ${day(credit.applied_at)}` : ""}
+            </Text>
+          )}
+        </div>
+        <Text size="small" weight="plus">
+          {money(credit.amount, credit.currency_code)}
+        </Text>
+      </div>
+      {isOpen && (
+        <ApplyControl
+          partnerId={partnerId}
+          credit={credit}
+          candidates={candidates}
+        />
+      )}
+    </div>
+  )
+}
+
+export const PartnerCreditsSection = ({ partnerId }: { partnerId: string }) => {
+  const { credits, open_total, currency, isLoading, isError } =
+    usePartnerCredits(partnerId, { enabled: !!partnerId })
+
+  /**
+   * The payouts a credit could discharge, read from the ledger this panel sits
+   * beside — never a second fetch of the submissions with its own rules. Two
+   * surfaces answering "what does this partner still claim" is how they start
+   * disagreeing about a money figure.
+   */
+  const { entries } = usePartnerLedger(partnerId, { enabled: !!partnerId })
+
+  const rows: PartnerCredit[] = credits || []
+
+  const candidatesFor = (credit: PartnerCredit): Candidate[] =>
+    (entries || [])
+      .filter((e) => e.kind === "payout" && e.submission_id)
+      .filter((e) => e.status !== "Paid" && e.status !== "Rejected")
+      .map((entry) => {
+        const remaining = remainingFor(entry)
+        const amount = Number(credit.amount ?? 0)
+        return {
+          entry,
+          remaining,
+          /**
+           * ⚠️ A credit applies WHOLE — there is no partial application — so a
+           * payout with less headroom than the credit is offered and disabled
+           * with the reason, rather than hidden. Hiding it leaves an operator
+           * wondering where the payout went.
+           */
+          blocked:
+            remaining <= 0
+              ? "nothing left to claim"
+              : amount > remaining
+                ? "credit is larger than this"
+                : null,
+        }
+      })
+
+  return (
+    <Container className="divide-y p-0" data-partner-id={partnerId}>
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-x-2">
+          <Heading level="h2">Credits</Heading>
+          <Badge size="2xsmall" className="ml-2">
+            {rows.length}
+          </Badge>
+        </div>
+        {(open_total ?? 0) > 0 && (
+          <Text size="small" className="text-ui-fg-subtle">
+            {money(open_total, currency)} held
+          </Text>
+        )}
+      </div>
+
+      {isError && (
+        /* Never an empty state on failure — that reads as "they hold nothing",
+           which is precisely the reading that lets a credit be paid twice. */
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            Could not load this partner's credits. Nothing below is missing
+            because it does not exist — the list simply could not be read.
+          </Text>
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        <div className="flex flex-col divide-y px-6 py-2">
+          {rows.map((credit) => (
+            <CreditRow
+              key={credit.id}
+              partnerId={partnerId}
+              credit={credit}
+              candidates={candidatesFor(credit)}
+            />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && (
+        <div className="px-6 py-8">
+          <Text size="small" className="text-ui-fg-subtle text-center">
+            This partner holds no credit — nothing has been paid to them that a
+            payout did not consume.
+          </Text>
+        </div>
+      )}
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
@@ -145,6 +145,21 @@ const PayoutRow = ({ entry }: { entry: PartnerLedgerEntry }) => {
               : ""}
           </Text>
         )}
+        {(entry.credited_amount ?? 0) > 0 && (
+          /**
+           * 🔴 An applied credit HAS already reduced `outstanding` (#1712).
+           * Unlike the warning below it is not advisory, which is exactly why
+           * it must be on the row: without it the footer shows a smaller
+           * amount owed than the payouts above add up to, and nothing on
+           * screen explains the difference.
+           */
+          <Text size="xsmall" className="text-ui-tag-green-text">
+            {money(entry.credited_amount!, entry.currency)} discharged by{" "}
+            {entry.credits_applied!.length === 1
+              ? entry.credits_applied![0].reason || "a credit"
+              : `${entry.credits_applied!.length} credits`}
+          </Text>
+        )}
         {entry.status !== "Paid" && (entry.recorded_against_total ?? 0) > 0 && (
           /**
            * 🔴 #1710 — the line that stops someone being paid twice.
@@ -342,6 +357,11 @@ export const PartnerLedgerSection = ({ partnerId }: { partnerId: string }) => {
         <div className="px-6 py-3">
           <Text size="small" className="text-ui-fg-subtle">
             {money(totals!.paid, totals!.currency)} paid ·{" "}
+            {(totals!.credited ?? 0) > 0 && (
+              <>
+                {money(totals!.credited, totals!.currency)} credited ·{" "}
+              </>
+            )}
             {money(totals!.outstanding, totals!.currency)} outstanding
             {totals!.recorded > 0 && (
               <>

--- a/apps/backend/src/admin/hooks/api/payments.ts
+++ b/apps/backend/src/admin/hooks/api/payments.ts
@@ -139,6 +139,31 @@ export type PartnerLedgerEntry = {
     inventory_order_name: string | null;
   }>;
   recorded_against_total?: number;
+  /**
+   * What has been SETTLED against this payout by payments a human linked to it
+   * (#1710). Capped at the payout's own amount.
+   *
+   * ⚠️ Was read by `payoutSettlementBadge` through its own local type while
+   * absent from THIS one — the #1679 shape, one edit away from a reader that
+   * silently sees `undefined`. Declared here now.
+   */
+  settled_amount?: number;
+  /**
+   * Credits a human APPLIED to this payout (#1712).
+   *
+   * 🔴 Declared here for the same reason as `recorded_against` above: a flag
+   * the server sends that the client TYPE never declares has zero readers
+   * (#1679). Unlike `recorded_against` this is NOT advisory — it has already
+   * reduced `outstanding`, so a panel that cannot see it shows a smaller
+   * amount owed with nothing on screen explaining why.
+   */
+  credits_applied?: Array<{
+    credit_id: string;
+    amount: number;
+    reason: string | null;
+    applied_at: string | null;
+  }>;
+  credited_amount?: number;
   // payment
   payment_type?: string | null;
   payment_date?: string | null;
@@ -158,6 +183,14 @@ export type PartnerLedgerResponse = {
     recorded: number;
     /** Of `recorded`, what sits against a source an UNPAID payout bills (#1710). */
     recorded_against_open: number;
+    /**
+     * Of `billed`, what applied credits discharged (#1712).
+     *
+     * ⚠️ Separate from `paid` on purpose. `paid` means money that transferred;
+     * a founder reconciling this panel against a bank statement must not find
+     * a figure no statement explains. `outstanding` is `billed - paid - credited`.
+     */
+    credited: number;
     currency: string | null;
   };
   count: number;
@@ -225,6 +258,97 @@ export const useSetPaymentSettles = (paymentId: string) => {
       // The ledger's totals move with this — `paid` and `outstanding` both
       // change — so a stale panel would show the old figures beside the new
       // state and read as if nothing happened.
+      queryClient.invalidateQueries({ queryKey: [PARTNER_LEDGER_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: adminPartnersQueryKeys.details() });
+    },
+  });
+};
+
+
+// ─── Partner credits (#1712) ────────────────────────────────────────────────
+
+/**
+ * Money a partner already holds that no payout consumed.
+ *
+ * ⚠️ `inventory_order_id` is the EARMARK — a second link the create route
+ * writes, which no read exposed until #1712's follow-up. It says where the
+ * money was meant to be consumed; it does not restrict which payout the credit
+ * may be applied to.
+ */
+export type PartnerCredit = {
+  id: string;
+  amount: number;
+  currency_code: string | null;
+  status: "Open" | "Applied" | "Cancelled" | string;
+  source_type: string | null;
+  reason: string | null;
+  source_submission_id: string | null;
+  applied_to_submission_id: string | null;
+  applied_at: string | null;
+  inventory_order_id: string | null;
+};
+
+export type PartnerCreditsResponse = {
+  credits: PartnerCredit[];
+  count: number;
+  /** Only `Open` credits — an `Applied` one has already reduced a payout. */
+  open_total: number;
+  currency: string | null;
+};
+
+export const PARTNER_CREDITS_QUERY_KEY = "partner-credits" as const;
+
+export const usePartnerCredits = (
+  partnerId: string,
+  options?: Omit<
+    UseQueryOptions<PartnerCreditsResponse, FetchError, PartnerCreditsResponse, QueryKey>,
+    "queryFn" | "queryKey"
+  >,
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: [PARTNER_CREDITS_QUERY_KEY, partnerId],
+    queryFn: async () =>
+      sdk.client.fetch<PartnerCreditsResponse>(
+        `/admin/partners/${partnerId}/credits`,
+        { method: "GET" },
+      ),
+    ...options,
+  });
+  return { ...data, ...rest };
+};
+
+/**
+ * Consume a credit against one payout (#1712).
+ *
+ * 🔑 The deliberate act. A credit is DISPLAYED beside `outstanding` and never
+ * netted against it automatically, because whether money already given
+ * discharges the next payout is a decision a human makes. This is where they
+ * make it.
+ *
+ * Forward-only — there is no unapply, so the panel confirms before calling.
+ */
+export const useApplyPartnerCredit = (partnerId: string, creditId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ submission_id }: { submission_id: string }) =>
+      sdk.client.fetch<{
+        credit: PartnerCredit;
+        submission_id: string;
+        remaining_before: number;
+        remaining_after: number;
+      }>(`/admin/partners/${partnerId}/credits/${creditId}/apply`, {
+        method: "POST",
+        body: { submission_id },
+      }),
+    onSuccess: () => {
+      /**
+       * BOTH lists move: the credit leaves `open_total`, and the ledger's
+       * `credited` and `outstanding` change. Invalidating one would leave the
+       * other showing the pre-apply figures beside the new state — which reads
+       * as though nothing happened.
+       */
+      queryClient.invalidateQueries({ queryKey: [PARTNER_CREDITS_QUERY_KEY] });
       queryClient.invalidateQueries({ queryKey: [PARTNER_LEDGER_QUERY_KEY] });
       queryClient.invalidateQueries({ queryKey: adminPartnersQueryKeys.details() });
     },

--- a/apps/backend/src/admin/routes/partners/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/partners/[id]/page.tsx
@@ -6,6 +6,7 @@ import { TwoColumnPage } from "../../../components/pages/two-column-pages"
 import { PartnerGeneralSection } from "../../../components/partners/partner-general-section"
 import { PartnerAdminsSection } from "../../../components/partners/partner-admins-section"
 import { PartnerLedgerSection } from "../../../components/partners/partner-ledger-section"
+import { PartnerCreditsSection } from "../../../components/partners/partner-credits-section"
 import { PartnerTasksSection } from "../../../components/partners/partner-tasks-section"
 import { PartnerFeedbacksSection } from "../../../components/partners/partner-feedbacks-section"
 import { PartnerStorefrontSection } from "../../../components/partners/partner-storefront-section"
@@ -65,6 +66,10 @@ const PartnerDetailPage = () => {
               `internal_payments` above, submissions below — which since #1638
               means each showed half the money with nothing saying so. */}
           <PartnerLedgerSection partnerId={partner.id} />
+          {/* Directly beneath the ledger, because the two are read together:
+              the ledger says what is still owed, and this says how much of it
+              money already in the partner's hands could discharge (#1712). */}
+          <PartnerCreditsSection partnerId={partner.id} />
           <PartnerTransactionFeesSection partnerId={partner.id} />
           <PartnerFeedbacksSection partnerId={partner.id} />
         </TwoColumnPage.Sidebar>

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -567,12 +567,39 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "get_partner_credits",
     description:
-      "Money this partner ALREADY HOLDS that no payout has consumed — an overpayment, an adjustment or a goodwill credit. Returns the credit rows plus `open_total` (only `Open` credits; an `Applied` one has already reduced a payout). 🔑 Reported beside `outstanding`, never netted against it: applying a credit is a deliberate act, and a partner can hold a credit on one order while being genuinely owed money on another.",
+      "Money this partner ALREADY HOLDS that no payout has consumed — an overpayment, an adjustment or a goodwill credit. Returns the credit rows plus `open_total` (only `Open` credits; an `Applied` one has already reduced a payout). 🔑 Reported beside `outstanding`, never netted against it: applying a credit is a deliberate act, and a partner can hold a credit on one order while being genuinely owed money on another — use apply_partner_credit to make that decision. Each row carries `inventory_order_id`: the order the credit is EARMARKED against, or null when it is partner-wide. An earmark is where the founder decided the credit should be consumed; it does not restrict which payout it may be applied to.",
     method: "GET",
     path: "/admin/partners/:id/credits",
     pathParams: ["id"],
     inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
-    nextSteps: ["get_partner_ledger"],
+    nextSteps: ["apply_partner_credit", "get_partner_ledger"],
+  },
+  {
+    name: "apply_partner_credit",
+    description:
+      "Consume an Open credit against a specific payout — the deliberate act that turns money the partner already holds into a reduction of what they are still owed. The credit becomes `Applied`, stamps the payout it discharged, and the ledger's `credited` rises while `outstanding` falls by the same amount. Sensitive: requires confirm:true. 🔑 `paid` does NOT move — that figure means money that transferred, and a founder reconciling the ledger against a bank statement must not find a number no statement explains. 🔴 This is the SAFE way to carry a surplus forward; never link one payment to two payouts to do it, because `paid` sums per payout with only a per-payout clamp and the same money would count in full against both. ⚠️ A credit applies WHOLE — there is no partial application — so it is refused if it is larger than what the payout still claims, if the credit is not Open, or if the payout is Paid or Rejected. The refusal names both numbers.",
+    method: "POST",
+    path: "/admin/partners/:id/credits/:creditId/apply",
+    pathParams: ["id", "creditId"],
+    bodyParams: ["submission_id"],
+    previewPath: "/admin/partners/:id/credits",
+    write: true,
+    sensitive: true,
+    inputSchema: obj(
+      {
+        id: STR("Partner id who holds the credit."),
+        creditId: STR(
+          "The credit to consume. Must belong to this partner — the route reads it through the partner link and 404s otherwise, because `partner_credit` has no partner column and an id alone would happily apply someone else's money."
+        ),
+        submission_id: STR(
+          "The payout (payment submission) this credit discharges. Must belong to the SAME partner. Required — a credit applied to a partner in general reduces nothing and stamps a decision nobody can audit."
+        ),
+      },
+      ["id", "creditId", "submission_id"]
+    ),
+    sideEffects:
+      "Sets the credit to `Applied` and stamps `applied_to_submission_id` + `applied_at`. Moves `credited` and `outstanding` on the partner ledger; leaves `paid`, every payment, and the payout's own status and amount untouched. Forward-only — there is no unapply, because reversing a settled money decision is a new decision that belongs in a credit of its own.",
+    nextSteps: ["get_partner_ledger", "get_partner_credits"],
   },
   {
     name: "link_payment_to_payout",

--- a/apps/backend/src/api/admin/partners/[id]/credits/[creditId]/apply/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/credits/[creditId]/apply/route.ts
@@ -1,0 +1,180 @@
+/**
+ * @route POST /admin/partners/:id/credits/:creditId/apply
+ * @scope admin
+ *
+ * Consume a credit against a specific payout (#1712).
+ *
+ * 🔑 This is the deliberate act the model was built around. `status` starts
+ * `Open` and is DISPLAYED, never subtracted, because whether money already
+ * given discharges the next payout is a decision a human makes — the same rule
+ * `recorded_against_open` follows. This route is where that human makes it.
+ *
+ * 🔴 And it is deliberately NOT "re-link the spare payment to the next payout",
+ * which is the obvious way to carry an overpayment forward and the one that
+ * pays twice: `paid` sums `settled_amount` PER PAYOUT with only a per-payout
+ * clamp, so one payment linked to two payouts is counted in full against both.
+ * Applying the credit in the claim amount cannot double-count.
+ *
+ * Forward-only. There is no unapply: reversing a settled money decision is a
+ * new decision with its own reason, and it belongs in a credit of its own
+ * rather than in a silent rollback of this one.
+ *
+ * Response: { credit, submission_id, remaining_before, remaining_after }
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+
+import PartnerCreditLink from "../../../../../../../links/partner-credit-link"
+import { INTERNAL_PAYMENTS_MODULE } from "../../../../../../../modules/internal_payments"
+import type InternalPaymentService from "../../../../../../../modules/internal_payments/service"
+import {
+  appliedCreditsFor,
+  checkCreditApplicable,
+} from "../../../../../../../modules/internal_payments/lib/apply-credit"
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../../../../modules/payment_submissions/service"
+import SubmissionPaymentLink from "../../../../../../../links/submission-payment-link"
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const partnerId = String(req.params.id)
+  const creditId = String(req.params.creditId)
+  const body = (req.validatedBody ?? req.body ?? {}) as any
+  const submissionId = String(body.submission_id ?? "").trim()
+
+  if (!submissionId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "submission_id is required — a credit is applied to a specific payout, never to a partner in general"
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  /**
+   * ⚠️ The credit is looked up THROUGH THE PARTNER LINK, not by id alone.
+   *
+   * `partner_credit` has no partner column, so fetching by id would happily
+   * return another partner's credit and apply it here — the shape that
+   * rendered every partner's quote on every storefront. The URL names a
+   * partner and the body names a payout; both ends are checked (#1595).
+   */
+  const { data: creditRows } = await query.graph({
+    entity: PartnerCreditLink.entryPoint,
+    fields: ["partner_credit.*"],
+    filters: { partner_id: partnerId },
+  })
+
+  const credits = (creditRows || [])
+    .map((row: any) => row?.partner_credit)
+    .filter(Boolean)
+
+  const credit = credits.find((c: any) => String(c?.id) === creditId)
+  if (!credit) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `credit ${creditId} does not belong to partner ${partnerId}`
+    )
+  }
+
+  const submissionsService: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+
+  /**
+   * Same rule for the other end: filtered by partner AND id, so a payout that
+   * belongs to someone else is a 404 rather than a discharge of their claim.
+   */
+  const submissions = (await submissionsService.listPaymentSubmissions({
+    partner_id: partnerId,
+    id: submissionId,
+  })) as any[]
+  const submission = submissions?.[0]
+  if (!submission) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `payout ${submissionId} does not belong to partner ${partnerId}`
+    )
+  }
+
+  /**
+   * What has already settled against this payout, by the SAME rule the ledger
+   * uses: only `Completed` payments a human LINKED to it.
+   *
+   * ⚠️ `Pending` is excluded on purpose. It is the status the partner portal
+   * writes on a payment a partner records themselves, so counting it would let
+   * a partner shrink the headroom this route checks — and thereby block a
+   * credit — by asserting they had been paid.
+   *
+   * Best-effort: an unreachable link understates what has settled, which makes
+   * this check STRICTER, never looser. A refusal is recoverable; a wrongly
+   * permitted application spends money that is not there.
+   */
+  let settledAmount = 0
+  try {
+    const { data } = await query.graph({
+      entity: SubmissionPaymentLink.entryPoint,
+      fields: ["payment_submission_id", "internal_payments.*"],
+      filters: { payment_submission_id: [submissionId] },
+    })
+    for (const row of (data || []) as any[]) {
+      const raw = row?.internal_payments
+      const rows = !raw ? [] : Array.isArray(raw) ? raw : [raw]
+      for (const p of rows) {
+        if (!p) continue
+        if (String(p.status ?? "") !== "Completed") continue
+        settledAmount += Number(p.amount ?? 0) || 0
+      }
+    }
+  } catch {
+    // Understating settlement can only refuse an application, never allow one.
+  }
+
+  const already = appliedCreditsFor(submissionId, credits)
+
+  const verdict = checkCreditApplicable({
+    credit,
+    submission,
+    settledAmount,
+    appliedCreditsTotal: already.total,
+  })
+
+  if (!verdict.ok) {
+    /**
+     * 🔑 The refusal names both numbers. "Cannot apply" with no figures is the
+     * shape that sends an operator to the database to find out why, and the
+     * shape that gets worked around by editing rows directly.
+     */
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      verdict.refusal.message
+    )
+  }
+
+  const service: InternalPaymentService = req.scope.resolve(
+    INTERNAL_PAYMENTS_MODULE
+  )
+
+  /**
+   * The three fields move TOGETHER. A credit marked `Applied` without
+   * `applied_to_submission_id` is an enum value with no writer of its own
+   * meaning — the shape that left one payout carrying three statuses and none
+   * of them joined to the order.
+   */
+  const appliedAt = new Date()
+  const updated = await (service as any).updatePartnerCredits({
+    id: creditId,
+    status: "Applied",
+    applied_to_submission_id: submissionId,
+    applied_at: appliedAt,
+  })
+
+  return res.status(200).json({
+    credit: Array.isArray(updated) ? updated[0] : updated,
+    submission_id: submissionId,
+    remaining_before: verdict.remaining_before,
+    remaining_after: verdict.remaining_after,
+  })
+}

--- a/apps/backend/src/api/admin/partners/[id]/credits/[creditId]/apply/validators.ts
+++ b/apps/backend/src/api/admin/partners/[id]/credits/[creditId]/apply/validators.ts
@@ -1,0 +1,17 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * ⚠️ `zodValidator` forces `.strict()`, so an unlisted field is a 400 rather
+ * than a silent drop. Wanted here for the same reason as the create schema: a
+ * typo'd field on a money write that vanished quietly is how `metadata` blobs
+ * ended up deciding payouts (#1557).
+ */
+export const ApplyPartnerCreditSchema = z.object({
+  /**
+   * The payout this credit discharges. Required — a credit applied to "the
+   * partner" in general reduces nothing and stamps a decision nobody can audit.
+   */
+  submission_id: z.string().min(1, "submission_id is required"),
+})
+
+export type ApplyPartnerCredit = z.infer<typeof ApplyPartnerCreditSchema>

--- a/apps/backend/src/api/admin/partners/[id]/credits/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/credits/route.ts
@@ -33,9 +33,59 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     filters: { partner_id: partnerId },
   })
 
-  const credits = (data || [])
+  const rows = (data || [])
     .map((row: any) => row?.partner_credit)
     .filter(Boolean)
+
+  /**
+   * ── The earmark ────────────────────────────────────────────────────────
+   *
+   * 🔴 The POST below writes TWO links — partner→credit and
+   * inventory_order→credit — and until this existed NO read exposed the
+   * second. `partner_credit.*` selects columns, and the earmark is a link, so
+   * the returned row simply had no such field: "this 1,380 is earmarked
+   * against order 01K36TE2WB" was a fact the database held and no surface
+   * showed. The same shape as the 1,380 itself was, one level down.
+   *
+   * Read through the LINK'S ENTRY POINT, filtered by the credit ids we already
+   * have. Traversing from `partner_credit` to a linked field returns no key at
+   * all, silently — the trap that made the submission link look unwritable for
+   * months.
+   *
+   * Best-effort: a credit with no earmark is the normal case, and a graph
+   * hiccup must not turn a panel that can answer "how much does this partner
+   * hold" into an error. It understates the earmark; it never invents one.
+   */
+  const earmarks = new Map<string, string>()
+  const creditIds = rows.map((c: any) => c?.id).filter(Boolean)
+  if (creditIds.length) {
+    try {
+      const { data: linked } = await query.graph({
+        entity: InventoryOrderPartnerCreditLink.entryPoint,
+        fields: ["inventory_orders_id", "partner_credit_id"],
+        filters: { partner_credit_id: creditIds },
+      })
+      for (const row of (linked || []) as any[]) {
+        if (!row?.partner_credit_id || !row?.inventory_orders_id) continue
+        earmarks.set(
+          String(row.partner_credit_id),
+          String(row.inventory_orders_id)
+        )
+      }
+    } catch {
+      // An unmarked credit reads as partner-wide, which is what it was before.
+    }
+  }
+
+  const credits = rows.map((c: any) => ({
+    ...c,
+    /**
+     * ⚠️ `null` means "no order named", never "we could not look". The two are
+     * indistinguishable to a reader, so the failure above is the one case where
+     * that matters — and it is why the catch understates rather than throws.
+     */
+    inventory_order_id: earmarks.get(String(c.id)) ?? null,
+  }))
 
   /**
    * `open_total` is what a reader actually needs — "how much does this partner

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/__tests__/fold.unit.spec.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/__tests__/fold.unit.spec.ts
@@ -602,3 +602,136 @@ describe("foldPartnerLedger — a payout settled in PART (#1710)", () => {
     expect(totals.paid).toBe(0)
   })
 })
+
+/**
+ * Applying a credit to a payout (#1712).
+ *
+ * hrhandloom's real shape: 1,380 already in their hands from being paid 30,000
+ * against a 28,620 payout, now named against a later claim.
+ */
+describe("foldPartnerLedger — applied credits (#1712)", () => {
+  const sub = (over: Record<string, any> = {}) => ({
+    id: "sub_10000",
+    status: "Approved",
+    total_amount: 10000,
+    currency: "inr",
+    submitted_at: "2026-09-01T00:00:00.000Z",
+    ...over,
+  })
+
+  const credit = (over: Record<string, any> = {}) => ({
+    id: "cred_1380",
+    amount: 1380,
+    status: "Applied",
+    currency_code: "inr",
+    reason: "Overpaid 30,000 against a 28,620 payout",
+    applied_to_submission_id: "sub_10000",
+    applied_at: "2026-09-02T00:00:00.000Z",
+    ...over,
+  })
+
+  const fold = (over: Record<string, any> = {}) =>
+    foldPartnerLedger({
+      submissions: [sub()],
+      items: [],
+      payments: [],
+      reconciliations: [],
+      ...over,
+    })
+
+  it("reduces what the payout still claims", () => {
+    const { totals } = fold({ credits: [credit()] })
+
+    expect(totals.billed).toBe(10000)
+    expect(totals.paid).toBe(0)
+    expect(totals.credited).toBe(1380)
+    expect(totals.outstanding).toBe(8620)
+  })
+
+  /**
+   * 🔑 Kept OUT of `paid`. `paid` means money that moved against these payouts;
+   * a founder reconciling this screen against a bank statement must not find a
+   * figure no statement can explain.
+   */
+  it("does NOT inflate paid", () => {
+    expect(fold({ credits: [credit()] }).totals.paid).toBe(0)
+  })
+
+  it("attaches the credit to the payout it discharged", () => {
+    const { entries } = fold({ credits: [credit()] })
+    const payout = entries.find((e) => e.kind === "payout")!
+
+    expect(payout.credited_amount).toBe(1380)
+    expect(payout.credits_applied).toEqual([
+      {
+        credit_id: "cred_1380",
+        amount: 1380,
+        reason: "Overpaid 30,000 against a 28,620 payout",
+        applied_at: "2026-09-02T00:00:00.000Z",
+      },
+    ])
+  })
+
+  it("ignores an Open credit — it has discharged nothing yet", () => {
+    const { totals } = fold({
+      credits: [credit({ status: "Open", applied_to_submission_id: null })],
+    })
+
+    expect(totals.credited).toBe(0)
+    expect(totals.outstanding).toBe(10000)
+  })
+
+  it("ignores a credit applied to a DIFFERENT payout", () => {
+    const { totals } = fold({
+      credits: [credit({ applied_to_submission_id: "sub_other" })],
+    })
+
+    expect(totals.credited).toBe(0)
+    expect(totals.outstanding).toBe(10000)
+  })
+
+  it("stacks with money settled against the same payout", () => {
+    const { totals } = fold({
+      payments: [
+        {
+          id: "pay_4000",
+          amount: 4000,
+          status: "Completed",
+          submission_id: "sub_10000",
+        },
+      ],
+      credits: [credit()],
+    })
+
+    expect(totals.paid).toBe(4000)
+    expect(totals.credited).toBe(1380)
+    expect(totals.outstanding).toBe(4620)
+  })
+
+  /**
+   * ⚠️ A Paid payout contributes its whole amount to `paid`. Also subtracting a
+   * credit would push `outstanding` negative and report the partner as overpaid
+   * on a row that is simply settled. The apply route refuses to create this
+   * state, but the ledger reads rows it did not write.
+   */
+  it("does not double-discharge a payout that is already Paid", () => {
+    const { totals } = fold({
+      submissions: [sub({ status: "Paid", paid_at: "2026-09-01T00:00:00.000Z" })],
+      credits: [credit()],
+    })
+
+    expect(totals.paid).toBe(10000)
+    expect(totals.credited).toBe(0)
+    expect(totals.outstanding).toBe(0)
+  })
+
+  /**
+   * Every caller that predates credits keeps its meaning — a ledger folded
+   * without them reports exactly what it reported before they existed.
+   */
+  it("reports credited: 0 when no credits are passed at all", () => {
+    const { totals } = fold()
+    expect(totals.credited).toBe(0)
+    expect(totals.outstanding).toBe(10000)
+  })
+})

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/fold.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/fold.ts
@@ -18,6 +18,18 @@
  * tested without a database behind it.
  */
 
+import { appliedCreditsFor } from "../../../../../../modules/internal_payments/lib/apply-credit"
+
+export type CreditLike = {
+  id?: string
+  amount?: number | string | null
+  status?: string | null
+  currency_code?: string | null
+  reason?: string | null
+  applied_to_submission_id?: string | null
+  applied_at?: string | Date | null
+}
+
 export type SubmissionLike = {
   id: string
   status?: string | null
@@ -175,6 +187,24 @@ export type LedgerEntry = {
    * must not make the partner look overpaid on this row.
    */
   settled_amount?: number
+  /**
+   * Credits a human APPLIED to this payout (#1712).
+   *
+   * 🔴 Unlike `recorded_against` this is NOT advisory — it enters `outstanding`.
+   * The distinction is the whole design: a shared order id is evidence someone
+   * should look, while an applied credit IS the decision, made by a human
+   * naming the payout it discharges. Treating the first as arithmetic pays
+   * twice; treating the second as advisory leaves a claim standing that
+   * everyone agreed was already settled.
+   */
+  credits_applied?: Array<{
+    credit_id: string
+    amount: number
+    reason: string | null
+    applied_at: string | null
+  }>
+  /** Sum of `credits_applied`. Enters `credited`, and so `outstanding`. */
+  credited_amount?: number
 
   // ── payment only ───────────────────────────────────────────────────────
   payment_type?: string | null
@@ -208,7 +238,18 @@ export type LedgerTotals = {
    * silently restate historical numbers nobody re-examined.
    */
   paid: number
-  /** Still owed. `billed - paid`. */
+  /**
+   * Of `billed`, what applied credits discharged (#1712).
+   *
+   * 🔑 Kept SEPARATE from `paid` rather than folded into it. `paid` means money
+   * that moved against these payouts; `credited` means money that had already
+   * moved, was recorded as a credit, and has now been named against a claim.
+   * Summing them would make a partner's `paid` figure grow without a transfer,
+   * and the next reader reconciling this screen against a bank statement would
+   * find a number no statement can explain.
+   */
+  credited: number
+  /** Still owed. `billed - paid - credited`. */
   outstanding: number
   /**
    * Historical money movement that NO payout accounts for. Deliberately not
@@ -310,8 +351,15 @@ export const foldPartnerLedger = (input: {
   items: SubmissionItemLike[]
   payments: PaymentLike[]
   reconciliations: ReconciliationLike[]
+  /**
+   * The partner's credits (#1712). Optional so every existing caller and test
+   * keeps its meaning: a ledger folded without them reports `credited: 0`,
+   * which is exactly what it reported before they existed.
+   */
+  credits?: CreditLike[]
 }): { entries: LedgerEntry[]; totals: LedgerTotals } => {
   const { submissions, items, payments, reconciliations } = input
+  const credits = input.credits || []
 
   const itemsBySubmission = new Map<string, SubmissionItemLike[]>()
   for (const item of items) {
@@ -445,6 +493,22 @@ export const foldPartnerLedger = (input: {
     const settledAmount =
       Math.round(Math.min(settledRaw, submissionAmount) * 100) / 100
 
+    /**
+     * Credits a human applied to THIS payout, by the shared rule the admin
+     * route checks before writing one. Only `Applied` rows naming this
+     * submission count — an `Open` credit has discharged nothing.
+     */
+    const applied = appliedCreditsFor(submission.id, credits)
+    const appliedCreditsTotal = applied.total
+    const appliedCredits = credits
+      .filter((c) => applied.ids.includes(String(c.id ?? "")))
+      .map((c) => ({
+        credit_id: String(c.id ?? ""),
+        amount: num(c.amount),
+        reason: c.reason ?? null,
+        applied_at: iso(c.applied_at),
+      }))
+
     return {
       id: `payout:${submission.id}`,
       kind: "payout",
@@ -484,6 +548,8 @@ export const foldPartnerLedger = (input: {
         0
       ),
       settled_amount: settledAmount,
+      credits_applied: appliedCredits,
+      credited_amount: appliedCreditsTotal,
     }
   })
 
@@ -536,6 +602,19 @@ export const foldPartnerLedger = (input: {
     return acc + (e.settled_amount ?? 0)
   }, 0)
 
+  /**
+   * ⚠️ Credits on a payout that is already `Paid` are excluded, the same way
+   * `paid` refuses to count status and settlement together. A Paid payout
+   * contributes its whole amount to `paid`; also subtracting a credit from it
+   * would push `outstanding` negative and report the partner as overpaid on a
+   * row that is simply settled. The apply route refuses to create that state,
+   * but a ledger must read historical rows it did not write.
+   */
+  const credited = live.reduce((acc, e) => {
+    if (PAID_STATUSES.has(String(e.status))) return acc
+    return acc + (e.credited_amount ?? 0)
+  }, 0)
+
   const currencies = new Set(live.map((e) => e.currency))
   for (const e of paymentEntries) currencies.add(e.currency)
 
@@ -544,7 +623,8 @@ export const foldPartnerLedger = (input: {
     totals: {
       billed,
       paid,
-      outstanding: billed - paid,
+      credited,
+      outstanding: billed - paid - credited,
       recorded: paymentEntries.reduce((acc, e) => acc + e.amount, 0),
       /**
        * Counted once per PAYMENT, not once per payout that mentions it — two

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/route.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/route.ts
@@ -46,6 +46,7 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
+import PartnerCreditLink from "../../../../../../links/partner-credit-link"
 import PartnerPaymentsLink from "../../../../../../links/partner-payments-link"
 import SubmissionPaymentLink from "../../../../../../links/submission-payment-link"
 import { PAYMENT_REPORTS_MODULE } from "../../../../../../modules/payment_reports"
@@ -287,11 +288,39 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
+  /**
+   * ── The partner's credits (#1712) ───────────────────────────────────────
+   *
+   * Money already given that no payout consumed. Read here so that a credit a
+   * human APPLIED to a payout actually reduces what that payout still claims —
+   * without this the fold would compute `credited: 0` forever and the apply
+   * route would stamp a decision no screen honoured. A guard reading a field
+   * the query never fetched is dead, and this is the query that fetches it.
+   *
+   * ⚠️ Through the LINK'S ENTRY POINT: `partner_credit` has no partner column.
+   *
+   * Best-effort, like every other source above. Losing credits understates
+   * `credited` and so OVERSTATES `outstanding` — the safe direction: it can
+   * make us look at a claim that is already discharged, never hide one.
+   */
+  let credits: any[] = []
+  try {
+    const { data } = await query.graph({
+      entity: PartnerCreditLink.entryPoint,
+      fields: ["partner_credit.*"],
+      filters: { partner_id },
+    })
+    credits = (data || []).map((r: any) => r?.partner_credit).filter(Boolean)
+  } catch {
+    credits = []
+  }
+
   const { entries, totals } = foldPartnerLedger({
     submissions,
     items,
     payments,
     reconciliations,
+    credits,
   })
 
   return res.status(200).json({ entries, totals, count: entries.length })

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -249,6 +249,7 @@ import {
 import { PaymentSchema, ListPaymentsQuerySchema, UpdatePaymentSchema, PaymentSettlesSchema } from "./admin/payments/validators";
 import { CreatePaymentAndLinkSchema } from "./admin/payments/link/validators";
 import { CreatePartnerCreditSchema } from "./admin/partners/[id]/credits/validators";
+import { ApplyPartnerCreditSchema } from "./admin/partners/[id]/credits/[creditId]/apply/validators";
 import { ListPaymentsByPersonQuerySchema } from "./admin/payments/persons/[id]/validators";
 import { ListPaymentsByPartnerQuerySchema } from "./admin/payments/partners/[id]/validators";
 import { ListPaymentMethodsByPersonQuerySchema, CreatePaymentMethodForPersonSchema } from "./admin/payments/persons/[id]/methods/validators";
@@ -4383,6 +4384,15 @@ export default defineMiddlewares({
       method: "POST",
       middlewares: [
         validateAndTransformBody(wrapSchema(CreatePartnerCreditSchema)),
+      ],
+    },
+    // Applying a credit to a payout (#1712) — the deliberate act the model was
+    // built around. Never inferred by a fold; always a human naming the payout.
+    {
+      matcher: "/admin/partners/:id/credits/:creditId/apply",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(ApplyPartnerCreditSchema)),
       ],
     },
     // Admin Partner Subscription

--- a/apps/backend/src/lib/mcp-core/__tests__/partner-money-tools.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/partner-money-tools.unit.spec.ts
@@ -252,3 +252,68 @@ describe("the ask an operator actually types reaches these tools", () => {
     )
   })
 })
+
+/**
+ * Applying a credit (#1712) — the write that turns money the partner already
+ * holds into a reduction of what they are still owed.
+ *
+ * The generic registry specs prove the row is well-formed. These prove it does
+ * the thing it was added for, and that the two guardrails around it are real:
+ * it is confirm-gated, and the partner surface cannot reach it.
+ */
+describe("admin: apply_partner_credit", () => {
+  const def = () => adminTool("apply_partner_credit")!
+
+  it("wraps the apply route as a sensitive write", () => {
+    expect(def()).toBeTruthy()
+    expect(def().method).toBe("POST")
+    expect(def().path).toBe("/admin/partners/:id/credits/:creditId/apply")
+    expect(def().write).toBe(true)
+    expect(isSensitive(def())).toBe(true)
+  })
+
+  /**
+   * 🔑 `pick()` is an allowlist walk: a field that reached neither queryParams
+   * nor bodyParams is dropped in SILENCE. `submission_id` is the whole
+   * instruction — dropped, the route would 400, and a future edit to where it
+   * reads its argument from would turn this into a no-op 200 that stamps
+   * nothing.
+   */
+  it("forwards submission_id in the body — the field that names the payout", () => {
+    expect(def().bodyParams).toContain("submission_id")
+  })
+
+  it("carries BOTH path params — a credit id alone names no partner", () => {
+    expect(def().pathParams).toEqual(["id", "creditId"])
+  })
+
+  it("requires all three inputs", () => {
+    expect(def().inputSchema.required).toEqual(
+      expect.arrayContaining(["id", "creditId", "submission_id"])
+    )
+  })
+
+  /**
+   * The partner surface is read-only by DECISION. A partner able to apply their
+   * own credit could declare their own payout discharged.
+   */
+  it("is not reachable from the partner surface", () => {
+    expect(partnerTool("apply_partner_credit")).toBeUndefined()
+  })
+
+  it("an operator's own words reach it", () => {
+    const names = selectAdminToolSlice(
+      "apply this partner's credit to the payout",
+      ADMIN_MCP_TOOLS
+    ).names
+    expect(names).toContain("apply_partner_credit")
+  })
+
+  /**
+   * ⚠️ A tool whose next step is not the screen that shows the change leaves
+   * the operator with a 200 and no way to see what moved.
+   */
+  it("points at the ledger afterwards, where credited and outstanding move", () => {
+    expect(def().nextSteps).toContain("get_partner_ledger")
+  })
+})

--- a/apps/backend/src/modules/internal_payments/lib/__tests__/apply-credit.unit.spec.ts
+++ b/apps/backend/src/modules/internal_payments/lib/__tests__/apply-credit.unit.spec.ts
@@ -1,0 +1,227 @@
+import {
+  appliedCreditsFor,
+  canApplyToStatus,
+  checkCreditApplicable,
+  remainingClaim,
+} from "../apply-credit"
+
+/**
+ * hrhandloom's real numbers throughout: a 1,380 credit born from being paid
+ * 30,000 against a 28,620 payout, earmarked for the still-open order
+ * 01K36TE2WB.
+ */
+const CREDIT = {
+  amount: 1380,
+  status: "Open",
+  currency_code: "inr",
+}
+
+const PAYOUT = {
+  total_amount: 10000,
+  status: "Approved",
+  currency: "inr",
+}
+
+describe("remainingClaim (#1712)", () => {
+  it("takes off both settled money and credits already applied", () => {
+    expect(
+      remainingClaim({
+        submissionAmount: 10000,
+        settledAmount: 4000,
+        appliedCreditsTotal: 1380,
+      })
+    ).toBe(4620)
+  })
+
+  it("floors at zero rather than reporting negative headroom", () => {
+    // An over-settled payout is a fact for the ledger to show, not room a
+    // further credit may be applied into.
+    expect(
+      remainingClaim({ submissionAmount: 1000, settledAmount: 1500 })
+    ).toBe(0)
+  })
+
+  it("treats a missing settlement as nothing settled, not as an error", () => {
+    expect(remainingClaim({ submissionAmount: 10000 })).toBe(10000)
+  })
+
+  /** #1613: money arrives fractional, and an integer rounded 11.8 to 12. */
+  it("keeps two decimals", () => {
+    expect(
+      remainingClaim({ submissionAmount: 100.55, settledAmount: 10.1 })
+    ).toBe(90.45)
+  })
+})
+
+describe("canApplyToStatus (#1712)", () => {
+  it("refuses Paid — the money already moved in full", () => {
+    expect(canApplyToStatus("Paid")).toBe(false)
+  })
+
+  it("refuses Rejected — a rejected claim owes nothing", () => {
+    expect(canApplyToStatus("Rejected")).toBe(false)
+  })
+
+  it("allows the statuses that still owe", () => {
+    expect(canApplyToStatus("Approved")).toBe(true)
+    expect(canApplyToStatus("Submitted")).toBe(true)
+    expect(canApplyToStatus("Draft")).toBe(true)
+  })
+})
+
+describe("checkCreditApplicable (#1712)", () => {
+  it("allows a credit that fits, and reports both sides of the claim", () => {
+    const v = checkCreditApplicable({ credit: CREDIT, submission: PAYOUT })
+    expect(v.ok).toBe(true)
+    if (!v.ok) throw new Error("expected ok")
+    expect(v.remaining_before).toBe(10000)
+    expect(v.remaining_after).toBe(8620)
+  })
+
+  it("counts money already settled against the payout", () => {
+    const v = checkCreditApplicable({
+      credit: CREDIT,
+      submission: PAYOUT,
+      settledAmount: 8000,
+    })
+    expect(v.ok).toBe(true)
+    if (!v.ok) throw new Error("expected ok")
+    expect(v.remaining_before).toBe(2000)
+    expect(v.remaining_after).toBe(620)
+  })
+
+  /**
+   * 🔴 The defect this whole model exists to avoid, one level up: a silent
+   * clamp is what hid the 1,380 in the first place.
+   */
+  it("REFUSES rather than clamping when the credit is larger than what is left", () => {
+    const v = checkCreditApplicable({
+      credit: CREDIT,
+      submission: PAYOUT,
+      settledAmount: 9500,
+    })
+    expect(v.ok).toBe(false)
+    if (v.ok) throw new Error("expected refusal")
+    expect(v.refusal.code).toBe("exceeds_remaining")
+    // Both numbers are named — an operator must not need the database to see why.
+    expect(v.refusal.message).toContain("1380")
+    expect(v.refusal.message).toContain("500")
+    expect(v.remaining_before).toBe(500)
+  })
+
+  it("refuses a credit that is not Open", () => {
+    for (const status of ["Applied", "Cancelled"]) {
+      const v = checkCreditApplicable({
+        credit: { ...CREDIT, status },
+        submission: PAYOUT,
+      })
+      expect(v.ok).toBe(false)
+      if (v.ok) throw new Error("expected refusal")
+      expect(v.refusal.code).toBe("credit_not_open")
+    }
+  })
+
+  it("refuses a Paid payout — that would claim the money was given twice", () => {
+    const v = checkCreditApplicable({
+      credit: CREDIT,
+      submission: { ...PAYOUT, status: "Paid" },
+    })
+    expect(v.ok).toBe(false)
+    if (v.ok) throw new Error("expected refusal")
+    expect(v.refusal.code).toBe("submission_paid")
+  })
+
+  it("refuses a Rejected payout — it would destroy money the partner holds", () => {
+    const v = checkCreditApplicable({
+      credit: CREDIT,
+      submission: { ...PAYOUT, status: "Rejected" },
+    })
+    expect(v.ok).toBe(false)
+    if (v.ok) throw new Error("expected refusal")
+    expect(v.refusal.code).toBe("submission_rejected")
+  })
+
+  it("refuses across currencies rather than inventing a rate", () => {
+    const v = checkCreditApplicable({
+      credit: { ...CREDIT, currency_code: "eur" },
+      submission: PAYOUT,
+    })
+    expect(v.ok).toBe(false)
+    if (v.ok) throw new Error("expected refusal")
+    expect(v.refusal.code).toBe("currency_mismatch")
+  })
+
+  /**
+   * ⚠️ A missing currency is not a mismatch. Refusing on it would block every
+   * historical row written before the column carried a value.
+   */
+  it("does not refuse when either side states no currency", () => {
+    expect(
+      checkCreditApplicable({
+        credit: { ...CREDIT, currency_code: null },
+        submission: PAYOUT,
+      }).ok
+    ).toBe(true)
+    expect(
+      checkCreditApplicable({
+        credit: CREDIT,
+        submission: { ...PAYOUT, currency: null },
+      }).ok
+    ).toBe(true)
+  })
+
+  it("allows a credit that exactly consumes the remainder", () => {
+    const v = checkCreditApplicable({
+      credit: CREDIT,
+      submission: PAYOUT,
+      settledAmount: 8620,
+    })
+    expect(v.ok).toBe(true)
+    if (!v.ok) throw new Error("expected ok")
+    expect(v.remaining_after).toBe(0)
+  })
+
+  it("counts credits already applied to the same payout", () => {
+    // 10,000 payout, 8,000 already credited: 1,380 no longer fits.
+    const v = checkCreditApplicable({
+      credit: { ...CREDIT, amount: 2500 },
+      submission: PAYOUT,
+      appliedCreditsTotal: 8000,
+    })
+    expect(v.ok).toBe(false)
+    if (v.ok) throw new Error("expected refusal")
+    expect(v.refusal.code).toBe("exceeds_remaining")
+    expect(v.remaining_before).toBe(2000)
+  })
+})
+
+describe("appliedCreditsFor (#1712)", () => {
+  const rows = [
+    { id: "c1", amount: 1380, status: "Applied", applied_to_submission_id: "sub_1" },
+    { id: "c2", amount: 500, status: "Open", applied_to_submission_id: null },
+    { id: "c3", amount: 900, status: "Applied", applied_to_submission_id: "sub_2" },
+    { id: "c4", amount: 120, status: "Cancelled", applied_to_submission_id: "sub_1" },
+    { id: "c5", amount: 20.5, status: "Applied", applied_to_submission_id: "sub_1" },
+  ]
+
+  it("sums only Applied credits naming THIS payout", () => {
+    const { total, ids } = appliedCreditsFor("sub_1", rows)
+    expect(total).toBe(1400.5)
+    expect(ids).toEqual(["c1", "c5"])
+  })
+
+  /**
+   * 🔑 An Open credit has discharged nothing and a Cancelled one never will.
+   * Counting either would report a payout as smaller than it is — an
+   * undercharge shaped exactly like the ones that underpaid partners before.
+   */
+  it("ignores Open, Cancelled, and credits applied elsewhere", () => {
+    expect(appliedCreditsFor("sub_3", rows).total).toBe(0)
+    expect(appliedCreditsFor("sub_2", rows).ids).toEqual(["c3"])
+  })
+
+  it("handles a missing list", () => {
+    expect(appliedCreditsFor("sub_1", null).total).toBe(0)
+    expect(appliedCreditsFor("sub_1", undefined).ids).toEqual([])
+  })
+})

--- a/apps/backend/src/modules/internal_payments/lib/apply-credit.ts
+++ b/apps/backend/src/modules/internal_payments/lib/apply-credit.ts
@@ -1,0 +1,193 @@
+/**
+ * Whether a credit may discharge a given payout, and by how much (#1712).
+ *
+ * PURE, and the ONE home for that arithmetic. The admin route asks it before
+ * writing, and `foldPartnerLedger` asks it again when reporting — two surfaces
+ * deciding for themselves how much of a payout a credit consumes is exactly how
+ * `foldPartnerBilling` ended up with a private copy in `partner-ui` and the
+ * run-line pricer ended up with two homes.
+ *
+ * ## Why applying is a write and not a fold
+ *
+ * `recorded_against` is advisory precisely because a shared order id is not a
+ * statement that money discharges a claim. A credit is the opposite: a human
+ * naming the payout it consumes. So unlike `recorded_against`, an applied
+ * credit DOES enter the arithmetic — it is the decision itself, not evidence
+ * that someone should make one.
+ *
+ * ## Why it refuses instead of clamping
+ *
+ * 🔴 A silent clamp is what hid the 1,380 in the first place. `foldPartnerLedger`
+ * caps `settled_amount` at the payout's own value, so 30,000 paid against a
+ * 28,620 payout reported 28,620 and the surplus fell out of every screen. If
+ * applying a 5,000 credit to a 1,000 remainder quietly consumed 1,000 and threw
+ * the rest away, this model would reintroduce the same defect one level up —
+ * and `partner_credit` has no `applied_amount` column to hold the difference,
+ * so a partial application cannot even be recorded. It refuses, and names both
+ * numbers.
+ */
+
+export type CreditForApply = {
+  amount?: number | string | null
+  status?: string | null
+  currency_code?: string | null
+}
+
+export type SubmissionForApply = {
+  total_amount?: number | string | null
+  status?: string | null
+  currency?: string | null
+}
+
+export type ApplyRefusal = {
+  code:
+    | "credit_not_open"
+    | "submission_rejected"
+    | "submission_paid"
+    | "currency_mismatch"
+    | "exceeds_remaining"
+  message: string
+}
+
+export type ApplyVerdict =
+  | { ok: true; remaining_before: number; remaining_after: number }
+  | { ok: false; remaining_before: number; refusal: ApplyRefusal }
+
+const num = (v: unknown): number => {
+  const n = Number(v ?? 0)
+  return Number.isFinite(n) ? n : 0
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100
+
+/**
+ * What is still claimable on a payout once money already settled against it and
+ * credits already applied to it are taken off.
+ *
+ * ⚠️ Floored at 0. A payout that is somehow over-settled is a fact for the
+ * ledger to show, not a negative headroom that would let a credit be applied
+ * to create one.
+ */
+export const remainingClaim = (input: {
+  submissionAmount: number | string | null | undefined
+  settledAmount?: number | string | null
+  appliedCreditsTotal?: number | string | null
+}): number =>
+  round2(
+    Math.max(
+      0,
+      num(input.submissionAmount) -
+        num(input.settledAmount) -
+        num(input.appliedCreditsTotal)
+    )
+  )
+
+/**
+ * The statuses a payout can be in and still have something left to discharge.
+ *
+ * ⚠️ `Paid` is excluded, and that is not the same rule as `PAID_STATUSES` in
+ * the ledger fold being about arithmetic. Here it is about meaning: a payout
+ * marked Paid asserts the whole amount moved, so applying a credit to it would
+ * claim the partner was given the money twice — once in the transfer and once
+ * as a credit that no longer reduces anything.
+ *
+ * `Rejected` is excluded because a rejected claim owes nothing; consuming a
+ * credit against it would destroy money the partner still holds.
+ */
+export const canApplyToStatus = (status: string | null | undefined): boolean =>
+  String(status ?? "") !== "Paid" && String(status ?? "") !== "Rejected"
+
+export const checkCreditApplicable = (input: {
+  credit: CreditForApply
+  submission: SubmissionForApply
+  settledAmount?: number | string | null
+  appliedCreditsTotal?: number | string | null
+}): ApplyVerdict => {
+  const { credit, submission } = input
+  const amount = num(credit.amount)
+  const remaining_before = remainingClaim({
+    submissionAmount: submission.total_amount,
+    settledAmount: input.settledAmount,
+    appliedCreditsTotal: input.appliedCreditsTotal,
+  })
+
+  const refuse = (
+    code: ApplyRefusal["code"],
+    message: string
+  ): ApplyVerdict => ({ ok: false, remaining_before, refusal: { code, message } })
+
+  if (String(credit.status ?? "") !== "Open") {
+    return refuse(
+      "credit_not_open",
+      `this credit is ${credit.status ?? "unknown"}, not Open — only an Open credit has money left to apply`
+    )
+  }
+
+  if (String(submission.status ?? "") === "Rejected") {
+    return refuse(
+      "submission_rejected",
+      "that payout is Rejected — it owes nothing, and applying a credit to it would consume money the partner still holds"
+    )
+  }
+
+  if (String(submission.status ?? "") === "Paid") {
+    return refuse(
+      "submission_paid",
+      "that payout is already Paid in full — applying a credit to it would claim the partner was given the same money twice"
+    )
+  }
+
+  /**
+   * ⚠️ Compared case-insensitively and only when BOTH sides state one. A
+   * missing currency is not evidence of a mismatch, and refusing on it would
+   * block every historical row that predates the column.
+   */
+  const cc = String(credit.currency_code ?? "").toLowerCase()
+  const sc = String(submission.currency ?? "").toLowerCase()
+  if (cc && sc && cc !== sc) {
+    return refuse(
+      "currency_mismatch",
+      `credit is in ${cc.toUpperCase()} and the payout is in ${sc.toUpperCase()} — this fold holds no exchange rate and must not invent one`
+    )
+  }
+
+  if (amount > remaining_before) {
+    return refuse(
+      "exceeds_remaining",
+      `credit of ${amount} is larger than the ${remaining_before} still claimable on that payout. A credit applies whole — there is no applied_amount column to hold a remainder — so split the credit or pick a payout it fits`
+    )
+  }
+
+  return {
+    ok: true,
+    remaining_before,
+    remaining_after: round2(remaining_before - amount),
+  }
+}
+
+/**
+ * The credits a payout has consumed, summed.
+ *
+ * 🔑 Only `Applied` rows, and only those naming THIS payout. An `Open` credit
+ * has discharged nothing and a `Cancelled` one never will — counting either
+ * would report a payout as smaller than it is and underpay the partner.
+ */
+export const appliedCreditsFor = (
+  submissionId: string,
+  credits: Array<{
+    id?: string
+    amount?: number | string | null
+    status?: string | null
+    applied_to_submission_id?: string | null
+  }> | null | undefined
+): { total: number; ids: string[] } => {
+  const rows = (credits || []).filter(
+    (c) =>
+      String(c?.status ?? "") === "Applied" &&
+      String(c?.applied_to_submission_id ?? "") === submissionId
+  )
+  return {
+    total: round2(rows.reduce((acc, c) => acc + num(c.amount), 0)),
+    ids: rows.map((c) => String(c.id ?? "")).filter(Boolean),
+  }
+}


### PR DESCRIPTION
Two halves of the same gap on #1712, plus the screen that makes them usable. A credit was a fact you could record and then do nothing with — and half of what it recorded was invisible.

## Applying a credit

`POST /admin/partners/:id/credits/:creditId/apply { submission_id }` stamps `status: Applied`, `applied_to_submission_id` and `applied_at` **together**, and `foldPartnerLedger` now subtracts it: `credited` rises and `outstanding` falls by the same amount.

**`paid` deliberately does not move.** It means money that *transferred*, and a founder reconciling this screen against a bank statement must not find a figure no statement explains. That is why `credited` is its own total rather than folded into `paid`.

Unlike `recorded_against`, an applied credit **is** arithmetic. A shared order id is evidence someone should look; a credit is a human naming the payout it discharges. Treating the first as arithmetic pays twice; treating the second as advisory leaves a claim standing that everyone agreed was already settled.

### It refuses rather than clamps

🔴 A silent clamp is what hid the 1,380 in the first place — `foldPartnerLedger` caps `settled_amount` at the payout's own value, so 30,000 paid against a 28,620 payout reported 28,620 and the surplus fell out of every screen. A credit applies **whole** (there is no `applied_amount` column), so one larger than the remaining claim is refused **with both numbers named**. Also refused: a credit that is not `Open`, a `Paid` or `Rejected` payout, and a currency mismatch.

### Both ends are checked

`partner_credit` has no partner column, so the credit is read **through the partner link** and the payout is listed filtered by `partner_id`. An id alone would happily apply another partner's money — the shape that rendered every partner's quote on every storefront. Two integration cases cover exactly this.

Forward-only: there is no unapply. Reversing a settled money decision is a new decision with its own reason.

## The earmark

`GET /admin/partners/:id/credits` selected `partner_credit.*` — **columns**. The create route writes two links, `partner→credit` and `inventory_order→credit`, and the second is a link, so the returned row had no such field at all. *"This 1,380 is earmarked against order `01K36TE2WB`"* was a fact the database held and no surface showed — the same shape as the 1,380 itself, one level down. Now read through the link's entry point; `null` means no order named.

## The screen

A **Credits panel** under the ledger on the partner page: what the partner holds, **why** (the reason, always), the earmarked order, and for an applied credit the payout it discharged and when.

Applying is a **visible list of candidate payouts, deliberately not a dropdown**. A `Select` renders its options only when opened, so every reason a payout cannot take this credit — "credit is larger than this", "nothing left to claim" — would be hidden behind a click and invisible to any test that renders the screen. On a money decision the reasons *are* the screen. This was caught by writing the test: the first version used a `Select` and three assertions could not see their own text.

The ledger panel gains `credited` in the footer beside paid and outstanding, and each payout says which credit discharged part of it — without that the footer shows a smaller amount owed than the payouts above add up to, with nothing explaining the difference.

## Arithmetic has one home

`remainingClaim` / `checkCreditApplicable` / `appliedCreditsFor` live in `modules/internal_payments/lib/apply-credit.ts`. The route asks before writing, the fold asks when reporting, and the panel imports the same `remainingClaim` rather than re-deriving it — a screen computing a money figure its own way is how a derived rate outranked the server's pricer and re-priced a ₹10,000 job to ₹12,857 (#1679). The panel's version is advisory: the server decides, refuses with both numbers named, and the panel surfaces that message verbatim.

Client types also gain `settled_amount`, which `payoutSettlementBadge` had been reading through its own local type while absent from `PartnerLedgerEntry` — #1679's shape, one edit from a silent `undefined`.

## MCP

`apply_partner_credit` (write + sensitive, confirm-gated, admin-only — the partner surface stays read-only by decision). `get_partner_credits` now documents the earmark and points at it.

## Verification

- 20 unit cases on the arithmetic, 10 on the ledger fold, 6 on the MCP row, 12 render cases on the new panel, 3 more on the ledger panel.
- **9 integration cases against a real database.** The link reads are the half unit tests cannot prove, and a link that writes fine and reads empty is this codebase's most expensive recurring bug.
- Mutation-checked all three new reads: neutering the earmark join, the `credited` subtraction, and the `credited` footer each fail their tests.
- `check:prod-build` green; tsc unchanged at 81 errors; existing ledger suites unchanged (a fold called without credits still reports `credited: 0`).
- ⚠️ `brief-shaper.unit.spec.ts` is red — verified pre-existing by stashing to a clean tree.

## Not in this PR

#1712's other two defects: `paid` double-counting a payment linked to two payouts, and the ledger blind to `paid_to → method → partner` (under-reporting `recorded` by 47,974).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4