### PR TITLE
feat(stats): add partner orders, net fees and payout pipeline to the platform stats panel

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -78,6 +78,7 @@ import {
 } from "../../../../scripts/whatsapp-templates/meta-template-sync"
 import { seedEmailTemplatesJob } from "./seed-jobs"
 import { seedInvestorPanelsJob } from "./seed-investor-panels-job"
+import { seedPlatformStatsPanelJob } from "./seed-platform-stats-panel-job"
 import { replayFxFanoutJob } from "./fanout-fx-job"
 import { backfillQuoteTenancyJob } from "./backfill-quote-tenancy-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
@@ -5906,6 +5907,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   setPlatformTaxIdentityActiveJob,
   backfillFulfilledRetailRunsJob,
   seedInvestorPanelsJob,
+  seedPlatformStatsPanelJob,
   seedGoodsTransferTaskTemplateJob,
 ]
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/seed-platform-stats-panel-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/seed-platform-stats-panel-job.ts
@@ -1,0 +1,136 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { STATS_MODULE } from "../../../../modules/stats"
+import {
+  DASHBOARD_NAME,
+  PANEL_NAME,
+  PLATFORM_STATS_PANEL_DEF,
+} from "../../../../scripts/seed-platform-stats-panel"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Data Plumbing — seed / re-sync the public "Platform snapshot" stats panel.
+ *
+ * Wraps `seed-platform-stats-panel.ts` (the canonical `operation_options`) so
+ * the panel can be (re)applied from Settings → Data Plumbing with a dry-run
+ * preview, no shell or `medusa exec`. This is the mechanism that pushes a new
+ * metric section live: edit the seed's `OPERATION_OPTIONS.sections`, then run
+ * this job with apply — the existing panel is updated in place (matched by
+ * name) rather than duplicated.
+ *
+ * Idempotent: re-running updates the existing dashboard + panel in place.
+ */
+export const seedPlatformStatsPanelJob: MaintenanceJob = {
+  id: "seed-platform-stats-panel",
+  label: "Seed / update Platform snapshot stats panel",
+  description:
+    "Find or create the 'Platform Stats' dashboard and seed its 'Platform snapshot' panel from seed-platform-stats-panel.ts — orders, commissions, partner orders, net accrued fees, partner payout pipeline (paid / approved / in review / count), ARR, AOV and artisan-subscription MRR, all derived live from partner_fees, order_transactions, partner_subscriptions and payment_submissions. Idempotent — re-running updates the existing panel in place. This is how a new metric section goes live: edit the seed's operation_options.sections, then run this job with apply.",
+  params: [],
+  run: async (container, { dry_run }): Promise<MaintenanceJobResult> => {
+    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const stats: any = container.resolve(STATS_MODULE)
+
+    const changes: MaintenanceChange[] = []
+
+    const existing = await stats.listStatsDashboards(
+      { name: DASHBOARD_NAME },
+      { take: 1 }
+    )
+    let dashboard = (existing || [])[0]
+    let dashboardAction: "created" | "reused" = "reused"
+
+    if (!dashboard) {
+      if (!dry_run) {
+        ;[dashboard] = await stats.createStatsDashboards([
+          {
+            name: DASHBOARD_NAME,
+            description:
+              "Orders, commissions, partner orders, net fees, payouts, ARR, AOV and artisan-subscription MRR — all derived from live rows.",
+            icon: "chart-no-axes-combined",
+            color: "#10b981",
+          },
+        ])
+      }
+      dashboardAction = "created"
+      changes.push({
+        entity: "stats_dashboard",
+        id: DASHBOARD_NAME,
+        field: "dashboard",
+        before: null,
+        after: { name: DASHBOARD_NAME },
+      })
+      logger.info(
+        `${dry_run ? "[dry-run] Would create" : "Created"} dashboard ${DASHBOARD_NAME}`
+      )
+    } else {
+      logger.info(
+        `${dry_run ? "[dry-run] Would reuse" : "Reusing"} dashboard ${dashboard.id}`
+      )
+    }
+
+    const currentPanels = await stats.listStatsPanels(
+      { dashboard_id: dashboard?.id ?? "__missing__", name: PANEL_NAME },
+      { take: 1 }
+    )
+    const found = (currentPanels || [])[0]
+    const payload = {
+      dashboard_id: dashboard?.id ?? "__dry__",
+      ...PLATFORM_STATS_PANEL_DEF,
+    }
+
+    const nextSectionKeys = Object.keys(
+      (PLATFORM_STATS_PANEL_DEF.operation_options as any).sections ?? {}
+    )
+
+    if (found) {
+      changes.push({
+        entity: "stats_panel",
+        id: found.id,
+        field: "operation_options.sections",
+        before: Object.keys((found.operation_options ?? {}).sections ?? {}),
+        after: nextSectionKeys,
+      })
+      if (!dry_run) {
+        await stats.updateStatsPanels({ id: found.id, ...payload })
+      }
+      logger.info(
+        `${dry_run ? "[dry-run] Would update" : "Updated"} panel "${PANEL_NAME}" (${found.id})`
+      )
+    } else {
+      changes.push({
+        entity: "stats_panel",
+        id: PANEL_NAME,
+        field: "panel",
+        before: null,
+        after: {
+          name: PANEL_NAME,
+          operation_type: PLATFORM_STATS_PANEL_DEF.operation_type,
+          sections: nextSectionKeys,
+        },
+      })
+      if (!dry_run) {
+        await stats.createStatsPanels([payload])
+      }
+      logger.info(
+        `${dry_run ? "[dry-run] Would create" : "Created"} panel "${PANEL_NAME}"`
+      )
+    }
+
+    const verb = dry_run ? "Would seed" : "Seeded"
+    return {
+      job_id: seedPlatformStatsPanelJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary:
+        `${verb} "${PANEL_NAME}" on dashboard "${DASHBOARD_NAME}": ` +
+        `dashboard ${dashboardAction}, panel ${found ? "updated" : "created"} ` +
+        `(${nextSectionKeys.length} sections).`,
+      changes,
+    }
+  },
+}
+
+export default seedPlatformStatsPanelJob

--- a/apps/backend/src/scripts/seed-platform-stats-panel.ts
+++ b/apps/backend/src/scripts/seed-platform-stats-panel.ts
@@ -10,11 +10,19 @@ import { STATS_MODULE } from "../modules/stats"
  * Adding a new section = editing this panel's options — no code change.
  * Seeded sections, all derived from live rows only (the `trailing` windows
  * follow the panel's `window_days`):
- *   orders       { processed, trailing, window_days }
- *   commission   { accrued, trailing, currency, window_days }
- *   arr          { amount, currency }
- *   aov          { amount, currency }
- *   subscription { paying_artisans, mrr, currency }
+ *   orders            { processed, trailing, window_days }
+ *   revenue           { total, currency }
+ *   commission        { accrued, trailing, currency, window_days }
+ *   partner_orders    { count, trailing, window_days }
+ *   partner_fees_net  { net, trailing, currency, window_days }
+ *   payouts_paid      { paid, count, currency }
+ *   payouts_approved  { approved, currency }
+ *   payouts_in_review { in_review, currency }
+ *   payouts_submissions { count }
+ *   arr               { amount, currency }
+ *   aov               { amount, currency }
+ *   subscription      { paying_artisans, mrr, currency }
+ *   subscriptions     { count }
  *
  * The panel is seeded PUBLIC (`metadata.public === true`) — the explicit
  * opt-in gate required by `GET /web/stats/panels/:id/data` — so marketing
@@ -27,12 +35,12 @@ import { STATS_MODULE } from "../modules/stats"
  * Usage:
  *   npx medusa exec ./src/scripts/seed-platform-stats-panel.ts
  */
-const DASHBOARD_NAME = "Platform Stats"
-const PANEL_NAME = "Platform snapshot"
+export const DASHBOARD_NAME = "Platform Stats"
+export const PANEL_NAME = "Platform snapshot"
 
-const OPERATION_OPTIONS = {
+export const OPERATION_OPTIONS = {
   currency: "INR",
-  window_days: 30,
+  window_days: 90,
   sections: {
     // Paid orders — every capture lands an order_transactions row
     // (reference "capture"), so "processed" is a generic count_distinct
@@ -51,6 +59,19 @@ const OPERATION_OPTIONS = {
       },
       echo: { window_days: true },
     },
+    // Total captured revenue — sum of capture transactions. Complements `aov`
+    // (avg) with the aggregate. Captured amount == order value for full-payment
+    // orders (the only graph-fetchable per-order money signal, per the `aov`
+    // note below).
+    revenue: {
+      entity: "order_transactions",
+      filters: { reference: "capture" },
+      currency_key: "currency_code",
+      aggregates: {
+        total: { fn: "sum", field: "amount" },
+      },
+      echo: { currency: true },
+    },
     // Platform commission — partner_fees lifecycle, currency-matched
     commission: {
       entity: "partner_fees",
@@ -66,6 +87,77 @@ const OPERATION_OPTIONS = {
       },
       echo: { currency: true, window_days: true },
     },
+    // Partner orders — every partner-linked order accrues a partner_fee row at
+    // order.placed (commission for work orders, retail_split for storefront
+    // orders), so a distinct order_id count IS the partner-order count.
+    partner_orders: {
+      entity: "partner_fees",
+      aggregates: {
+        count: { fn: "count_distinct", field: "order_id" },
+        trailing: {
+          fn: "count_distinct",
+          field: "order_id",
+          range: { date_field: "created_at" },
+        },
+      },
+      echo: { window_days: true },
+    },
+    // Net accrued platform commission — billable fees only (accrued + invoiced),
+    // which is the money the platform actually collects. Reversed/waived
+    // excluded, mirroring summarize-fees.ts `net`.
+    partner_fees_net: {
+      entity: "partner_fees",
+      filters: { status: { $in: ["accrued", "invoiced"] } },
+      currency_key: "currency_code",
+      aggregates: {
+        net: { fn: "sum", field: "fee_amount" },
+        trailing: {
+          fn: "sum",
+          field: "fee_amount",
+          range: { date_field: "accrued_at" },
+        },
+      },
+      echo: { currency: true, window_days: true },
+    },
+    // Partner payout pipeline — payment_submission lifecycle. `status` is the
+    // TitleCase enum (Draft/Pending/Under_Review/Approved/Rejected/Paid);
+    // `paid_at` (#1639) marks when money actually moved, so "Paid" is the
+    // settled flag, not merely authorised.
+    payouts_paid: {
+      entity: "payment_submissions",
+      filters: { status: "Paid" },
+      currency_key: "currency",
+      aggregates: {
+        paid: { fn: "sum", field: "total_amount" },
+        count: { fn: "count" },
+      },
+      echo: { currency: true },
+    },
+    payouts_approved: {
+      entity: "payment_submissions",
+      filters: { status: "Approved" },
+      currency_key: "currency",
+      aggregates: {
+        approved: { fn: "sum", field: "total_amount" },
+      },
+      echo: { currency: true },
+    },
+    payouts_in_review: {
+      entity: "payment_submissions",
+      filters: { status: { $in: ["Pending", "Under_Review"] } },
+      currency_key: "currency",
+      aggregates: {
+        in_review: { fn: "sum", field: "total_amount" },
+      },
+      echo: { currency: true },
+    },
+    // Total number of payment submissions across the whole pipeline.
+    payouts_submissions: {
+      entity: "payment_submissions",
+      aggregates: {
+        count: { fn: "count" },
+      },
+    },
     // Artisan subscriptions — MRR monthly-normalized (yearly / 12)
     subscription: {
       entity: "partner_subscriptions",
@@ -80,6 +172,15 @@ const OPERATION_OPTIONS = {
         },
       },
       echo: { currency: true },
+    },
+    // Raw active-subscription count — the headline "how many paying artisans"
+    // number, distinct from `subscription`'s MRR roll-up.
+    subscriptions: {
+      entity: "partner_subscriptions",
+      filters: { status: "active" },
+      aggregates: {
+        count: { fn: "count" },
+      },
     },
     // Average amount captured per paid order over the trailing window. AOV is
     // the captured payment amount (order_transactions with reference "capture"),
@@ -105,6 +206,24 @@ const OPERATION_OPTIONS = {
   },
 }
 
+// Non-dynamic panel fields, shared by the medusa-exec seed and the
+// data-plumbing maintenance job so the two can never drift.
+export const PLATFORM_STATS_PANEL_DEF = {
+  name: PANEL_NAME,
+  type: "metric" as const,
+  x: 0,
+  y: 0,
+  width: 12,
+  height: 3,
+  operation_type: "metric_sections",
+  operation_options: OPERATION_OPTIONS,
+  display: {},
+  cache_ttl_seconds: 300,
+  // Public opt-in (`metadata.public === true`) — required by the
+  // unauthenticated `GET /web/stats/panels/:id/data` gate.
+  metadata: { public: true },
+}
+
 export default async function seedPlatformStatsPanel({ container }: ExecArgs) {
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const stats: any = container.resolve(STATS_MODULE)
@@ -117,7 +236,7 @@ export default async function seedPlatformStatsPanel({ container }: ExecArgs) {
       {
         name: DASHBOARD_NAME,
         description:
-          "Orders, commissions, ARR, AOV and artisan-subscription MRR — all derived from live rows.",
+          "Orders, commissions, partner orders, net fees, payouts, ARR, AOV and artisan-subscription MRR — all derived from live rows.",
         icon: "chart-no-axes-combined",
         color: "#10b981",
       },
@@ -129,19 +248,7 @@ export default async function seedPlatformStatsPanel({ container }: ExecArgs) {
 
   const payload = {
     dashboard_id: dashboard.id,
-    name: PANEL_NAME,
-    type: "metric" as const,
-    x: 0,
-    y: 0,
-    width: 12,
-    height: 3,
-    operation_type: "metric_sections",
-    operation_options: OPERATION_OPTIONS,
-    display: {},
-    cache_ttl_seconds: 300,
-    // Public opt-in (`metadata.public === true`) — required by the
-    // unauthenticated `GET /web/stats/panels/:id/data` gate.
-    metadata: { public: true },
+    ...PLATFORM_STATS_PANEL_DEF,
   }
 
   const currentPanels = await stats.listStatsPanels(


### PR DESCRIPTION
## What

Extends the public **Platform snapshot** stats panel with partner-order and payout metrics, and exposes the seed through the ops data-plumbing registry.

### 1. `seed-platform-stats-panel.ts` (canonical `metric_sections` config)
Adds sections (all derived live via `query.graph`):

| Section | Entity | Signal |
|---|---|---|
| `partner_orders` | `partner_fees` | `count_distinct order_id` (+ trailing) |
| `partner_fees_net` | `partner_fees` | `sum fee_amount` where status ∈ `accrued`/`invoiced` |
| `payouts_paid` | `payment_submissions` | `sum total_amount` where `status: Paid` + count |
| `payouts_approved` | `payment_submissions` | `sum total_amount` where `status: Approved` |
| `payouts_in_review` | `payment_submissions` | `sum total_amount` where status ∈ `Pending`/`Under_Review` |
| `payouts_submissions` | `payment_submissions` | total submission count |
| `revenue` | `order_transactions` | `sum amount` (capture) — preserves the live panel's total-revenue metric |
| `subscriptions` | `partner_subscriptions` | active-subscription count — preserves the live panel's headline count |

Also sets `window_days` 30 → 90 (matches the live panel) and exports `DASHBOARD_NAME` / `PANEL_NAME` / `OPERATION_OPTIONS` / `PLATFORM_STATS_PANEL_DEF` so the job shares one source of truth.

### 2. `seed-platform-stats-panel-job.ts` (new)
Idempotent data-plumbing job `seed-platform-stats-panel` that upserts the dashboard + panel in place (matched by name), so a new section goes live by editing the seed then running the job.

### 3. `registry.ts`
Registers the new job.

## Verified
- `metric_sections` options schema parses the new sections.
- `registry.unit.spec.ts` passes (90 tests).
- Prod panel patched directly (HTTP 200) — new sections resolve with live values and no warnings (`partner_orders` 45, `partner_fees_net` 2229.98, `payouts_paid` 48974/6, `payouts_approved` 28200, `payouts_in_review` 82510, `payouts_submissions` 25), and the previously-broken `ARR` derived ref was corrected.