### PR TITLE
feat(inventory-orders): assign a partner to a historical order without commissioning it (#1737)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -5313,6 +5313,146 @@ setupSharedTestSuite(() => {
         })
       })
 
+      /**
+       * #1737 — assigning a partner to a HISTORICAL order without commissioning
+       * anything. `send-to-partner` is the only other writer of this link and
+       * it emits `inventory_order_assigned_to_partner` and parks
+       * `awaitOrderStart`/`awaitOrderCompletion` — right for new work, wrong for
+       * a delivery from five months ago.
+       */
+      describe("POST /admin/inventory-orders/:id/assign-partner (#1737)", () => {
+        /**
+         * An order created with NO partner link — the historical-record shape
+         * this route exists for. `seedOrderForPartner` cannot be used here: it
+         * goes through `send-to-partner`, which links the order as a side
+         * effect, and a test built on it would assert nothing.
+         */
+        const seedUnlinkedOrder = async (tag: string) => {
+          const inventoryItemId = await seedInventoryItem(tag)
+          const stockLocationId = await seedStockLocation()
+          const created = await api
+            .post(
+              "/admin/inventory-orders",
+              {
+                order_lines: [
+                  { inventory_item_id: inventoryItemId, quantity: 4, price: 250 },
+                ],
+                quantity: 4,
+                total_price: 1000,
+                status: "Pending",
+                expected_delivery_date: new Date().toISOString(),
+                order_date: new Date().toISOString(),
+                shipping_address: {},
+                stock_location_id: stockLocationId,
+              },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+          expect(created.status).toBe(201)
+          return created.data.inventoryOrder.id as string
+        }
+
+        const visibleTo = async (partnerId: string, orderId: string) => {
+          const list = await api.get(
+            `/admin/payment-submissions/payable-inventory-orders?partner_id=${partnerId}`,
+            adminHeaders
+          )
+          expect(list.status).toBe(200)
+          return list.data.payable_inventory_orders.some(
+            (o: any) => o.inventory_order_id === orderId
+          )
+        }
+
+        /**
+         * 🔑 Without the link an order is invisible in every partner-scoped
+         * view: `payable-inventory-orders` reaches orders THROUGH the partner,
+         * because there is no partner column on an inventory order.
+         */
+        it("makes an unlinked order visible to its partner", async () => {
+          const stamp = Date.now() + 410
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedUnlinkedOrder(`ap0-${stamp}`)
+
+          // It genuinely starts invisible — otherwise this asserts nothing.
+          expect(await visibleTo(owner.partnerId, orderId)).toBe(false)
+
+          const res = await api
+            .post(
+              `/admin/inventory-orders/${orderId}/assign-partner`,
+              { partner_id: owner.partnerId },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(200)
+          /** Stated plainly on the response: nothing was commissioned. */
+          expect(res.data.notified).toBe(false)
+
+          expect(await visibleTo(owner.partnerId, orderId)).toBe(true)
+        })
+
+        it("is idempotent — re-stating the same assignment is not a 500", async () => {
+          const stamp = Date.now() + 420
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `ap1-${stamp}`)
+
+          for (const _ of [1, 2]) {
+            const res = await api
+              .post(
+                `/admin/inventory-orders/${orderId}/assign-partner`,
+                { partner_id: owner.partnerId },
+                adminHeaders
+              )
+              .catch((e: any) => e.response)
+            expect(res.status).toBe(200)
+          }
+        })
+
+        /**
+         * 🔴 Silently re-pointing an order would move a debt between partners,
+         * and the previous owner would simply stop seeing work they may already
+         * have billed.
+         */
+        it("refuses to move an order that already belongs to someone else", async () => {
+          const stamp = Date.now() + 430
+          const a = await createPartnerWithAuth(stamp)
+          const b = await createPartnerWithAuth(stamp + 1)
+          const orderId = await seedOrderForPartner(a.partnerId, `ap2-${stamp}`)
+
+          await api.post(
+            `/admin/inventory-orders/${orderId}/assign-partner`,
+            { partner_id: a.partnerId },
+            adminHeaders
+          )
+
+          const res = await api
+            .post(
+              `/admin/inventory-orders/${orderId}/assign-partner`,
+              { partner_id: b.partnerId },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(400)
+        })
+
+        it("refuses a partner that does not exist", async () => {
+          const stamp = Date.now() + 440
+          const owner = await createPartnerWithAuth(stamp)
+          const orderId = await seedOrderForPartner(owner.partnerId, `ap3-${stamp}`)
+
+          const res = await api
+            .post(
+              `/admin/inventory-orders/${orderId}/assign-partner`,
+              { partner_id: "partner_does_not_exist" },
+              adminHeaders
+            )
+            .catch((e: any) => e.response)
+
+          expect(res.status).toBe(404)
+        })
+      })
+
       it("still refuses a submission naming nothing at all", async () => {
         const res = await api
           .post(

--- a/apps/backend/src/api/admin/inventory-orders/[id]/assign-partner/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/assign-partner/route.ts
@@ -1,0 +1,128 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/modules-sdk"
+
+import PartnerInventoryOrderLink from "../../../../../links/partner-inventory-order"
+import { ORDER_INVENTORY_MODULE } from "../../../../../modules/inventory_orders"
+import { PARTNER_MODULE } from "../../../../../modules/partner"
+
+/**
+ * POST /admin/inventory-orders/:id/assign-partner  { partner_id }
+ *
+ * Say which partner an inventory order belongs to, and nothing else (#1737).
+ *
+ * ## Why this exists next to `send-to-partner`
+ *
+ * `POST /admin/inventory-orders/:id/send-to-partner` is the only writer of the
+ * `partner-inventory-order` link, and it does far more than write it: it emits
+ * `inventory_order_assigned_to_partner` (which a subscriber turns into a real
+ * message to the partner) and it starts `awaitOrderStart` / `awaitOrderCompletion`,
+ * async steps that park a workflow until the partner signals they have begun
+ * and finished.
+ *
+ * That is exactly right for commissioning NEW work. It is wrong for recording
+ * work that is already done: a historical order backfilled during a
+ * reconciliation would message a partner about a delivery from five months ago
+ * and leave a workflow waiting for them to start it — and a workflow await
+ * cannot outlive 24.85 days anyway (#1547), so the park is noise that later
+ * fails.
+ *
+ * 🔑 Without the link an order is invisible in every partner-scoped view:
+ * `payable-inventory-orders` reaches orders THROUGH the partner, because there
+ * is no partner column on an inventory order. So an order created for a
+ * historical record and never linked is an order nobody can bill or see — the
+ * capability-with-no-door shape this issue is about.
+ *
+ * ⚠️ This route commissions NOTHING. No event, no notification, no workflow, no
+ * status change. If you are assigning work a partner has not started, use
+ * `send-to-partner` — it is the one that tells them.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const partnerId = String(
+    (req.validatedBody as any)?.partner_id ??
+      (req.body as any)?.partner_id ??
+      ""
+  ).trim()
+
+  if (!partnerId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "partner_id is required"
+    )
+  }
+
+  /**
+   * 🔴 BOTH ends validated, the same rule as `/settles` and `/records-against`.
+   * A request naming two ids that checks one is the #778 shape, and here the
+   * unchecked id decides whose payables an order appears in.
+   */
+  const orderService: any = req.scope.resolve(ORDER_INVENTORY_MODULE)
+  const [order] = (await orderService.listInventoryOrders({
+    id: [req.params.id],
+  })) as any[]
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Inventory order ${req.params.id} not found`
+    )
+  }
+
+  const partnerService: any = req.scope.resolve(PARTNER_MODULE)
+  const [partner] = (await partnerService.listPartners({
+    id: [partnerId],
+  })) as any[]
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Partner ${partnerId} not found`
+    )
+  }
+
+  /**
+   * ⚠️ Refuse to move an order that already belongs to someone else. Silently
+   * re-pointing it would move a debt between partners — and the previous owner
+   * would simply stop seeing work they may already have billed.
+   */
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  const { data: existing } = await query.graph({
+    entity: PartnerInventoryOrderLink.entryPoint,
+    fields: ["partner_id"],
+    filters: { inventory_orders_id: req.params.id },
+  })
+  const current = ((existing || []) as any[])
+    .map((r) => r?.partner_id)
+    .filter(Boolean)
+    .map(String)
+
+  const other = current.find((id) => id !== partnerId)
+  if (other) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Inventory order ${req.params.id} already belongs to partner ${other}. Reassigning it would move a debt between partners — unlink it deliberately first.`
+    )
+  }
+
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link
+
+  /**
+   * ⚠️ `link.create` is not idempotent — a repeat raises on the composite key
+   * (#1129). Dismiss first so re-stating the same fact is a no-op.
+   */
+  const definition = {
+    [PARTNER_MODULE]: { partner_id: partnerId },
+    [ORDER_INVENTORY_MODULE]: { inventory_orders_id: req.params.id },
+  }
+  await remoteLink.dismiss(definition).catch(() => undefined)
+  await remoteLink.create(definition as any)
+
+  return res.status(200).json({
+    inventory_order_id: req.params.id,
+    partner_id: partnerId,
+    assigned: true,
+    /** Stated plainly: nothing was commissioned and nobody was told. */
+    notified: false,
+  })
+}

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -270,3 +270,17 @@ export const createInventoryOrderChargeSchema = z.object({
 export type CreateInventoryOrderCharge = z.infer<
   typeof createInventoryOrderChargeSchema
 >
+
+/**
+ * Which partner an inventory order belongs to (#1737).
+ *
+ * ⚠️ Assignment only — `send-to-partner` is what COMMISSIONS work and tells the
+ * partner. See the route for why a historical record needs a quiet writer.
+ */
+export const assignInventoryOrderPartnerSchema = z.object({
+  partner_id: z.string().min(1),
+})
+
+export type AssignInventoryOrderPartner = z.infer<
+  typeof assignInventoryOrderPartnerSchema
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -191,7 +191,7 @@ import { updatePartnerMeSchema } from "./partners/me/validators";
 import { onboardingProfileUpdateSchema } from "./partners/onboarding-profile/validators";
 import { setLayoutConfigurationSchema } from "./partners/layouts/validators";
 import { AdminGetPartnersParamsSchema } from "./admin/persons/partner/validators";
-import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema, createInventoryOrderChargeSchema } from "./admin/inventory-orders/validators";
+import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema, createInventoryOrderChargeSchema, assignInventoryOrderPartnerSchema } from "./admin/inventory-orders/validators";
 import { createRawMaterialGroupSchema, updateRawMaterialGroupSchema, listRawMaterialGroupsQuerySchema, addGroupColorSchema, addGroupColorFullSchema, linkGroupColorsSchema, createGroupOrderSchema, readGroupQuerySchema } from "./admin/raw-material-groups/validators";
 import { pinDesignGroupSchema, updateDesignGroupSchema } from "./admin/designs/[id]/material-groups/validators";
 // Import already defined above
@@ -4259,6 +4259,13 @@ export default defineMiddlewares({
       matcher: "/admin/inventory-orders",
       method: 'GET',
       middlewares: [validateAndTransformQuery(wrapSchema(listInventoryOrdersQuerySchema), {})]
+    },
+    {
+      matcher: "/admin/inventory-orders/:id/assign-partner",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(assignInventoryOrderPartnerSchema)),
+      ],
     },
     /**
      * #1737 — amounts on an order that are not goods.


### PR DESCRIPTION
`POST /admin/inventory-orders/:id/send-to-partner` was the **only** writer of the `partner-inventory-order` link, and it does far more than write it:

- emits `inventory_order_assigned_to_partner`, which a subscriber turns into a real message to the partner
- starts `awaitOrderStart` / `awaitOrderCompletion` — async steps that park a workflow until the partner signals they have begun and finished

Right for commissioning **new** work. Wrong for recording work already done: backfilling a March order would message a partner about a five-month-old delivery and park a workflow waiting for them to start it — and a workflow await cannot outlive 24.85 days anyway (#1547), so the park is noise that later fails.

🔑 **The link is not optional.** `payable-inventory-orders` reaches orders *through* the partner — there is no partner column on an inventory order — so an order created as a historical record and never linked is invisible to every partner-scoped view. Nobody can bill it or even see it.

`assign-partner` writes the link and nothing else. No event, no notification, no workflow, no status change; the response says `notified: false` rather than leaving a caller to assume. Both ends validated against each other, and it **refuses to move an order that already belongs to someone else** — silently re-pointing one moves a debt between partners, and the previous owner stops seeing work they may already have billed.

## 🔴 My first version of the main test asserted nothing

It used `seedOrderForPartner`, which goes through `send-to-partner` and therefore links the order **as a side effect**. The order was already visible before the route ran, so *"makes an unlinked order visible"* was true either way. The mutation appeared to catch it only because removing the `create` left the `dismiss`, which deleted the pre-existing link — a pass for the wrong reason.

Rewritten against `seedUnlinkedOrder`, which posts the order directly, and it now asserts `visibleTo === false` **before** assigning. Re-mutated: the corrected test fails without the create, for the right reason.

## Verification

- 4 new integration cases; **18 across #1737**
- `check:prod-build` green

```
cd apps/backend
TEST_TYPE=integration:http NODE_OPTIONS="--experimental-vm-modules" \
  npx jest --testPathPattern="payment-submissions-api" -t "assign-partner"
```

Refs #1737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
