### PR TITLE
feat(textile): resume a folder extraction a deploy killed mid-loop (#1742)

### DIFF
--- a/apps/backend/integration-tests/http/folder-extraction-resume.spec.ts
+++ b/apps/backend/integration-tests/http/folder-extraction-resume.spec.ts
@@ -1,0 +1,472 @@
+/**
+ * #1742 — a folder extraction that a deploy killed mid-loop must be resumable,
+ * and must be VISIBLY stopped rather than claiming to run forever.
+ *
+ * ## The production case these tests reproduce
+ *
+ * Folder `01KZTFAA2TFN5RXFVDMD2RAWZG` (62 images) stopped at 18 completed / 1
+ * failed when the 02:29→03:06 deploy replaced the ECS task holding the loop.
+ * Five hours later the admin still showed a spinning blue "running" bar, the
+ * workflow execution still said `invoking`, and the only route that could
+ * restart anything — "retry failed" — offered to re-run **1** file, because the
+ * 43 it never reached are not errors.
+ *
+ * Every case below is written against that shape: a folder with some analysed
+ * images, one recorded failure, and a pile that was never touched.
+ *
+ * The AI generation is stubbed exactly as `textile-extract-features-stubbed`
+ * does it — the real Medusa long-running machinery runs, no vision traffic
+ * leaves the process.
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { mastra } from "../../src/mastra"
+import { persistTextileAnalysis } from "../../src/modules/textile-analysis/lib/persist"
+
+jest.setTimeout(120000)
+
+const FAKE_VISUAL_OBSERVATIONS = {
+  visible_colors: ["indigo blue"],
+  visible_pattern: "block-print",
+  pattern_description: "Repeating floral block-print motif",
+  design_elements: ["woven border"],
+  fabric: {
+    type_idea: "cotton-like",
+    texture: "matte",
+    weave_or_knit: "plain weave",
+    perceived_weight: "lightweight & drapey",
+    finish: "hand-dyed",
+  },
+  visible_item: "folded yardage of printed cloth",
+  visible_text: [],
+  shot_type: "flat lay",
+  not_visible_or_uncertain: [],
+}
+
+const FAKE_EXTRACTION = {
+  title: "Indigo Block-Print Cotton Yardage",
+  description: "Hand-printed cotton yardage in indigo with a repeating floral block-print.",
+  designer: null,
+  model_name: null,
+  cloth_type: "fabric",
+  pattern: "block-print",
+  fabric_weight: "lightweight",
+  care_instructions: ["Hand wash cold"],
+  season: ["summer"],
+  occasion: ["casual"],
+  colors: ["indigo blue"],
+  category: "fabric",
+  suggested_price: { amount: 1200, currency: "INR" },
+  seo_keywords: ["indigo", "block print"],
+  target_audience: "women",
+  confidence: 0.9,
+}
+
+const makeFakeRunResult = () => ({
+  steps: {
+    observeVisibleFeatures: { status: "success", output: FAKE_VISUAL_OBSERVATIONS },
+    deriveProductFields: { status: "success", output: FAKE_EXTRACTION },
+    validateTextileExtraction: { status: "success", output: FAKE_EXTRACTION },
+  },
+})
+
+let mockRunStart: jest.Mock
+const realGetWorkflow = (mastra as any).getWorkflow.bind(mastra)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+  let headers: any
+
+  beforeAll(() => {
+    mockRunStart = jest.fn()
+    ;(mastra as any).getWorkflow = (id: string) => {
+      if (id === "textileProductExtractionWorkflow") {
+        return { createRun: () => ({ start: mockRunStart }) }
+      }
+      return realGetWorkflow(id)
+    }
+  })
+
+  afterAll(() => {
+    ;(mastra as any).getWorkflow = realGetWorkflow
+  })
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+
+    mockRunStart.mockReset()
+    mockRunStart.mockImplementation(async () => makeFakeRunResult())
+  })
+
+  const unique = () => `t${Date.now()}${Math.floor(Math.random() * 1e6)}`
+  const getMediaService = () => getContainer().resolve("media") as any
+
+  const seedFolderWithImages = async (imageCount: number) => {
+    const mediaService = getMediaService()
+    const token = unique()
+    const folder = await mediaService.createFolders({
+      name: `Resume Test ${token}`,
+      slug: `resume-test-${token}`,
+      path: `/resume-test-${token}`,
+      level: 0,
+      sort_order: 0,
+      is_public: true,
+    })
+
+    const images: any[] = []
+    for (let i = 0; i < imageCount; i++) {
+      const t = unique()
+      images.push(
+        await mediaService.createMediaFiles({
+          file_name: `${t}.jpg`,
+          original_name: `${t}.jpg`,
+          file_path: `https://cdn.example.com/${t}.jpg`,
+          file_type: "image",
+          mime_type: "image/jpeg",
+          file_size: 1024,
+          file_hash: `hash-${t}`,
+          extension: "jpg",
+          is_public: true,
+          folder_id: folder.id,
+        })
+      )
+    }
+    return { folder, images }
+  }
+
+  /**
+   * Mark an image analysed the way the workflow does — the real writer, so the
+   * link row and its table name are the real ones.
+   *
+   * ⚠️ Deliberately NOT the extraction route. A seed helper that performs the
+   * thing under test asserts nothing: the resume would pass before the resume
+   * code ran.
+   */
+  const markAnalysed = async (mediaId: string) => {
+    await persistTextileAnalysis(getContainer(), {
+      media_id: mediaId,
+      payload: FAKE_EXTRACTION,
+      source: "internal_extraction",
+    })
+  }
+
+  /**
+   * Write the progress a killed run leaves behind: still "running", last
+   * touched `silentMinutes` ago, with whatever it managed to record.
+   */
+  const writeStalledProgress = async (
+    folder: any,
+    opts: { total: number; completed: number; failedMediaId?: string; silentMinutes: number }
+  ) => {
+    const mediaService = getMediaService()
+    const updatedAt = new Date(Date.now() - opts.silentMinutes * 60_000).toISOString()
+
+    await mediaService.updateFolders({
+      selector: { id: folder.id },
+      data: {
+        metadata: {
+          ...(folder.metadata || {}),
+          folder_extraction: {
+            status: "running",
+            total: opts.total,
+            completed: opts.completed,
+            failed: opts.failedMediaId ? 1 : 0,
+            interval_ms: 5000,
+            started_at: new Date(Date.now() - (opts.silentMinutes + 60) * 60_000).toISOString(),
+            updated_at: updatedAt,
+            finished_at: null,
+            last_media_id: null,
+            errors: opts.failedMediaId
+              ? [
+                  {
+                    media_id: opts.failedMediaId,
+                    error:
+                      "Textile extraction failed at step deriveProductFields: expected string, received array",
+                  },
+                ]
+              : [],
+          },
+        },
+      },
+    })
+  }
+
+  const waitFor = async (check: () => Promise<boolean>, timeoutMs = 60000) => {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      try {
+        if (await check()) return true
+      } catch {
+        // transient polling errors must not abort the wait
+      }
+      await new Promise((r) => setTimeout(r, 500))
+    }
+    return false
+  }
+
+  const getStatus = async (folderId: string) =>
+    (await api.get(`/admin/medias/folder/${folderId}/extract-features/status`, headers)).data
+
+  // ============================================
+  // Knowing it stopped
+  // ============================================
+
+  describe("GET .../extract-features/status", () => {
+    /**
+     * 🔴 The whole reason the production folder sat unnoticed for five hours.
+     * `status` is written by the process, and a process that dies writes
+     * nothing — least of all "I died".
+     */
+    it("calls a run that has written no progress in hours stalled, though its status still says running", async () => {
+      const { folder, images } = await seedFolderWithImages(4)
+      await markAnalysed(images[0].id)
+      await writeStalledProgress(folder, {
+        total: 4,
+        completed: 1,
+        failedMediaId: images[1].id,
+        silentMinutes: 300,
+      })
+
+      const status = await getStatus(folder.id)
+
+      expect(status.progress.status).toBe("running")
+      expect(status.stalled).toBe(true)
+      expect(status.silent_for_ms).toBeGreaterThan(status.stall_threshold_ms)
+      expect(status.resumable).toBe(true)
+    })
+
+    it("leaves a run that wrote progress moments ago alone", async () => {
+      const { folder, images } = await seedFolderWithImages(2)
+      await markAnalysed(images[0].id)
+      await writeStalledProgress(folder, { total: 2, completed: 1, silentMinutes: 0 })
+
+      const status = await getStatus(folder.id)
+
+      expect(status.progress.status).toBe("running")
+      expect(status.stalled).toBe(false)
+      expect(status.resumable).toBe(false)
+    })
+
+    /**
+     * 🔑 The count that matters is "images with no analysis", and it comes from
+     * the same derivation the resume uses — so the number on screen and the
+     * number actually processed cannot disagree.
+     */
+    it("reports the outstanding count, counting the failed and the never-attempted alike", async () => {
+      const { folder, images } = await seedFolderWithImages(5)
+      await markAnalysed(images[0].id)
+      await markAnalysed(images[1].id)
+      await writeStalledProgress(folder, {
+        total: 5,
+        completed: 2,
+        failedMediaId: images[2].id,
+        silentMinutes: 300,
+      })
+
+      const status = await getStatus(folder.id)
+
+      expect(status.folder_total).toBe(5)
+      // 1 failed + 2 never attempted — NOT the 1 in `errors`.
+      expect(status.pending_count).toBe(3)
+    })
+  })
+
+  // ============================================
+  // Resuming it
+  // ============================================
+
+  describe("POST .../extract-features/retry (resume)", () => {
+    /**
+     * 🔴 THE defect. The old route read `folder_extraction.errors` and would
+     * have answered `retried: 1` here, leaving two images no route could ever
+     * reach.
+     */
+    it("resumes every outstanding image, not just the one recorded as failed", async () => {
+      const { folder, images } = await seedFolderWithImages(4)
+      await markAnalysed(images[0].id)
+      await writeStalledProgress(folder, {
+        total: 4,
+        completed: 1,
+        failedMediaId: images[1].id,
+        silentMinutes: 300,
+      })
+
+      const res = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features/retry`,
+        {},
+        headers
+      )
+
+      expect(res.status).toBe(202)
+      expect(res.data.folder_total).toBe(4)
+      // 1 failed + 2 never attempted. The old route said 1.
+      expect(res.data.resumed).toBe(3)
+
+      const finished = await waitFor(async () => {
+        const status = await getStatus(folder.id)
+        return status.progress?.status === "completed"
+      })
+      expect(finished).toBe(true)
+
+      const status = await getStatus(folder.id)
+      expect(status.pending_count).toBe(0)
+      expect(status.resumable).toBe(false)
+    })
+
+    /**
+     * ⚠️ The already-analysed image must not be extracted a second time.
+     * `link.create` is not idempotent, so a re-do leaves a duplicate analysis
+     * row for every image — and bills a vision call for each.
+     */
+    it("does not re-extract images that already have an analysis", async () => {
+      const { folder, images } = await seedFolderWithImages(3)
+      await markAnalysed(images[0].id)
+      await markAnalysed(images[1].id)
+      await writeStalledProgress(folder, { total: 3, completed: 2, silentMinutes: 300 })
+
+      mockRunStart.mockClear()
+
+      const res = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features/retry`,
+        {},
+        headers
+      )
+      expect(res.data.resumed).toBe(1)
+
+      const finished = await waitFor(async () => {
+        const status = await getStatus(folder.id)
+        return status.progress?.status === "completed"
+      })
+      expect(finished).toBe(true)
+
+      // Exactly one image was sent to the model — the one that had no analysis.
+      expect(mockRunStart).toHaveBeenCalledTimes(1)
+    })
+
+    it("answers 'nothing to resume' when every image is already analysed", async () => {
+      const { folder, images } = await seedFolderWithImages(2)
+      await markAnalysed(images[0].id)
+      await markAnalysed(images[1].id)
+      await writeStalledProgress(folder, { total: 2, completed: 2, silentMinutes: 300 })
+
+      const res = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features/retry`,
+        {},
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.resumed).toBe(0)
+      expect(res.data.pending_count).toBe(0)
+    })
+
+    /**
+     * 🔴 Two loops over one folder would extract every pending image twice, in
+     * parallel, at double the provider rate the pacing exists to respect.
+     */
+    it("refuses to start a second run while one is genuinely still alive", async () => {
+      const { folder, images } = await seedFolderWithImages(3)
+      await markAnalysed(images[0].id)
+      await writeStalledProgress(folder, { total: 3, completed: 1, silentMinutes: 0 })
+
+      const res = await api
+        .post(`/admin/medias/folder/${folder.id}/extract-features/retry`, {}, headers)
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(String(res.data.message)).toMatch(/still running/i)
+    })
+  })
+
+  // ============================================
+  // Asking for the remainder directly
+  // ============================================
+
+  describe("POST .../extract-features with scope", () => {
+    /**
+     * 🔴 `media_ids` had been an input on the workflow since it was written,
+     * but no schema declared it and the route never destructured it — so the
+     * only thing the API could ask for was "all of them". A field the caller
+     * cannot send is a capability that does not exist.
+     */
+    it("scope=pending extracts only the images with no analysis yet", async () => {
+      const { folder, images } = await seedFolderWithImages(3)
+      await markAnalysed(images[0].id)
+
+      mockRunStart.mockClear()
+
+      const extractRes = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features`,
+        { persist: true, interval_ms: 5000, scope: "pending" },
+        headers
+      )
+      expect(extractRes.status).toBe(202)
+
+      await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features/${extractRes.data.transaction_id}/confirm`,
+        {},
+        headers
+      )
+
+      const finished = await waitFor(async () => {
+        const status = await getStatus(folder.id)
+        return status.progress?.status === "completed"
+      })
+      expect(finished).toBe(true)
+
+      const status = await getStatus(folder.id)
+      expect(status.progress.total).toBe(2)
+      expect(status.progress.scope).toBe("pending")
+      expect(status.progress.folder_total).toBe(3)
+      expect(status.progress.already_done).toBe(1)
+      expect(mockRunStart).toHaveBeenCalledTimes(2)
+    })
+
+    it("accepts an explicit media_ids list", async () => {
+      const { folder, images } = await seedFolderWithImages(3)
+
+      mockRunStart.mockClear()
+
+      const extractRes = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features`,
+        { persist: true, interval_ms: 5000, media_ids: [images[2].id] },
+        headers
+      )
+      expect(extractRes.status).toBe(202)
+
+      await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features/${extractRes.data.transaction_id}/confirm`,
+        {},
+        headers
+      )
+
+      const finished = await waitFor(async () => {
+        const status = await getStatus(folder.id)
+        return status.progress?.status === "completed"
+      })
+      expect(finished).toBe(true)
+
+      expect((await getStatus(folder.id)).progress.total).toBe(1)
+      expect(mockRunStart).toHaveBeenCalledTimes(1)
+    })
+
+    it("400s a scope=pending run on a folder that has nothing left", async () => {
+      const { folder, images } = await seedFolderWithImages(1)
+      await markAnalysed(images[0].id)
+
+      const res = await api
+        .post(
+          `/admin/medias/folder/${folder.id}/extract-features`,
+          { persist: true, interval_ms: 5000, scope: "pending" },
+          headers
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(String(res.data.message)).toMatch(/already has a textile analysis/i)
+    })
+  })
+})

--- a/apps/backend/src/admin/components/media/folders/folder-extraction-progress.tsx
+++ b/apps/backend/src/admin/components/media/folders/folder-extraction-progress.tsx
@@ -1,10 +1,16 @@
-import { Text, Tooltip, clx } from "@medusajs/ui";
-import { CheckCircle, Spinner, XCircle } from "@medusajs/icons";
-import { useFolderExtractionStatus } from "../../../hooks/api/textile-extraction";
+import { Button, Text, Tooltip, clx, toast } from "@medusajs/ui";
+import { CheckCircle, ExclamationCircle, Spinner, XCircle } from "@medusajs/icons";
+import {
+  useFolderExtractionStatus,
+  useResumeFolderExtraction,
+} from "../../../hooks/api/textile-extraction";
 
 interface FolderExtractionProgressProps {
   folderId: string;
 }
+
+const minutes = (ms: number | null | undefined) =>
+  ms == null ? "" : `${Math.max(1, Math.round(ms / 60000))} min`;
 
 /**
  * Live progress bar for a folder-wide textile extraction run.
@@ -13,26 +19,93 @@ interface FolderExtractionProgressProps {
  * renders an at-a-glance status strip: a determinate bar with a moving light
  * while running, a green bar when finished, and a red error chip (with a tooltip
  * listing the failed media + reason) when any photo failed.
+ *
+ * 🔴 A fourth state was missing, and it is the one production was actually in
+ * (#1742): **stalled**. The loop runs inside one Node process, so a deploy kills
+ * it without writing anything — `status` stays `"running"` for ever. This strip
+ * spun a blue "running" bar and polled every 5 seconds for five hours against a
+ * job whose process had been replaced twice. The server now decides liveness
+ * (three intervals of silence, ten-minute floor) and this renders the verdict,
+ * with the button that fixes it.
  */
 export const FolderExtractionProgress = ({ folderId }: FolderExtractionProgressProps) => {
   const { data } = useFolderExtractionStatus(folderId, {
+    /**
+     * ⚠️ Stop polling once the server calls it stalled. Polling a dead job
+     * every 5 seconds forever is what the old condition did, and it never
+     * changed its mind because nothing was left alive to change it.
+     */
     refetchInterval: (query) =>
-      query.state.data?.progress?.status === "running" ? 5000 : false,
+      query.state.data?.progress?.status === "running" && !query.state.data?.stalled
+        ? 5000
+        : false,
   });
+
+  const { mutateAsync: resume, isPending: isResuming } = useResumeFolderExtraction();
 
   const progress = data?.progress;
   if (!progress) return null;
 
   const { status, total, completed, failed, errors } = progress;
-  const running = status === "running";
+  const stalled = !!data?.stalled;
+  const running = status === "running" && !stalled;
   const failedRun = status === "failed";
 
-  const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+  /**
+   * A resume run's `total` is the remainder, not the folder — so counting only
+   * this run would report "3/44" on a 62-image folder that is 21 done. Where
+   * the server gave us the folder-wide figures, show those instead.
+   */
+  const folderTotal = progress.folder_total ?? data?.folder_total ?? total;
+  const doneBefore = progress.already_done ?? 0;
+  const doneOverall = doneBefore + completed;
+  const denominator = folderTotal || total;
+
+  const pct = denominator > 0 ? Math.round((doneOverall / denominator) * 100) : 0;
   const fillPct = failedRun ? 100 : running ? Math.max(pct, 4) : pct;
 
-  const StatusIcon = running ? Spinner : failedRun ? XCircle : CheckCircle;
-  const barColor = running ? "bg-blue-500" : failedRun ? "bg-red-500" : "bg-emerald-500";
-  const textColor = running ? "text-blue-500" : failedRun ? "text-red-500" : "text-emerald-500";
+  const StatusIcon = running
+    ? Spinner
+    : stalled
+      ? ExclamationCircle
+      : failedRun
+        ? XCircle
+        : CheckCircle;
+
+  const barColor = running
+    ? "bg-blue-500"
+    : stalled
+      ? "bg-amber-500"
+      : failedRun
+        ? "bg-red-500"
+        : "bg-emerald-500";
+
+  const textColor = running
+    ? "text-blue-500"
+    : stalled
+      ? "text-amber-500"
+      : failedRun
+        ? "text-red-500"
+        : "text-emerald-500";
+
+  const label = running
+    ? "running"
+    : stalled
+      ? "stopped"
+      : failedRun
+        ? "failed"
+        : "completed";
+
+  const pendingCount = data?.pending_count ?? null;
+  const canResume = !!data?.resumable && !running;
+
+  const handleResume = async () => {
+    try {
+      await resume(folderId);
+    } catch (error: any) {
+      toast.error(error?.message || "Failed to resume extraction");
+    }
+  };
 
   return (
     <div className="px-6 py-4">
@@ -45,13 +118,31 @@ export const FolderExtractionProgress = ({ folderId }: FolderExtractionProgressP
             Feature extraction
           </Text>
           <Text size="xsmall" className={textColor}>
-            {running ? "running" : failedRun ? "failed" : "completed"}
+            {label}
           </Text>
+          {stalled && (
+            <Tooltip
+              content={
+                <div className="w-80">
+                  <Text size="xsmall">
+                    No progress written in {minutes(data?.silent_for_ms)}, and progress is
+                    written after every photo. The run processes photos inside a single
+                    server process, so a deploy or restart ends it without marking it
+                    finished. Resume picks up only the photos that still have no analysis.
+                  </Text>
+                </div>
+              }
+            >
+              <Text size="xsmall" className="cursor-default text-ui-fg-muted underline decoration-dotted">
+                silent {minutes(data?.silent_for_ms)}
+              </Text>
+            </Tooltip>
+          )}
         </div>
 
         <div className="flex items-center gap-x-3">
           <Text size="xsmall" className="text-ui-fg-muted">
-            {completed}/{total}
+            {doneOverall}/{denominator}
           </Text>
 
           {failed > 0 &&
@@ -93,6 +184,17 @@ export const FolderExtractionProgress = ({ folderId }: FolderExtractionProgressP
                 </Text>
               </div>
             ))}
+
+          {canResume && (
+            <Button
+              size="small"
+              variant="secondary"
+              isLoading={isResuming}
+              onClick={handleResume}
+            >
+              {pendingCount != null ? `Resume (${pendingCount})` : "Resume"}
+            </Button>
+          )}
         </div>
       </div>
 

--- a/apps/backend/src/admin/components/media/folders/folder-media-section.tsx
+++ b/apps/backend/src/admin/components/media/folders/folder-media-section.tsx
@@ -12,7 +12,10 @@ import { TextileExtractionModal } from "../textile-extraction-modal";
 import { CreateProductFromMediaModal } from "../create-product-from-media-modal";
 import { FolderExtractionProgress } from "./folder-extraction-progress";
 import { useTextileAnalyses } from "../../../hooks/api/textile-analyses";
-import { useRetryFolderExtraction } from "../../../hooks/api/textile-extraction";
+import {
+  useFolderExtractionStatus,
+  useResumeFolderExtraction,
+} from "../../../hooks/api/textile-extraction";
 
 const MAX_PRODUCT_PHOTOS = 4
 
@@ -28,13 +31,21 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
   const [createProductModalOpen, setCreateProductModalOpen] = useState(false)
   const queryClient = useQueryClient()
   const selectedCount = useMemo(() => Object.keys(selection).length, [selection])
-  const { mutateAsync: retryFailed, isPending: isRetrying } = useRetryFolderExtraction()
+  const { mutateAsync: resumeExtraction } = useResumeFolderExtraction()
 
-  // Failed files from the last folder-wide extraction (mirrored into metadata).
-  const failedCount = useMemo(() => {
-    const errors = (folder.metadata?.folder_extraction as any)?.errors
-    return Array.isArray(errors) ? errors.length : 0
-  }, [folder.metadata])
+  /**
+   * 🔴 This used to count `folder_extraction.errors` and offer "Retry Failed
+   * (N)". On production that read **1** while **44** images were outstanding:
+   * the run had died mid-loop when a deploy replaced its task, and the 43
+   * images it never reached are not errors (#1742). The outstanding count now
+   * comes from the server, which derives it the same way the resume itself
+   * does — from images with no analysis row — so the number on the button and
+   * the number actually processed cannot disagree.
+   */
+  const { data: extractionStatus } = useFolderExtractionStatus(folder.id)
+  const pendingCount = extractionStatus?.pending_count ?? 0
+  const extractionRunning =
+    extractionStatus?.progress?.status === "running" && !extractionStatus?.stalled
 
   // Get selected image media files only (extraction only works on images)
   const selectedImageMediaIds = useMemo(() => {
@@ -148,12 +159,12 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
     setCreateProductModalOpen(true)
   }
 
-  const handleRetryFailed = async () => {
+  const handleResumeExtraction = async () => {
     try {
-      await retryFailed(folder.id)
+      await resumeExtraction(folder.id)
       await queryClient.invalidateQueries({ queryKey: mediaFolderDetailQueryKeys.detail(folder.id) })
     } catch (error: any) {
-      toast.error(error?.message || "Failed to retry extraction")
+      toast.error(error?.message || "Failed to resume extraction")
     }
   }
 
@@ -180,12 +191,12 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
                   icon: <Sparkles />,
                   onClick: handleExtractAll,
                 },
-                ...(failedCount > 0
+                ...(pendingCount > 0 && !extractionRunning
                   ? [
                       {
-                        label: `Retry Failed (${failedCount})`,
+                        label: `Resume Extraction (${pendingCount})`,
                         icon: <Sparkles />,
-                        onClick: handleRetryFailed,
+                        onClick: handleResumeExtraction,
                       },
                     ]
                   : []),

--- a/apps/backend/src/admin/hooks/api/textile-extraction.ts
+++ b/apps/backend/src/admin/hooks/api/textile-extraction.ts
@@ -255,12 +255,30 @@ export type FolderExtractionProgress = {
   finished_at?: string | null;
   last_media_id?: string | null;
   errors?: Array<{ media_id: string; error: string }>;
+  /** Folder-wide truth, so a resume run does not read as the whole folder. */
+  scope?: "all" | "pending";
+  folder_total?: number;
+  already_done?: number;
+  resume_attempts?: number;
 };
 
 export type ExtractFolderFeaturesStatusResponse = {
   folder_id: string;
   has_run: boolean;
   progress: FolderExtractionProgress | null;
+  /**
+   * A run that CLAIMS to be running but has written no progress in three
+   * intervals (ten-minute floor). The loop lives in one Node process, so a
+   * deploy kills it without ever writing "I stopped" — `status` alone cannot
+   * tell a live run from a dead one (#1742).
+   */
+  stalled?: boolean;
+  silent_for_ms?: number | null;
+  stall_threshold_ms?: number;
+  /** Images in the folder with no analysis yet — what a resume would process. */
+  pending_count?: number | null;
+  folder_total?: number | null;
+  resumable?: boolean;
 };
 
 /**
@@ -375,11 +393,15 @@ export const useFolderExtractionStatus = (
 };
 
 /**
- * Hook to retry the media files that FAILED a previous folder extraction.
- * One call — the endpoint reads `folder_extraction.errors` and re-runs only
- * those files (auto-confirmed), no separate trigger/confirm step.
+ * Hook to resume a folder extraction — every image that still has no analysis,
+ * whether it failed loudly or was never reached because a deploy killed the run
+ * mid-loop (#1742). One call, auto-confirmed.
+ *
+ * ⚠️ The endpoint used to re-run only `folder_extraction.errors`. On production
+ * that was 1 file out of 44 outstanding, because an image nobody tried is not
+ * an error.
  */
-export const useRetryFolderExtraction = () => {
+export const useResumeFolderExtraction = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -390,25 +412,32 @@ export const useRetryFolderExtraction = () => {
       );
       if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.message || "Failed to retry extraction");
+        throw new Error(error.message || "Failed to resume extraction");
       }
       return response.json() as Promise<{
         message: string;
-        transaction_id: string;
+        transaction_id?: string;
         folder_id: string;
+        resumed: number;
         retried: number;
+        pending_count: number;
+        folder_total: number;
       }>;
     },
     onSuccess: (data) => {
-      toast.success(data.message || "Retrying failed extractions");
+      toast.success(data.message || "Resuming outstanding extractions");
       queryClient.invalidateQueries({
         queryKey: mediaFolderDetailQueryKeys.all,
       });
+      queryClient.invalidateQueries({ queryKey: ["folder-extraction-status"] });
     },
     onError: (error: any) => {
-      const message = error?.message || "Failed to retry extraction";
+      const message = error?.message || "Failed to resume extraction";
       toast.error(message);
-      console.error("[useRetryFolderExtraction] Error:", error);
+      console.error("[useResumeFolderExtraction] Error:", error);
     },
   });
 };
+
+/** @deprecated Renamed to {@link useResumeFolderExtraction} — it resumes everything outstanding, not just failures. */
+export const useRetryFolderExtraction = useResumeFolderExtraction;

--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/retry/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/retry/route.ts
@@ -1,12 +1,26 @@
 /**
- * Retry the media files that FAILED a previous folder-wide extraction.
+ * Resume a folder-wide extraction — every image that still has no analysis.
  *
  *   POST /admin/medias/folder/:id/extract-features/retry
  *
- * Reads the failed media ids recorded in `folder.metadata.folder_extraction.errors`
- * and re-runs the folder extraction workflow scoped to just those files
- * (`media_ids`), auto-confirming so processing starts immediately — one call,
- * no separate confirm step.
+ * ## What this used to do, and why it could not finish the job (#1742)
+ *
+ * It read `folder.metadata.folder_extraction.errors` and re-ran exactly those
+ * files. On production that was **one** file out of the **44** outstanding: the
+ * run had died mid-loop when a deploy replaced its ECS task, so 43 images were
+ * never attempted at all — and an image nobody tried is not an error. No route
+ * in the system could reach them.
+ *
+ * Worse, it then re-initialised progress with `total: 1`, overwriting the
+ * "18 of 62 done, 1 failed" record with "0 of 1". The only place the
+ * outstanding work was counted was the thing being overwritten.
+ *
+ * 🔑 The work-list now comes from state — images with no `textile_analysis`
+ * row — which is the shape `backfillAllGeocodesWorkflow` has always used and
+ * the reason running it twice is harmless. A file the run failed on and a file
+ * the run never reached are the same thing to the work that remains.
+ *
+ * The URL keeps its name so existing callers and the admin bundle keep working.
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
@@ -21,6 +35,10 @@ import {
   waitConfirmationTextileFolderExtractionStepId,
   FolderExtractionProgress,
 } from "../../../../../../../workflows/ai/textile-folder-extraction"
+import {
+  folderExtractionLiveness,
+  pendingFolderExtractionMedia,
+} from "../../../../../../../workflows/ai/lib/folder-extraction-resume"
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
@@ -33,23 +51,57 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const progress = (folder.metadata?.folder_extraction as FolderExtractionProgress) || null
-  const failedMediaIds = (progress?.errors ?? [])
-    .map((e) => e?.media_id)
-    .filter(Boolean)
+  const { pending_media_ids, all_media_ids } = await pendingFolderExtractionMedia(
+    req.scope,
+    folder_id
+  )
 
-  if (!failedMediaIds.length) {
+  if (!pending_media_ids.length) {
     return res.json({
-      message: "No failed extractions to retry.",
+      message: "Nothing to resume — every image in this folder already has an analysis.",
       folder_id,
-      retried: 0,
+      resumed: 0,
+      pending_count: 0,
+      folder_total: all_media_ids.length,
     })
   }
 
-  // Re-run the folder extraction scoped to the failed files only.
+  /**
+   * ⚠️ Refuse while a run is genuinely alive, and say which. Two loops over the
+   * same folder would extract every pending image twice, in parallel, at double
+   * the provider rate the pacing exists to respect — and `link.create` is not
+   * idempotent, so each would leave its own duplicate analysis row.
+   *
+   * The test is liveness, not `status`: a `running` that has gone quiet past
+   * the threshold is exactly the case this route exists for, so it must NOT be
+   * treated as a run in progress.
+   */
+  const liveness = folderExtractionLiveness(progress)
+  if (progress?.status === "running" && !liveness.stalled) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `A folder extraction is still running here — last progress ${
+        liveness.silent_for_ms === null
+          ? "unknown"
+          : `${Math.round(liveness.silent_for_ms / 1000)}s ago`
+      }, and it is only presumed stalled after ${Math.round(
+        liveness.threshold_ms / 1000
+      )}s of silence. Wait for it to finish or stall.`
+    )
+  }
+
   const { transaction } = await textileFolderExtractionMedusaWorkflow(req.scope).run({
     input: {
       folder_id,
-      media_ids: failedMediaIds,
+      /**
+       * Both, deliberately. `media_ids` pins the run to the list this request
+       * measured and reported back, and `scope: "pending"` re-asks the question
+       * at the moment processing starts — so anything analysed in between (a
+       * single-image extraction, a concurrent resume that won the race) is
+       * dropped rather than paid for twice.
+       */
+      media_ids: pending_media_ids,
+      scope: "pending",
       persist: true,
       interval_ms: progress?.interval_ms,
     },
@@ -70,13 +122,17 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   logger.info(
-    `[FolderExtractFeatures/Retry] Retrying ${failedMediaIds.length} failed file(s) in folder ${folder_id}`
+    `[FolderExtractFeatures/Resume] Resuming ${pending_media_ids.length} of ${all_media_ids.length} file(s) in folder ${folder_id}`
   )
 
   return res.status(202).json({
-    message: `Retrying ${failedMediaIds.length} failed extraction(s).`,
+    message: `Resuming ${pending_media_ids.length} outstanding extraction(s).`,
     transaction_id: transaction.transactionId,
     folder_id,
-    retried: failedMediaIds.length,
+    resumed: pending_media_ids.length,
+    /** Kept for callers written against the old response. */
+    retried: pending_media_ids.length,
+    pending_count: pending_media_ids.length,
+    folder_total: all_media_ids.length,
   })
 }

--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/route.ts
@@ -47,6 +47,7 @@ import { ExtractFolderFeaturesRequestSchema, ExtractFolderFeaturesRequest } from
 import { textileFolderExtractionMedusaWorkflow } from "../../../../../../workflows/ai/textile-folder-extraction";
 import MediaService from "../../../../../../modules/media/service";
 import { MEDIA_MODULE } from "../../../../../../modules/media";
+import { pendingFolderExtractionMedia } from "../../../../../../workflows/ai/lib/folder-extraction-resume";
 
 export const POST = async (
   req: MedusaRequest<ExtractFolderFeaturesRequest>,
@@ -64,7 +65,7 @@ export const POST = async (
       throw new MedusaError(MedusaError.Types.INVALID_DATA, message || "Invalid request body");
     }
 
-    const { hints, gender, persist, interval_ms } = parsed.data;
+    const { hints, gender, persist, interval_ms, media_ids, scope } = parsed.data;
     const folder_id = req.params.id;
 
     // Verify folder exists and count extractable images for the response
@@ -88,6 +89,34 @@ export const POST = async (
       );
     }
 
+    /**
+     * 🔴 Refuse an empty `scope: "pending"` run HERE, at the door (#1742).
+     *
+     * `listFolderMediaStep` throws the same refusal, but it runs inside the
+     * background step AFTER confirmation — so the caller would get a cheerful
+     * 202 and a transaction id, confirm it, and only then have the run die
+     * where nobody is looking. The trigger already checks `imageCount` for
+     * exactly this reason; the pending count is the same check for the scope
+     * that was just added.
+     */
+    let pendingCount: number | null = null;
+    if (scope === "pending") {
+      const { pending_media_ids } = await pendingFolderExtractionMedia(
+        req.scope,
+        folder_id
+      );
+      pendingCount = media_ids?.length
+        ? pending_media_ids.filter((id) => media_ids.includes(id)).length
+        : pending_media_ids.length;
+
+      if (pendingCount === 0) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Folder ${folder_id} has no images left to extract — every image already has a textile analysis`
+        );
+      }
+    }
+
     // Run the long-running workflow
     const { result, transaction } = await textileFolderExtractionMedusaWorkflow(req.scope).run({
       input: {
@@ -96,6 +125,8 @@ export const POST = async (
         gender,
         persist,
         interval_ms,
+        media_ids,
+        scope,
       },
     });
 
@@ -106,6 +137,9 @@ export const POST = async (
       status: "pending_confirmation",
       folder_id,
       total_images: imageCount,
+      /** What this run will actually process — the folder, unless it is scoped. */
+      scheduled_images: pendingCount ?? media_ids?.length ?? imageCount,
+      scope,
       summary: result,
     });
   } catch (error) {

--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/status/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/status/route.ts
@@ -34,6 +34,10 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import MediaService from "../../../../../../../modules/media/service";
 import { MEDIA_MODULE } from "../../../../../../../modules/media";
 import { FolderExtractionProgress } from "../../../../../../../workflows/ai/textile-folder-extraction";
+import {
+  folderExtractionLiveness,
+  pendingFolderExtractionMedia,
+} from "../../../../../../../workflows/ai/lib/folder-extraction-resume";
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
@@ -49,10 +53,65 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
     const progress = (folder.metadata?.folder_extraction as FolderExtractionProgress) || null;
 
+    /**
+     * 🔴 `status` alone cannot answer "is this still going?" (#1742).
+     *
+     * The loop runs inside one step in one Node process; when a deploy replaces
+     * the task the process dies without writing anything — least of all "I
+     * died" — so `status` stays the string `"running"` for ever. On production
+     * a folder sat at 18/62 with `status: "running"` for five hours while every
+     * task that could have been running it had been replaced twice.
+     *
+     * The only evidence of liveness is how long ago progress was written, and
+     * progress is written after EVERY item. So the route computes the verdict
+     * rather than making each caller re-derive it — the admin strip, the
+     * sweeper and anyone with curl otherwise each invent their own threshold.
+     */
+    const liveness = folderExtractionLiveness(progress);
+
+    /**
+     * The outstanding count comes from the same place a resume gets its
+     * work-list, so the number on screen and the number that would actually be
+     * processed cannot disagree. Best-effort: a folder that has never been
+     * extracted still answers, and a link failure must not 500 a status poll
+     * the UI hits every 5 seconds.
+     */
+    let pending_count: number | null = null;
+    let folder_total: number | null = null;
+    try {
+      const pending = await pendingFolderExtractionMedia(req.scope, folder_id);
+      pending_count = pending.pending_media_ids.length;
+      folder_total = pending.all_media_ids.length;
+    } catch (err: any) {
+      logger.warn(
+        `[FolderExtractFeatures/Status] Could not count pending media for ${folder_id}: ${err?.message}`
+      );
+    }
+
     return res.json({
       folder_id,
       has_run: !!progress,
       progress,
+      stalled: liveness.stalled,
+      silent_for_ms: liveness.silent_for_ms,
+      stall_threshold_ms: liveness.threshold_ms,
+      pending_count,
+      folder_total,
+      /**
+       * True only when a resume would be both useful and permitted: there is
+       * outstanding work AND nothing is currently working on it.
+       *
+       * ⚠️ The second half matters. Offering Resume beside a healthy run
+       * invites a second loop over the same folder — every pending image
+       * extracted twice, in parallel, at double the provider rate the pacing
+       * exists to respect, and `link.create` is not idempotent so each leaves
+       * its own duplicate row. The resume route refuses that; this stops the
+       * screen from asking for it in the first place.
+       */
+      resumable:
+        !!progress &&
+        (pending_count ?? 0) > 0 &&
+        !(progress.status === "running" && !liveness.stalled),
     });
   } catch (error) {
     logger.error(`[FolderExtractFeatures/Status] Error: ${error}`, error);

--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/validators.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/validators.ts
@@ -16,6 +16,22 @@ export const ExtractFolderFeaturesRequestSchema = z.object({
    * Clamped between 5 seconds and 15 minutes.
    */
   interval_ms: z.number().int().positive().optional(),
+  /**
+   * Restrict the run to these media files (#1742).
+   *
+   * 🔴 The workflow has accepted `media_ids` since it was written, but this
+   * schema never declared it and the route never destructured it — so the only
+   * thing the API could ask for was "all 62 images", and a folder left half
+   * done by a deploy had no way back except paying for the whole folder again.
+   * A field the caller cannot send is a capability that does not exist.
+   */
+  media_ids: z.array(z.string()).optional(),
+  /**
+   * `pending` skips images that already have a `textile_analysis` row, which is
+   * what turns a re-run into a resume. Default `all` keeps the original
+   * behaviour for anyone deliberately re-extracting a folder.
+   */
+  scope: z.enum(["all", "pending"]).optional().default("all"),
 });
 
 export type ExtractFolderFeaturesRequest = z.infer<typeof ExtractFolderFeaturesRequestSchema>;

--- a/apps/backend/src/jobs/__tests__/resume-stalled-folder-extractions.unit.spec.ts
+++ b/apps/backend/src/jobs/__tests__/resume-stalled-folder-extractions.unit.spec.ts
@@ -1,0 +1,228 @@
+import resumeStalledFolderExtractions, {
+  MAX_RESUME_ATTEMPTS,
+  config,
+} from "../resume-stalled-folder-extractions"
+
+/**
+ * #1742 — the sweeper that finishes what a deploy interrupted.
+ *
+ * The production case: 62 images, 18 done, killed at 03:04 by the ECS task
+ * replacement that a deploy performs, still claiming `status: "running"` five
+ * hours later with nothing alive to change its mind. At the measured pace —
+ * ~3.2 min per photo — a full folder is a 3.3-hour run inside one Node process,
+ * and there were six deploys that day. Nobody was ever going to be watching.
+ *
+ * These tests pin the three properties that decide whether the sweep is safe to
+ * leave running unattended: it must fire on its own, it must never touch a run
+ * that is alive, and it must give up rather than burn vision calls forever.
+ */
+
+const mockRun = jest.fn()
+const mockSetStepSuccess = jest.fn()
+const mockPending = jest.fn()
+
+jest.mock("../../workflows/ai/textile-folder-extraction", () => ({
+  textileFolderExtractionMedusaWorkflow: () => ({ run: mockRun }),
+  textileFolderExtractionWorkflowId: "textile-folder-extraction",
+  waitConfirmationTextileFolderExtractionStepId: "wait-confirmation",
+}))
+
+jest.mock("../../workflows/ai/lib/folder-extraction-resume", () => {
+  const actual = jest.requireActual("../../workflows/ai/lib/folder-extraction-resume")
+  return {
+    ...actual,
+    pendingFolderExtractionMedia: (...args: any[]) => mockPending(...args),
+  }
+})
+
+const logger = () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })
+
+const minutesAgo = (n: number) => new Date(Date.now() - n * 60_000).toISOString()
+
+const folderWith = (over: Record<string, any> = {}, id = "folder_1") => ({
+  id,
+  name: `Folder ${id}`,
+  metadata: {
+    folder_extraction: {
+      status: "running",
+      total: 62,
+      completed: 18,
+      failed: 1,
+      interval_ms: 60_000,
+      updated_at: minutesAgo(300),
+      ...over,
+    },
+  },
+})
+
+const containerWith = (folders: any[]) => {
+  const log = logger()
+  const mediaService = {
+    listFolders: jest.fn(async () => folders),
+    updateFolders: jest.fn(async () => undefined),
+  }
+
+  return {
+    log,
+    mediaService,
+    container: {
+      resolve: (key: string) => {
+        if (key === "logger") return log
+        if (key === "media") return mediaService
+        if (key === "workflows") return { setStepSuccess: mockSetStepSuccess }
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    } as any,
+  }
+}
+
+describe("resume-stalled-folder-extractions", () => {
+  beforeEach(() => {
+    mockRun.mockReset()
+    mockRun.mockResolvedValue({ transaction: { transactionId: "tx_1" } })
+    mockSetStepSuccess.mockReset()
+    mockSetStepSuccess.mockResolvedValue(undefined)
+    mockPending.mockReset()
+    mockPending.mockResolvedValue({
+      all_media_ids: Array.from({ length: 62 }, (_, i) => `m${i + 1}`),
+      pending_media_ids: Array.from({ length: 44 }, (_, i) => `m${i + 19}`),
+      done_media_ids: Array.from({ length: 18 }, (_, i) => `m${i + 1}`),
+    })
+  })
+
+  it("is scheduled — a run this long cannot rely on someone watching it", () => {
+    expect(config.name).toBe("resume-stalled-folder-extractions")
+    expect(config.schedule).toBe("*/30 * * * *")
+  })
+
+  /**
+   * 🔑 The production shape, end to end: silent for five hours, 44 outstanding,
+   * resumed as a `pending`-scoped run over exactly those 44.
+   */
+  it("resumes a stalled folder over exactly the outstanding images", async () => {
+    const { container } = containerWith([folderWith()])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).toHaveBeenCalledTimes(1)
+    const input = mockRun.mock.calls[0][0].input
+    expect(input.folder_id).toBe("folder_1")
+    expect(input.scope).toBe("pending")
+    expect(input.media_ids).toHaveLength(44)
+    expect(input.persist).toBe(true)
+    // The pacing the run was started with is kept, not reset to the default.
+    expect(input.interval_ms).toBe(60_000)
+
+    // Auto-confirmed, or it would sit at the wait step forever.
+    expect(mockSetStepSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * 🔴 The one that matters most. Two loops over one folder would extract every
+   * pending image twice, in parallel, at double the provider rate the pacing
+   * exists to respect — and `link.create` is not idempotent, so each leaves its
+   * own duplicate analysis row.
+   */
+  it("never touches a run that is still writing progress", async () => {
+    const { container } = containerWith([folderWith({ updated_at: minutesAgo(1) })])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).not.toHaveBeenCalled()
+  })
+
+  it.each(["completed", "failed"])("ignores a %s run", async (status) => {
+    const { container } = containerWith([
+      folderWith({ status, updated_at: minutesAgo(5000) }),
+    ])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).not.toHaveBeenCalled()
+  })
+
+  it("ignores folders that have never been extracted", async () => {
+    const { container } = containerWith([{ id: "f", name: "f", metadata: {} }])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).not.toHaveBeenCalled()
+  })
+
+  /**
+   * 🔴 A folder whose images fail for a reason that will not change must stop
+   * costing vision calls and be left for a human — the same rule
+   * `process-email-queue` applies with `MAX_ATTEMPTS`.
+   */
+  it("gives up after the attempt cap and says so", async () => {
+    const { container, log } = containerWith([
+      folderWith({ resume_attempts: MAX_RESUME_ATTEMPTS }),
+    ])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).not.toHaveBeenCalled()
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("leaving it for a human"))
+  })
+
+  it("still resumes one attempt short of the cap", async () => {
+    const { container } = containerWith([
+      folderWith({ resume_attempts: MAX_RESUME_ATTEMPTS - 1 }),
+    ])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The run died after its last photo but before `finalizeFolderExtractionStep`.
+   * There is nothing to extract — but leaving it `running` means the admin strip
+   * spins forever and every future sweep finds it again.
+   */
+  it("closes a folder that is actually complete instead of re-running it", async () => {
+    mockPending.mockResolvedValue({
+      all_media_ids: ["m1", "m2"],
+      pending_media_ids: [],
+      done_media_ids: ["m1", "m2"],
+    })
+    const { container, mediaService } = containerWith([folderWith()])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).not.toHaveBeenCalled()
+    const write = (mediaService.updateFolders as jest.Mock).mock.calls[0]?.[0] as any
+    expect(write?.data?.metadata?.folder_extraction?.status).toBe("completed")
+    expect(write?.data?.metadata?.folder_extraction?.finished_at).toBeTruthy()
+  })
+
+  /**
+   * 🔑 A cap that trims the list silently reads as "everything was handled" on
+   * the next pass.
+   */
+  it("caps how many folders it resumes in one pass, and names what it left", async () => {
+    const stalled = Array.from({ length: 8 }, (_, i) => folderWith({}, `folder_${i}`))
+    const { container, log } = containerWith(stalled)
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).toHaveBeenCalledTimes(5)
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("left for the next run"))
+  })
+
+  it("keeps going when one folder fails to resume", async () => {
+    mockRun
+      .mockRejectedValueOnce(new Error("engine unavailable"))
+      .mockResolvedValue({ transaction: { transactionId: "tx_2" } })
+
+    const { container, log } = containerWith([
+      folderWith({}, "folder_a"),
+      folderWith({}, "folder_b"),
+    ])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).toHaveBeenCalledTimes(2)
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining("folder_a"))
+  })
+})

--- a/apps/backend/src/jobs/resume-stalled-folder-extractions.ts
+++ b/apps/backend/src/jobs/resume-stalled-folder-extractions.ts
@@ -1,0 +1,210 @@
+import type { MedusaContainer } from "@medusajs/framework/types"
+import {
+  ContainerRegistrationKeys,
+  Modules,
+  TransactionHandlerType,
+} from "@medusajs/framework/utils"
+import { StepResponse } from "@medusajs/framework/workflows-sdk"
+import type { IWorkflowEngineService } from "@medusajs/framework/types"
+
+import { MEDIA_MODULE } from "../modules/media"
+import {
+  textileFolderExtractionMedusaWorkflow,
+  textileFolderExtractionWorkflowId,
+  waitConfirmationTextileFolderExtractionStepId,
+  FolderExtractionProgress,
+} from "../workflows/ai/textile-folder-extraction"
+import {
+  folderExtractionLiveness,
+  pendingFolderExtractionMedia,
+} from "../workflows/ai/lib/folder-extraction-resume"
+
+/**
+ * Finish folder extractions that a deploy killed mid-loop (#1742).
+ *
+ * ## Why a job and not a workflow retry
+ *
+ * `processFolderMediaSequentiallyStep` is one step holding a `for` loop with
+ * `await sleep()` in it. At the measured production pace — ~3.2 min per photo,
+ * because the vision call costs ~2.2 min on top of the 60 s interval — a
+ * 62-image folder is a **3.3-hour** run inside a single Node process. There
+ * were six deploys on 2026-09-02 alone. A run that long does not survive, and
+ * Medusa cannot rescue it: the step is `async, backgroundExecution`, so the
+ * engine waits for a callback from a process that no longer exists. All five
+ * `textile-folder-extraction` executions ever started on production are still
+ * sitting in `invoking`.
+ *
+ * Retrying the workflow is therefore not the fix; noticing and starting a fresh
+ * scoped run is. That is what this does, and it is only safe because the
+ * work-list is derived from state — images with no `textile_analysis` row —
+ * so a resume can never redo what is already done.
+ *
+ * ## What it deliberately does NOT do
+ *
+ * 🔴 It does not resume a run that merely LOOKS slow. The threshold is three
+ * intervals of silence with a ten-minute floor, and progress is written after
+ * every single item, so a live run cannot trip it. Two loops over one folder
+ * would double the provider rate the pacing exists to respect and leave a
+ * duplicate analysis row for every image — `link.create` is not idempotent.
+ *
+ * 🔴 It does not resume forever. `resume_attempts` is capped the way
+ * `process-email-queue` caps `MAX_ATTEMPTS`: a folder whose images fail for a
+ * reason that will not change must stop costing vision calls, and be left for a
+ * human to look at. A person pressing Resume in the admin is never blocked by
+ * the count — they can see the errors and are making the call.
+ *
+ * 🔴 It never widens scope. A folder extraction covers the images that were in
+ * the folder; images added afterwards are a new decision by whoever added them.
+ * The resume asks only for what is outstanding, which is the same list the
+ * status route reports.
+ */
+
+/** Stop auto-resuming a folder after this many attempts. */
+export const MAX_RESUME_ATTEMPTS = 3
+
+/** Never resume more than this many folders in one pass. */
+const MAX_FOLDERS_PER_RUN = 5
+
+export default async function resumeStalledFolderExtractions(
+  container: MedusaContainer
+) {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const mediaService: any = container.resolve(MEDIA_MODULE)
+
+  let folders: any[] = []
+  try {
+    folders = (await mediaService.listFolders({}, { take: 1000 })) || []
+  } catch (e: any) {
+    logger.error(`[resume-folder-extraction] Could not list folders: ${e?.message}`)
+    return
+  }
+
+  /**
+   * ⚠️ Filtered in memory. `folder_extraction` lives inside `metadata`, a JSON
+   * bag, and the module service cannot filter on a subkey — asking it to would
+   * silently return every folder, which is the shape that turns a scoped sweep
+   * into an unscoped one.
+   */
+  const candidates = folders
+    .map((folder: any) => ({
+      folder,
+      progress: (folder?.metadata?.folder_extraction as FolderExtractionProgress) || null,
+    }))
+    .filter(({ progress }) => progress?.status === "running")
+    .map((row) => ({ ...row, liveness: folderExtractionLiveness(row.progress) }))
+    .filter(({ liveness }) => liveness.stalled)
+
+  if (!candidates.length) {
+    logger.info("[resume-folder-extraction] No stalled folder extractions")
+    return
+  }
+
+  logger.info(
+    `[resume-folder-extraction] ${candidates.length} stalled folder extraction(s) found`
+  )
+
+  let resumed = 0
+
+  for (const { folder, progress, liveness } of candidates) {
+    if (resumed >= MAX_FOLDERS_PER_RUN) {
+      /**
+       * 🔑 Named, not silent. A cap that trims the list without saying so reads
+       * as "everything was handled" on the next pass.
+       */
+      logger.info(
+        `[resume-folder-extraction] Cap of ${MAX_FOLDERS_PER_RUN} reached — ${
+          candidates.length - resumed
+        } stalled folder(s) left for the next run`
+      )
+      break
+    }
+
+    const attempts = Number(progress?.resume_attempts ?? 0) || 0
+    if (attempts >= MAX_RESUME_ATTEMPTS) {
+      logger.warn(
+        `[resume-folder-extraction] Folder ${folder.id} has been resumed ${attempts} time(s) and is still stalling — leaving it for a human`
+      )
+      continue
+    }
+
+    try {
+      const { pending_media_ids, all_media_ids } = await pendingFolderExtractionMedia(
+        container,
+        folder.id
+      )
+
+      if (!pending_media_ids.length) {
+        /**
+         * Every image was analysed — the run died after its last item but
+         * before `finalizeFolderExtractionStep`. Nothing to extract; just stop
+         * the folder claiming to be running, so the admin strip stops spinning
+         * and this sweep stops finding it.
+         */
+        await mediaService.updateFolders({
+          selector: { id: folder.id },
+          data: {
+            metadata: {
+              ...(folder.metadata || {}),
+              folder_extraction: {
+                ...(progress || {}),
+                status: "completed",
+                updated_at: new Date().toISOString(),
+                finished_at: new Date().toISOString(),
+              },
+            },
+          },
+        })
+        logger.info(
+          `[resume-folder-extraction] Folder ${folder.id} was already complete — marked finished`
+        )
+        continue
+      }
+
+      const { transaction } = await textileFolderExtractionMedusaWorkflow(container).run({
+        input: {
+          folder_id: folder.id,
+          media_ids: pending_media_ids,
+          scope: "pending",
+          persist: true,
+          interval_ms: progress?.interval_ms,
+        },
+      })
+
+      const workflowEngineService: IWorkflowEngineService = container.resolve(
+        Modules.WORKFLOW_ENGINE
+      )
+      await workflowEngineService.setStepSuccess({
+        idempotencyKey: {
+          action: TransactionHandlerType.INVOKE,
+          transactionId: transaction.transactionId,
+          stepId: waitConfirmationTextileFolderExtractionStepId,
+          workflowId: textileFolderExtractionWorkflowId,
+        },
+        stepResponse: new StepResponse(true),
+      })
+
+      resumed++
+      logger.info(
+        `[resume-folder-extraction] Folder ${folder.id} (${folder.name}) silent for ${Math.round(
+          (liveness.silent_for_ms ?? 0) / 60000
+        )} min — resumed ${pending_media_ids.length} of ${all_media_ids.length} image(s), attempt ${
+          attempts + 1
+        }/${MAX_RESUME_ATTEMPTS}, tx ${transaction.transactionId}`
+      )
+    } catch (e: any) {
+      logger.error(
+        `[resume-folder-extraction] Failed to resume folder ${folder.id}: ${e?.message}`
+      )
+    }
+  }
+}
+
+export const config = {
+  name: "resume-stalled-folder-extractions",
+  /**
+   * Every 30 minutes. A stalled run is discovered within roughly one deploy's
+   * worth of time, and the threshold (three intervals, ten-minute floor) is
+   * well inside that — so nothing live is ever caught by it.
+   */
+  schedule: "*/30 * * * *",
+}

--- a/apps/backend/src/workflows/ai/lib/__tests__/folder-extraction-resume.unit.spec.ts
+++ b/apps/backend/src/workflows/ai/lib/__tests__/folder-extraction-resume.unit.spec.ts
@@ -1,0 +1,252 @@
+import {
+  MIN_STALL_THRESHOLD_MS,
+  STALL_INTERVAL_MULTIPLIER,
+  folderExtractionLiveness,
+  pendingFolderExtractionMedia,
+} from "../folder-extraction-resume"
+
+/**
+ * #1742 — a run that stops writing has stopped, and nothing else can tell you.
+ */
+describe("folderExtractionLiveness", () => {
+  const now = new Date("2026-09-02T08:00:00.000Z")
+  const at = (iso: string) => ({
+    status: "running",
+    updated_at: iso,
+    interval_ms: 60_000,
+  })
+
+  it("calls the production case stalled — 18/62, silent since 03:04", () => {
+    const verdict = folderExtractionLiveness(at("2026-09-02T03:04:56.885Z"), now)
+
+    expect(verdict.stalled).toBe(true)
+    // Just under five hours of silence against a ten-minute threshold.
+    expect(verdict.silent_for_ms).toBe(
+      now.getTime() - Date.parse("2026-09-02T03:04:56.885Z")
+    )
+    expect(verdict.threshold_ms).toBe(MIN_STALL_THRESHOLD_MS)
+  })
+
+  it("leaves a run that wrote a moment ago alone", () => {
+    expect(folderExtractionLiveness(at("2026-09-02T07:59:30.000Z"), now).stalled).toBe(
+      false
+    )
+  })
+
+  /**
+   * 🔴 The floor is what stops a tight pacing from declaring a live run dead.
+   * At 5 s intervals, three intervals is 15 s — one slow vision call.
+   */
+  it("never judges faster than the ten-minute floor, however tight the pacing", () => {
+    const verdict = folderExtractionLiveness(
+      { status: "running", updated_at: "2026-09-02T07:55:00.000Z", interval_ms: 5_000 },
+      now
+    )
+
+    expect(verdict.threshold_ms).toBe(MIN_STALL_THRESHOLD_MS)
+    expect(verdict.silent_for_ms).toBe(5 * 60 * 1000)
+    expect(verdict.stalled).toBe(false)
+  })
+
+  it("scales the threshold with a slow pacing", () => {
+    const interval = 15 * 60 * 1000
+    const verdict = folderExtractionLiveness(
+      { status: "running", updated_at: "2026-09-02T07:00:00.000Z", interval_ms: interval },
+      now
+    )
+
+    // 45-minute threshold, 60 minutes of silence.
+    expect(verdict.threshold_ms).toBe(interval * STALL_INTERVAL_MULTIPLIER)
+    expect(verdict.silent_for_ms).toBe(60 * 60 * 1000)
+    expect(verdict.stalled).toBe(true)
+  })
+
+  it("holds one interval short of the threshold", () => {
+    const interval = 15 * 60 * 1000
+    const verdict = folderExtractionLiveness(
+      { status: "running", updated_at: "2026-09-02T07:30:00.000Z", interval_ms: interval },
+      now
+    )
+
+    expect(verdict.threshold_ms).toBe(45 * 60 * 1000)
+    expect(verdict.silent_for_ms).toBe(30 * 60 * 1000)
+    expect(verdict.stalled).toBe(false)
+  })
+
+  /**
+   * ⚠️ Only `running` can stall. Reporting a finished run as stalled would put
+   * a Resume button on every folder ever extracted.
+   */
+  it.each(["completed", "failed"])("never calls a %s run stalled", (status) => {
+    const verdict = folderExtractionLiveness(
+      { status, updated_at: "2026-01-01T00:00:00.000Z", interval_ms: 60_000 },
+      now
+    )
+    expect(verdict.stalled).toBe(false)
+  })
+
+  it("is not stalled when there is no progress at all", () => {
+    expect(folderExtractionLiveness(null, now).stalled).toBe(false)
+  })
+
+  /**
+   * A missing or unparseable timestamp is an absence of evidence. Treating it
+   * as death would start a second loop over a folder that may still be live.
+   */
+  it.each([undefined, null, "", "not a date"])(
+    "refuses to judge on updated_at=%p",
+    (updated_at) => {
+      const verdict = folderExtractionLiveness(
+        { status: "running", updated_at: updated_at as any, interval_ms: 60_000 },
+        now
+      )
+      expect(verdict.stalled).toBe(false)
+      expect(verdict.silent_for_ms).toBeNull()
+    }
+  )
+})
+
+describe("pendingFolderExtractionMedia", () => {
+  const image = (id: string) => ({
+    id,
+    file_type: "image",
+    file_path: `https://cdn.example/${id}.jpg`,
+  })
+
+  const containerWith = (opts: {
+    mediaFiles: any[]
+    linkRows: any[]
+    onGraph?: (args: any) => void
+  }) => {
+    const graph = jest.fn(async (args: any) => {
+      opts.onGraph?.(args)
+      return { data: opts.linkRows }
+    })
+
+    return {
+      graph,
+      container: {
+        resolve: (key: string) => {
+          if (key === "query") return { graph }
+          return { listMediaFiles: jest.fn(async () => opts.mediaFiles) }
+        },
+      } as any,
+    }
+  }
+
+  it("counts an image with an analysis as done and everything else as pending", async () => {
+    const { container } = containerWith({
+      mediaFiles: [image("m1"), image("m2"), image("m3")],
+      linkRows: [{ media_file_id: "m2", textile_analysis_id: "ta_2" }],
+    })
+
+    const result = await pendingFolderExtractionMedia(container, "folder_1")
+
+    expect(result.all_media_ids).toEqual(["m1", "m2", "m3"])
+    expect(result.done_media_ids).toEqual(["m2"])
+    expect(result.pending_media_ids).toEqual(["m1", "m3"])
+  })
+
+  /**
+   * 🔴 The defect this whole change exists for. A file that FAILED and a file
+   * the run never reached are indistinguishable to the work outstanding — the
+   * old retry route could only see the first kind, so it offered to re-run 1 of
+   * 44.
+   */
+  it("returns never-attempted images, not just ones that errored", async () => {
+    const mediaFiles = Array.from({ length: 62 }, (_, i) => image(`m${i + 1}`))
+    // 18 completed before the process was killed; m19 failed; m20..m62 untouched.
+    const linkRows = mediaFiles
+      .slice(0, 18)
+      .map((m) => ({ media_file_id: m.id, textile_analysis_id: `ta_${m.id}` }))
+
+    const { container } = containerWith({ mediaFiles, linkRows })
+
+    const result = await pendingFolderExtractionMedia(container, "folder_1")
+
+    expect(result.done_media_ids).toHaveLength(18)
+    expect(result.pending_media_ids).toHaveLength(44)
+    expect(result.pending_media_ids[0]).toBe("m19")
+  })
+
+  it("ignores non-images and media with no file_path", async () => {
+    const { container } = containerWith({
+      mediaFiles: [
+        image("m1"),
+        { id: "v1", file_type: "video", file_path: "https://cdn/v1.mp4" },
+        { id: "m2", file_type: "image", file_path: null },
+      ],
+      linkRows: [],
+    })
+
+    const result = await pendingFolderExtractionMedia(container, "folder_1")
+
+    expect(result.all_media_ids).toEqual(["m1"])
+    expect(result.pending_media_ids).toEqual(["m1"])
+  })
+
+  /**
+   * 🔴 Read through the LINK's entryPoint. Asking the media entity for a linked
+   * field returns no key at all, silently — and every image would then look
+   * pending, which here means re-billing the whole folder.
+   */
+  /**
+   * ⚠️ This asserts the link's SHAPE, not its name. `defineLink().entryPoint`
+   * is empty until the modules are registered, so a unit test comparing it to
+   * a string would either fail or — worse — pass vacuously against `""`. The
+   * name is pinned by the integration test, which runs a real container; what
+   * is checkable here is that exactly one graph call is made, asking for the
+   * link's own columns and filtered to this folder's media rather than
+   * unfiltered.
+   */
+  it("makes one link query, asking for link columns filtered to this folder's media", async () => {
+    const seen: any[] = []
+    const { container } = containerWith({
+      mediaFiles: [image("m1"), image("m2")],
+      linkRows: [],
+      onGraph: (args) => seen.push(args),
+    })
+
+    await pendingFolderExtractionMedia(container, "folder_1")
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].fields).toEqual(["media_file_id", "textile_analysis_id"])
+    expect(seen[0].filters).toEqual({ media_file_id: ["m1", "m2"] })
+  })
+
+  it("does not query the link at all for an empty folder", async () => {
+    const { container, graph } = containerWith({ mediaFiles: [], linkRows: [] })
+
+    const result = await pendingFolderExtractionMedia(container, "folder_1")
+
+    expect(result).toEqual({
+      all_media_ids: [],
+      pending_media_ids: [],
+      done_media_ids: [],
+    })
+    expect(graph).not.toHaveBeenCalled()
+  })
+
+  /**
+   * 🔴 Let the error out. Swallowing it reports every image as pending, and the
+   * caller pays for a full re-extraction believing it is resuming.
+   */
+  it("throws rather than reporting everything as pending when the link fails", async () => {
+    const container = {
+      resolve: (key: string) => {
+        if (key === "query") {
+          return {
+            graph: jest.fn(async () => {
+              throw new Error("link unreachable")
+            }),
+          }
+        }
+        return { listMediaFiles: jest.fn(async () => [image("m1")]) }
+      },
+    } as any
+
+    await expect(pendingFolderExtractionMedia(container, "folder_1")).rejects.toThrow(
+      "link unreachable"
+    )
+  })
+})

--- a/apps/backend/src/workflows/ai/lib/folder-extraction-resume.ts
+++ b/apps/backend/src/workflows/ai/lib/folder-extraction-resume.ts
@@ -1,0 +1,183 @@
+/**
+ * What a folder-wide textile extraction still owes, and whether the run that
+ * was supposed to deliver it is still alive (#1742).
+ *
+ * ## Why this file exists
+ *
+ * `processFolderMediaSequentiallyStep` is ONE step containing a `for` loop with
+ * `await sleep()` inside it. The loop lives in the Node process, so an ECS task
+ * replacement — a deploy — takes it with it. Medusa cannot recover from that:
+ * the step is `async: true, backgroundExecution: true`, so the engine sits
+ * waiting for a callback from a process that no longer exists. Measured on
+ * production 2026-09-02: folder `01KZTFAA2TFN5RXFVDMD2RAWZG` stopped at 18 of
+ * 62 when the 02:29→03:06 deploy replaced the task mid-run, and every one of
+ * the five `textile-folder-extraction` executions ever started is still sitting
+ * in `invoking`.
+ *
+ * Two things were missing, and both are here:
+ *
+ * 1. **A way to know.** `status` stays the string `"running"` forever, because
+ *    a process that dies writes nothing — least of all "I died". The status is
+ *    a claim about the past, and the only evidence of liveness is how long ago
+ *    it was written. {@link folderExtractionLiveness} turns that into an answer.
+ *
+ * 2. **A work-list derived from STATE, not from a fixed list.** This is the
+ *    shape `backfillAllGeocodesWorkflow` already uses: its
+ *    `getAllUngeocodedAddressesStep` asks which addresses still lack a geocode,
+ *    so re-running it is automatically a resume and running it twice is
+ *    harmless. Folder extraction asked for "every image in the folder" instead,
+ *    which makes a re-run a full re-do — 62 vision calls to recover 44, and a
+ *    duplicate `textile_analysis` row for each of the 18 already done.
+ *    {@link pendingFolderExtractionMedia} is the geocode question, asked about
+ *    images.
+ *
+ * 🔴 "Pending" is deliberately defined as *has no `textile_analysis` row*, NOT
+ * as *appears in `folder_extraction.errors`*. The retry route used the second
+ * definition and could therefore only ever see the 1 file that failed loudly —
+ * the 43 that were never attempted at all are not errors, and no route in the
+ * system could reach them. A file the run never got to and a file the run
+ * failed on are the same thing to the work that remains.
+ */
+
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import { MEDIA_MODULE } from "../../../modules/media"
+import MediaTextileAnalysisLink from "../../../links/media-textile-analysis-link"
+
+/** Never call a run stalled sooner than this, however tight the pacing. */
+export const MIN_STALL_THRESHOLD_MS = 10 * 60 * 1000
+
+/**
+ * How many intervals of silence before a run is presumed dead.
+ *
+ * Progress is written after EVERY item, so one missed write is already odd.
+ * Three is slack for a slow vision call — measured pace on production is ~3.2
+ * min per photo against a 60 s `interval_ms`, because the extraction itself
+ * costs ~2.2 min on top of the sleep.
+ */
+export const STALL_INTERVAL_MULTIPLIER = 3
+
+export type LivenessInput = {
+  status?: string | null
+  updated_at?: string | null
+  interval_ms?: number | null
+}
+
+export type Liveness = {
+  /** True only for a run that CLAIMS to be running and has gone quiet. */
+  stalled: boolean
+  /** Milliseconds since the last progress write, or null if never written. */
+  silent_for_ms: number | null
+  /** The silence this run was judged against. */
+  threshold_ms: number
+}
+
+/**
+ * Whether a run claiming to be `running` has actually stopped.
+ *
+ * ⚠️ Only `running` can stall. A `completed` or `failed` run is finished and
+ * silence is expected — reporting those as stalled would put a Resume button on
+ * every folder that has ever been extracted.
+ *
+ * ⚠️ An unparseable or missing `updated_at` is NOT stalled. A missing timestamp
+ * is an absence of evidence, and killing a live run on the strength of one
+ * would be worse than leaving a dead one alone for a human to notice.
+ */
+export const folderExtractionLiveness = (
+  progress: LivenessInput | null | undefined,
+  now: Date = new Date()
+): Liveness => {
+  const interval = Number(progress?.interval_ms ?? 0) || 0
+  const threshold_ms = Math.max(
+    MIN_STALL_THRESHOLD_MS,
+    interval * STALL_INTERVAL_MULTIPLIER
+  )
+
+  if (!progress || String(progress.status ?? "") !== "running") {
+    return { stalled: false, silent_for_ms: null, threshold_ms }
+  }
+
+  const updatedAt = progress.updated_at ? Date.parse(progress.updated_at) : NaN
+  if (!Number.isFinite(updatedAt)) {
+    return { stalled: false, silent_for_ms: null, threshold_ms }
+  }
+
+  const silent_for_ms = Math.max(0, now.getTime() - updatedAt)
+
+  return {
+    stalled: silent_for_ms > threshold_ms,
+    silent_for_ms,
+    threshold_ms,
+  }
+}
+
+export type PendingFolderMedia = {
+  /** Every image in the folder, in the order the run would process them. */
+  all_media_ids: string[]
+  /** Those with no `textile_analysis` row yet — the work that remains. */
+  pending_media_ids: string[]
+  /** Those that already have one. */
+  done_media_ids: string[]
+}
+
+/**
+ * Which images in a folder have never been successfully analysed.
+ *
+ * 🔴 The link is read through `MediaTextileAnalysisLink.entryPoint`, not by
+ * asking the media entity for a linked field. `query.graph` from an ENTITY to a
+ * linked field returns no key at all — silently — and a folder whose images
+ * were all analysed would come back looking entirely pending, which here means
+ * re-billing every vision call in it.
+ *
+ * ⚠️ Ordered by `created_at ASC`, the same order `listFolderMediaStep` uses, so
+ * a resumed run continues through the folder rather than restarting the
+ * sequence somewhere arbitrary.
+ */
+export const pendingFolderExtractionMedia = async (
+  container: MedusaContainer,
+  folder_id: string
+): Promise<PendingFolderMedia> => {
+  const mediaService: any = container.resolve(MEDIA_MODULE)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const mediaFiles = await mediaService.listMediaFiles(
+    { folder_id },
+    { select: ["id", "file_path", "file_type"], order: { created_at: "ASC" } }
+  )
+
+  const all_media_ids: string[] = (mediaFiles || [])
+    .filter((f: any) => f.file_type === "image" && f.file_path)
+    .map((f: any) => String(f.id))
+
+  if (!all_media_ids.length) {
+    return { all_media_ids: [], pending_media_ids: [], done_media_ids: [] }
+  }
+
+  /**
+   * 🔴 Deliberately NOT wrapped in a try/catch. An unreachable link would
+   * report every image as pending, and the caller would then pay for a full
+   * re-extraction believing it was resuming. Letting the error out is the
+   * recoverable outcome; swallowing it spends money and overwrites good
+   * results. This is the opposite of `writeProgress`, where a failure must
+   * never take the run down — there, losing a progress write costs a stale
+   * number; here, losing the answer costs 62 vision calls.
+   */
+  const { data } = await query.graph({
+    entity: MediaTextileAnalysisLink.entryPoint,
+    fields: ["media_file_id", "textile_analysis_id"],
+    filters: { media_file_id: all_media_ids },
+  })
+
+  const analysed = new Set<string>()
+  for (const row of (data || []) as any[]) {
+    const id = row?.media_file_id
+    if (id) analysed.add(String(id))
+  }
+
+  return {
+    all_media_ids,
+    pending_media_ids: all_media_ids.filter((id) => !analysed.has(id)),
+    done_media_ids: all_media_ids.filter((id) => analysed.has(id)),
+  }
+}

--- a/apps/backend/src/workflows/ai/textile-folder-extraction.ts
+++ b/apps/backend/src/workflows/ai/textile-folder-extraction.ts
@@ -31,6 +31,7 @@ import {
   persistTextileExtractionResult,
   TextileProductExtractionOutput,
 } from "./textile-product-extraction";
+import { pendingFolderExtractionMedia } from "./lib/folder-extraction-resume";
 
 // ============================================
 // Types
@@ -49,6 +50,19 @@ export type TextileFolderExtractionInput = {
    * that failed a previous folder extraction.
    */
   media_ids?: string[];
+  /**
+   * Which images in the folder this run is for (#1742).
+   *
+   * - `"all"` (default) — every image, the original behaviour.
+   * - `"pending"` — only images with no `textile_analysis` row yet, which is
+   *   what makes a re-run a RESUME rather than a full re-do. This is the same
+   *   question `getAllUngeocodedAddressesStep` asks for the geocode backfill:
+   *   derive the work from state and running twice becomes harmless.
+   *
+   * ⚠️ Applied AFTER `media_ids`, so the two compose: an explicit list is
+   * narrowed to the ones still outstanding rather than overriding the scope.
+   */
+  scope?: "all" | "pending";
 };
 
 export type FolderMediaItem = {
@@ -65,10 +79,16 @@ export type FolderMediaListOutput = {
   hints?: string[];
   gender?: string;
   persist: boolean;
+  scope: "all" | "pending";
+  /** Every image in the folder, whatever this run's scope is. */
+  folder_total: number;
+  /** Images already carrying a `textile_analysis` row when this run started. */
+  already_done: number;
 };
 
 export type FolderExtractionProgress = {
   status: "running" | "completed" | "failed";
+  /** Images THIS run is processing. For a resume that is the remainder, not the folder. */
   total: number;
   completed: number;
   failed: number;
@@ -78,6 +98,25 @@ export type FolderExtractionProgress = {
   finished_at?: string | null;
   last_media_id?: string | null;
   errors?: Array<{ media_id: string; error: string }>;
+  /**
+   * Folder-wide truth, so a resume does not erase the record of what came
+   * before it (#1742).
+   *
+   * 🔴 The retry route used to re-init progress with `total: 1` — the count of
+   * files in `errors[]` — which overwrote "18 of 62 done, 43 never attempted"
+   * with "0 of 1". The only place the outstanding work was counted was the
+   * thing being overwritten. These three fields are what a screen needs to say
+   * "18 + 3 of 62" instead of "3 of 44" and lose the folder.
+   */
+  scope?: "all" | "pending";
+  folder_total?: number;
+  already_done?: number;
+  /**
+   * How many times a stalled run has been resumed for this folder. Capped, the
+   * way `process-email-queue` caps `MAX_ATTEMPTS`: a folder whose images fail
+   * for a reason that will not change must stop costing vision calls.
+   */
+  resume_attempts?: number;
 };
 
 export type TextileFolderExtractionSummary = {
@@ -155,6 +194,7 @@ const listFolderMediaStep = createStep(
     );
 
     let images = (mediaFiles || []).filter((f: any) => f.file_type === "image" && f.file_path);
+    const folder_total = images.length;
 
     // Scope to an explicit subset (the "retry failed" path) when requested.
     if (input.media_ids?.length) {
@@ -162,10 +202,40 @@ const listFolderMediaStep = createStep(
       images = images.filter((f: any) => wanted.has(f.id));
     }
 
+    /**
+     * The resume scope (#1742): drop images that already carry a
+     * `textile_analysis` row, so re-running finishes the folder instead of
+     * re-doing it. Same idea as `getAllUngeocodedAddressesStep` — the work-list
+     * is a question about state, which is what makes the workflow safe to run
+     * again after a deploy has killed it mid-loop.
+     */
+    const scope: "all" | "pending" = input.scope === "pending" ? "pending" : "all";
+    let already_done = 0;
+
+    if (scope === "pending") {
+      const { done_media_ids } = await pendingFolderExtractionMedia(
+        container,
+        input.folder_id
+      );
+      const done = new Set(done_media_ids);
+      already_done = done_media_ids.length;
+      images = images.filter((f: any) => !done.has(String(f.id)));
+    }
+
     if (images.length === 0) {
+      /**
+       * ⚠️ Two different nothings, and they must not read the same.
+       *
+       * An empty FOLDER is a caller mistake worth a 400. A folder with nothing
+       * PENDING is a resume that has already succeeded — refusing it as invalid
+       * data would make the sweeper log an error every time it found a folder
+       * someone had finished by hand.
+       */
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
-        `Folder ${input.folder_id} has no image files to extract features from`
+        scope === "pending"
+          ? `Folder ${input.folder_id} has no images left to extract — every image already has a textile analysis`
+          : `Folder ${input.folder_id} has no image files to extract features from`
       );
     }
 
@@ -178,6 +248,9 @@ const listFolderMediaStep = createStep(
       hints: input.hints,
       gender: input.gender,
       persist: input.persist ?? false,
+      scope,
+      folder_total,
+      already_done,
     });
   }
 );
@@ -191,6 +264,8 @@ const initFolderExtractionProgressStep = createStep(
   async (input: FolderMediaListOutput, { container }) => {
     const mediaService: MediaService = container.resolve(MEDIA_MODULE);
     const folder = await mediaService.retrieveFolder(input.folder_id);
+    const previous =
+      (folder.metadata?.folder_extraction as FolderExtractionProgress) || null;
 
     const progress: FolderExtractionProgress = {
       status: "running",
@@ -203,6 +278,21 @@ const initFolderExtractionProgressStep = createStep(
       finished_at: null,
       last_media_id: null,
       errors: [],
+      scope: input.scope,
+      folder_total: input.folder_total,
+      already_done: input.already_done,
+      /**
+       * Counted across runs, not reset (#1742). The counter exists to stop a
+       * folder being resumed forever, so a fresh run inheriting zero would
+       * defeat it — the same way `process-email-queue` counts attempts on the
+       * row rather than on the pass. Only an explicit full re-run clears it,
+       * because that is a human saying "start this folder over".
+       *
+       * ⚠️ Only the SWEEPER consults this. A human pressing Resume is never
+       * refused on a count: they can see the errors and are making the call.
+       */
+      resume_attempts:
+        input.scope === "pending" ? (previous?.resume_attempts ?? 0) + 1 : 0,
     };
 
     await mediaService.updateFolders({
@@ -454,6 +544,7 @@ export const textileFolderExtractionMedusaWorkflow = createWorkflow(
       persist: data.input.persist ?? false,
       interval_ms: data.input.interval_ms,
       media_ids: data.input.media_ids,
+      scope: data.input.scope,
     }));
 
     // Use runAsStep with backgroundExecution for the long rate-limited run


### PR DESCRIPTION
Closes #1742.

Folder `01KZTFAA2TFN5RXFVDMD2RAWZG` sat at 18/62 for five hours showing a spinning "running" bar. It had not slowed down — the deploy of `6bad9574f` (02:29:50 → 03:06:45) replaced the ECS task holding the loop at 03:04:56.

## The two things that were missing

**1. A way to know it stopped.** `status` stays `"running"` for ever, because a process that dies writes nothing — least of all "I died". Progress is written after *every* item, so silence is the only evidence of liveness. `folderExtractionLiveness` makes the call (three intervals, ten-minute floor); the status route returns it; the admin strip gets a fourth state — **stopped**, amber, with a Resume button — instead of polling a corpse every 5 s.

**2. A work-list derived from STATE.** Copied from `backfillAllGeocodesWorkflow`, which has always done this: `getAllUngeocodedAddressesStep` asks which addresses still lack a geocode, so re-running it *is* a resume and running it twice is harmless. `pendingFolderExtractionMedia` is that question asked about images — which have no `textile_analysis` row — read through the **link's entryPoint**, because a `query.graph` from the media entity to a linked field returns no key at all, silently, and every image would look pending.

## Why "retry failed" could never have finished it

It read `folder_extraction.errors` and re-ran exactly those: **1** file of the **44** outstanding. The 43 it never reached are not errors. It then re-inited progress with `total: 1`, overwriting "18 of 62 done" — the only place the outstanding work was counted was the thing being overwritten.

A file the run failed on and a file the run never reached are the same thing to the work that remains.

## Changes

| file | what |
|---|---|
| `workflows/ai/lib/folder-extraction-resume.ts` | new — liveness verdict + pending derivation, one home for both |
| `workflows/ai/textile-folder-extraction.ts` | `scope: all\|pending`; progress carries `folder_total` / `already_done` / `resume_attempts` so a resume does not erase the folder's record |
| `…/extract-features/route.ts` + `validators.ts` | `media_ids` and `scope` are reachable at last; an empty pending scope is a 400 **at the door**, not a 202 that dies in the background |
| `…/extract-features/retry/route.ts` | resumes everything outstanding; refuses while a run is genuinely alive |
| `…/extract-features/status/route.ts` | `stalled`, `silent_for_ms`, `pending_count`, `resumable` |
| `jobs/resume-stalled-folder-extractions.ts` | new — sweeps every 30 min |
| admin strip + hooks | stopped state, Resume button, folder-wide `18+n/62` counting, stops polling a dead run |

## What the sweeper deliberately will not do

- **Touch a run still writing progress.** Two loops over one folder would extract every pending image twice, in parallel, at double the provider rate the pacing exists to respect — and `link.create` is not idempotent, so each leaves its own duplicate row.
- **Resume for ever.** `MAX_RESUME_ATTEMPTS = 3`, the way `process-email-queue` caps its attempts. A human pressing Resume is never blocked by the count — they can see the errors and are making the call.
- **Trim silently.** It logs what it left when it hits its per-pass cap.

## Verification

29 unit + 10 integration cases (real Medusa long-running machinery, vision stubbed).

**Mutation-checked four ways** — each reverts one half of the fix and the right tests go red:

| mutation | result |
|---|---|
| drop the `running` guard in liveness | 2 cases fail |
| treat every image as pending | 2 cases fail |
| revert resume to errors-only | **expected 3, received 1** — the production number |
| remove the attempt cap / stalled filter | sweeper cases fail |

`textile-extract-features-stubbed` (7 cases) still green. `check:prod-build` green.

⚠️ `ai-image-extraction-persist` fails on a clean tree too — pre-existing, unrelated to this branch.

## Not fixed here

The 3.3-hour loop inside a single step is still a single step. This makes it *recoverable*, not *survivable* — chunking into per-image steps, or a queue, is the real answer and a bigger piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
