### PR TITLE
fix(textile): resume one stalled folder at a time, never beside a live run (#1742)

### DIFF
--- a/apps/backend/src/jobs/__tests__/resume-stalled-folder-extractions.unit.spec.ts
+++ b/apps/backend/src/jobs/__tests__/resume-stalled-folder-extractions.unit.spec.ts
@@ -200,14 +200,37 @@ describe("resume-stalled-folder-extractions", () => {
    * 🔑 A cap that trims the list silently reads as "everything was handled" on
    * the next pass.
    */
-  it("caps how many folders it resumes in one pass, and names what it left", async () => {
+  /**
+   * 🔴 The pacing knob is PER RUN. Three stalled folders resumed together are
+   * three requests per interval, whatever the knob says — which defeats the
+   * only reason the workflow sleeps between photos. Production had exactly
+   * this: three stalled folders, 92 images outstanding between them.
+   */
+  it("resumes one folder per pass and names the ones it left", async () => {
     const stalled = Array.from({ length: 8 }, (_, i) => folderWith({}, `folder_${i}`))
     const { container, log } = containerWith(stalled)
 
     await resumeStalledFolderExtractions(container)
 
-    expect(mockRun).toHaveBeenCalledTimes(5)
+    expect(mockRun).toHaveBeenCalledTimes(1)
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining("left for the next run"))
+  })
+
+  /**
+   * 🔴 The per-folder guard stops this sweep double-running ONE folder. This
+   * one stops it adding a second loop alongside a healthy run on a DIFFERENT
+   * folder — the case the first version of the sweeper missed.
+   */
+  it("stands down entirely while any other folder is genuinely extracting", async () => {
+    const { container, log } = containerWith([
+      folderWith({}, "stalled_folder"),
+      folderWith({ updated_at: minutesAgo(1) }, "live_folder"),
+    ])
+
+    await resumeStalledFolderExtractions(container)
+
+    expect(mockRun).not.toHaveBeenCalled()
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("still extracting"))
   })
 
   it("keeps going when one folder fails to resume", async () => {

--- a/apps/backend/src/jobs/resume-stalled-folder-extractions.ts
+++ b/apps/backend/src/jobs/resume-stalled-folder-extractions.ts
@@ -62,8 +62,24 @@ import {
 /** Stop auto-resuming a folder after this many attempts. */
 export const MAX_RESUME_ATTEMPTS = 3
 
-/** Never resume more than this many folders in one pass. */
-const MAX_FOLDERS_PER_RUN = 5
+/**
+ * One folder per pass, and never alongside a live run.
+ *
+ * 🔴 The pacing knob protects the vision provider PER RUN. It says nothing
+ * about how many runs exist, so N concurrent resumes are N times the rate the
+ * knob was set to — which defeats the only reason the workflow sleeps between
+ * photos at all.
+ *
+ * Found immediately after the first version of this sweeper merged: production
+ * had **three** stalled folders, not the one that was reported (92 images
+ * outstanding between them). A cap of five would have started all three at
+ * once, tripling the request rate against a provider the interval exists to
+ * stay under.
+ *
+ * At a 30-minute cadence the queue still drains — it just drains in single
+ * file, which is what the pacing asked for.
+ */
+const MAX_FOLDERS_PER_RUN = 1
 
 export default async function resumeStalledFolderExtractions(
   container: MedusaContainer
@@ -85,17 +101,39 @@ export default async function resumeStalledFolderExtractions(
    * silently return every folder, which is the shape that turns a scoped sweep
    * into an unscoped one.
    */
-  const candidates = folders
+  const runs = folders
     .map((folder: any) => ({
       folder,
       progress: (folder?.metadata?.folder_extraction as FolderExtractionProgress) || null,
     }))
     .filter(({ progress }) => progress?.status === "running")
     .map((row) => ({ ...row, liveness: folderExtractionLiveness(row.progress) }))
-    .filter(({ liveness }) => liveness.stalled)
+
+  const candidates = runs.filter(({ liveness }) => liveness.stalled)
 
   if (!candidates.length) {
     logger.info("[resume-folder-extraction] No stalled folder extractions")
+    return
+  }
+
+  /**
+   * 🔴 Stand down entirely while ANY folder is genuinely extracting.
+   *
+   * The interval between photos is the whole rate-limit story, and it is
+   * per-run: two live runs are two requests per interval, whatever the knob
+   * says. The per-folder liveness check further down stops this sweep
+   * double-running one folder; this one stops it adding a second loop
+   * ALONGSIDE a healthy run on a different folder — the case the first version
+   * missed, and the case production was one pass away from hitting with three
+   * stalled folders sitting in the list.
+   */
+  const live = runs.filter(({ liveness }) => !liveness.stalled)
+  if (live.length) {
+    logger.info(
+      `[resume-folder-extraction] ${candidates.length} stalled folder(s) waiting, but ${
+        live[0].folder.id
+      } is still extracting — holding off so the pacing stays one photo per interval overall`
+    )
     return
   }
 


### PR DESCRIPTION
Follow-up to #1743, found minutes after it merged while checking whether the reported folder could be restarted.

**Production has three stalled folder extractions, not one:**

| folder | progress | silent since | outstanding |
|---|---|---|---|
| mariam-model-work-August | 18/62, 1 failed | 09-02 03:04 | **44** |
| WhatsApp — Saransh Sharma | 3/42, 2 failed | 09-01 03:14 | **39** |
| WhatsApp — Afzal Alam | 2/11 | 08-30 11:43 | **9** |

92 images between them — and the sweeper's cap of five would have started **all three loops on its first pass**.

## Why that's wrong

The pacing knob protects the vision provider **per run**. It says nothing about how many runs exist, so three concurrent resumes are three requests per interval whatever the knob says — defeating the only reason the workflow sleeps between photos.

The per-folder liveness check already stopped the sweep double-running *one* folder. It did nothing about a second loop on a *different* folder. That's the gap.

## Changes

- `MAX_FOLDERS_PER_RUN` 5 → **1**. At a 30-minute cadence the queue still drains; it drains in single file.
- **Stand down entirely** when any folder is genuinely extracting — stalled ones waiting or not — and log which folder is holding the queue.

## Verification

12 sweeper cases. Mutation-checked: removing the stand-down guard fails `stands down entirely while any other folder is genuinely extracting`; the per-pass cap case now pins 1, not 5. `check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
