### PR TITLE
fix(payments): one payment across two payouts, and the fourth home (#1712)

### DIFF
--- a/apps/backend/integration-tests/http/partner-payment-ledger.spec.ts
+++ b/apps/backend/integration-tests/http/partner-payment-ledger.spec.ts
@@ -143,6 +143,60 @@ setupSharedTestSuite(() => {
 
   // ─── the cases ────────────────────────────────────────────────────────────
 
+  /**
+   * ── The fourth home (#1712 defect 4) ──────────────────────────────────
+   *
+   * 🔴 A payment carries `paid_to` — the bank account it was sent to — and that
+   * method belongs to a partner. Six of 35 production payments (52,974) carry
+   * ONLY that association: no partner link, no order link, no submission link.
+   * The ledger read the other three and reported nothing for money that was
+   * always attributable — Sharlho's page said 46,000 where the truth was 54,974.
+   *
+   * This has to be an integration test for the same reason as the rest of this
+   * file: the question is whether the READ reaches the money, and a link that
+   * writes fine and reads empty is indistinguishable from no money at all.
+   */
+  it("finds a payment attributable only through its paid_to payment method", async () => {
+    const partnerId = await createPartner("paid-to")
+
+    const pmRes = await api.post(
+      `/admin/payments/partners/${partnerId}/methods`,
+      {
+        type: "bank_account",
+        account_name: "Partner Primary",
+        account_number: "999888777",
+        bank_name: "Test Bank",
+        ifsc_code: "TEST0009999",
+      },
+      adminHeaders
+    )
+    expect(pmRes.status).toBe(201)
+    const methodId = pmRes.data.paymentMethod.id as string
+
+    // Deliberately NO partnerIds — this payment's only tie to the partner is
+    // the method it was paid to. That is the production shape.
+    const payRes = await api.post(
+      "/admin/payments/link",
+      {
+        payment: {
+          amount: 8974,
+          payment_type: "Bank",
+          payment_date: new Date("2026-07-01T00:00:00.000Z").toISOString(),
+          paid_to_id: methodId,
+        },
+      },
+      adminHeaders
+    )
+    expect(payRes.status).toBe(201)
+
+    const { totals, entries } = await ledger(partnerId)
+
+    expect(totals.recorded).toBe(8974)
+    expect(
+      entries.some((e: any) => e.kind === "payment" && e.amount === 8974)
+    ).toBe(true)
+  })
+
   it("renders a payout that has no internal_payments row behind it", async () => {
     // Since #1638 approval writes no payment row, so this is EVERY payout made
     // since. A panel reading `internal_payments` alone shows nothing here.

--- a/apps/backend/src/admin/components/partners/__tests__/partner-ledger-section.unit.spec.ts
+++ b/apps/backend/src/admin/components/partners/__tests__/partner-ledger-section.unit.spec.ts
@@ -250,3 +250,30 @@ describe("PartnerLedgerSection — applied credits (#1712)", () => {
     expect(html).not.toContain("discharged by")
   })
 })
+
+/** One payment across two payouts (#1712 defect 2) — the row explains itself. */
+describe("PartnerLedgerSection — a shared payment (#1712)", () => {
+  it("says a payout shares its payment, so a small settled figure is not a bug", () => {
+    const html = render(
+      [
+        payout({
+          recorded_against: [],
+          recorded_against_total: 0,
+          settled_amount: 0,
+          settled_shared_with: ["01M13T9OTHER"],
+        }),
+      ],
+      totals({ paid: 0 })
+    )
+    expect(html).toContain("shares a payment with")
+    expect(html).toContain("counted once")
+  })
+
+  it("says nothing when the payment is this payout's alone", () => {
+    const html = render(
+      [payout({ recorded_against: [], recorded_against_total: 0 })],
+      totals()
+    )
+    expect(html).not.toContain("shares a payment with")
+  })
+})

--- a/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
@@ -145,6 +145,19 @@ const PayoutRow = ({ entry }: { entry: PartnerLedgerEntry }) => {
               : ""}
           </Text>
         )}
+        {(entry.settled_shared_with?.length ?? 0) > 0 && (
+          /**
+           * 🔑 One payment, two payouts (#1712). The payment is spent once and
+           * allocated oldest-payout-first, so a payout can show less settled
+           * than the payment it is linked to. Saying so is the difference
+           * between "money went elsewhere" and "this screen cannot add up".
+           */
+          <Text size="xsmall" className="text-ui-fg-muted">
+            shares a payment with {entry.settled_shared_with!.length} other
+            payout{entry.settled_shared_with!.length > 1 ? "s" : ""} — the money
+            is counted once, oldest claim first
+          </Text>
+        )}
         {(entry.credited_amount ?? 0) > 0 && (
           /**
            * 🔴 An applied credit HAS already reduced `outstanding` (#1712).

--- a/apps/backend/src/admin/hooks/api/payments.ts
+++ b/apps/backend/src/admin/hooks/api/payments.ts
@@ -149,6 +149,15 @@ export type PartnerLedgerEntry = {
    */
   settled_amount?: number;
   /**
+   * Other payouts that share a payment with this one (#1712 defect 2).
+   *
+   * Present only when a payment really is linked to more than one payout.
+   * Declared here so the panel can explain a payout showing less settled than
+   * the linked payment's face value — otherwise the gap reads as an arithmetic
+   * bug rather than as money already spent on another claim.
+   */
+  settled_shared_with?: string[];
+  /**
    * Credits a human APPLIED to this payout (#1712).
    *
    * 🔴 Declared here for the same reason as `recorded_against` above: a flag

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/__tests__/fold.unit.spec.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/__tests__/fold.unit.spec.ts
@@ -735,3 +735,149 @@ describe("foldPartnerLedger — applied credits (#1712)", () => {
     expect(totals.outstanding).toBe(10000)
   })
 })
+
+/**
+ * One payment, two payouts (#1712 defect 2).
+ *
+ * 🔴 The recorded defect said `paid` DOUBLE-counts such a payment. Probed
+ * before fixing, and it did not: `mergePaymentSources` filled `submission_id`
+ * once, so the SECOND payout silently read `settled: 0` and its money looked
+ * still owed. An overstated `outstanding` is the direction that gets a partner
+ * paid twice, so the bug was real and the mechanism was the opposite one.
+ *
+ * The fix has to close both — every linked payout is settled, and the payment
+ * is still only spent once.
+ */
+describe("foldPartnerLedger — one payment linked to two payouts (#1712)", () => {
+  const subA = {
+    id: "sub_A",
+    status: "Approved",
+    total_amount: 10000,
+    currency: "inr",
+    submitted_at: "2026-08-01T00:00:00.000Z",
+  }
+  const subB = {
+    id: "sub_B",
+    status: "Approved",
+    total_amount: 10000,
+    currency: "inr",
+    submitted_at: "2026-08-02T00:00:00.000Z",
+  }
+  const row = { id: "pay_1", amount: 10000, status: "Completed" }
+
+  const linkedToBoth = () =>
+    mergePaymentSources([
+      { rows: [row], attribution: { submission_id: "sub_A" } },
+      { rows: [row], attribution: { submission_id: "sub_B" } },
+    ])
+
+  it("keeps EVERY payout the payment names, not just the first", () => {
+    const merged = linkedToBoth()
+    expect(merged).toHaveLength(1)
+    expect(merged[0].submission_ids).toEqual(["sub_A", "sub_B"])
+  })
+
+  /** The money that moved is 10,000. `paid` may never claim more than that. */
+  it("spends the payment ONCE — paid never exceeds the money that moved", () => {
+    const { totals } = foldPartnerLedger({
+      submissions: [subA, subB],
+      items: [],
+      payments: linkedToBoth(),
+      reconciliations: [],
+    })
+
+    expect(totals.billed).toBe(20000)
+    expect(totals.paid).toBe(10000)
+    expect(totals.outstanding).toBe(10000)
+  })
+
+  it("allocates oldest payout first, and says which payouts share the payment", () => {
+    const { entries } = foldPartnerLedger({
+      submissions: [subB, subA], // deliberately out of order
+      items: [],
+      payments: linkedToBoth(),
+      reconciliations: [],
+    })
+    const byId = Object.fromEntries(
+      entries.filter((e) => e.kind === "payout").map((e) => [e.submission_id, e])
+    )
+
+    expect(byId.sub_A.settled_amount).toBe(10000)
+    expect(byId.sub_B.settled_amount).toBe(0)
+    // The row explains its own zero rather than looking like an arithmetic bug.
+    expect(byId.sub_B.settled_shared_with).toEqual(["sub_A"])
+    expect(byId.sub_A.settled_shared_with).toEqual(["sub_B"])
+  })
+
+  /**
+   * ⚠️ Order is FIXED, not graph order. An allocation that moved money between
+   * payouts on a page refresh would be worse than either bug it replaces.
+   */
+  it("allocates the same way whichever order the submissions arrive in", () => {
+    const one = foldPartnerLedger({
+      submissions: [subA, subB], items: [], payments: linkedToBoth(), reconciliations: [],
+    })
+    const two = foldPartnerLedger({
+      submissions: [subB, subA], items: [], payments: linkedToBoth(), reconciliations: [],
+    })
+    const settled = (r: any) =>
+      Object.fromEntries(
+        r.entries.filter((e: any) => e.kind === "payout").map((e: any) => [e.submission_id, e.settled_amount])
+      )
+    expect(settled(one)).toEqual(settled(two))
+  })
+
+  it("spills the remainder onto the second payout when the first cannot absorb it", () => {
+    const small = { ...subA, total_amount: 4000 }
+    const { entries, totals } = foldPartnerLedger({
+      submissions: [small, subB],
+      items: [],
+      payments: linkedToBoth(),
+      reconciliations: [],
+    })
+    const byId = Object.fromEntries(
+      entries.filter((e) => e.kind === "payout").map((e) => [e.submission_id, e])
+    )
+
+    expect(byId.sub_A.settled_amount).toBe(4000)
+    expect(byId.sub_B.settled_amount).toBe(6000)
+    expect(totals.paid).toBe(10000)
+  })
+
+  /** A payout never absorbs more than it claims — the surplus is a credit's job. */
+  it("never allocates a payout more than its own claim", () => {
+    const big = { ...row, amount: 30000 }
+    const merged = mergePaymentSources([
+      { rows: [big], attribution: { submission_id: "sub_A" } },
+    ])
+    const { entries, totals } = foldPartnerLedger({
+      submissions: [subA], items: [], payments: merged, reconciliations: [],
+    })
+    expect(entries.find((e) => e.kind === "payout")!.settled_amount).toBe(10000)
+    expect(totals.paid).toBe(10000)
+    expect(totals.outstanding).toBe(0)
+  })
+
+  /** Pending is not money. A partner must not move their own `paid`. */
+  it("allocates nothing from a Pending payment", () => {
+    const merged = mergePaymentSources([
+      { rows: [{ ...row, status: "Pending" }], attribution: { submission_id: "sub_A" } },
+    ])
+    const { totals } = foldPartnerLedger({
+      submissions: [subA], items: [], payments: merged, reconciliations: [],
+    })
+    expect(totals.paid).toBe(0)
+  })
+
+  it("says nothing about sharing when a payment names one payout", () => {
+    const merged = mergePaymentSources([
+      { rows: [row], attribution: { submission_id: "sub_A" } },
+    ])
+    const { entries } = foldPartnerLedger({
+      submissions: [subA, subB], items: [], payments: merged, reconciliations: [],
+    })
+    for (const e of entries.filter((x) => x.kind === "payout")) {
+      expect(e.settled_shared_with).toBeUndefined()
+    }
+  })
+})

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/fold.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/fold.ts
@@ -80,6 +80,23 @@ export type PaymentLike = {
   inventory_order_name?: string | null
   /** The payout this payment settles, via the direct link (#1710). */
   submission_id?: string | null
+  /**
+   * EVERY payout this payment is linked to (#1712 defect 2).
+   *
+   * 🔴 `submission_id` is one field, and `mergePaymentSources` fills an absent
+   * field once — so a payment a human linked to TWO payouts arrived carrying
+   * only the first, and the second read as unsettled with nothing saying why.
+   * Measured: two payouts of 10,000 with one 10,000 payment linked to both gave
+   * `settled: 10000` and `settled: 0`, and `outstanding: 10000` on money that
+   * had already moved. An overstated `outstanding` is the direction that gets a
+   * partner paid twice.
+   *
+   * ⚠️ The recorded defect said `paid` DOUBLE-counts such a payment. It does
+   * not — the merge dropped the second link before any arithmetic saw it. The
+   * risk was real but the mechanism was the opposite one, and the fix has to
+   * close both: see the allocation below.
+   */
+  submission_ids?: string[] | null
 }
 
 /**
@@ -187,6 +204,15 @@ export type LedgerEntry = {
    * must not make the partner look overpaid on this row.
    */
   settled_amount?: number
+  /**
+   * Other payouts that share a payment with this one (#1712 defect 2).
+   *
+   * 🔑 Present only when a payment really is linked to more than one payout.
+   * Without it a payout shows less settled than the linked payment's face value
+   * and nothing on the row explains the gap — which reads as an arithmetic bug
+   * rather than as money already spent on another claim.
+   */
+  settled_shared_with?: string[]
   /**
    * Credits a human APPLIED to this payout (#1712).
    *
@@ -298,6 +324,17 @@ export type LedgerTotals = {
  * PURE, so the union that decides whether money is visible at all can be tested
  * without a graph behind it.
  */
+/**
+ * Accumulate rather than overwrite. `submission_id` keeps first-writer-wins for
+ * every existing reader; `submission_ids` is the complete set, and a payout is
+ * settled from THAT (#1712 defect 2).
+ */
+const addSubmissionId = (row: any, id: unknown) => {
+  if (typeof id !== "string" || !id) return
+  if (!Array.isArray(row.submission_ids)) row.submission_ids = []
+  if (!row.submission_ids.includes(id)) row.submission_ids.push(id)
+}
+
 export const mergePaymentSources = (
   sources: Array<{
     rows: any[]
@@ -316,9 +353,13 @@ export const mergePaymentSources = (
         for (const [k, v] of Object.entries(extra)) {
           if (v != null && existing[k] == null) existing[k] = v
         }
+        addSubmissionId(existing, extra.submission_id)
         continue
       }
-      byId.set(row.id, { ...row, ...extra })
+      const merged = { ...row, ...extra }
+      merged.submission_ids = []
+      addSubmissionId(merged, extra.submission_id)
+      byId.set(row.id, merged)
     }
   }
 
@@ -345,6 +386,17 @@ const iso = (v: unknown): string | null => {
  * founder a partner is settled while the transfer is still owed.
  */
 const PAID_STATUSES = new Set(["Paid"])
+
+/**
+ * Only a `Completed` payment settles anything.
+ *
+ * ⚠️ `Pending` is the status the partner portal writes on a payment a partner
+ * records themselves, so counting it would let a partner move their own `paid`
+ * figure by asserting they had been paid. The admin marking it `Completed` is
+ * the only control on that assertion.
+ */
+const SETTLES_ONLY_COMPLETED = (p: PaymentLike): boolean =>
+  String(p.status ?? "") === "Completed"
 
 export const foldPartnerLedger = (input: {
   submissions: SubmissionLike[]
@@ -433,6 +485,89 @@ export const foldPartnerLedger = (input: {
     paymentsByOrder.set(p.inventory_order_id, list)
   }
 
+  /**
+   * ── Allocating a payment across the payouts it settles (#1712 defect 2) ──
+   *
+   * A human may link ONE payment to TWO payouts — it is the obvious way to
+   * carry a surplus forward. Both readings of that were wrong before:
+   *
+   *   - the merge kept only the first link, so the second payout read
+   *     `settled: 0` and its money looked still owed. An overstated
+   *     `outstanding` is the direction that gets a partner paid twice.
+   *   - and had the merge kept both, each payout would have counted the
+   *     payment IN FULL, so `paid` would have claimed more money moved than
+   *     ever left the bank.
+   *
+   * Allocation closes both. Each payment is spent ONCE, across the payouts it
+   * names, and no payout receives more than it still claims. `recorded_against_open`
+   * has counted per PAYMENT since #1710 for the same reason; this gives `paid`
+   * the same protection.
+   *
+   * ⚠️ Order matters and is therefore FIXED — oldest payout first, id as the
+   * tie-break. An allocation that depended on graph row order would move money
+   * between payouts on a page refresh.
+   *
+   * 🔑 Only `Completed` payments allocate, the same rule as below: a payout must
+   * not read as settled before the transfer happened.
+   */
+  const SETTLING_STATUSES = new Set(["Completed"])
+  const allocationBySubmission = new Map<string, number>()
+  const sharedWithBySubmission = new Map<string, string[]>()
+
+  const submissionOrder = [...submissions].sort((a, b) => {
+    const at = iso(a.submitted_at) || iso(a.created_at) || ""
+    const bt = iso(b.submitted_at) || iso(b.created_at) || ""
+    return at === bt ? a.id.localeCompare(b.id) : at.localeCompare(bt)
+  })
+  const claimById = new Map(
+    submissionOrder.map((sub) => [sub.id, num(sub.total_amount)])
+  )
+  const headroom = new Map(claimById)
+
+  for (const p of payments) {
+    if (!SETTLES_ONLY_COMPLETED(p)) continue
+    const named = (
+      Array.isArray(p.submission_ids) && p.submission_ids.length
+        ? p.submission_ids
+        : p.submission_id
+          ? [p.submission_id]
+          : []
+    ).filter((id) => claimById.has(id))
+    if (!named.length) continue
+
+    let remaining = num(p.amount)
+    const ordered = submissionOrder
+      .map((sub) => sub.id)
+      .filter((id) => named.includes(id))
+
+    for (const id of ordered) {
+      if (remaining <= 0) break
+      const room = Math.max(0, headroom.get(id) ?? 0)
+      if (room <= 0) continue
+      const take = Math.round(Math.min(remaining, room) * 100) / 100
+      if (take <= 0) continue
+      allocationBySubmission.set(id, (allocationBySubmission.get(id) ?? 0) + take)
+      headroom.set(id, room - take)
+      remaining = Math.round((remaining - take) * 100) / 100
+    }
+
+    /**
+     * A payout that shares its payment with another says so. Without this a
+     * payout linked to a payment shows less settled than the payment's face
+     * value and nothing on the row explains the difference — which reads as an
+     * arithmetic bug rather than as money spent elsewhere.
+     */
+    if (ordered.length > 1) {
+      for (const id of ordered) {
+        const others = ordered.filter((o) => o !== id)
+        sharedWithBySubmission.set(
+          id,
+          Array.from(new Set([...(sharedWithBySubmission.get(id) ?? []), ...others]))
+        )
+      }
+    }
+  }
+
   const payoutEntries: LedgerEntry[] = submissions.map((submission) => {
     const settlingPaymentId = paymentBySubmission.get(submission.id)
     const settlingPayment = settlingPaymentId
@@ -483,15 +618,15 @@ export const foldPartnerLedger = (input: {
      * ⚠️ Deliberately STRICTER than `recorded_against_open`, which counts
      * Pending on purpose. A warning should over-fire; a settlement must not.
      */
-    const SETTLES = new Set(["Completed"])
-    const settledRaw = payments
-      .filter((p) => p.submission_id === submission.id)
-      .filter((p) => SETTLES.has(String(p.status ?? "")))
-      .reduce((acc, p) => acc + num(p.amount), 0)
-
-    const submissionAmount = num(submission.total_amount)
+    /**
+     * What the allocation above gave this payout. Already capped at the payout's
+     * own claim, so the `Math.min` the old code applied per payment is now a
+     * property of the allocation rather than a clamp that could silently absorb
+     * a surplus — the clamp that hid hrhandloom's 1,380 (#1712 defect 3).
+     */
     const settledAmount =
-      Math.round(Math.min(settledRaw, submissionAmount) * 100) / 100
+      Math.round((allocationBySubmission.get(submission.id) ?? 0) * 100) / 100
+    const settledSharedWith = sharedWithBySubmission.get(submission.id) ?? []
 
     /**
      * Credits a human applied to THIS payout, by the shared rule the admin
@@ -548,6 +683,7 @@ export const foldPartnerLedger = (input: {
         0
       ),
       settled_amount: settledAmount,
+      settled_shared_with: settledSharedWith.length ? settledSharedWith : undefined,
       credits_applied: appliedCredits,
       credited_amount: appliedCreditsTotal,
     }

--- a/apps/backend/src/api/admin/payments/partners/[id]/ledger/route.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/ledger/route.ts
@@ -47,8 +47,10 @@ import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 import PartnerCreditLink from "../../../../../../links/partner-credit-link"
+import PartnerPaymentMethodsLink from "../../../../../../links/partner-payment-methods-link"
 import PartnerPaymentsLink from "../../../../../../links/partner-payments-link"
 import SubmissionPaymentLink from "../../../../../../links/submission-payment-link"
+import { INTERNAL_PAYMENTS_MODULE } from "../../../../../../modules/internal_payments"
 import { PAYMENT_REPORTS_MODULE } from "../../../../../../modules/payment_reports"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../../modules/payment_submissions"
 import type PaymentSubmissionsService from "../../../../../../modules/payment_submissions/service"
@@ -262,6 +264,54 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     } catch {
       // The other two homes still answer.
     }
+  }
+
+  /**
+   * ── 4. through the PAYMENT METHOD (`paid_to`) ───────────────────────────
+   *
+   * 🔴 #1712 defect 4, and the same class as #1710 one link over. A payment
+   * carries `paid_to` — the bank account or wallet it was sent to — and that
+   * method is linked to the partner who owns it. Six of 35 production payments
+   * (52,974) carry ONLY that association: no partner link, no order link, no
+   * submission link. Five of them map to a partner (47,974), so `recorded`
+   * under-reported by that much and Sharlho's ledger read 46,000 where the
+   * truth is 54,974.
+   *
+   * The money was always attributable. The ledger simply had no path to it —
+   * which reads as "this partner was not paid", the reading that pays someone
+   * a second time.
+   *
+   * ⚠️ Listed LAST so it only ever fills in rows the other three homes missed.
+   * A payment reached through the partner keeps that provenance; this one adds
+   * nothing but its own existence, which is exactly what was missing.
+   *
+   * ⚠️ The method must belong to THIS partner. Scoped through the link, never
+   * by reading `paid_to` and trusting it — a method is shared by nothing today,
+   * but a read that assumed so would attribute another partner's money here.
+   */
+  try {
+    const { data: methodRows } = await query.graph({
+      entity: PartnerPaymentMethodsLink.entryPoint,
+      fields: ["internal_payment_details.id"],
+      filters: { partner_id },
+    })
+    const methodIds = (methodRows || [])
+      .map((r: any) => r?.internal_payment_details?.id)
+      .filter(Boolean)
+      .map(String)
+
+    if (methodIds.length) {
+      const internalPayments: any = req.scope.resolve(INTERNAL_PAYMENTS_MODULE)
+      const rows = (await internalPayments.listPayments(
+        { paid_to_id: methodIds },
+        { relations: ["paid_to", "attachments"] }
+      )) as any[]
+      sources.push({ rows: (rows || []).filter(Boolean) })
+    }
+  } catch {
+    // Same reason as every source above: an incomplete panel beats a broken
+    // one. Losing this source understates `recorded`, which is the state this
+    // block exists to fix — it cannot invent money that is not there.
   }
 
   const payments = mergePaymentSources(sources)


### PR DESCRIPTION
Defects **2** and **4** from the 2026-09-01 partner-estate reconciliation.

## Defect 2 — and the recorded mechanism was wrong

The note said `paid` **double-counts** a payment linked to two payouts. I probed before fixing, and it does not. `mergePaymentSources` fills an absent field once, so the second link was dropped before any arithmetic saw it. Two 10,000 payouts, one 10,000 payment linked to both:

```
merged:  [{ id: "pay_1", …, submission_id: "sub_A" }]   ← only ONE id survives
totals:  paid: 10000            (not 20000 — no double count)
settled: sub_A → 10000,  sub_B → 0
```

So the second payout **silently read as unsettled** and its money looked still owed. An overstated `outstanding` is the direction that gets a partner paid twice — the risk was real, the mechanism was the opposite one, and a fix aimed only at double-counting would have left the real bug in place.

**Both are closed by allocating rather than summing.** The merge accumulates `submission_ids`, and each `Completed` payment is spent **once** across the payouts it names — oldest claim first, never more than a payout still claims. `paid` can therefore never claim more money moved than left the bank, and no payout loses a settlement it is linked to. `recorded_against_open` has counted per PAYMENT since #1710 for exactly this reason; this gives `paid` the same protection.

Allocation order is **fixed** (`submitted_at`, id as tie-break). An allocation that depended on graph row order would move money between payouts on a page refresh.

A payout that shares a payment now says so on the row — without it, a payout shows less settled than the payment's face value and nothing explains the gap, which reads as an arithmetic bug rather than as money spent on another claim.

## Defect 4 — the fourth home

A payment carries `paid_to`, the account it was sent to, and that method is linked to its owning partner. **Six of 35 production payments (52,974) carry only that association** — no partner link, no order link, no submission link. The ledger read the other three and had no path to it, so `recorded` under-reported by **47,974** and Sharlho's page said 46,000 where the truth is 54,974.

The money was always attributable; the read simply could not reach it — which presents as *"this partner was not paid"*, the reading that pays someone a second time. Same class as #1710, one link over.

Added as a fourth source, listed **last** so it only fills in rows the other three missed, and scoped through the partner→method link rather than by trusting `paid_to` alone.

## Verification

- 8 new fold cases, 2 panel cases, 1 integration case.
- **Mutation-checked both fixes**: reverting the merge accumulation fails 3 tests; removing the fourth source fails the integration test.
- 103 ledger unit tests green, 18 integration green (against a real database), `check:prod-build` green.
- ⚠️ `brief-shaper.unit.spec.ts` is red on a clean tree — pre-existing, verified by stashing.

## Still open on #1712

Defect 1 (`payable-inventory-orders` re-offers the same receipts — ~63,215 of re-billable headroom on a partially-received order), defect 5 (a run with no `partner_cost_estimate` prices at 0 and vanishes), and the write-side ceiling in the issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4