### PR TITLE
feat(payments): report completed runs that nobody ever priced (#1712)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -125,6 +125,50 @@ setupSharedTestSuite(() => {
      * because the job has no write path at all. A job whose safety rests on a
      * caller passing dry_run is one keystroke from writing.
      */
+    /**
+     * #1712 defect 5 — a completed run with no agreed price was visible only
+     * to someone who already opened that partner's payout screen, so one sat
+     * at 0 for four months. The job that asks the question must be REACHABLE
+     * (a capability with no door is no capability) and must never write: the
+     * agreed price is not derivable from anything in the database.
+     */
+    it("GET lists the audit-unpriced-completed-runs job", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const job = res.data.jobs.find(
+        (j: any) => j.id === "audit-unpriced-completed-runs"
+      )
+      expect(job).toBeTruthy()
+      expect(job.params.map((p: any) => p.name).sort()).toEqual([
+        "limit",
+        "min_age_days",
+        "partner_id",
+      ])
+      expect(job.params.every((p: any) => p.required === false)).toBe(true)
+    })
+
+    it("POST audit-unpriced-completed-runs changes nothing even with dry_run=false", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/audit-unpriced-completed-runs/run",
+        { dry_run: false, params: { limit: 50 } },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.dry_run).toBe(false)
+      expect(res.data.result.applied).toBe(false)
+      expect(Array.isArray(res.data.result.changes)).toBe(true)
+    })
+
+    it("POST audit-unpriced-completed-runs rejects a limit above the scan cap", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/audit-unpriced-completed-runs/run",
+          { dry_run: true, params: { limit: 5000 } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
     it("POST audit-inventory-receipt-drift changes nothing even with dry_run=false", async () => {
       const res = await api.post(
         "/admin/ops/maintenance-jobs/audit-inventory-receipt-drift/run",

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-unpriced-completed-runs.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-unpriced-completed-runs.unit.spec.ts
@@ -1,0 +1,127 @@
+import {
+  assessRunPricing,
+  daysSinceCompletion,
+} from "../audit-unpriced-completed-runs-job"
+import { runPayableOffer } from "../../../../../workflows/production-runs/lib/run-payable"
+
+/**
+ * #1712 defect 5 — `prod_run_01KP4ZVE3R` was completed, produced 2 pieces and
+ * carried no price for four months. Nothing hid it; nothing reported it either.
+ * These cover the one decision the report makes: does this run carry a price,
+ * and if not, which kind of absence is it.
+ */
+describe("assessRunPricing", () => {
+  it("reads a run with an agreed rate as priced", () => {
+    expect(assessRunPricing({ partner_cost_estimate: 500 })).toEqual({
+      verdict: "priced",
+      agreed: 500,
+    })
+  })
+
+  /**
+   * 🔴 The distinction the whole report rests on. `Number(null)` is 0, so an
+   * implementation that coerces before reading the raw field would report every
+   * never-priced run as one that had a zero deliberately written to it — and
+   * "nobody has said what this costs" is a different event from "something
+   * decided this is worth nothing" (#1676, #1563).
+   */
+  it("separates a rate that was never recorded from a zero somebody wrote", () => {
+    expect(assessRunPricing({ partner_cost_estimate: null }).verdict).toBe(
+      "no_rate_recorded"
+    )
+    expect(assessRunPricing({ partner_cost_estimate: 0 }).verdict).toBe(
+      "zero_rate_recorded"
+    )
+  })
+
+  it("keeps the written zero on the row, and reports no figure for an absent one", () => {
+    expect(assessRunPricing({ partner_cost_estimate: 0 }).agreed).toBe(0)
+    expect(assessRunPricing({ partner_cost_estimate: null }).agreed).toBeNull()
+  })
+
+  it("treats an undefined field, a missing run and unparseable text as never recorded", () => {
+    expect(assessRunPricing({}).verdict).toBe("no_rate_recorded")
+    // `""` passes every `is not null` check and coerces to 0 — a blank is an
+    // unanswered question, not a price of nothing.
+    expect(
+      assessRunPricing({ partner_cost_estimate: "" as any }).verdict
+    ).toBe("no_rate_recorded")
+    expect(assessRunPricing(null).verdict).toBe("no_rate_recorded")
+    expect(
+      assessRunPricing({ partner_cost_estimate: "abc" as any }).verdict
+    ).toBe("no_rate_recorded")
+  })
+
+  /** A negative is a written figure, not an absent one — and still unpayable. */
+  it("counts a negative as a written zero rather than a price", () => {
+    expect(assessRunPricing({ partner_cost_estimate: -50 })).toEqual({
+      verdict: "zero_rate_recorded",
+      agreed: -50,
+    })
+  })
+
+  /**
+   * 🔑 The report and the payout screen must draw the SAME line, or this job
+   * names partners the screen shows as payable (or stays silent about work the
+   * screen refuses to price). Asserted against `runPayableOffer` itself rather
+   * than against a remembered threshold.
+   */
+  it.each([
+    [null, false],
+    [0, false],
+    [-1, false],
+    [0.5, true],
+    [500, true],
+  ])(
+    "agrees with runPayableOffer's payable flag for an estimate of %p",
+    (estimate, expectedPayable) => {
+      const run = {
+        partner_cost_estimate: estimate as any,
+        cost_type: "per_unit" as const,
+        quantity: 2,
+        produced_quantity: 2,
+      }
+      expect(runPayableOffer(run).payable).toBe(expectedPayable)
+      expect(assessRunPricing(run).verdict === "priced").toBe(expectedPayable)
+    }
+  )
+
+  /**
+   * The real row. `cost_type: total` with no estimate is the shape that priced
+   * at 0 and read as "nothing owed" for four months.
+   */
+  it("reports the Flowy Skirt shape as unpriced", () => {
+    const flowySkirt = {
+      id: "prod_run_01KP4ZVE3R",
+      partner_cost_estimate: null,
+      cost_type: "total" as const,
+      quantity: 2,
+      produced_quantity: 2,
+    }
+    expect(assessRunPricing(flowySkirt).verdict).toBe("no_rate_recorded")
+    expect(runPayableOffer(flowySkirt).amount).toBe(0)
+  })
+})
+
+describe("daysSinceCompletion", () => {
+  const now = new Date("2026-09-02T00:00:00.000Z")
+
+  it("counts whole days from the completion stamp", () => {
+    expect(daysSinceCompletion("2026-05-02T00:00:00.000Z", now)).toBe(123)
+  })
+
+  /**
+   * ⚠️ An unknown age is not an age of zero. A run with no completion stamp
+   * sorted as "finished today" would rank at the bottom of a longest-waiting
+   * list and never be looked at.
+   */
+  it("returns null for a run with no completion stamp, not 0", () => {
+    expect(daysSinceCompletion(null, now)).toBeNull()
+    expect(daysSinceCompletion(undefined, now)).toBeNull()
+    expect(daysSinceCompletion("not a date", now)).toBeNull()
+  })
+
+  it("does not report a future completion as a negative age", () => {
+    expect(daysSinceCompletion("2026-10-01T00:00:00.000Z", now)).toBeNull()
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/audit-unpriced-completed-runs-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/audit-unpriced-completed-runs-job.ts
@@ -1,0 +1,389 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "zod"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
+import { listPartnerSubmissionItems } from "../../../../workflows/payment_submissions/lib/run-claims"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Find completed production runs that nobody has ever put a price on (#1712).
+ *
+ * ## What this is for
+ *
+ * `prod_run_01KP4ZVE3R` — Prince Tailors, Tangaliya Weave Flowy Skirt — was
+ * completed, produced 2 pieces, and carried `partner_cost_estimate: null` for
+ * **four months**. Nobody was hiding it: `payable-runs` lists it, the create
+ * grid badges it "no rate" and prints an em dash instead of a 0, and an
+ * operator can type the rate straight into the row.
+ *
+ * The gap is that all of that is PULL. The run is only visible to someone who
+ * already decided to open that partner's payout screen, and nothing ever said
+ * "this finished work has no agreed price". So a partner waits, and the silence
+ * looks exactly like a partner with no outstanding work.
+ *
+ * This job is the push side: it asks the question nobody was asking.
+ *
+ * ## 🔴 Report-only, always — there is nothing here to repair
+ *
+ * Unlike every `backfill-*` job, the missing datum is not derivable. A run's
+ * agreed price is a thing two people said to each other; it is not in the
+ * database in another shape. `design.estimated_cost` is NOT it — that figure is
+ * per finished unit and routinely disagrees with what was agreed (pricing
+ * Bakshi's from the design would bill 11,530.80 against the run's 7,650, which
+ * is #1554). It is reported here as a STARTING POINT for the human who types
+ * the real number, and is never written anywhere.
+ *
+ * So `dry_run: false` changes nothing either, deliberately. `applied` is always
+ * false. This job creates nothing, pays nobody and emails no one.
+ *
+ * ## Why "no rate" and "a rate of zero" are counted separately
+ *
+ * `runPayableOffer` treats both as unpayable and it is right to. But they are
+ * different events: `null` means the question was never answered, while a
+ * stored `0` means something WROTE a zero — and a 0 passes every `!= null`
+ * check, sums cleanly into a total and renders as a real payout of nothing.
+ * That is how an estimator's "found nothing = 0" reached a storefront till
+ * (#1564). Folding them together would hide the worse of the two.
+ */
+
+/** Hard cap per call — bounds the scan, and is reported when it bites. */
+export const MAX_UNPRICED_RUN_SCAN = 1000
+
+export type RunPricingVerdict =
+  /** An agreed rate or total is recorded. Nothing to report. */
+  | "priced"
+  /** No figure was ever written. The question was never answered. */
+  | "no_rate_recorded"
+  /** A figure WAS written, and it is zero or negative. Something decided this. */
+  | "zero_rate_recorded"
+
+export type RunForPricingAudit = {
+  id?: string
+  partner_cost_estimate?: number | null
+}
+
+/**
+ * PURE: whether a run carries a usable agreed price, and which kind of absence
+ * it has when it does not.
+ *
+ * 🔑 Reads the RAW field before coercing. `Number(null)` is 0, so testing the
+ * coerced value first would report every never-priced run as one that had a
+ * zero deliberately written to it — the exact confusion this split exists to
+ * prevent (#1676 bit three times on this).
+ *
+ * Matches `runPayableOffer`'s threshold exactly (`> 0` after coercion), so a
+ * run this job reports is precisely a run that screen shows as unpayable. A
+ * second, differently-drawn line would let the report and the screen disagree
+ * about who is waiting to be paid.
+ */
+export function assessRunPricing(
+  run: RunForPricingAudit | null | undefined
+): { verdict: RunPricingVerdict; agreed: number | null } {
+  const raw = run?.partner_cost_estimate
+
+  if (raw === null || raw === undefined || String(raw).trim() === "") {
+    return { verdict: "no_rate_recorded", agreed: null }
+  }
+
+  const agreed = Number(raw)
+  if (!Number.isFinite(agreed)) {
+    return { verdict: "no_rate_recorded", agreed: null }
+  }
+  if (agreed <= 0) {
+    return { verdict: "zero_rate_recorded", agreed }
+  }
+  return { verdict: "priced", agreed }
+}
+
+/**
+ * PURE: how long this work has been sitting unpriced, in whole days.
+ *
+ * `now` is a parameter rather than a `Date.now()` inside, so the report can be
+ * tested against a fixed clock instead of being assertable only to the day.
+ * Returns null when the run never recorded a completion date — an unknown age
+ * is not an age of zero.
+ */
+export function daysSinceCompletion(
+  completedAt: string | Date | null | undefined,
+  now: Date
+): number | null {
+  if (!completedAt) return null
+  const then = new Date(completedAt as any).getTime()
+  if (!Number.isFinite(then)) return null
+  const days = Math.floor((now.getTime() - then) / 86_400_000)
+  return days >= 0 ? days : null
+}
+
+const paramsSchema = z.object({
+  /** Restrict to one partner (default: every partner). */
+  partner_id: z.string().min(1).optional(),
+  /**
+   * Only report runs finished at least this many days ago. 0 reports
+   * everything, which is the honest default for an audit — a run completed
+   * yesterday with no price is still a run with no price.
+   */
+  min_age_days: z.number().int().min(0).max(3650).optional().default(0),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_UNPRICED_RUN_SCAN)
+    .optional()
+    .default(200),
+})
+
+export const auditUnpricedCompletedRunsJob: MaintenanceJob = {
+  id: "audit-unpriced-completed-runs",
+  label: "Find completed production runs that carry no agreed price",
+  description:
+    `Report every COMPLETED production run whose partner_cost_estimate is absent or zero, so finished work with no agreed price stops waiting to be noticed. prod_run_01KP4ZVE3R sat unpriced for four months: nothing hid it — payable-runs lists it and the create grid badges it "no rate" — but all of that is PULL, visible only to someone who already opened that partner's payout screen, and a partner with unpriced work looks exactly like a partner with no work (#1712). 🔴 REPORTS ONLY AND CHANGES NOTHING, even with dry_run=false: a run's agreed price is a thing two people said to each other and is not derivable from anything in the database. design.estimated_cost is NOT it — that figure is per finished unit and routinely disagrees with what was agreed (#1554) — so it is reported beside each row as a STARTING POINT for the human who types the real number, and is written nowhere. Runs already claimed by a live payout are excluded (a Rejected submission releases its runs), as are provenance runs minted by a retail fulfilment, which are not billable labour (#1606). "No rate recorded" and "a zero was written" are counted separately on purpose: both are unpayable, but a stored 0 means something decided this, and a 0 passes every != null check and renders as a real payout of nothing. Scans up to 'limit' completed runs per call (default 200, max ${MAX_UNPRICED_RUN_SCAN}), newest first, and says so when the cap bites.`,
+  params: [
+    {
+      name: "partner_id",
+      type: "string",
+      required: false,
+      description: "Restrict to one partner (default: all)",
+    },
+    {
+      name: "min_age_days",
+      type: "number",
+      required: false,
+      description:
+        "Only report runs completed at least this many days ago (default 0 — report everything)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max completed runs to scan in one call (default 200, max ${MAX_UNPRICED_RUN_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { partner_id, min_age_days, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const now = new Date()
+
+    const filters: Record<string, unknown> = { status: "completed" }
+    if (partner_id) filters.partner_id = partner_id
+
+    const { data: runs } = await query.graph({
+      entity: "production_runs",
+      fields: [
+        "id",
+        "design_id",
+        "partner_id",
+        "status",
+        "quantity",
+        "produced_quantity",
+        "partner_cost_estimate",
+        "cost_type",
+        "completed_at",
+        "order_id",
+        // Read by `isProvenanceRun` — a guard reading a field the query never
+        // fetched is dead code that types perfectly (#1606).
+        "metadata",
+      ],
+      filters,
+      pagination: { take: limit + 1, order: { completed_at: "DESC" } },
+    })
+
+    const scanned = ((runs || []) as any[]).filter(Boolean)
+    /**
+     * A silent cap reads as "covered everything". One row over the limit is
+     * fetched purely so the summary can say the scan was truncated rather than
+     * implying the list is the whole population.
+     */
+    const truncated = scanned.length > limit
+    const inScope = truncated ? scanned.slice(0, limit) : scanned
+
+    /**
+     * A run minted by a retail fulfilment shipped from stock is not unpaid
+     * labour with a missing price — there was no shop-floor work in it at all,
+     * and reporting one as "waiting to be priced" would send an operator to
+     * invent a payment for work nobody did (#1606, #1123).
+     */
+    const provenanceRuns = inScope.filter((r) => isProvenanceRun(r))
+    const candidates = inScope.filter((r) => !isProvenanceRun(r))
+
+    const unpriced = candidates
+      .map((run) => ({ run, ...assessRunPricing(run) }))
+      .filter((row) => row.verdict !== "priced")
+
+    /**
+     * Runs already claimed by a live payout.
+     *
+     * A run can be billed by a line that states an explicit amount — that is
+     * the NORMAL path for a run carrying no rate, and `resolveRunLineAmount`
+     * exists to make it so. Such a run has no missing price problem: somebody
+     * already said what it was worth. Reporting it would send an operator to
+     * price work that has been paid for.
+     *
+     * ⚠️ A Rejected submission releases its runs, matching `foldPartnerBilling`
+     * — a rejected claim is not a payment.
+     */
+    const service: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    const partnerIds = [
+      ...new Set(
+        unpriced.map((row) => String(row.run.partner_id ?? "")).filter(Boolean)
+      ),
+    ]
+
+    const claimedRunIds = new Set<string>()
+    const errors: Array<{ id: string; message: string }> = []
+    for (const pid of partnerIds) {
+      try {
+        const items = await listPartnerSubmissionItems(service as any, pid)
+        for (const item of items || []) {
+          if (String(item?.submission?.status || "") === "Rejected") continue
+          for (const runId of (item?.production_run_ids || []) as string[]) {
+            claimedRunIds.add(String(runId))
+          }
+        }
+      } catch (e: any) {
+        /**
+         * A partner whose claims could not be read is reported, never assumed
+         * clear: treating the failure as "nothing is claimed" would put already
+         * paid work on a list headed "needs a price".
+         */
+        errors.push({
+          id: pid,
+          message: `Could not read existing claims for this partner, so their unpriced runs are omitted rather than reported as unclaimed: ${
+            e?.message ?? String(e)
+          }`,
+        })
+      }
+    }
+    const unreadablePartners = new Set(errors.map((e) => e.id))
+
+    const reportable = unpriced.filter(
+      (row) =>
+        !claimedRunIds.has(String(row.run.id)) &&
+        !unreadablePartners.has(String(row.run.partner_id ?? ""))
+    )
+
+    const designIds = [
+      ...new Set(
+        reportable.map((row) => String(row.run.design_id ?? "")).filter(Boolean)
+      ),
+    ]
+    const { data: designs } = designIds.length
+      ? await query.graph({
+          entity: "designs",
+          fields: ["id", "name", "estimated_cost", "production_cost"],
+          filters: { id: designIds },
+        })
+      : { data: [] as any[] }
+    const designById = new Map(
+      ((designs || []) as any[]).map((d: any) => [String(d.id), d])
+    )
+
+    const aged = reportable
+      .map((row) => ({
+        ...row,
+        age_days: daysSinceCompletion(row.run.completed_at, now),
+      }))
+      .filter(
+        (row) =>
+          min_age_days === 0 ||
+          (row.age_days != null && row.age_days >= min_age_days)
+      )
+      /** Longest-waiting first: that is the order an operator should work in. */
+      .sort((a, b) => (b.age_days ?? -1) - (a.age_days ?? -1))
+
+    const changes: MaintenanceChange[] = aged.map((row) => {
+      const run = row.run
+      const design = designById.get(String(run.design_id ?? ""))
+      const produced = Number(run.produced_quantity)
+      const hasProduced = Number.isFinite(produced) && produced > 0
+      /**
+       * ⚠️ The RAW ordered figure. `Number(null)` is 0, and a run reported as
+       * "ordered 0" is a different and much worse statement than one that never
+       * agreed a quantity — which since #1676 is a legitimate open-ended run.
+       */
+      const ordered =
+        run.quantity === null || run.quantity === undefined
+          ? null
+          : Number(run.quantity)
+
+      const suggestion =
+        design?.production_cost != null
+          ? `design production_cost ${Number(design.production_cost)}/unit`
+          : design?.estimated_cost != null
+            ? `design estimated_cost ${Number(design.estimated_cost)}/unit`
+            : "no design cost to start from either"
+
+      return {
+        entity: "production_run",
+        id: String(run.id),
+        field: `partner_cost_estimate (cost_type ${run.cost_type ?? "unset — read as total"})`,
+        before: row.verdict === "zero_rate_recorded" ? row.agreed : null,
+        after: "REPORTED ONLY — a human must state the agreed price",
+        note:
+          `${row.verdict === "zero_rate_recorded" ? "A zero was written" : "No rate was ever recorded"}. ` +
+          `Partner ${run.partner_id ?? "unknown"}, design ${
+            design?.name ?? run.design_id ?? "none"
+          }, ` +
+          `produced ${hasProduced ? produced : "not recorded"} of ${
+            ordered ?? "no agreed quantity"
+          } ordered, ` +
+          `completed ${run.completed_at ?? "date not recorded"}${
+            row.age_days != null ? ` (${row.age_days} days ago)` : ""
+          }. ` +
+          `Starting point: ${suggestion} — a suggestion, never a price (#1554).`,
+      }
+    })
+
+    const zeroWritten = aged.filter(
+      (r) => r.verdict === "zero_rate_recorded"
+    ).length
+    const neverPriced = aged.length - zeroWritten
+
+    const summary = aged.length
+      ? `${aged.length} completed run(s) carry no agreed price — ${neverPriced} never priced, ${zeroWritten} with a zero written. ` +
+        `Nothing was changed: the agreed price is not derivable and must be typed by someone who knows it. ` +
+        `Scanned ${inScope.length} completed run(s)${
+          truncated
+            ? ` — TRUNCATED at the limit of ${limit}, so this is not the whole population; raise 'limit' or narrow by partner_id`
+            : ""
+        }, excluded ${provenanceRuns.length} provenance run(s) and ${
+          unpriced.length - reportable.length
+        } already claimed by a live payout.`
+      : `No unpriced completed runs found. Scanned ${inScope.length} completed run(s)${
+          truncated ? ` — TRUNCATED at the limit of ${limit}` : ""
+        }, excluded ${provenanceRuns.length} provenance run(s).`
+
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    logger?.info?.(`[audit-unpriced-completed-runs] ${summary}`)
+
+    return {
+      job_id: "audit-unpriced-completed-runs",
+      dry_run,
+      /**
+       * 🔴 Always false. There is no apply path: `dry_run: false` reports the
+       * same thing, because the missing figure cannot be derived from anything
+       * here. Saying `applied: true` because the job ran would claim a repair
+       * that did not happen.
+       */
+      applied: false,
+      summary,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -90,6 +90,7 @@ import { auditInventoryReceiptDriftJob } from "./audit-inventory-receipt-drift-j
 import { repairRoundedReceiptQuantitiesJob } from "./repair-rounded-receipt-quantities-job"
 import { backfillOrderLineMaterialJob } from "./backfill-order-line-material-job"
 import { auditPartnerPayoutQuantityJob } from "./audit-partner-payout-quantity-job"
+import { auditUnpricedCompletedRunsJob } from "./audit-unpriced-completed-runs-job"
 import { capFreeShippingBandJob } from "./cap-free-shipping-band-job"
 import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
 import { restoreOrphanStoreJob } from "./restore-orphan-store-job"
@@ -5865,6 +5866,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   repairRoundedReceiptQuantitiesJob,
   backfillOrderLineMaterialJob,
   auditPartnerPayoutQuantityJob,
+  auditUnpricedCompletedRunsJob,
   capFreeShippingBandJob,
   deleteOrphanStoreJob,
   restoreOrphanStoreJob,


### PR DESCRIPTION
Defect 5 from the 2026-09-01 partner-estate reconciliation — and the filed symptom turned out to be already closed.

## What the note said, and what is actually true

The note said a run with `cost_type: total` and no `partner_cost_estimate` *"prices at 0, `payable: false`, and vanishes from everything billable"*.

Probed before fixing, and it does not vanish:

- `payable-runs` lists it, and `payable` is documented on the row as **"NOT can this be paid"**
- the admin grid badges it **"no rate"**, labels the basis **"no rate yet"**, prints an **em dash** rather than a `0` in Amount, and offers a typable rate cell
- neither the admin nor the partner route filters on `payable`
- production's instance, `prod_run_01KP4ZVE3R`, was repriced on 2026-09-01 and now reads `per_unit @ 500`, 2 pieces, 1,000, `billed`

What is left is narrower, and it is the reason that run sat at 0 for four months: **all of the above is PULL.** The run is visible only to someone who already decided to open that partner's payout screen, and a partner with unpriced finished work looks exactly like a partner with no work. Nothing ever asked the question.

## The job

`audit-unpriced-completed-runs` reports every completed run whose `partner_cost_estimate` is absent or zero, longest-waiting first.

**🔴 Report-only, always** — `applied: false` even with `dry_run: false`. Unlike every `backfill-*` job the missing datum is not derivable: an agreed price is a thing two people said to each other. `design.estimated_cost` is **not** it (per finished unit, and pricing Bakshi's from the design would bill 11,530.80 against the run's 7,650 — #1554), so it is reported beside each row as a starting point and written nowhere.

**"No rate recorded" and "a zero was written" are counted separately.** Both are unpayable, but a stored `0` means something decided this, and a `0` passes every `!= null` check. `assessRunPricing` reads the RAW field before coercing — `Number(null)` is `0`, so coercing first would report every never-priced run as one that had a zero deliberately written to it.

**Excludes** runs already claimed by a live payout (a Rejected submission releases its runs) — such a run was billed by an explicit amount and has no missing-price problem — and provenance runs, which are not billable labour (#1606). A partner whose claims cannot be read is reported as an **error**, never assumed clear: the other reading puts paid work on a list headed "needs a price". The scan cap announces itself when it bites.

## Verification

- **14 unit cases**, **3 integration cases**
- **Mutation-checked both guards:** removing the raw-field read fails 3; removing the empty-string guard fails 1
- One case pins `assessRunPricing` to `runPayableOffer`'s own threshold across `null / 0 / -1 / 0.5 / 500`, so the report and the payout screen cannot disagree about who is waiting to be paid
- `check:prod-build` green

```
TEST_TYPE=unit npx jest --testPathPattern="audit-unpriced-completed-runs"
TEST_TYPE=integration:http NODE_OPTIONS="--experimental-vm-modules" \
  npx jest --testPathPattern="ops-maintenance-jobs" -t "audit-unpriced"
```

## Also verified while here (no code change)

- **Defect 1 was already fixed and live** — `8d3fa5e36` (PR #1715), an ancestor of the deployed `4fb4492f9`. hrhandloom's `inv_order_01K36TE2WB` now offers `amount: 0` against `remaining: 63,215`; the phantom headroom is gone.
- **The `recorded → 54,974` probe expectation was stale.** `6bad9574f` is confirmed live by image digest, and `recorded: 46,000` is correct: Sharlho's 8,974 is attached to its payout (`settled_by`), and `recorded` deliberately sums standalone payments only, or the money would count twice.

Refs #1712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
