### PR TITLE
feat(payments): tell an order about money that moved, and about what is not goods (#1737)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -4919,6 +4919,400 @@ setupSharedTestSuite(() => {
         })
       })
 
+      /**
+       * #1737 — stating that an EXISTING payment was recorded against an
+       * inventory order. The mirror of `/settles`, one entity over.
+       *
+       * 🔴 The measured gap: `inv_order_01K5QSCSK…` on production reads
+       * `recorded_total: 0` and is offered at its full 56,856.94 while 58,000
+       * has already been paid against it in two unlinked payments. Nothing
+       * could put a payment there — `inventoryOrderIds` writes only at
+       * creation, `UpdatePaymentSchema` is `.strict()`, and the backfill job
+       * only walks payments that came through a payout.
+       */
+      describe("POST /admin/payments/:id/records-against (#1737)", () => {
+        /** A payment with NO order link — the historical row this route is for. */
+        const recordStandalonePayment = async (
+          partnerId: string,
+          amount: number
+        ) => {
+          const res = await api
+            .post(
+              "/admin/payments/link",
+              {
+                payment: {
+                  amount,
+                  status: "Completed",
+                  payment_type: "Bank",
+                  payment_date: new Date().toISOString(),
+                },
+                partnerIds: [partnerId],
+              },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(res.status).toBe(201)
+          return res.data.payment.id as string
+        }
+
+        const orderRow = async (partnerId: string, orderId: string) => {
+          const res = await api.get(
+            `/admin/payment-submissions/payable-inventory-orders?partner_id=${partnerId}`,
+            adminHeaders
+          )
+          expect(res.status).toBe(200)
+          return res.data.payable_inventory_orders.find(
+            (o: any) => o.inventory_order_id === orderId
+          )
+        }
+
+        it("arms the double-pay warning on an order money had already reached", async () => {
+          const stamp = Date.now() + 210
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `pra-${stamp}`)
+          const paymentId = await recordStandalonePayment(owner.partnerId, 400)
+
+          /**
+           * Before: the order has no idea. This is the production state of
+           * `inv_order_01K5QSCSK…` — paid, and reading as untouched.
+           */
+          const before = await orderRow(owner.partnerId, orderId)
+          expect(before.recorded_total).toBe(0)
+          expect(before.recorded_covers_amount).toBe(false)
+
+          const link = await api
+            .post(
+              `/admin/payments/${paymentId}/records-against`,
+              { inventory_order_id: orderId },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(link.status).toBe(200)
+
+          const after = await orderRow(owner.partnerId, orderId)
+          expect(after.recorded_total).toBe(400)
+        })
+
+        /**
+         * 🔴 Recording is NOT settling. `payable-inventory-orders` reports
+         * `recorded_total` and refuses to subtract it, because a payment on an
+         * order may be an advance rather than a discharge — netting silently
+         * underpays, which is this codebase's recurring failure mode.
+         */
+        it("reports the money without reducing what the order still offers", async () => {
+          const stamp = Date.now() + 220
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `prb-${stamp}`)
+          const paymentId = await recordStandalonePayment(owner.partnerId, 400)
+
+          const before = await orderRow(owner.partnerId, orderId)
+          await api.post(
+            `/admin/payments/${paymentId}/records-against`,
+            { inventory_order_id: orderId },
+            adminHeaders
+          )
+          const after = await orderRow(owner.partnerId, orderId)
+
+          expect(after.amount).toBe(before.amount)
+          expect(after.recorded_total).toBe(400)
+        })
+
+        it("is idempotent — re-stating the same fact is not a 500", async () => {
+          /**
+           * ⚠️ `link.create` raises on the composite primary key, so a repeat
+           * would 500 without the dismiss-first (#1129).
+           */
+          const stamp = Date.now() + 230
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `prc-${stamp}`)
+          const paymentId = await recordStandalonePayment(owner.partnerId, 400)
+
+          for (const _ of [1, 2]) {
+            const res = await api
+              .post(
+                `/admin/payments/${paymentId}/records-against`,
+                { inventory_order_id: orderId },
+                adminHeaders
+              )
+              .catch((e: any) => e.response)
+            expect(res.status).toBe(200)
+          }
+
+          // Linked once, counted once — not 800.
+          expect((await orderRow(owner.partnerId, orderId)).recorded_total).toBe(400)
+        })
+
+        it("takes the statement back", async () => {
+          const stamp = Date.now() + 240
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `prd-${stamp}`)
+          const paymentId = await recordStandalonePayment(owner.partnerId, 400)
+
+          await api.post(
+            `/admin/payments/${paymentId}/records-against`,
+            { inventory_order_id: orderId },
+            adminHeaders
+          )
+          expect((await orderRow(owner.partnerId, orderId)).recorded_total).toBe(400)
+
+          const res = await api
+            .delete(
+              `/admin/payments/${paymentId}/records-against?inventory_order_id=${orderId}`,
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(res.status).toBe(200)
+          expect((await orderRow(owner.partnerId, orderId)).recorded_total).toBe(0)
+        })
+
+        /**
+         * 🔴 The guard that matters. Existence checks alone let partner A's
+         * money silence the double-pay warning on partner B's order — and a
+         * bulk reconciliation pass is exactly where an id gets typed wrong.
+         * This route exists because of such a pass.
+         */
+        it("refuses to record one partner's payment against another's order", async () => {
+          const stamp = Date.now() + 250
+          const a = await createPartnerWithAuth(stamp)
+          const b = await createPartnerWithAuth(stamp + 1)
+          const bOrderId = await seedOrderForPartner(b.partnerId, `pre-${stamp}`)
+          const aPaymentId = await recordStandalonePayment(a.partnerId, 400)
+
+          const res = await api
+            .post(
+              `/admin/payments/${aPaymentId}/records-against`,
+              { inventory_order_id: bOrderId },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(400)
+          // And nothing was written.
+          expect((await orderRow(b.partnerId, bOrderId)).recorded_total).toBe(0)
+        })
+
+        it("refuses an order that does not exist, rather than linking to nothing", async () => {
+          const stamp = Date.now() + 260
+          const owner = await createPartnerWithAuth(stamp)
+          const paymentId = await recordStandalonePayment(owner.partnerId, 400)
+
+          const res = await api
+            .post(
+              `/admin/payments/${paymentId}/records-against`,
+              { inventory_order_id: "inv_order_does_not_exist" },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(404)
+        })
+
+        it("accepts inventory_order_id at all — the route ordering trap", async () => {
+          /**
+           * 🔴 `/admin/payments/:id` POST carries a `.strict()` validator and
+           * matching is prefix-based. Registered after it, this body would be
+           * rejected as an unrecognised field — a 400 that reads like a bad
+           * request rather than a mis-ordered route.
+           */
+          const stamp = Date.now() + 270
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `prf-${stamp}`)
+          const paymentId = await recordStandalonePayment(owner.partnerId, 400)
+
+          const res = await api
+            .post(
+              `/admin/payments/${paymentId}/records-against`,
+              { inventory_order_id: orderId },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).not.toBe(400)
+          expect(res.status).toBe(200)
+        })
+      })
+
+      /**
+       * #1737 — amounts on an order that are not goods. Three turned up in one
+       * reconciliation with no home: 200 of tax, 1,960 of shipping, an 829
+       * write-off. `metadata` was the only writable place, which is the trap
+       * #1557 closed.
+       */
+      describe("POST /admin/inventory-orders/:id/charges (#1737)", () => {
+        const orderRow = async (partnerId: string, orderId: string) => {
+          const res = await api.get(
+            `/admin/payment-submissions/payable-inventory-orders?partner_id=${partnerId}`,
+            adminHeaders
+          )
+          expect(res.status).toBe(200)
+          return res.data.payable_inventory_orders.find(
+            (o: any) => o.inventory_order_id === orderId
+          )
+        }
+
+        /**
+         * 🔴 The property that makes adding a term to a live money guard safe:
+         * an order with no charges is EXACTLY what it was before.
+         */
+        it("leaves an order with no charges exactly as it was", async () => {
+          const stamp = Date.now() + 310
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `chg0-${stamp}`)
+
+          const row = await orderRow(owner.partnerId, orderId)
+          expect(row.charges_total).toBe(0)
+          expect(row.payable_ceiling).toBe(row.ordered_total)
+        })
+
+        it("raises the ceiling by tax, and says so without touching ordered_total", async () => {
+          const stamp = Date.now() + 320
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `chg1-${stamp}`)
+          const before = await orderRow(owner.partnerId, orderId)
+
+          const res = await api
+            .post(
+              `/admin/inventory-orders/${orderId}/charges`,
+              { type: "tax", amount: 200 },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(res.status).toBe(201)
+
+          const after = await orderRow(owner.partnerId, orderId)
+          expect(after.charges_total).toBe(200)
+          /** 🔑 GOODS is unchanged — the field did not silently widen. */
+          expect(after.ordered_total).toBe(before.ordered_total)
+          expect(after.payable_ceiling).toBe(before.payable_ceiling + 200)
+        })
+
+        it("lowers the ceiling by a discount", async () => {
+          const stamp = Date.now() + 330
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `chg2-${stamp}`)
+          const before = await orderRow(owner.partnerId, orderId)
+
+          const res = await api
+            .post(
+              `/admin/inventory-orders/${orderId}/charges`,
+              { type: "discount", amount: 100, note: "settled short by agreement" },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(res.status).toBe(201)
+
+          const after = await orderRow(owner.partnerId, orderId)
+          expect(after.charges_total).toBe(-100)
+          expect(after.payable_ceiling).toBe(before.payable_ceiling - 100)
+        })
+
+        /**
+         * 🔴 The 829 write-off sat as an unexplained gap and read as an
+         * OVERpayment until a human remembered the shipping. A reduction with
+         * no reason is indistinguishable from an underpayment.
+         */
+        it("refuses a reduction that does not say why", async () => {
+          const stamp = Date.now() + 340
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `chg3-${stamp}`)
+
+          const res = await api
+            .post(
+              `/admin/inventory-orders/${orderId}/charges`,
+              { type: "discount", amount: 100 },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(400)
+          expect((await orderRow(owner.partnerId, orderId)).charges_total).toBe(0)
+        })
+
+        /** A raise needs no note — tax is self-explanatory and always owed. */
+        it("does not demand a reason for a charge that raises what is owed", async () => {
+          const stamp = Date.now() + 350
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `chg4-${stamp}`)
+
+          const res = await api
+            .post(
+              `/admin/inventory-orders/${orderId}/charges`,
+              { type: "shipping", amount: 1960 },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(201)
+        })
+
+        /**
+         * ⚠️ The amount is always positive; the TYPE carries the direction. A
+         * signed amount would let one typo turn an obligation into a reduction.
+         */
+        it("refuses a negative amount rather than inferring a direction from it", async () => {
+          const stamp = Date.now() + 360
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `chg5-${stamp}`)
+
+          const res = await api
+            .post(
+              `/admin/inventory-orders/${orderId}/charges`,
+              { type: "tax", amount: -200 },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(400)
+        })
+
+        /**
+         * 🔴 The whole point: the screen and the write guard must agree. A tax
+         * charge has to make the claim `create` accepts LARGER, or the partner
+         * is silently short of the tax they invoiced.
+         */
+        it("lets a claim reach the tax the partner invoiced", async () => {
+          const stamp = Date.now() + 370
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `chg6-${stamp}`)
+          const row = await orderRow(owner.partnerId, orderId)
+          const goods = row.ordered_total
+
+          // Without the charge, billing goods + 50 is refused by the guard.
+          const refused = await api
+            .post(
+              "/partners/payment-submissions",
+              {
+                inventory_order_lines: [
+                  { inventory_order_id: orderId, amount: goods + 50 },
+                ],
+              },
+              { headers: owner.partnerHeaders }
+            )
+            .catch((e: any) => e.response)
+          expect(refused.status).toBe(400)
+
+          await api.post(
+            `/admin/inventory-orders/${orderId}/charges`,
+            { type: "tax", amount: 50 },
+            adminHeaders
+          )
+
+          // With it recorded, the same claim is accepted.
+          const accepted = await api
+            .post(
+              "/partners/payment-submissions",
+              {
+                inventory_order_lines: [
+                  { inventory_order_id: orderId, amount: goods + 50 },
+                ],
+              },
+              { headers: owner.partnerHeaders }
+            )
+            .catch((e: any) => e.response)
+          expect(accepted.status).toBe(201)
+        })
+      })
+
       it("still refuses a submission naming nothing at all", async () => {
         const res = await api
           .post(

--- a/apps/backend/src/api/admin/inventory-orders/[id]/charges/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/charges/route.ts
@@ -1,0 +1,131 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { ORDER_INVENTORY_MODULE } from "../../../../../modules/inventory_orders"
+import {
+  foldOrderCharges,
+  orderPayableCeiling,
+} from "../../../../../modules/inventory_orders/lib/order-charges"
+
+/**
+ * GET  /admin/inventory-orders/:id/charges
+ * POST /admin/inventory-orders/:id/charges  { type, amount, note? }
+ *
+ * Amounts on an order that are not goods — tax, shipping, a discount or a
+ * write-off (#1737).
+ *
+ * ## Why this exists
+ *
+ * Three turned up in one reconciliation and none had a home: 200 of tax on a
+ * Terry Towel order, 1,960 of shipping on `inv_order_01K5QSCSK…`, and an 829
+ * write-off on the same order. The model carried `total_price` and nothing
+ * else, so an order whose real cost included freight understated it and a
+ * settled remainder could not be recorded at all. The only writable home was
+ * `metadata` — the trap #1557 closed, where an untyped blob decided payouts.
+ *
+ * ## What it moves
+ *
+ * 🔴 A charge changes the CEILING a claim may reach — `orderPayableCeiling`,
+ * read by both `assessInventoryOrderClaims` (the write guard) and
+ * `payable-inventory-orders` (the offer screen). Recording 200 of tax makes
+ * 200 more billable; recording an 829 discount makes 829 less. This is a money
+ * decision, which is why it is an explicit action and never inferred.
+ *
+ * ⚠️ It does NOT touch `total_price`. That column means "what was ordered" to
+ * every reader, and widening it in place is the one-column-two-meanings trap
+ * that already cost us `quantity` being a rate or a total (#1559).
+ */
+
+/** The types that REDUCE what a partner is owed. */
+const LOWERING = new Set(["discount", "adjustment"])
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(ORDER_INVENTORY_MODULE)
+
+  const [order] = (await service.listInventoryOrders({
+    id: [req.params.id],
+  })) as any[]
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Inventory order ${req.params.id} not found`
+    )
+  }
+
+  const charges = (await service.listOrderCharges({
+    inventory_orders_id: req.params.id,
+  })) as any[]
+
+  return res.status(200).json({
+    charges,
+    /** Folded here too, so a caller never re-derives the direction rule. */
+    totals: foldOrderCharges(charges),
+    goods_total: Number(order.total_price ?? 0),
+    payable_ceiling: orderPayableCeiling(order, charges),
+  })
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.validatedBody ?? req.body ?? {}) as any
+  const type = String(body.type ?? "").trim()
+  const amount = Number(body.amount)
+  const note = body.note == null ? null : String(body.note).trim()
+
+  const service: any = req.scope.resolve(ORDER_INVENTORY_MODULE)
+
+  const [order] = (await service.listInventoryOrders({
+    id: [req.params.id],
+  })) as any[]
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Inventory order ${req.params.id} not found`
+    )
+  }
+
+  /**
+   * ⚠️ A cancelled order is not owed, so nothing can be charged against it —
+   * the same reasoning that stops a payment being recorded against one.
+   */
+  if (String(order.status) === "Cancelled") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Inventory order ${req.params.id} was cancelled — it is not owed, so no charge can be added to it.`
+    )
+  }
+
+  /**
+   * 🔴 A reduction has to say WHY, at the door.
+   *
+   * An 829 write-off with no reason is indistinguishable from an underpayment,
+   * and that is exactly how this one was nearly lost: it sat as an unexplained
+   * gap between 56,856.94 ordered and 58,000 paid, and read as an overpayment
+   * until a human remembered the shipping. Required at the route rather than on
+   * the column so historical rows can still be backfilled by a job that has no
+   * reason to give.
+   */
+  if (LOWERING.has(type) && !note) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `A ${type} reduces what this partner is owed, so it must say why — send a 'note'. An unexplained reduction is indistinguishable from an underpayment.`
+    )
+  }
+
+  const created = await service.createOrderCharges({
+    type,
+    amount,
+    note,
+    inventory_orders_id: req.params.id,
+  })
+
+  const charges = (await service.listOrderCharges({
+    inventory_orders_id: req.params.id,
+  })) as any[]
+
+  return res.status(201).json({
+    charge: Array.isArray(created) ? created[0] : created,
+    totals: foldOrderCharges(charges),
+    /** What a claim may now reach — the figure the guard will enforce. */
+    payable_ceiling: orderPayableCeiling(order, charges),
+  })
+}

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -250,3 +250,23 @@ export const updateInventoryOrderLinesSchema = z.object({
 });
 
 export type UpdateInventoryOrderLines = z.infer<typeof updateInventoryOrderLinesSchema>;
+
+/**
+ * An amount on an order that is not goods (#1737).
+ *
+ * ⚠️ `amount` is POSITIVE and the `type` carries the direction. A signed amount
+ * would let one typo turn an obligation into a reduction with nothing in the
+ * way — see `lib/order-charges.ts`.
+ *
+ * The `note` requirement for the lowering types is enforced in the route, not
+ * here, so the message can name which type triggered it.
+ */
+export const createInventoryOrderChargeSchema = z.object({
+  type: z.enum(["tax", "shipping", "discount", "adjustment"]),
+  amount: z.number().positive("A charge amount must be positive — the type carries the direction"),
+  note: z.string().min(1).optional(),
+})
+
+export type CreateInventoryOrderCharge = z.infer<
+  typeof createInventoryOrderChargeSchema
+>

--- a/apps/backend/src/api/admin/payments/[id]/records-against/route.ts
+++ b/apps/backend/src/api/admin/payments/[id]/records-against/route.ts
@@ -1,0 +1,223 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/modules-sdk"
+
+import InventoryOrdersInternalPaymentsLink from "../../../../../links/inventory-orders-internal-payments"
+import PartnerInventoryOrderLink from "../../../../../links/partner-inventory-order"
+import PartnerPaymentMethodsLink from "../../../../../links/partner-payment-methods-link"
+import PartnerPaymentsLink from "../../../../../links/partner-payments-link"
+import { INTERNAL_PAYMENTS_MODULE } from "../../../../../modules/internal_payments"
+import { ORDER_INVENTORY_MODULE } from "../../../../../modules/inventory_orders"
+import type InternalPaymentService from "../../../../../modules/internal_payments/service"
+import { decideSamePartner, resolvePaymentOwners } from "../settles/same-partner"
+
+/**
+ * POST   /admin/payments/:id/records-against  { inventory_order_id }
+ * DELETE /admin/payments/:id/records-against  { inventory_order_id }
+ *
+ * State that an EXISTING payment was recorded against an inventory order — or
+ * take it back. The mirror of `/settles`, one entity over (#1737).
+ *
+ * ## Why this exists
+ *
+ * `inventoryOrderIds` on `POST /admin/payments/link` writes the link only at
+ * CREATION. A payment already in the system can never be attached to an order
+ * afterwards: `UpdatePaymentSchema` is `.strict()` and carries no link fields,
+ * and `backfill-inventory-order-payment-links` only walks payments that arrived
+ * through a payout, so it cannot reach a standalone one. The only workaround
+ * was to delete the row and recreate it — which loses its id and its
+ * `created_at`, and is the same delete-and-recreate that produced a duplicate
+ * 4,500 on Sunny's ledger.
+ *
+ * 🔴 Measured cost of the gap. `inv_order_01K5QSCSKB4YC40ZSR47RVN80J`
+ * (Shramdaan) reads `recorded_total: 0` and `payable-inventory-orders` offers
+ * its full 56,856.94 as freshly billable, while 58,000 has already been paid
+ * against it in two unlinked payments. The guard that would warn
+ * (`recorded_total`) reads `internal_payments` on the order, and nobody could
+ * put one there. A capability reachable only for rows that do not exist yet is
+ * a capability nobody has (#1612).
+ *
+ * ## Why it is a deliberate action and not an inference
+ *
+ * 🔴 Nothing infers this, deliberately — the same rule `/settles` follows. A
+ * payment to a partner may be an advance, a deposit, a correction, or money for
+ * a different delivery. `payable-inventory-orders` REPORTS `recorded_total` and
+ * refuses to subtract it, because netting silently underpays and that is this
+ * codebase's recurring failure mode. This route is where a human turns the
+ * report into a stated fact.
+ *
+ * ⚠️ Recording a payment against an order does NOT discharge a payout. It makes
+ * the money visible on the order and arms the warning; `/settles` remains the
+ * only thing that moves `paid`. Those are different assertions and conflating
+ * them is how an advance gets read as a settlement.
+ *
+ * ## Scope
+ *
+ * ⚠️ `inventory_order` only, today. The customer-order case in #1737 needs a
+ * store-order↔internal-payment link that does not exist yet — a new link table
+ * and a migration — so it is deliberately NOT stubbed here. A `target_type`
+ * accepting a value the route cannot honour would be worse than its absence.
+ */
+
+const resolveBoth = async (
+  req: MedusaRequest,
+  inventoryOrderId: string
+): Promise<void> => {
+  if (!inventoryOrderId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "inventory_order_id is required"
+    )
+  }
+
+  /**
+   * 🔴 BOTH ends validated, not just the one in the URL — the same rule as
+   * `/settles`. A request naming two ids and checking one is the shape that let
+   * body ids through unexamined (#778), and here the unchecked id decides which
+   * order stops looking payable.
+   */
+  const paymentService: InternalPaymentService = req.scope.resolve(
+    INTERNAL_PAYMENTS_MODULE
+  )
+  const [payment] = (await paymentService.listPayments({
+    id: [req.params.id],
+  })) as any[]
+  if (!payment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Payment ${req.params.id} not found`
+    )
+  }
+
+  const orderService: any = req.scope.resolve(ORDER_INVENTORY_MODULE)
+  const [order] = (await orderService.listInventoryOrders({
+    id: [inventoryOrderId],
+  })) as any[]
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Inventory order ${inventoryOrderId} not found`
+    )
+  }
+
+  /**
+   * ⚠️ A cancelled order was never owed, so no money can have been recorded
+   * against it — the same reasoning that stops a Rejected payout being settled.
+   * Allowing it would put a payment against an obligation we withdrew.
+   */
+  if (String(order.status) === "Cancelled") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Inventory order ${inventoryOrderId} was cancelled — it is not owed, so no payment can be recorded against it.`
+    )
+  }
+
+  /**
+   * 🔴 BOTH ENDS AGAINST EACH OTHER, not merely both present.
+   *
+   * Existence checks alone let partner A's money be recorded against partner
+   * B's order. That silences the double-pay warning on an order nobody paid,
+   * and leaves a link nobody would think to question. A bulk reconciliation
+   * pass is exactly where an id gets typed one character wrong — this route
+   * exists BECAUSE of such a pass.
+   *
+   * Permissive when the payment has no traceable owner; see
+   * `settles/same-partner.ts` for why that is deliberate.
+   */
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  const owners = await resolvePaymentOwners(
+    query,
+    {
+      partnerPayments: PartnerPaymentsLink,
+      orderPayments: InventoryOrdersInternalPaymentsLink,
+      partnerOrders: PartnerInventoryOrderLink,
+      partnerMethods: PartnerPaymentMethodsLink,
+    },
+    String(req.params.id),
+    /**
+     * ⚠️ `paid_to` is a `belongsTo`, so an unexpanded `listPayments` returns the
+     * FK column, not the object. Reading only `.paid_to.id` leaves the payment-
+     * method home permanently unreached — a check that never runs reads as a
+     * pass.
+     */
+    (payment as any)?.paid_to?.id ?? (payment as any)?.paid_to_id ?? null
+  )
+
+  /**
+   * The order's partner, reached through the link — there is no partner column
+   * on an inventory order.
+   */
+  const { data: ownerRows } = await query.graph({
+    entity: PartnerInventoryOrderLink.entryPoint,
+    fields: ["partner_id"],
+    filters: { inventory_orders_id: inventoryOrderId },
+  })
+  const orderPartnerId =
+    ((ownerRows || []) as any[]).map((r) => r?.partner_id).filter(Boolean)[0] ??
+    null
+
+  const decision = decideSamePartner(owners, orderPartnerId)
+  if (!decision.allowed) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Payment ${req.params.id} belongs to partner ${decision.owners.join(
+        ", "
+      )}, but inventory order ${inventoryOrderId} belongs to partner ${orderPartnerId}. A payment cannot be recorded against another partner's order.`
+    )
+  }
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const inventoryOrderId = String(
+    (req.validatedBody as any)?.inventory_order_id ??
+      (req.body as any)?.inventory_order_id ??
+      ""
+  ).trim()
+
+  await resolveBoth(req, inventoryOrderId)
+
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link
+
+  /**
+   * ⚠️ `link.create` is NOT idempotent — a repeat raises on the composite
+   * primary key (#1129). Dismiss first so re-stating the same fact is a no-op
+   * rather than a 500 an operator reads as "it did not work".
+   */
+  const definition = {
+    [ORDER_INVENTORY_MODULE]: { inventory_orders_id: inventoryOrderId },
+    [INTERNAL_PAYMENTS_MODULE]: { internal_payments_id: req.params.id },
+  }
+  await remoteLink.dismiss(definition).catch(() => undefined)
+  await remoteLink.create(definition as any)
+
+  return res.status(200).json({
+    payment_id: req.params.id,
+    inventory_order_id: inventoryOrderId,
+    records_against: true,
+  })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const inventoryOrderId = String(
+    (req.query as any)?.inventory_order_id ??
+      (req.body as any)?.inventory_order_id ??
+      ""
+  ).trim()
+
+  await resolveBoth(req, inventoryOrderId)
+
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link
+  await remoteLink.dismiss({
+    [ORDER_INVENTORY_MODULE]: { inventory_orders_id: inventoryOrderId },
+    [INTERNAL_PAYMENTS_MODULE]: { internal_payments_id: req.params.id },
+  })
+
+  return res.status(200).json({
+    payment_id: req.params.id,
+    inventory_order_id: inventoryOrderId,
+    records_against: false,
+  })
+}

--- a/apps/backend/src/api/admin/payments/validators.ts
+++ b/apps/backend/src/api/admin/payments/validators.ts
@@ -51,3 +51,18 @@ export const PaymentSettlesSchema = z.object({
 })
 
 export type PaymentSettles = z.infer<typeof PaymentSettlesSchema>
+
+/**
+ * Which inventory order an existing payment was recorded against (#1737).
+ *
+ * ⚠️ Its middleware entry MUST precede `/admin/payments/:id`, for the same
+ * reason `/settles` does: matching is prefix-based and `UpdatePaymentSchema` is
+ * `.strict()`, so the update entry would otherwise claim this path and reject
+ * `inventory_order_id` as an unrecognised field — a 400 that reads like a bad
+ * request rather than a mis-ordered route.
+ */
+export const PaymentRecordsAgainstSchema = z.object({
+  inventory_order_id: z.string().min(1),
+})
+
+export type PaymentRecordsAgainst = z.infer<typeof PaymentRecordsAgainstSchema>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -191,7 +191,7 @@ import { updatePartnerMeSchema } from "./partners/me/validators";
 import { onboardingProfileUpdateSchema } from "./partners/onboarding-profile/validators";
 import { setLayoutConfigurationSchema } from "./partners/layouts/validators";
 import { AdminGetPartnersParamsSchema } from "./admin/persons/partner/validators";
-import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema } from "./admin/inventory-orders/validators";
+import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema, createInventoryOrderChargeSchema } from "./admin/inventory-orders/validators";
 import { createRawMaterialGroupSchema, updateRawMaterialGroupSchema, listRawMaterialGroupsQuerySchema, addGroupColorSchema, addGroupColorFullSchema, linkGroupColorsSchema, createGroupOrderSchema, readGroupQuerySchema } from "./admin/raw-material-groups/validators";
 import { pinDesignGroupSchema, updateDesignGroupSchema } from "./admin/designs/[id]/material-groups/validators";
 // Import already defined above
@@ -246,7 +246,7 @@ import {
   AdminUpdateFormSchema,
 } from "./admin/forms/validators";
 // Payments: schemas
-import { PaymentSchema, ListPaymentsQuerySchema, UpdatePaymentSchema, PaymentSettlesSchema } from "./admin/payments/validators";
+import { PaymentSchema, ListPaymentsQuerySchema, UpdatePaymentSchema, PaymentSettlesSchema, PaymentRecordsAgainstSchema } from "./admin/payments/validators";
 import { CreatePaymentAndLinkSchema } from "./admin/payments/link/validators";
 import { CreatePartnerCreditSchema } from "./admin/partners/[id]/credits/validators";
 import { ApplyPartnerCreditSchema } from "./admin/partners/[id]/credits/[creditId]/apply/validators";
@@ -3591,6 +3591,23 @@ export default defineMiddlewares({
       method: "DELETE",
       middlewares: [],
     },
+    /**
+     * #1737 — the mirror of `/settles`, one entity over. Same ordering rule:
+     * this MUST precede `/admin/payments/:id`, whose `.strict()` update schema
+     * would otherwise claim the path and reject `inventory_order_id`.
+     */
+    {
+      matcher: "/admin/payments/:id/records-against",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(PaymentRecordsAgainstSchema)),
+      ],
+    },
+    {
+      matcher: "/admin/payments/:id/records-against",
+      method: "DELETE",
+      middlewares: [],
+    },
     {
       matcher: "/admin/payments/:id",
       method: "POST",
@@ -4242,6 +4259,26 @@ export default defineMiddlewares({
       matcher: "/admin/inventory-orders",
       method: 'GET',
       middlewares: [validateAndTransformQuery(wrapSchema(listInventoryOrdersQuerySchema), {})]
+    },
+    /**
+     * #1737 — amounts on an order that are not goods.
+     *
+     * ⚠️ Registered BEFORE `/admin/inventory-orders/:id`: matching is
+     * prefix-based, and the `:id` GET carries a query validator that would
+     * otherwise claim this path. Same trap as `/settles` and
+     * `/records-against` on the payments side.
+     */
+    {
+      matcher: "/admin/inventory-orders/:id/charges",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(createInventoryOrderChargeSchema)),
+      ],
+    },
+    {
+      matcher: "/admin/inventory-orders/:id/charges",
+      method: "GET",
+      middlewares: [],
     },
     {
       matcher: "/admin/inventory-orders/:id",

--- a/apps/backend/src/modules/inventory_orders/lib/__tests__/order-charges.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/__tests__/order-charges.unit.spec.ts
@@ -1,0 +1,105 @@
+import {
+  foldOrderCharges,
+  orderPayableCeiling,
+} from "../order-charges"
+
+/**
+ * #1737 — the three real amounts that had no home, and the rule that keeps the
+ * write guard and the offer screen agreeing to the paisa.
+ */
+describe("foldOrderCharges", () => {
+  it("separates what raises the obligation from what lowers it", () => {
+    expect(
+      foldOrderCharges([
+        { type: "tax", amount: 200 },
+        { type: "shipping", amount: 1960 },
+        { type: "discount", amount: 829 },
+      ])
+    ).toEqual({ raises: 2160, lowers: 829, net: 1331 })
+  })
+
+  /**
+   * 🔑 The sign lives on the TYPE, not on the number. A tax of 200 and a
+   * discount of 200 are the same figure and opposite facts.
+   */
+  it("reads the same amount in opposite directions by type", () => {
+    expect(foldOrderCharges([{ type: "tax", amount: 200 }]).net).toBe(200)
+    expect(foldOrderCharges([{ type: "discount", amount: 200 }]).net).toBe(-200)
+  })
+
+  /**
+   * ⚠️ A negative that slipped into the column must not flip its own type's
+   * direction — a `tax` of -200 quietly reducing what we owe is the shape that
+   * underpays a partner and looks like arithmetic.
+   */
+  it("refuses to let a negative amount invert its type", () => {
+    expect(foldOrderCharges([{ type: "tax", amount: -200 }]).net).toBe(200)
+    expect(foldOrderCharges([{ type: "discount", amount: -200 }]).net).toBe(-200)
+  })
+
+  /**
+   * ⚠️ An unknown type counts in NEITHER direction. Guessing it upward would
+   * invent an obligation, which is the direction that overpays.
+   */
+  it("ignores a type it does not understand rather than guessing upward", () => {
+    expect(
+      foldOrderCharges([
+        { type: "tax", amount: 100 },
+        { type: "gratuity" as any, amount: 5000 },
+      ])
+    ).toEqual({ raises: 100, lowers: 0, net: 100 })
+  })
+
+  it("treats no charges, null and junk amounts as nothing", () => {
+    expect(foldOrderCharges(null).net).toBe(0)
+    expect(foldOrderCharges([]).net).toBe(0)
+    expect(foldOrderCharges([{ type: "tax", amount: "abc" as any }]).net).toBe(0)
+  })
+})
+
+describe("orderPayableCeiling", () => {
+  /**
+   * 🔴 The property that makes this safe behind a live money guard: an order
+   * with no charges yields EXACTLY `total_price`, so every existing row on
+   * production behaves identically the moment this ships.
+   */
+  it("is exactly total_price when there are no charges", () => {
+    expect(orderPayableCeiling({ total_price: 56856.94 }, [])).toBe(56856.94)
+    expect(orderPayableCeiling({ total_price: 56856.94 }, null)).toBe(56856.94)
+  })
+
+  /** The Terry Towel order: 4 × 1,000 of goods, 200 of tax. */
+  it("raises the ceiling by tax so the invoice total is billable", () => {
+    expect(
+      orderPayableCeiling({ total_price: 4000 }, [{ type: "tax", amount: 200 }])
+    ).toBe(4200)
+  })
+
+  /** `inv_order_01K5QSCSK…`: goods, freight on top, and the remainder written off. */
+  it("reproduces the Shramdaan order once shipping and the write-off are counted", () => {
+    expect(
+      orderPayableCeiling({ total_price: 56869 }, [
+        { type: "shipping", amount: 1960 },
+        { type: "discount", amount: 829 },
+      ])
+    ).toBe(58000)
+  })
+
+  /**
+   * ⚠️ Never negative. A write-off larger than the order would otherwise read
+   * as "this partner owes us", a claim no data here supports.
+   */
+  it("floors at zero rather than reporting a partner as owing us", () => {
+    expect(
+      orderPayableCeiling({ total_price: 1000 }, [
+        { type: "discount", amount: 5000 },
+      ])
+    ).toBe(0)
+  })
+
+  it("keeps money to two decimals rather than float dust", () => {
+    expect(
+      orderPayableCeiling({ total_price: 0.1 }, [{ type: "tax", amount: 0.2 }])
+    ).toBe(0.3)
+  })
+})

--- a/apps/backend/src/modules/inventory_orders/lib/order-charges.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/order-charges.ts
@@ -1,0 +1,101 @@
+/**
+ * What an inventory order is really worth, once the amounts that are not goods
+ * are counted (#1737).
+ *
+ * 🔴 ONE place. `assessInventoryOrderClaims` (the write guard) and
+ * `payable-inventory-orders` (the offer screen) must agree to the paisa, or the
+ * screen offers a figure the guard rejects and the operator learns the rule
+ * from a 400 — the defect `runPayableOffer` was extracted to prevent (#1616).
+ *
+ * PURE, so the arithmetic can be tested without a database.
+ */
+
+export type ChargeType = "tax" | "shipping" | "discount" | "adjustment"
+
+export type OrderCharge = {
+  type?: ChargeType | string | null
+  amount?: number | string | null
+}
+
+/**
+ * Which types RAISE what we owe and which LOWER it.
+ *
+ * 🔑 The sign lives here, not on the stored amount. A `tax` of 200 and a
+ * `discount` of 200 are the same number and opposite facts; storing a signed
+ * amount would let one typo turn an obligation into a reduction with nothing in
+ * the way. An amount is always positive and its type decides the direction.
+ */
+const RAISES = new Set<string>(["tax", "shipping"])
+const LOWERS = new Set<string>(["discount", "adjustment"])
+
+const num = (value: unknown): number => {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const round = (value: number): number => Math.round(value * 100) / 100
+
+export type ChargeTotals = {
+  /** Tax + shipping. What the partner is owed ON TOP of the goods. */
+  raises: number
+  /** Discounts + adjustments. What has been written off. */
+  lowers: number
+  /** `raises - lowers`. May be negative; that is a net reduction, not an error. */
+  net: number
+}
+
+/**
+ * PURE: fold a list of charges into the two directions.
+ *
+ * ⚠️ An UNKNOWN type is counted in neither direction and is not silently
+ * treated as a raise. A type this code does not understand is a question, and
+ * guessing it upward would invent an obligation — the direction that overpays.
+ * Callers that care can compare `raises + lowers` against the row count.
+ */
+export const foldOrderCharges = (
+  charges: OrderCharge[] | null | undefined
+): ChargeTotals => {
+  const rows = Array.isArray(charges) ? charges.filter(Boolean) : []
+
+  let raises = 0
+  let lowers = 0
+  for (const charge of rows) {
+    /**
+     * ⚠️ `Math.abs`, because the type carries the sign. A negative amount that
+     * slipped into the column would otherwise flip its own type's direction and
+     * a `tax` of -200 would quietly reduce what we owe.
+     */
+    const amount = Math.abs(num(charge?.amount))
+    const type = String(charge?.type ?? "")
+    if (RAISES.has(type)) raises += amount
+    else if (LOWERS.has(type)) lowers += amount
+  }
+
+  return {
+    raises: round(raises),
+    lowers: round(lowers),
+    net: round(raises - lowers),
+  }
+}
+
+/**
+ * PURE: the ceiling a claim against this order may not exceed.
+ *
+ * 🔴 `total_price` is GOODS and stays that way — see the model. This adds the
+ * charges rather than folding them in, so an order with no charges yields
+ * EXACTLY `total_price` and every existing row behaves identically. That
+ * property is what makes this safe to put behind a live money guard, and there
+ * is a test that asserts it.
+ *
+ * ⚠️ Never below zero. A write-off larger than the order would otherwise
+ * produce a negative ceiling, which reads as "this partner owes us" — a claim
+ * no data here supports.
+ */
+export const orderPayableCeiling = (
+  order: { total_price?: number | string | null } | null | undefined,
+  charges: OrderCharge[] | null | undefined
+): number => {
+  const goods = num(order?.total_price)
+  const { net } = foldOrderCharges(charges)
+  return round(Math.max(0, goods + net))
+}

--- a/apps/backend/src/modules/inventory_orders/migrations/.snapshot-inventory-orders.json
+++ b/apps/backend/src/modules/inventory_orders/migrations/.snapshot-inventory-orders.json
@@ -728,6 +728,22 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "batch_number": {
+          "name": "batch_number",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
         "metadata": {
           "name": "metadata",
           "type": "jsonb",
@@ -870,6 +886,223 @@
           ],
           "referencedTableName": "public.inventory_orders",
           "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "tax",
+            "shipping",
+            "discount",
+            "adjustment"
+          ],
+          "mappedType": "enum"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "decimal"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "inventory_orders_id": {
+          "name": "inventory_orders_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "raw_amount": {
+          "name": "raw_amount",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "inventory_order_charge",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_inventory_order_charge_inventory_orders_id",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_inventory_order_charge_inventory_orders_id\" ON \"inventory_order_charge\" (\"inventory_orders_id\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_inventory_order_charge_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_inventory_order_charge_deleted_at\" ON \"inventory_order_charge\" (\"deleted_at\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "inventory_order_charge_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "inventory_order_charge_inventory_orders_id_foreign": {
+          "constraintName": "inventory_order_charge_inventory_orders_id_foreign",
+          "columnNames": [
+            "inventory_orders_id"
+          ],
+          "localTableName": "public.inventory_order_charge",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.inventory_orders",
           "updateRule": "cascade"
         }
       },

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260902045214.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260902045214.ts
@@ -1,0 +1,17 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260902045214 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "inventory_order_charge" ("id" text not null, "type" text check ("type" in ('tax', 'shipping', 'discount', 'adjustment')) not null, "amount" numeric not null, "note" text null, "metadata" jsonb null, "inventory_orders_id" text not null, "raw_amount" jsonb not null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "inventory_order_charge_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_inventory_order_charge_inventory_orders_id" ON "inventory_order_charge" ("inventory_orders_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_inventory_order_charge_deleted_at" ON "inventory_order_charge" ("deleted_at") WHERE deleted_at IS NULL;`);
+
+    this.addSql(`alter table if exists "inventory_order_charge" add constraint "inventory_order_charge_inventory_orders_id_foreign" foreign key ("inventory_orders_id") references "inventory_orders" ("id") on update cascade;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "inventory_order_charge" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/inventory_orders/models/order-charge.ts
+++ b/apps/backend/src/modules/inventory_orders/models/order-charge.ts
@@ -1,0 +1,66 @@
+import { model } from "@medusajs/framework/utils";
+import Order from "./order";
+
+/**
+ * An amount on an inventory order that is NOT goods (#1737).
+ *
+ * ## Why this exists
+ *
+ * Three of these turned up in a single reconciliation and none had a home:
+ * 200 of tax on a Terry Towel order, 1,960 of shipping on
+ * `inv_order_01K5QSCSK…`, and an 829 write-off on the same order. The model
+ * carried `total_price` and nothing else, so an order whose real cost included
+ * freight understated it, and a settled remainder could not be recorded at all.
+ * The only writable home was `metadata` — the trap #1557 closed, where an
+ * untyped blob decided payouts.
+ *
+ * ## Why on the ORDER and not the payout
+ *
+ * Tax is a property of the obligation, not of the settlement. Three consequences
+ * if it lived on the payout instead:
+ *
+ *  1. `assessInventoryOrderClaims` refuses any claim past the order's ceiling,
+ *     so a payout correctly including tax would be refused by the guard.
+ *  2. One order is often paid by several payouts, so the charge would have to
+ *     be apportioned across them — the arithmetic that already underpaid a run
+ *     by 22% (#1596). Nobody agreed to a fraction of a tax.
+ *  3. `payable-inventory-orders` derives value from order LINES; a charge off
+ *     the order can never be reached by receipts.
+ *
+ * ## 🔴 `total_price` still means GOODS
+ *
+ * Charges are deliberately NOT folded into it. That column means "what was
+ * ordered" to every reader and every guard, and changing its meaning in place
+ * is the one-column-two-meanings trap that already cost us `quantity` being a
+ * rate or a total (#1559). The payable ceiling is derived from both, in one
+ * place — `lib/order-charges.ts` — so nothing re-derives it differently.
+ */
+const OrderCharge = model.define("inventory_order_charge", {
+  id: model.id({ prefix: "invchg" }).primaryKey(),
+  /**
+   * 🔑 What KIND of amount this is, because the sign is not a property of the
+   * number — it is a property of the type. A `tax` of 200 and a `discount` of
+   * 200 are the same figure and opposite facts, and storing a signed amount
+   * would let a typo flip an obligation into a reduction with nothing to catch
+   * it.
+   */
+  type: model.enum(["tax", "shipping", "discount", "adjustment"]),
+  /** Always POSITIVE. The type decides which way it moves the ceiling. */
+  amount: model.bigNumber(),
+  /**
+   * ⚠️ Why this amount exists, in the operator's words.
+   *
+   * Required in practice for the lowering types — a reduction nobody explained
+   * is exactly how an 829 write-off gets lost and then rediscovered as an
+   * overpayment. Enforced at the route rather than the column so historical
+   * rows can be backfilled without a reason nobody remembers.
+   */
+  note: model.text().nullable(),
+  metadata: model.json().nullable(),
+
+  inventory_orders: model.belongsTo(() => Order, {
+    mappedBy: "charges",
+  }),
+});
+
+export default OrderCharge;

--- a/apps/backend/src/modules/inventory_orders/models/order.ts
+++ b/apps/backend/src/modules/inventory_orders/models/order.ts
@@ -1,5 +1,6 @@
 import { model } from "@medusajs/framework/utils";
 import OrderLine from "./orderline";
+import OrderCharge from "./order-charge";
 
 const InventoryOrder = model.define("inventory_orders", {
   id: model.id({prefix: 'inv_order'}).primaryKey(),
@@ -23,6 +24,12 @@ const InventoryOrder = model.define("inventory_orders", {
   expected_delivery_date: model.dateTime().nullable(),
   order_date: model.dateTime().nullable(),
   orderlines: model.hasMany(() => OrderLine),
+  /**
+   * Amounts that are not goods — tax, shipping, a discount or a write-off
+   * (#1737). ⚠️ `total_price` above stays GOODS; the payable ceiling is derived
+   * from both in `lib/order-charges.ts`, never by folding them together.
+   */
+  charges: model.hasMany(() => OrderCharge),
   metadata: model.json().nullable(),
   shipping_address: model.json().nullable(),
   is_sample: model.boolean().default(false),

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -8,6 +8,7 @@ import {
 import InventoryOrder from "./models/order";
 import OrderLine from "./models/orderline";
 import InventoryOrderActivity from "./models/inventory-order-activity";
+import OrderCharge from "./models/order-charge";
 import type { InventoryOrderInputStatus } from "./constants";
 
 import { InferTypeOf, Context } from "@medusajs/framework/types"
@@ -44,6 +45,7 @@ class InventoryOrderService extends MedusaService({
   InventoryOrder,
   OrderLine,
   InventoryOrderActivity,
+  OrderCharge,
 }) {
   constructor() {
     super(...arguments)

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -1374,6 +1374,15 @@ const validateInventoryOrderLinesStep = createStep(
         "orderlines.price",
         "orderlines.material_name",
         "orderlines.line_fulfillments.quantity_delta",
+        /**
+         * 🔴 The amounts that are not goods (#1737). `assessInventoryOrderClaims`
+         * reads these to build the ceiling; without them here the guard sees
+         * `undefined`, silently falls back to bare `total_price`, and refuses a
+         * legitimate claim for the tax the partner is owed. A guard reading a
+         * field the query never fetched is dead code that types perfectly.
+         */
+        "charges.type",
+        "charges.amount",
       ],
       filters: { id: orderIds },
     })

--- a/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
@@ -5,6 +5,10 @@ import { PAYMENT_SUBMISSIONS_MODULE } from "../../../modules/payment_submissions
 import type PaymentSubmissionsService from "../../../modules/payment_submissions/service"
 import { listPartnerClaims } from "./run-claims"
 import { valueInventoryOrderByReceipts } from "./inventory-order-value"
+import {
+  foldOrderCharges,
+  orderPayableCeiling,
+} from "../../../modules/inventory_orders/lib/order-charges"
 
 /**
  * What a partner is owed for GOODS, as opposed to for work (#1612, #1710).
@@ -28,8 +32,19 @@ export type PayableInventoryOrder = {
   status: string | null
   is_sample: boolean
   currency_code: string | null
-  /** What was ORDERED. This is the guard's ceiling. */
+  /**
+   * What was ORDERED — GOODS only, unchanged in meaning (#1737). Charges sit
+   * beside it in `charges_total`; `payable_ceiling` is what a claim may reach.
+   */
   ordered_total: number | null
+  /** Tax + shipping − discounts on this order, folded once (#1737). */
+  charges_total: number
+  /**
+   * What a claim against this order may not exceed: goods + charges. The SAME
+   * figure `assessInventoryOrderClaims` enforces — both call
+   * `orderPayableCeiling`, so the screen cannot offer what the guard refuses.
+   */
+  payable_ceiling: number | null
   /** What the RECEIPTS are worth, before any cap. */
   receipts_total: number
   received_quantity: number
@@ -135,6 +150,14 @@ export const listPayableInventoryOrders = async (
       "inventory_orders.internal_payments.id",
       "inventory_orders.internal_payments.amount",
       "inventory_orders.internal_payments.status",
+      /**
+       * 🔴 The amounts that are not goods (#1737). The ceiling this screen
+       * offers from MUST be the one `assessInventoryOrderClaims` enforces —
+       * a figure an operator reads must be the figure that gets written
+       * (#1616). Both now call `orderPayableCeiling`.
+       */
+      "inventory_orders.charges.type",
+      "inventory_orders.charges.amount",
     ],
     filters: { id: partnerId },
   })
@@ -175,7 +198,16 @@ export const listPayableInventoryOrders = async (
        * figure the guard rejects and the operator learns the rule from a 400.
        */
       const ordered = Number(order.total_price ?? 0)
-      const ceiling = Number.isFinite(ordered) && ordered > 0 ? ordered : null
+      /**
+       * 🔴 Goods PLUS the charges that are not goods (#1737), from the SAME
+       * function the write guard uses. Offering a figure `create` then rejects
+       * is the defect `runPayableOffer` was extracted to prevent (#1616), and
+       * the reverse — a guard that allows more than the screen offers — leaves
+       * a partner silently short of the tax they invoiced.
+       */
+      const withCharges = orderPayableCeiling(order, order.charges)
+      const ceiling =
+        Number.isFinite(withCharges) && withCharges > 0 ? withCharges : null
 
       const remaining =
         ceiling == null
@@ -234,7 +266,19 @@ export const listPayableInventoryOrders = async (
         status: order.status ?? null,
         is_sample: !!order.is_sample,
         currency_code: order.currency_code ?? null,
-        ordered_total: ceiling,
+        /**
+         * 🔴 GOODS, as it always meant. Charges are reported beside it rather
+         * than folded in — silently widening this field would be the
+         * one-column-two-meanings trap that already cost us `quantity` being a
+         * rate or a total (#1559). Read `payable_ceiling` for what a claim may
+         * reach.
+         */
+        ordered_total:
+          Number.isFinite(ordered) && ordered > 0 ? ordered : null,
+        /** Tax + shipping − discounts, folded once (#1737). */
+        charges_total: foldOrderCharges(order.charges).net,
+        /** What a claim against this order may not exceed: goods + charges. */
+        payable_ceiling: ceiling,
         receipts_total: uncapped,
         received_quantity: value.received_quantity,
         lines: value.lines,

--- a/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
@@ -41,6 +41,10 @@
 
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { runBillableCeiling, isOpenEndedRun } from "./run-billable-ceiling"
+import {
+  orderPayableCeiling,
+  type OrderCharge,
+} from "../../../modules/inventory_orders/lib/order-charges"
 
 export type PriorRunLine = {
   submission_id: string | null
@@ -753,7 +757,23 @@ export type OverclaimedInventoryOrder = {
 export function assessInventoryOrderClaims(input: {
   /** Requested amount per order, already summed across this submission. */
   requestedByOrder: Map<string, number>
-  orders: Map<string, { total_price?: number | string | null }>
+  orders: Map<
+    string,
+    {
+      total_price?: number | string | null
+      /**
+       * Amounts that are not goods — tax, shipping, a discount (#1737).
+       *
+       * ⚠️ Must be FETCHED by the caller. A guard reading a field the query
+       * never asked for is dead code that types perfectly (#1606).
+       *
+       * 🔑 Absent or empty leaves the ceiling EXACTLY `total_price`, so every
+       * order without charges behaves precisely as it did before this existed.
+       * That property is what makes adding a term to a live money guard safe.
+       */
+      charges?: OrderCharge[] | null
+    }
+  >
   claims: Map<string, InventoryOrderClaim>
 }): OverclaimedInventoryOrder[] {
   const overclaimed: OverclaimedInventoryOrder[] = []
@@ -776,8 +796,14 @@ export function assessInventoryOrderClaims(input: {
      * ABOVE the ordered total — so an amountless line, which defaults to the
      * receipts figure, is refused here rather than silently overpaying.
      */
-    const ordered = Number(order.total_price ?? 0)
-    const ceiling = Number.isFinite(ordered) ? ordered : 0
+    /**
+     * 🔴 Goods PLUS the charges that are not goods (#1737). `orderPayableCeiling`
+     * is the single owner of that arithmetic — `payable-inventory-orders`
+     * offers from the same function, because a screen offering a figure this
+     * guard then rejects is the defect `runPayableOffer` was extracted to
+     * prevent (#1616).
+     */
+    const ceiling = orderPayableCeiling(order, order.charges)
 
     // A ceiling of zero means the order is worth nothing we can read. Refusing
     // on that would block every payout on an unpriced order; the whole-order


### PR DESCRIPTION
Two missing doors, both found by trying to reconcile one partner's estate and being unable to record what a human already knew.

## 1. `POST`/`DELETE /admin/payments/:id/records-against`

`inventoryOrderIds` on `/admin/payments/link` writes the order link **only at creation**. `UpdatePaymentSchema` is `.strict()` with no link fields, and `backfill-inventory-order-payment-links` only walks payments that came through a payout. So a payment already in the system could **never** be attached to an order — the only workaround was delete-and-recreate, losing its id and `created_at`, which is the same manoeuvre that produced a duplicate 4,500 on Sunny's ledger.

**Measured:** `inv_order_01K5QSCSK…` reads `recorded_total: 0` and is offered at its full **56,856.94** while **58,000** has been paid against it in two unlinked payments. The guard that would warn reads `internal_payments` on the order, and nobody could put one there.

The mirror of `/settles`, one entity over — both ends validated against each other via the shared `same-partner` lib, a cancelled order refused, dismiss-before-create so re-stating a fact isn't a 500, and `DELETE` to take it back.

⚠️ **Recording is not settling.** It makes money visible and arms the warning; `/settles` remains the only thing that moves `paid`. A test asserts the order's offered `amount` is unchanged after linking.

**Scope:** `inventory_order` only. The customer-order case needs a store-order link table that doesn't exist, so it is deliberately **not** stubbed — a `target_type` accepting a value the route can't honour is worse than its absence.

## 2. Charges on an inventory order

Three amounts turned up in one reconciliation with no home: **200** of tax, **1,960** of shipping, an **829** write-off. The model had `total_price` and nothing else. `metadata` was the only writable place — the trap #1557 closed.

**On the order, not the payout:** tax is a property of the obligation; the ceiling guard would otherwise refuse a payout that correctly includes it; and an order paid in tranches would force the charge to be apportioned — the arithmetic that already underpaid a run by 22% (#1596).

🔴 **`total_price` still means GOODS.** Charges are added, never folded in — widening that column in place is the one-column-two-meanings trap that already cost us `quantity` being a rate or a total (#1559). The row now reports `ordered_total`, `charges_total` and `payable_ceiling` separately.

🔑 **The sign lives on the type, not the amount.** A `tax` of 200 and a `discount` of 200 are the same figure and opposite facts. Amounts are positive and `Math.abs`-ed, so a negative that slips into the column can't invert its own type. An unknown type counts in **neither** direction rather than being guessed upward — guessing invents an obligation, the direction that overpays.

🔴 **A reduction must say why**, enforced at the route. The 829 sat as an unexplained gap and read as an *over*payment until a human remembered the shipping.

`orderPayableCeiling` is the single owner of the arithmetic, read by both `assessInventoryOrderClaims` and `payable-inventory-orders` — a screen offering what the guard refuses is the defect `runPayableOffer` was extracted to prevent (#1616). The caller now **fetches** `charges.type`/`charges.amount`; a guard reading a field the query never asked for is dead code that types perfectly.

## Safety

🔑 **An order with no charges yields exactly `total_price`**, so every existing production row behaves identically. There's a test for that property, and it's what makes adding a term to a live money guard safe.

⚠️ The generated migration also re-emitted `inventory_order_line.batch_number`, already shipped by `Migration20260702130000` (hand-written, so the snapshot never recorded it). **Stripped** — `up` was idempotent but `down` would have dropped a column another migration owns.

## Verification

- **10 unit** cases on the ceiling arithmetic, **14 integration** cases
- **Both guards mutation-checked:** disabling the same-partner check fails the cross-partner case; reverting the ceiling to bare `total_price` fails *"lets a claim reach the tax the partner invoiced"* — which asserts the same claim is **400 before** the charge and **201 after**
- `check:prod-build` green

```
cd apps/backend
TEST_TYPE=unit npx jest --testPathPattern="order-charges"
TEST_TYPE=integration:http NODE_OPTIONS="--experimental-vm-modules" \
  npx jest --testPathPattern="payment-submissions-api" -t "#1737"
```

Closes part of #1737 — the customer-order target and the run tax-inclusivity note remain open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
