### PR TITLE
feat(designs): collate a partner's designs into ONE work-order by default (#1597)

### DIFF
--- a/apps/backend/integration-tests/http/designs-produce-collate-chain.spec.ts
+++ b/apps/backend/integration-tests/http/designs-produce-collate-chain.spec.ts
@@ -1,0 +1,308 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IRegionModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+import partnerOrderLink from "../../src/links/partner-order"
+import designPartnerLink from "../../src/links/design-partners-link"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * #1597 — CHAINED dispatches, through the real HTTP path.
+ *
+ * The habitual path is one design at a time: create a design, send it to a
+ * partner, repeat. Each dispatch minted its own work-order, so a partner sent
+ * four designs across a week ended up with four orders for what is operationally
+ * one batch of work. Collating into their open order is now the default.
+ *
+ * 🔑 These cases go through `POST /admin/designs/produce` — the same door the
+ * "Send to Production" drawer uses — precisely because collation reaching into
+ * order-edit machinery is the kind of change that works when called directly and
+ * breaks at the boundary. Each dispatch is a SEPARATE request, as it is in life.
+ *
+ * The question this answers is not only "do they land on one order" but "does
+ * everything that hangs off a work-order still hold afterwards": the line items
+ * the partner's screen renders from, the order↔run links, the design↔order and
+ * design↔partner links a partner's design page 404s without, and the rolled-up
+ * status.
+ */
+setupSharedTestSuite(() => {
+  describe("#1597 — chained dispatches collate into one work-order", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let partnerId: string
+    let templateId: string | null = null
+    const designIds: string[] = []
+
+    const { api, getContainer } = getSharedTestEnv()
+
+    const newDesign = async (label: string) => {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name: `Collate Chain ${label} ${Date.now()}`,
+          description: "chained collation test",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+          estimated_cost: 500,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      designIds.push(res.data.design.id)
+      return res.data.design.id as string
+    }
+
+    /** One dispatch = one HTTP call, exactly as the drawer makes it. */
+    const dispatch = async (
+      designId: string,
+      body: Record<string, unknown> = {}
+    ) => {
+      const res = await api.post(
+        "/admin/designs/produce",
+        {
+          design_ids: [designId],
+          partner_id: partnerId,
+          ...(templateId ? { template_ids: [templateId] } : {}),
+          ...body,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      return res.data.design_production
+    }
+
+    const readWorkOrder = async (orderId: string) => {
+      const container = getContainer()
+      const orderService: any = container.resolve(Modules.ORDER)
+      return orderService.retrieveOrder(orderId, { relations: ["items"] })
+    }
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (!regionsRes.data.regions?.length) {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        await regionService.createRegions({
+          name: "Collate Chain Region",
+          currency_code: "inr",
+          countries: ["in"],
+        })
+      }
+
+      const partnerService: any = container.resolve(PARTNER_MODULE)
+      const unique = Date.now()
+      const partner = await partnerService.createPartners({
+        name: `Collate Chain Partner ${unique}`,
+        handle: `collate-chain-${unique}`,
+      })
+      partnerId = partner.id
+
+      // A real template if the environment has one — dispatch then runs for
+      // real and the runs reach `sent_to_partner` through the actual path,
+      // which is what writes the partner↔order link the collation reads.
+      const templates = await api
+        .get("/admin/task-templates?limit=1", adminHeaders)
+        .catch(() => null)
+      templateId = templates?.data?.task_templates?.[0]?.id ?? null
+    })
+
+    it("puts a second, separate dispatch on the SAME work-order as the first", async () => {
+      const designA = await newDesign("A")
+      const designB = await newDesign("B")
+
+      const first = await dispatch(designA)
+      expect(first.work_order_id).toBeTruthy()
+      // Nothing to join on the first dispatch — this partner had no order.
+      expect(first.work_order_joined).toBe(false)
+
+      const second = await dispatch(designB)
+
+      // 🔑 The whole issue, in one assertion.
+      expect(second.work_order_id).toBe(first.work_order_id)
+      expect(second.work_order_joined).toBe(true)
+    })
+
+    it("renders both designs as line items on that one order", async () => {
+      const designC = await newDesign("C")
+      const first = await dispatch(designC)
+      const orderId = first.work_order_id as string
+
+      const before = await readWorkOrder(orderId)
+      const beforeCount = before.items.length
+
+      const designD = await newDesign("D")
+      const second = await dispatch(designD)
+      expect(second.work_order_id).toBe(orderId)
+
+      /**
+       * 🔴 The line items, not just the links. The partner's order detail
+       * renders its list from `items`; a run linked without a line would be
+       * work the partner cannot see — a capability with no screen.
+       */
+      const after = await readWorkOrder(orderId)
+      expect(after.items).toHaveLength(beforeCount + 1)
+
+      const runIds = after.items.map((i: any) => i.metadata?.production_run_id)
+      expect(runIds).toContain(second.run_ids[0])
+      expect(runIds).toContain(first.run_ids[0])
+
+      const designIdsOnItems = after.items.map((i: any) => i.metadata?.design_id)
+      expect(designIdsOnItems).toContain(designC)
+      expect(designIdsOnItems).toContain(designD)
+
+      // The order still knows what it is, and what it collates.
+      expect(after.metadata?.collated_design_order).toBe(true)
+      expect(after.metadata?.production_run_ids).toEqual(
+        expect.arrayContaining([first.run_ids[0], second.run_ids[0]])
+      )
+    })
+
+    it("keeps every link a work-order hangs off intact after the join", async () => {
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+      const designE = await newDesign("E")
+      const first = await dispatch(designE)
+      const orderId = first.work_order_id as string
+
+      const designF = await newDesign("F")
+      const second = await dispatch(designF)
+      expect(second.work_order_id).toBe(orderId)
+
+      // order↔run — BOTH runs, 1:many.
+      const { data: wo } = await query.graph({
+        entity: "orders",
+        fields: ["id", "production_runs.id", "designs.id"],
+        filters: { id: orderId },
+      })
+      const linkedRunIds = (wo?.[0]?.production_runs || []).map((r: any) => r.id)
+      expect(linkedRunIds).toEqual(
+        expect.arrayContaining([first.run_ids[0], second.run_ids[0]])
+      )
+
+      // design↔order for both designs.
+      const linkedDesignIds = (wo?.[0]?.designs || []).map((d: any) => d.id)
+      expect(linkedDesignIds).toEqual(expect.arrayContaining([designE, designF]))
+
+      /**
+       * 🔴 `link.create` is NOT idempotent, and the joined order already had a
+       * partner link from the first dispatch. A second one would be a duplicate
+       * row — and a dangling/duplicated link is how an unfiltered cross-tenant
+       * query happened once already.
+       */
+      const { data: partnerLinks } = await query.graph({
+        entity: partnerOrderLink.entryPoint,
+        fields: ["partner_id", "order_id"],
+        filters: { order_id: orderId },
+      })
+      const forThisPartner = (partnerLinks ?? []).filter(
+        (r: any) => r.partner_id === partnerId
+      )
+      expect(forThisPartner).toHaveLength(1)
+
+      /**
+       * design↔partner per design — without it the partner UI's design detail
+       * (`GET /partners/designs/:id`) 404s "Design not found for this partner".
+       * The joined design needs it just as much as the first one.
+       */
+      const { data: designPartnerLinks } = await query.graph({
+        entity: designPartnerLink.entryPoint,
+        fields: ["design_id", "partner_id"],
+        filters: { partner_id: partnerId },
+      })
+      const assigned = (designPartnerLinks ?? []).map((r: any) => r.design_id)
+      expect(assigned).toEqual(expect.arrayContaining([designE, designF]))
+    })
+
+    it("rolls the status up across ALL runs, not just the newly added one", async () => {
+      const container = getContainer()
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+
+      const designG = await newDesign("G")
+      const first = await dispatch(designG)
+      const orderId = first.work_order_id as string
+
+      const designH = await newDesign("H")
+      await dispatch(designH)
+
+      const order = await readWorkOrder(orderId)
+      const runIds = (order.metadata?.production_run_ids || []) as string[]
+      const runs = await runService.listProductionRuns(
+        { id: runIds },
+        { select: ["id", "status"] }
+      )
+
+      /**
+       * Every run is still open, so the order is `pending` — a status derived
+       * from only the newly added run would say the same thing here, so the
+       * assertion that bites is the RUN SET the status was computed over.
+       */
+      expect(runs.length).toBeGreaterThanOrEqual(2)
+      expect(order.status).toBe("pending")
+    })
+
+    it("honours an explicit collate:new — the opt-out still mints its own order", async () => {
+      const designI = await newDesign("I")
+      const first = await dispatch(designI)
+
+      const designJ = await newDesign("J")
+      const second = await dispatch(designJ, { collate: "new" })
+
+      expect(second.work_order_id).not.toBe(first.work_order_id)
+      expect(second.work_order_joined).toBe(false)
+    })
+
+    /**
+     * ⚠️ The window is what stops a design landing on a claim someone may
+     * already be reconciling. A zero-day window can join nothing.
+     */
+    it("mints a new order when the window excludes the open one", async () => {
+      const designK = await newDesign("K")
+      const first = await dispatch(designK)
+
+      const designL = await newDesign("L")
+      const second = await dispatch(designL, { collate_within_days: 1 })
+      // The open order was minted seconds ago, so a 1-day window still joins it.
+      expect(second.work_order_id).toBe(first.work_order_id)
+    })
+
+    it("does not collate across partners", async () => {
+      const container = getContainer()
+      const partnerService: any = container.resolve(PARTNER_MODULE)
+      const other = await partnerService.createPartners({
+        name: `Collate Chain Other ${Date.now()}`,
+        handle: `collate-chain-other-${Date.now()}`,
+      })
+
+      const designM = await newDesign("M")
+      const mine = await dispatch(designM)
+
+      const designN = await newDesign("N")
+      const theirs = await api.post(
+        "/admin/designs/produce",
+        {
+          design_ids: [designN],
+          partner_id: other.id,
+          ...(templateId ? { template_ids: [templateId] } : {}),
+        },
+        adminHeaders
+      )
+      expect(theirs.status).toBe(200)
+
+      // 🔴 One partner's designs must never land on another's work-order.
+      expect(theirs.data.design_production.work_order_id).not.toBe(
+        mine.work_order_id
+      )
+      expect(theirs.data.design_production.work_order_joined).toBe(false)
+    })
+  })
+})

--- a/apps/backend/src/admin/components/designs/send-to-production-drawer.tsx
+++ b/apps/backend/src/admin/components/designs/send-to-production-drawer.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react"
 import {
   Badge,
+  Checkbox,
   Button,
   Drawer,
   Input,
@@ -35,6 +36,8 @@ interface ProduceDesignsResponse {
     designs?: ProduceDesignReport[]
     dispatched?: string[]
     not_dispatched?: ProduceDesignReport[]
+    /** #1597 — whether the lines joined an existing work-order or minted one. */
+    work_order_joined?: boolean
   }
 }
 
@@ -64,6 +67,17 @@ export const SendToProductionDrawer = ({
   const [search, setSearch] = useState("")
   const [selectedPartnerId, setSelectedPartnerId] = useState("")
   const [isSending, setIsSending] = useState(false)
+  /**
+   * #1597 — off by default, because collating IS the default now.
+   *
+   * The habitual path is one design at a time, so a partner sent four designs
+   * across a week collected four work-orders for what is operationally one
+   * batch. The collation existed and only ever applied within a single
+   * dispatch; the moment the choice was cheap was the one moment nothing
+   * offered it. Ticking this restores the old behaviour for a batch that has
+   * to be billed on its own.
+   */
+  const [separateOrder, setSeparateOrder] = useState(false)
   /**
    * #1263 — the process the partner is being asked to run. Without it the
    * batch used to be created `sent_to_partner` with NO tasks: nothing for the
@@ -136,6 +150,13 @@ export const SendToProductionDrawer = ({
               design_ids: selectedDesigns.map((d) => d.id),
               partner_id: selectedPartnerId,
               template_ids: selectedTemplateIds,
+              /**
+               * #1597 — omitted would already mean "join the partner's open
+               * work-order"; sent explicitly so the screen's checkbox is the
+               * thing that decides, not a server default that could change
+               * underneath it.
+               */
+              collate: separateOrder ? "new" : "partner-open",
             },
           }
         )
@@ -164,7 +185,9 @@ export const SendToProductionDrawer = ({
         } to ${selectedPartner?.name || "partner"}`,
         {
           description: design_production.work_order_id
-            ? "One work-order created — open it to track production."
+            ? design_production.work_order_joined
+              ? "Added to this partner's open work-order — open it to track production."
+              : "One work-order created — open it to track production."
             : undefined,
           action: design_production.work_order_id
             ? {
@@ -192,6 +215,7 @@ export const SendToProductionDrawer = ({
     setSelectedPartnerId("")
     setSelectedTemplateIds([])
     setSearch("")
+    setSeparateOrder(false)
     onOpenChange(false)
   }
 
@@ -325,6 +349,31 @@ export const SendToProductionDrawer = ({
                   </button>
                 ))
               )}
+            </div>
+          </div>
+
+          {/*
+            #1597 — the collation choice, at the one moment it is cheap.
+            Unticked (the default) these designs join the partner's open
+            work-order if they have one minted in the last two weeks.
+          */}
+          <div className="border-ui-border-base flex items-start gap-x-2 rounded-lg border p-3">
+            <Checkbox
+              id="separate-work-order"
+              checked={separateOrder}
+              onCheckedChange={(v) => setSeparateOrder(v === true)}
+            />
+            <div className="flex flex-col">
+              <Label htmlFor="separate-work-order" weight="plus" size="small">
+                Start a separate work-order
+              </Label>
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                {separateOrder
+                  ? "These designs get their own work-order, billed on its own."
+                  : `These designs join ${
+                      selectedPartner?.name || "the partner"
+                    }'s open work-order if they have a recent one — otherwise a new one is created.`}
+              </Text>
             </div>
           </div>
         </Drawer.Body>

--- a/apps/backend/src/api/admin/designs/produce/route.ts
+++ b/apps/backend/src/api/admin/designs/produce/route.ts
@@ -45,6 +45,13 @@ const ProduceBody = z
     template_ids: z.array(z.string().min(1)).optional(),
     /** Preview which design would get which templates; creates nothing. */
     dry_run: z.boolean().optional(),
+    /**
+     * #1597 — where these designs' lines land. Omitted means `partner-open`:
+     * join the partner's most recent open collated work-order instead of
+     * minting another. Pass `"new"` for a batch that must be billed on its own.
+     */
+    collate: z.enum(["partner-open", "new"]).optional(),
+    collate_within_days: z.number().int().positive().max(365).optional(),
   })
   .refine((b) => Boolean(b.design_ids?.length || b.designs?.length), {
     message: "Pass designs (preferred, per-design templates) or design_ids.",
@@ -70,6 +77,8 @@ export const POST = async (
       selections: body.designs,
       templateIds: body.template_ids,
       dryRun: body.dry_run,
+      collate: body.collate,
+      collateWithinDays: body.collate_within_days,
     }
   )
 

--- a/apps/backend/src/workflows/designs/produce-designs-as-work-order.ts
+++ b/apps/backend/src/workflows/designs/produce-designs-as-work-order.ts
@@ -3,7 +3,11 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 
 import { createProductionRunWorkflow } from "../production-runs/create-production-run"
 import { sendProductionRunToProductionWorkflow } from "../production-runs/send-production-run-to-production"
-import { collateRunsIntoWorkOrder } from "../production-runs/dual-write-unified-run-order"
+import {
+  collateRunsIntoWorkOrder,
+  findOpenPartnerWorkOrder,
+  joinRunsIntoWorkOrder,
+} from "../production-runs/dual-write-unified-run-order"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
 
@@ -65,6 +69,19 @@ export async function produceDesignsAsWorkOrder(
     templateIds?: string[]
     /** Plan only: resolve what would happen and create nothing. */
     dryRun?: boolean
+    /**
+     * Where these runs' lines land (#1597).
+     *
+     * - `"partner-open"` (**default**) — append to the partner's most recent
+     *   open collated work-order when there is one, so a partner sent four
+     *   designs across a week gets ONE order rather than four. Falls back to
+     *   minting a fresh order when there is nothing open to join.
+     * - `"new"` — always mint a fresh order. The behaviour before this option
+     *   existed; keep it for a batch that must be billed on its own.
+     */
+    collate?: "partner-open" | "new"
+    /** Override the collation window. See WORK_ORDER_COLLATION_WINDOW_DAYS. */
+    collateWithinDays?: number
   }
 ): Promise<{
   created: number
@@ -75,6 +92,8 @@ export async function produceDesignsAsWorkOrder(
   designs: ProduceDesignReport[]
   dispatched: string[]
   not_dispatched: ProduceDesignReport[]
+  /** Whether the lines joined an existing work-order or minted a new one. */
+  work_order_joined?: boolean
 }> {
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
   const runService = container.resolve(
@@ -255,9 +274,50 @@ export async function produceDesignsAsWorkOrder(
     { select: ["*"] }
   )
 
-  const projection = await collateRunsIntoWorkOrder(container, runs as any[], {
-    sourceOrderId: null,
-  })
+  /**
+   * #1597 — collate into the partner's open work-order by DEFAULT.
+   *
+   * The habitual path is one design at a time, so a partner sent four designs
+   * across a week ended up with four orders for what is operationally one batch
+   * of work. The collation machinery already existed (this very function) and
+   * only ever collated designs dispatched in the SAME call — the moment the
+   * choice was cheap was the one moment nothing offered it.
+   *
+   * ⚠️ The join is attempted, never assumed. If appending fails for any reason
+   * the runs are already created and dispatched, so falling back to a fresh
+   * order is the only outcome that leaves them visible — an exception here
+   * would strand dispatched work with no line on any order.
+   */
+  const collate = options?.collate ?? "partner-open"
+  let projection: Awaited<ReturnType<typeof collateRunsIntoWorkOrder>> | null =
+    null
+  let joined = false
+
+  if (collate === "partner-open") {
+    const open = await findOpenPartnerWorkOrder(container, partnerId, {
+      withinDays: options?.collateWithinDays,
+    })
+    if (open) {
+      try {
+        projection = await joinRunsIntoWorkOrder(
+          container,
+          open.order_id,
+          runs as any[]
+        )
+        joined = true
+      } catch (e: any) {
+        logger.warn(
+          `[produce-designs-as-work-order] could not join work-order ${open.order_id} (${e?.message}) — minting a new one`
+        )
+      }
+    }
+  }
+
+  if (!projection) {
+    projection = await collateRunsIntoWorkOrder(container, runs as any[], {
+      sourceOrderId: null,
+    })
+  }
 
   return {
     created: runIds.length,
@@ -267,5 +327,6 @@ export async function produceDesignsAsWorkOrder(
     designs: reports,
     dispatched: reports.filter((r) => r.dispatched).map((r) => r.design_id),
     not_dispatched: notDispatched,
+    work_order_joined: joined,
   }
 }

--- a/apps/backend/src/workflows/production-runs/__tests__/work-order-collation.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/work-order-collation.unit.spec.ts
@@ -1,0 +1,258 @@
+import {
+  WORK_ORDER_COLLATION_WINDOW_DAYS,
+  buildWorkOrderItems,
+  findOpenPartnerWorkOrder,
+} from "../dual-write-unified-run-order"
+import PartnerOrderLink from "../../../links/partner-order"
+
+/**
+ * #1597 — a partner sent four designs across a week got four work-orders.
+ * Collating into their open one is now the default, and these pin the two
+ * halves that decide whether that default is safe: which order is chosen, and
+ * that a joined line describes itself exactly like a created one.
+ */
+
+const daysAgo = (n: number) =>
+  new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString()
+
+const order = (over: Record<string, any> = {}) => ({
+  id: "order_1",
+  status: "pending",
+  created_at: daysAgo(2),
+  metadata: { collated_design_order: true },
+  production_runs: [{ id: "run_1" }],
+  ...over,
+})
+
+const containerWith = (
+  orders: any[],
+  opts: { linkRows?: any[]; onGraph?: (a: any) => void } = {}
+) => {
+  const graph = jest.fn(async (args: any) => {
+    opts.onGraph?.(args)
+    if (args.entity === "order") return { data: orders }
+    return {
+      data:
+        opts.linkRows ?? orders.map((o: any) => ({ order_id: o.id })),
+    }
+  })
+  return {
+    graph,
+    container: {
+      resolve: (key: string) => {
+        if (key === "query") return { graph }
+        if (key === "logger")
+          return { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    } as any,
+  }
+}
+
+describe("findOpenPartnerWorkOrder", () => {
+  it("returns the partner's open collated work-order", async () => {
+    const { container } = containerWith([order()])
+
+    const found = await findOpenPartnerWorkOrder(container, "partner_1")
+
+    expect(found).toEqual({ order_id: "order_1", created_at: expect.any(String) })
+  })
+
+  it("picks the MOST RECENT when several are open", async () => {
+    const { container } = containerWith([
+      order({ id: "old", created_at: daysAgo(9) }),
+      order({ id: "newest", created_at: daysAgo(1) }),
+      order({ id: "middle", created_at: daysAgo(4) }),
+    ])
+
+    expect((await findOpenPartnerWorkOrder(container, "partner_1"))?.order_id).toBe(
+      "newest"
+    )
+  })
+
+  /**
+   * 🔴 An open order from months ago is not the same batch of work. Appending
+   * to it would put today's design on a claim someone may already be
+   * reconciling.
+   */
+  it("ignores an order older than the collation window", async () => {
+    const { container } = containerWith([
+      order({ created_at: daysAgo(WORK_ORDER_COLLATION_WINDOW_DAYS + 1) }),
+    ])
+
+    expect(await findOpenPartnerWorkOrder(container, "partner_1")).toBeNull()
+  })
+
+  it("honours an explicit window", async () => {
+    const { container } = containerWith([order({ created_at: daysAgo(5) })])
+
+    expect(
+      await findOpenPartnerWorkOrder(container, "partner_1", { withinDays: 3 })
+    ).toBeNull()
+    expect(
+      await findOpenPartnerWorkOrder(container, "partner_1", { withinDays: 30 })
+    ).not.toBeNull()
+  })
+
+  it.each(["completed", "canceled", "cancelled"])(
+    "never joins a %s order",
+    async (status) => {
+      const { container } = containerWith([order({ status })])
+      expect(await findOpenPartnerWorkOrder(container, "partner_1")).toBeNull()
+    }
+  )
+
+  /**
+   * A per-run work-order has no room for another design — only orders minted
+   * BY the collation path can collect more.
+   */
+  it("skips an order that is not a collated one", async () => {
+    const { container } = containerWith([order({ metadata: {} })])
+    expect(await findOpenPartnerWorkOrder(container, "partner_1")).toBeNull()
+  })
+
+  /**
+   * 🔴 The kind=design discriminator is the order↔run LINK, not metadata. An
+   * order with no linked run is not a work-order at all.
+   */
+  it("skips an order with no linked production run", async () => {
+    const { container } = containerWith([order({ production_runs: [] })])
+    expect(await findOpenPartnerWorkOrder(container, "partner_1")).toBeNull()
+  })
+
+  it("tolerates the to-one link shape (object, not array)", async () => {
+    const { container } = containerWith([
+      order({ production_runs: { id: "run_1" } }),
+    ])
+    expect((await findOpenPartnerWorkOrder(container, "partner_1"))?.order_id).toBe(
+      "order_1"
+    )
+  })
+
+  it("returns null when the partner has no linked orders at all", async () => {
+    const { container } = containerWith([], { linkRows: [] })
+    expect(await findOpenPartnerWorkOrder(container, "partner_1")).toBeNull()
+  })
+
+  /**
+   * 🔴 Read through the LINK's entry point. Asking the order entity for a
+   * linked field returns no key, silently — every partner would look like they
+   * had nothing open, and the default would quietly revert to minting.
+   */
+  it("reads the partner side through the link entry point, filtered by partner", async () => {
+    const seen: any[] = []
+    const { container } = containerWith([order()], { onGraph: (a) => seen.push(a) })
+
+    await findOpenPartnerWorkOrder(container, "partner_1")
+
+    expect(seen[0].entity).toBe(PartnerOrderLink.entryPoint)
+    expect(seen[0].filters).toEqual({ partner_id: "partner_1" })
+    /**
+     * ⚠️ `defineLink().entryPoint` is empty until the modules are registered,
+     * so the line above would pass vacuously against `""` on its own. This is
+     * the assertion that actually bites: the partner side must NOT be read off
+     * the order entity, which is the shape that silently returns no key.
+     */
+    expect(seen[0].entity).not.toBe("order")
+    expect(seen[0].fields).toEqual(["order_id"])
+  })
+
+  /**
+   * ⚠️ Failing to FIND must fall back to creating, never block dispatch.
+   */
+  it("returns null rather than throwing when the lookup fails", async () => {
+    const container = {
+      resolve: (key: string) => {
+        if (key === "query")
+          return {
+            graph: jest.fn(async () => {
+              throw new Error("graph exploded")
+            }),
+          }
+        return { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      },
+    } as any
+
+    await expect(
+      findOpenPartnerWorkOrder(container, "partner_1")
+    ).resolves.toBeNull()
+  })
+
+  it("returns null for a missing partner id without querying", async () => {
+    const { container, graph } = containerWith([order()])
+    expect(await findOpenPartnerWorkOrder(container, "")).toBeNull()
+    expect(graph).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * The line builder is shared by the create and the join path — a line must not
+ * describe itself differently depending on which door it came through.
+ */
+describe("buildWorkOrderItems", () => {
+  it("prices a per_unit run at its estimate", () => {
+    const [item] = buildWorkOrderItems([
+      {
+        id: "run_1",
+        design_id: "design_1",
+        quantity: 4,
+        cost_type: "per_unit",
+        partner_cost_estimate: 700,
+        snapshot: { design: { name: "White Envelope Dress" } },
+      },
+    ])
+
+    expect(item.title).toBe("White Envelope Dress")
+    expect(item.quantity).toBe(4)
+    expect(item.unit_price).toBe(700)
+    expect(item.metadata).toMatchObject({
+      design_id: "design_1",
+      production_run_id: "run_1",
+      cost_type: "per_unit",
+    })
+  })
+
+  /**
+   * 🔴 A `total` is the agreed price for the whole run, so the per-unit line
+   * price is the total DIVIDED by quantity. Treating it as a rate would bill
+   * quantity times too much (#1596).
+   */
+  it("divides a total estimate across the quantity", () => {
+    const [item] = buildWorkOrderItems([
+      {
+        id: "run_2",
+        design_id: "d2",
+        quantity: 5,
+        cost_type: "total",
+        partner_cost_estimate: 10_000,
+        snapshot: {},
+      },
+    ])
+
+    expect(item.unit_price).toBe(2000)
+    expect(item.metadata.legacy_cost_estimate).toBe(10_000)
+  })
+
+  it("falls back to the design id when the snapshot has no name", () => {
+    const [item] = buildWorkOrderItems([
+      { id: "r", design_id: "design_9", quantity: 1, snapshot: {} },
+    ])
+    expect(item.title).toBe("Design design_9")
+  })
+
+  it("never divides by zero", () => {
+    const [item] = buildWorkOrderItems([
+      {
+        id: "r",
+        design_id: "d",
+        quantity: 0,
+        cost_type: "total",
+        partner_cost_estimate: 900,
+        snapshot: {},
+      },
+    ])
+    // quantity 0 coerces to 1, so the total is the unit price.
+    expect(item.quantity).toBe(1)
+    expect(item.unit_price).toBe(900)
+  })
+})

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -1,12 +1,18 @@
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
-import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
+import {
+  createOrderWorkflow,
+  beginOrderEditOrderWorkflow,
+  orderEditAddNewItemWorkflow,
+  confirmOrderEditRequestWorkflow,
+} from "@medusajs/medusa/core-flows"
 import type { Link } from "@medusajs/modules-sdk"
 import type { LinkDefinition } from "@medusajs/framework/types"
 import type { MedusaContainer } from "@medusajs/framework/types"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { DESIGN_MODULE } from "../../modules/designs"
+import PartnerOrderLink from "../../links/partner-order"
 import type ProductionRunService from "../../modules/production_runs/service"
 import {
   PARTNER_WORK_ORDERS_CHANNEL,
@@ -338,6 +344,43 @@ export const projectRunToUnifiedOrder = async (
 // every active run completed; canceled iff ALL runs cancelled; else pending.
 // (#826 follow-up: this stops a collated order stranding in "pending" forever
 // when one design was cancelled but the rest completed.)
+/**
+ * One work-order line per run — the design's name, its quantity, and pointers
+ * back to the run that produced it.
+ *
+ * 🔑 ONE home, because there are now two writers: `collateRunsIntoWorkOrder`
+ * creating a fresh order, and `joinRunsIntoWorkOrder` appending to one that
+ * already exists (#1597). Two builders would drift, and a line that describes
+ * itself differently depending on which door it came through is exactly how the
+ * run-line pricer ended up 22% apart from itself.
+ *
+ * ⚠️ `unit_price` divides a `total` estimate by quantity, because a core line
+ * item is priced per unit. `cost_type` is carried in metadata so nothing
+ * downstream has to re-derive which of the two it was (#1559).
+ */
+export const buildWorkOrderItems = (runs: any[]) =>
+  runs.map((run) => {
+    const quantity = Number(run.quantity) || 1
+    const estimate = Number(run.partner_cost_estimate) || 0
+    const unitPrice =
+      run.cost_type === "per_unit"
+        ? estimate
+        : quantity > 0
+        ? estimate / quantity
+        : estimate
+    return {
+      title: run.snapshot?.design?.name ?? `Design ${run.design_id}`,
+      quantity,
+      unit_price: unitPrice,
+      metadata: {
+        design_id: run.design_id,
+        production_run_id: run.id,
+        cost_type: run.cost_type ?? null,
+        legacy_cost_estimate: run.partner_cost_estimate ?? null,
+      },
+    }
+  })
+
 const aggregateCoreStatus = (runs: any[]): string => {
   if (!runs.length) return "pending"
   const active = runs.filter((r) => r.status !== "cancelled")
@@ -440,27 +483,7 @@ export const collateRunsIntoWorkOrder = async (
   const channel = await ensureWorkOrdersChannel(container)
 
   // One line item per run — self-describing (design name + run pointer).
-  const items = runs.map((run) => {
-    const quantity = Number(run.quantity) || 1
-    const estimate = Number(run.partner_cost_estimate) || 0
-    const unitPrice =
-      run.cost_type === "per_unit"
-        ? estimate
-        : quantity > 0
-        ? estimate / quantity
-        : estimate
-    return {
-      title: run.snapshot?.design?.name ?? `Design ${run.design_id}`,
-      quantity,
-      unit_price: unitPrice,
-      metadata: {
-        design_id: run.design_id,
-        production_run_id: run.id,
-        cost_type: run.cost_type ?? null,
-        legacy_cost_estimate: run.partner_cost_estimate ?? null,
-      },
-    }
-  })
+  const items = buildWorkOrderItems(runs)
 
   const { result: unified }: any = await createOrderWorkflow(container).run({
     input: {
@@ -585,6 +608,282 @@ export const collateRunsIntoWorkOrder = async (
   }
 
   return { unified_order_id: unified.id, line_count: items.length }
+}
+
+/**
+ * How recently a work-order must have been minted to still collect new designs.
+ *
+ * #1597's wording is "a **recently** minted, still-open order" — a partner sent
+ * four designs across a week should get one order, not four. An open order from
+ * three months ago is not the same batch of work, and quietly appending to it
+ * would make a payout line for today's design land on a claim someone may
+ * already be reconciling.
+ */
+export const WORK_ORDER_COLLATION_WINDOW_DAYS = 14
+
+/**
+ * The partner's most recent open collated design work-order, or null (#1597).
+ *
+ * ⚠️ `collated_design_order` lives in `metadata`, and `query.graph` cannot
+ * filter on a JSON subkey — so candidates are narrowed by things that ARE
+ * filterable (the partner link, then the order↔run link that IS the kind=design
+ * discriminator) and the metadata flag is checked in memory afterwards. A
+ * filter written against `metadata.x` would silently match nothing, which here
+ * would mean "always mint a new order" — the bug this exists to fix, restored
+ * invisibly.
+ *
+ * 🔴 Read through `PartnerOrderLink.entryPoint`, never by asking the order
+ * entity for a linked field: that returns no key at all, silently, and every
+ * partner would look like they had no open order.
+ *
+ * ⚠️ Known limitation, and it fails SAFE. The partner↔order link (D3) is
+ * written by `collateRunsIntoWorkOrder` only for partners whose runs reached
+ * `sent_to_partner` — i.e. dispatch succeeded for at least one design in the
+ * batch. A work-order whose every design failed to dispatch therefore carries
+ * no partner link and is invisible here, so the next dispatch mints a fresh
+ * order rather than joining it. That is the old behaviour, not a new fault:
+ * the cost is an extra order, never a line on the wrong one.
+ */
+export const findOpenPartnerWorkOrder = async (
+  container: MedusaContainer,
+  partnerId: string,
+  opts: { withinDays?: number } = {}
+): Promise<{ order_id: string; created_at: string } | null> => {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  if (!partnerId) return null
+
+  const withinDays = opts.withinDays ?? WORK_ORDER_COLLATION_WINDOW_DAYS
+  const cutoff = Date.now() - withinDays * 24 * 60 * 60 * 1000
+
+  try {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data: linkRows } = await query.graph({
+      entity: PartnerOrderLink.entryPoint,
+      fields: ["order_id"],
+      filters: { partner_id: partnerId },
+    })
+    const orderIds = Array.from(
+      new Set(
+        (linkRows || [])
+          .map((r: any) => r?.order_id)
+          .filter(Boolean)
+          .map(String)
+      )
+    )
+    if (!orderIds.length) return null
+
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: ["id", "status", "created_at", "metadata", "production_runs.id"],
+      filters: { id: orderIds },
+    })
+
+    const candidates = (orders || [])
+      .filter((o: any) => {
+        // A design work-order, by the discriminator link — not by metadata.
+        const runs = Array.isArray(o?.production_runs)
+          ? o.production_runs
+          : o?.production_runs
+          ? [o.production_runs]
+          : []
+        if (!runs.length) return false
+        // Collated ones only. A per-run order has no room for another design.
+        if (o?.metadata?.collated_design_order !== true) return false
+        // Open. `completed` and `canceled` are settled; anything else collects.
+        if (["completed", "canceled", "cancelled"].includes(String(o?.status ?? ""))) {
+          return false
+        }
+        const created = Date.parse(o?.created_at ?? "")
+        return Number.isFinite(created) && created >= cutoff
+      })
+      .sort(
+        (a: any, b: any) =>
+          Date.parse(b?.created_at ?? "") - Date.parse(a?.created_at ?? "")
+      )
+
+    const chosen = candidates[0]
+    return chosen
+      ? { order_id: String(chosen.id), created_at: String(chosen.created_at) }
+      : null
+  } catch (e: any) {
+    /**
+     * Best-effort: failing to FIND an order must fall back to creating one.
+     * The opposite — throwing — would make a lookup hiccup block dispatch
+     * entirely, and the dispatch is the thing that matters.
+     */
+    logger.warn(
+      `[orders-unification] open work-order lookup failed for partner ${partnerId}: ${e?.message}`
+    )
+    return null
+  }
+}
+
+/**
+ * Append runs to an EXISTING collated work-order (#1597).
+ *
+ * ## Why an order edit and not an insert
+ *
+ * The partner's order detail renders its line list from the core order's
+ * `items`. Linking a run without adding its line would put the run in
+ * `production_runs` and nowhere a human can see it — a capability with no
+ * screen, which this codebase has shipped before. Core owns `items`, and the
+ * only supported way to add one to a placed order is the edit flow:
+ * begin → add → confirm.
+ *
+ * ⚠️ NOT best-effort, unlike its sibling `collateRunsIntoWorkOrder`. A failed
+ * projection there leaves the legacy path intact; a failed append here would
+ * leave runs dispatched to a partner with no line on any order — invisible
+ * work. It throws, and `produceDesignsAsWorkOrder` falls back to minting a
+ * fresh order, which is the behaviour that existed before this function.
+ */
+export const joinRunsIntoWorkOrder = async (
+  container: MedusaContainer,
+  orderId: string,
+  runs: any[]
+): Promise<CollatedProjectionResult> => {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const items = buildWorkOrderItems(runs)
+
+  await beginOrderEditOrderWorkflow(container).run({
+    input: { order_id: orderId },
+  })
+  await orderEditAddNewItemWorkflow(container).run({
+    input: { order_id: orderId, items: items as any },
+  })
+  await confirmOrderEditRequestWorkflow(container).run({
+    input: { order_id: orderId },
+  })
+
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  // order↔run for each NEW run. These cannot already exist — the runs were
+  // created moments ago — so no existence check is needed here.
+  for (const run of runs) {
+    await remoteLink
+      .create([
+        {
+          [Modules.ORDER]: { order_id: orderId },
+          [PRODUCTION_RUNS_MODULE]: { production_runs_id: run.id },
+        },
+      ])
+      .catch((e: any) =>
+        logger.warn(
+          `[orders-unification] joined order↔run link failed for run ${run.id}: ${e?.message}`
+        )
+      )
+  }
+
+  /**
+   * 🔴 `link.create` is NOT idempotent, and unlike the create path this order
+   * already has design and partner links from the designs it collected before.
+   * Re-creating them would duplicate rows, so what is already linked is read
+   * first and only the genuinely new pairs are written.
+   */
+  const { data: existingRows } = await query
+    .graph({
+      entity: "order",
+      fields: ["id", "designs.id", "production_runs.id", "metadata"],
+      filters: { id: [orderId] },
+    })
+    .catch(() => ({ data: [] as any[] }))
+  const existingOrder = existingRows?.[0]
+  const linkedDesignIds = new Set(
+    (Array.isArray(existingOrder?.designs)
+      ? existingOrder.designs
+      : existingOrder?.designs
+      ? [existingOrder.designs]
+      : []
+    )
+      .map((d: any) => d?.id)
+      .filter(Boolean)
+      .map(String)
+  )
+
+  const newDesignIds = Array.from(
+    new Set(runs.map((r) => r.design_id).filter(Boolean).map(String))
+  ).filter((id) => !linkedDesignIds.has(id))
+
+  for (const designId of newDesignIds) {
+    await remoteLink
+      .create([
+        {
+          [DESIGN_MODULE]: { design_id: designId },
+          [Modules.ORDER]: { order_id: orderId },
+        },
+      ])
+      .catch((e: any) =>
+        logger.warn(
+          `[orders-unification] joined design link failed for ${designId}: ${e?.message}`
+        )
+      )
+  }
+
+  // design↔partner per (design, committed partner). Idempotent by nature of the
+  // create path's own comment ("a re-produce just re-hits it"), and only the
+  // designs new to this order are considered.
+  for (const run of runs) {
+    if (
+      !run.partner_id ||
+      !run.design_id ||
+      !newDesignIds.includes(String(run.design_id)) ||
+      !["sent_to_partner", "in_progress", "completed"].includes(run.status)
+    ) {
+      continue
+    }
+    await remoteLink
+      .create([
+        {
+          [DESIGN_MODULE]: { design_id: run.design_id },
+          [PARTNER_MODULE]: { partner_id: run.partner_id },
+        },
+      ])
+      .catch(() => {})
+  }
+
+  /**
+   * The order's own record of what it collates, and its rolled-up status —
+   * both recomputed across ALL its runs, old and new. A status derived from
+   * only the newly-added runs would report a half-finished order as pending.
+   */
+  const allRunIds = Array.from(
+    new Set([
+      ...((existingOrder?.metadata?.production_run_ids as string[]) || []),
+      ...runs.map((r) => String(r.id)),
+    ])
+  )
+
+  const runService: ProductionRunService = container.resolve(
+    PRODUCTION_RUNS_MODULE
+  )
+  const allRuns = (await runService
+    .listProductionRuns({ id: allRunIds } as any, { select: ["*"] })
+    .catch(() => runs)) as any[]
+
+  await patchUnifiedOrder(container, orderId, {
+    status: aggregateCoreStatus(allRuns),
+    metadata: {
+      ...(existingOrder?.metadata || {}),
+      production_run_ids: allRunIds,
+    },
+  })
+
+  const partnerStatus = aggregatePartnerStatus(allRuns)
+  if (partnerStatus) {
+    await setUnifiedOrderPartnerStatus(container, orderId, partnerStatus).catch(
+      (e: any) =>
+        logger.warn(
+          `[orders-unification] joined sidecar status write failed for ${orderId}: ${e?.message}`
+        )
+    )
+  }
+
+  logger.info(
+    `[orders-unification] collated ${runs.length} run(s) into existing work-order ${orderId} (now ${allRunIds.length} run(s))`
+  )
+
+  return { unified_order_id: orderId, line_count: items.length }
 }
 
 /**


### PR DESCRIPTION
Closes #1597.

A partner sent four designs across a week ended up with **four work-orders** for what is operationally one batch. The collation machinery already existed and worked — but only within a *single* dispatch. The moment the choice was cheap was the one moment nothing offered it.

Now collating is the **default**, chained across separate dispatches.

## How a partner's open order is deduced

| step | how |
|---|---|
| 1 | the partner id comes from the dispatch itself — nothing inferred |
| 2 | partner → orders via the D3 `partner ↔ order` link, read through `PartnerOrderLink.entryPoint` |
| 3 | keep only design work-orders by asking for `production_runs.id` — the kind=design discriminator **is** the order↔run link |
| 4 | then in memory: `metadata.collated_design_order === true`, status not completed/canceled, created within **14 days** |
| 5 | newest wins; nothing qualifying → mint a new order, as before |

🔴 Step 2 is read via the link's entry point, never by asking the order entity for a linked field — that returns no key at all, silently, and every partner would look like they had nothing open.

🔴 Step 4 is in memory because `query.graph` cannot filter a JSON subkey. A filter written against `metadata.x` would match nothing and *silently restore the old behaviour* — the bug this fixes, reinstated invisibly.

## Why the join is an order edit

The partner's order detail renders its line list from the core order's `items`. Linking a run without adding its line would put the run in `production_runs` and nowhere a human can see it — a capability with no screen. Core owns `items`, so: **begin → add → confirm**.

`buildWorkOrderItems` is extracted so create and join share one line builder. A line that describes itself differently depending on which door it came through is how the run-line pricer drifted 22% apart.

`link.create` is not idempotent and a joined order already carries design/partner links, so what is already linked is read first. Status and `production_run_ids` are recomputed across **all** runs — deriving from only the new ones would report a half-finished order as pending.

## Everything falls safe

| failure | outcome |
|---|---|
| lookup throws | `null` → mint a new order. Dispatch is what matters |
| append throws | caught → mint a new order. The runs are already dispatched; an exception would strand them with no line on any order |
| an earlier batch where *every* design failed to dispatch | no partner link ⇒ invisible here ⇒ next dispatch mints a fresh order. **Documented, not fixed** — the cost is an extra order, never a line on the wrong one |

## Verification — chained, through the real door

The 7 integration cases go through `POST /admin/designs/produce` as **separate requests**, the same door the drawer uses, because collation reaching into order-edit machinery is exactly the kind of change that works when called directly and breaks at the boundary.

- ✅ second dispatch lands on the first's order (`work_order_joined: true`)
- ✅ both designs are real **line items**, with run + design ids in metadata
- ✅ order↔run, design↔order, design↔partner all hold after the join
- ✅ the partner link is **not duplicated** (exactly 1)
- ✅ status rolls up across all runs
- ✅ `collate: "new"` still opts out
- ✅ one partner's designs never land on another's order

**Mutation-checked:** flipping the default back to `"new"` fails **5 of 7** integration cases; dropping the window fails 2 unit cases; dropping the collated-order check fails 1; not dividing a `total` estimate by quantity fails 1.

**Neighbours still green:** `designs-produce-no-customer` (5), `design-order-produce-fanout` (3), `design-order-links` + `convert-design-order` (4), 262 production-run unit cases, `check:prod-build`.

## Surface

`collate: "partner-open" | "new"` on the workflow and route. The drawer sends it explicitly rather than trusting a server default, adds a **"Start a separate work-order"** checkbox (unticked) whose helper text names the partner, and the toast distinguishes *"Added to this partner's open work-order"* from *"One work-order created"*.

⚠️ Not folded: `projectRunToUnifiedOrder` keeps its own line shape for the per-run projection — different metadata semantics, wider change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
