### PR TITLE
fix(deploy): a missing sharp binary took the server down at boot (#1729)

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -105,6 +105,20 @@ RUN pnpm run build
 RUN pnpm deploy --legacy --filter=@jyt/backend --prod --ignore-scripts \
       --prefer-offline --store-dir "$PNPM_STORE_DIR" /prod-deps
 
+# --- native modules the --ignore-scripts above skipped ----------------------
+# `--ignore-scripts` keeps the deploy deterministic, but it also skips the
+# install script that fetches sharp's PLATFORM BINARY, so /prod-deps ships a
+# `sharp` package with no build/Release/sharp-linux-x64.node.
+#
+# 🔴 That gap was invisible for as long as nothing loaded sharp at BOOT. When
+# #1729 added a top-level `import sharp`, the server exited 1 on startup with
+# "Cannot find module '../build/Release/sharp-linux-x64.node'", the ECS
+# deployment circuit breaker rolled production back through two consecutive
+# deploys, and prod ran an older image with two commits' migrations already
+# applied. The image built, pushed, and passed every check — the only thing that
+# knew it was broken was the container, at runtime.
+RUN cd /prod-deps && pnpm rebuild sharp
+
 # `medusa build` copies apps/backend's dependencies verbatim into
 # .medusa/server/package.json, so the tree above is exactly what the compiled
 # server needs. That is an assumption about Medusa's build, not a guarantee —
@@ -115,6 +129,17 @@ const deps=Object.keys(require('/app/apps/backend/.medusa/server/package.json').
 const missing=deps.filter(d=>!require('fs').existsSync('/prod-deps/node_modules/'+d+'/package.json'));\
 if(missing.length){console.error('Missing from the deployed prod tree: '+missing.join(', '));process.exit(1);}\
 console.log('runtime dep check OK ('+deps.length+' deps)');"
+
+# The check above proves each dependency's package.json is PRESENT. That is not
+# the same as loadable: a native module can have a perfect package.json and no
+# binary, which is exactly how sharp shipped broken. Requiring it here loads the
+# binding, so the build fails loudly instead of producing an image that dies at
+# boot — the stated intent of the check above, extended to the failure mode that
+# got past it.
+RUN node -e "\
+const s=require('/prod-deps/node_modules/sharp');\
+if(typeof s!=='function'){console.error('sharp did not load as a function');process.exit(1);}\
+console.log('sharp native binding OK (libvips '+(s.versions&&s.versions.vips)+')');"
 
 # -----------------------------------------------------------------------------
 # Runtime image — ships only the compiled server and its prod deps.

--- a/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
+++ b/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
@@ -16,7 +16,47 @@ import {
 } from "../../agents/textileExtractionAgent";
 import { PinoLogger } from "@mastra/loggers";
 import { readModelJsonOrThrow } from "../../../lib/ai/model-json";
-import sharp from "sharp";
+
+/**
+ * `sharp`, loaded LAZILY and never as a top-level import.
+ *
+ * 🔴 It is a NATIVE module, and the production image builds its dependency tree
+ * with `pnpm deploy --ignore-scripts` — which skips the install script that
+ * fetches the platform binary. So `node_modules/sharp` ships without
+ * `build/Release/sharp-linux-x64.node`, and a static `import sharp from "sharp"`
+ * turns that absence into:
+ *
+ *     Error starting server: Something went wrong installing the "sharp" module
+ *     Cannot find module '../build/Release/sharp-linux-x64.node'
+ *
+ * which exits the container with code 1 before it can serve a request. The ECS
+ * circuit breaker then rolled production back through two consecutive deploys
+ * (#1729), leaving migrations applied and the code that needed them not live.
+ *
+ * The binary is now installed in the image and asserted at build time, so this
+ * should not recur — but the import stays lazy regardless, because the caller
+ * ALREADY treats an unusable sharp as non-fatal: it warns and sends the
+ * original bytes. A top-level import defeated that design by failing before any
+ * of that code could run. An image-processing nicety must never be able to take
+ * the server down at boot.
+ *
+ * Cached after the first attempt, including the failure — a missing binary does
+ * not become present, and retrying the import per image would log once per
+ * request.
+ */
+let sharpModule: any | null | undefined
+const loadSharp = async (logger: any): Promise<any | null> => {
+  if (sharpModule !== undefined) return sharpModule
+  try {
+    sharpModule = (await import("sharp")).default
+  } catch (err) {
+    logger?.warn?.(
+      `[TextileExtraction] sharp is unavailable — images will be sent as fetched, so HEIC will still be rejected by the vision providers: ${err}`
+    )
+    sharpModule = null
+  }
+  return sharpModule
+}
 
 const logger = new PinoLogger();
 
@@ -242,7 +282,13 @@ const prepareImageForAgent = async (image_url: string): Promise<{ image: string;
       // that isn't already JPEG/PNG/WebP is re-encoded, and everything is capped
       // to MAX_IMAGE_DIM so the body stays small.
       const needsReencode = !isJpeg && !isPng && !isWebp; // HEIC, GIF, TIFF, …
+      const sharp = await loadSharp(logger);
       try {
+        if (!sharp) {
+          throw new Error(
+            "sharp is unavailable in this runtime — cannot re-encode"
+          );
+        }
         const meta = await sharp(buf, { failOn: "none" }).metadata();
         const tooBig =
           (meta.width ?? 0) > MAX_IMAGE_DIM || (meta.height ?? 0) > MAX_IMAGE_DIM;


### PR DESCRIPTION
🔴 **Production has been rolling back since `da7ff17d0`.** Re-running the deploy job does not fix it — I tried, and it failed the same way.

## What is actually happening

The container starts, gets through Redis, S3, CRM and Mastra, then:

```
Error starting server: Something went wrong installing the "sharp" module
Cannot find module '../build/Release/sharp-linux-x64.node'
 ELIFECYCLE  Command failed with exit code 1
```

ECS's deployment circuit breaker rolled back twice — once for #1729, once for #1730 — so:

| commit | migrations | code live |
|---|---|---|
| `2902a2baa` #1725 | ✅ | ✅ |
| `da7ff17d0` #1729 | ✅ | ❌ |
| `7b894e12d` #1730 | ✅ | ❌ |

**Schema ahead of code, and nothing said so.** The image built, pushed, and passed every check. The only thing that knew it was broken was the container, at runtime — the health check never even ran (`skipped`).

The first symptom was a red herring: the earlier attempts showed `CannotPullContainerError … not found` on a digest that demonstrably exists in ECR, which looked like tag contention between overlapping deploys. Once the service was idle and I re-ran the job, the pull succeeded and the real failure surfaced — tasks starting, registering with the target group, then exiting 1.

## Two independent causes, both fixed

**1. The binary was never in the image.** The Dockerfile builds the runtime tree with `pnpm deploy … --ignore-scripts`, which skips the install script that fetches sharp's platform binary. `sharp` has been a dependency since #907 and this has been true the whole time — invisible because nothing loaded it at **boot**. `pnpm rebuild sharp` now runs against `/prod-deps`.

And the build now **asserts** it. The existing dependency check proves each `package.json` is *present*, which is not the same as *loadable* — a native module can have a perfect `package.json` and no binary, which is exactly how this shipped. Requiring sharp at build time makes the build fail loudly instead of the container, which is precisely what the comment beside that check already says it is for.

**2. The import was fatal.** #1729 added a top-level `import sharp from "sharp"`. Its caller **already** treats an unusable sharp as non-fatal — it warns and sends the original bytes. The static import defeated that design by failing before any of that code could run. It is now loaded lazily and cached, failure included.

Either fix alone unblocks the deploy. Both are kept because they answer different questions: (1) makes HEIC transcoding actually work, (2) makes its absence cost a warning rather than the server. An image-processing nicety must never be able to take the server down at boot.

## Verification

- Textile suites green (13 tests), `check:prod-build` green.
- ⚠️ The Dockerfile change is verified by the **Docker Build Check** workflow on this PR — I did not build the 647MB image locally. If `pnpm rebuild sharp` cannot run in `/prod-deps`, that job will say so, and the lazy import still unblocks the deploy on its own.

## After merge

The deploy of this commit carries `da7ff17d0` and `7b894e12d` with it, so both stranded merges go live in the same roll. Verify by **probing behaviour, not the badge**: `GET /admin/partners/:id/credits` rows should carry `inventory_order_id`, and the ledger's `totals` should carry `credited`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4