### PR TITLE
feat(shipping): add Delhivery International (StarFleet) cross-border client

### DIFF
--- a/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
+++ b/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
@@ -136,6 +136,20 @@ export const CARRIER_CAPABILITIES: CarrierCapability[] = [
     notes:
       "Cross-border only (India → international). Rates (`/rates/calculate`), books (`/order/add`), labels (`/order/getLabel`), tracks (`/tools/tracking`) and cancels (`/order/cancelRefundOrder`) via HTTP Basic auth at app.shipglobal.in/apiv1. No domestic product, so it never appears in a domestic lane.",
   },
+  {
+    id: "starfleet",
+    label: "Delhivery International (StarFleet)",
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: false, can_ship: false },
+    international: { can_rate: false, can_ship: true },
+    // `add_on_services.free_domicile` = "bill duties to shipper" = DDP, mapped
+    // from the order's incoterm — so the client can DECLARE DDP (whether the
+    // account is billed the duty is the usual commercial arrangement).
+    can_declare_ddp: true,
+    notes:
+      "Delhivery's cross-border product (India → international), OAuth2 password-grant at api-starfleet.delhivery.com. Manifests (batch + poll), tracks via auth-track, but has NO rate API (so it can only be a flat-priced option) and no cancellation. Label/invoice/KYC endpoints are still gated on Delhivery's side (403/502) — see apps/docs/notes/STARFLEET_API.md.",
+  },
 ]
 
 /** The Medusa fulfillment-provider id a carrier registers under. */

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -326,4 +326,10 @@ export interface ShippingProviderClient {
 }
 
 /** Known carrier identifiers persisted on `fulfillment.data.carrier`. */
-export type CarrierId = "delhivery" | "shiprocket" | "bluedart" | "dtdc" | "shipglobal"
+export type CarrierId =
+  | "delhivery"
+  | "shiprocket"
+  | "bluedart"
+  | "dtdc"
+  | "shipglobal"
+  | "starfleet"

--- a/apps/backend/src/modules/shipping-providers/resolver.ts
+++ b/apps/backend/src/modules/shipping-providers/resolver.ts
@@ -28,6 +28,7 @@ import { BlueDartProviderAdapter } from "./bluedart/adapter"
 import { DhlUnifiedTrackingClient } from "./dhl-unified-tracking"
 import { DtdcProviderAdapter } from "@jytextiles/medusa-plugin-dtdc-shipping/providers/dtdc/adapter"
 import { ShipglobalClient } from "./shipglobal/client"
+import { StarfleetClient, StarfleetConsignorKyc } from "./starfleet/client"
 
 /** Carriers `resolveShippingProvider` can return a live client for. */
 export const SUPPORTED_CARRIERS: CarrierId[] = [
@@ -36,6 +37,7 @@ export const SUPPORTED_CARRIERS: CarrierId[] = [
   "bluedart",
   "dtdc",
   "shipglobal",
+  "starfleet",
 ]
 
 /**
@@ -310,6 +312,54 @@ export async function resolveShippingProvider(
       username: username!,
       password: password!,
       service: cfg.service || process.env.SHIPGLOBAL_SERVICE,
+      fetchImpl,
+    })
+  }
+
+  if (id === "starfleet") {
+    // Delhivery International ("StarFleet") — OAuth2 password grant. Cross-border
+    // only; the pickup warehouse is env-specific (a prod warehouse does not exist
+    // in staging). See apps/docs/notes/STARFLEET_API.md.
+    const username = cfg.username || cfg.email || process.env.STARFLEET_USERNAME
+    const password =
+      readSecret(cfg, "password", encryption) || process.env.STARFLEET_PASSWORD
+    const clientId = cfg.client_id || process.env.STARFLEET_CLIENT_ID
+    const clientSecret =
+      readSecret(cfg, "client_secret", encryption) ||
+      process.env.STARFLEET_CLIENT_SECRET
+    if (!username || !password || !clientId || !clientSecret) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "Delhivery International (StarFleet) credentials not configured (no shipping platform record or STARFLEET_USERNAME + STARFLEET_PASSWORD + STARFLEET_CLIENT_ID + STARFLEET_CLIENT_SECRET)"
+      )
+    }
+
+    const consignorKyc: StarfleetConsignorKyc = {
+      document_id: cfg.document_id,
+      document_type: cfg.document_type,
+      iec: cfg.iec,
+      pan: readSecret(cfg, "pan", encryption),
+      gstin: readSecret(cfg, "gstin", encryption),
+      bank_ad_code: cfg.bank_ad_code,
+      bank_ifsc: cfg.bank_ifsc,
+      bank_ac: readSecret(cfg, "bank_ac", encryption),
+    }
+
+    const fetchImpl =
+      process.env.STARFLEET_STUB === "1"
+        ? require("./starfleet/stub-fetch").createStarfleetStubFetch()
+        : undefined
+
+    return new StarfleetClient({
+      username: username!,
+      password: password!,
+      client_id: clientId!,
+      client_secret: clientSecret!,
+      client_name: cfg.client_name || process.env.STARFLEET_CLIENT_NAME,
+      service_type: cfg.service_type || process.env.STARFLEET_SERVICE_TYPE,
+      pickup_warehouse_id:
+        cfg.pickup_warehouse_id || process.env.STARFLEET_PICKUP_WAREHOUSE_ID,
+      consignor_kyc: consignorKyc,
       fetchImpl,
     })
   }

--- a/apps/backend/src/modules/shipping-providers/starfleet/__tests__/client.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/__tests__/client.unit.spec.ts
@@ -4,6 +4,7 @@ import {
   normalizeStarfleetTracking,
   scanTypeForAction,
   shipmentTypeForReason,
+  starfleetBaseUrl,
   starfleetTrackingUrl,
 } from "../client"
 import { CreateShipmentInput } from "../../provider-interface"
@@ -207,5 +208,31 @@ describe("starfleetTrackingUrl", () => {
   })
   it("returns empty for a blank awb", () => {
     expect(starfleetTrackingUrl("")).toBe("")
+  })
+})
+/**
+ * Host selection.
+ *
+ * The client shipped with both hosts hardcoded to STAGING while its own tool
+ * description and the API note both named the prod host. Credentials for prod
+ * pointed at the sandbox do not fail loudly: they authenticate, and then
+ * `pickup_warehouse_id` resolves against a registry that does not contain the
+ * warehouse (gotcha #3), so it surfaces as a manifestation error instead.
+ */
+describe("starfleetBaseUrl", () => {
+  it("defaults to staging when unset, so prod is never reached by accident", () => {
+    expect(starfleetBaseUrl(undefined)).toContain("api-stage-starfleet")
+    expect(starfleetBaseUrl("")).toContain("api-stage-starfleet")
+  })
+
+  it("selects the prod host only on an explicit 'prod'", () => {
+    expect(starfleetBaseUrl("prod")).toBe("https://api-starfleet.delhivery.com")
+    expect(starfleetBaseUrl(" PROD ")).toBe("https://api-starfleet.delhivery.com")
+  })
+
+  it("treats anything else as staging rather than guessing", () => {
+    for (const v of ["staging", "stage", "production", "live", "true", "1"]) {
+      expect(starfleetBaseUrl(v)).toContain("api-stage-starfleet")
+    }
   })
 })

--- a/apps/backend/src/modules/shipping-providers/starfleet/__tests__/client.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/__tests__/client.unit.spec.ts
@@ -1,0 +1,211 @@
+import {
+  buildPackagePayload,
+  extractWaybillForOrder,
+  normalizeStarfleetTracking,
+  scanTypeForAction,
+  shipmentTypeForReason,
+  starfleetTrackingUrl,
+} from "../client"
+import { CreateShipmentInput } from "../../provider-interface"
+
+const baseInput: CreateShipmentInput = {
+  reference_id: "order_123",
+  payment_mode: "prepaid",
+  pickup_location_name: "JaalYantraTextilesPr-in-B2C",
+  to: {
+    name: "Test Customer",
+    phone: "+33123456789",
+    email: "test@example.com",
+    address_1: "1 Rue de Test",
+    city: "Paris",
+    state: "Paris",
+    pincode: "75002",
+    country: "FR",
+  },
+  from: {
+    name: "Jaal Yantra Textiles",
+    phone: "+919876543210",
+    email: "ops@jaalyantra.com",
+    address_1: "House no 86, Street no 8, South Ganesh Nagar",
+    city: "Delhi",
+    state: "Delhi",
+    pincode: "110092",
+    country: "IN",
+  },
+  items: [{ name: "Scarf", sku: "S1", quantity: 2, unit_price: 100, hsn: "62141090" }],
+  weight_grams: 200,
+  dimensions_cm: { length: 20, width: 15, height: 5 },
+  currency: "INR",
+  sub_total: 200,
+}
+
+const opts = {
+  client_name: "JaalYantraTextilesPr-in-B2C",
+  service_type: "EXPORTS_EXPRESS",
+  billing_mode: "E" as const,
+}
+
+describe("shipmentTypeForReason", () => {
+  it("maps reason codes to StarFleet shipment_type", () => {
+    expect(shipmentTypeForReason(2)).toBe("gift")
+    expect(shipmentTypeForReason(1)).toBe("sample")
+    expect(shipmentTypeForReason(0)).toBe("sample")
+    expect(shipmentTypeForReason(3)).toBe("commercial")
+    expect(shipmentTypeForReason(undefined)).toBe("commercial")
+  })
+})
+
+describe("buildPackagePayload", () => {
+  it("populates the mandatory product IGST fields (even at 0)", () => {
+    const pkg = buildPackagePayload(baseInput, opts)
+    const p = pkg.products[0]
+    expect(p.quantity).toBe(2)
+    expect(p.product_amount).toBe(200)
+    expect(p.item_commodity_value).toBe(200)
+    expect(p.igst_rate).toBe(0)
+    expect(p.igst_amount).toBe(0)
+    expect(p.euec).toBe(false)
+    expect(p.meis).toBe(false)
+    expect(p.hsn_code).toBe("62141090")
+  })
+
+  it("uses the registered pickup shape (pickup_warehouse_id + zip/state/city)", () => {
+    const pkg = buildPackagePayload(baseInput, {
+      ...opts,
+      pickup_warehouse_id: "JaalYantraTextilesPr-in-B2C",
+    })
+    expect(pkg.pickup_location).toEqual({
+      pickup_warehouse_id: "JaalYantraTextilesPr-in-B2C",
+      country: "IN",
+      zip: "110092",
+      state: "Delhi",
+      city: "Delhi",
+    })
+  })
+
+  it("falls back to an unregistered pickup (no `name` key)", () => {
+    const pkg = buildPackagePayload(baseInput, opts)
+    expect(pkg.pickup_location.name).toBeUndefined()
+    expect(pkg.pickup_location.pickup_warehouse_id).toBeUndefined()
+    expect(pkg.pickup_location).toMatchObject({
+      type: "Office",
+      city: "Delhi",
+      state: "Delhi",
+      country: "IN",
+      zip: "110092",
+    })
+  })
+
+  it("carries return_location + add_on_services + full consignor KYC", () => {
+    const pkg = buildPackagePayload(baseInput, {
+      ...opts,
+      consignor_kyc: {
+        document_id: "D1",
+        document_type: "PAN",
+        iec: "795003556",
+        pan: "AAACT5410T",
+        gstin: "29AAACT5410T2RJ",
+        bank_ad_code: "01234567891234",
+        bank_ifsc: "HDFC0000003",
+        bank_ac: "5010003456792",
+      },
+    })
+    expect(pkg.return_location).toEqual({
+      address: "House no 86, Street no 8, South Ganesh Nagar",
+      zip: "110092",
+    })
+    expect(pkg.add_on_services).toEqual({ free_domicile: false, signature_pod: false })
+    expect(pkg.consignor.iec).toBe("795003556")
+    expect(pkg.consignor.gstin).toBe("29AAACT5410T2RJ")
+    expect(pkg.consignor.bank_ac).toBe("5010003456792")
+  })
+
+  it("flags free_domicile (DDP) from incoterm and terms from customs", () => {
+    const pkg = buildPackagePayload(
+      { ...baseInput, customs: { incoterm: "DDP", terms_of_invoice: "CIF" } },
+      opts
+    )
+    expect(pkg.add_on_services.free_domicile).toBe(true)
+    expect(pkg.invoice.terms).toBe("CIF")
+  })
+
+  it("stamps igst_payment_status only for commercial exports", () => {
+    const sample = buildPackagePayload({ ...baseInput, customs: { reason_of_export: 1 } }, opts)
+    expect(sample.invoice.igst_payment_status).toBeUndefined()
+    const commercial = buildPackagePayload({ ...baseInput, customs: { reason_of_export: 3 } }, opts)
+    expect(commercial.invoice.igst_payment_status).toBe("Paid")
+    expect(commercial.shipment_type).toBe("commercial")
+  })
+
+  it("computes package_amount from sub_total and total_commodity_value pre-tax", () => {
+    const pkg = buildPackagePayload(baseInput, opts)
+    expect(pkg.package_amount).toBe(200)
+    expect(pkg.total_commodity_value).toBe(200)
+  })
+})
+
+describe("extractWaybillForOrder", () => {
+  const batch = {
+    payload: {
+      status: "COMPLETED",
+      data: {
+        success_waybills: [
+          { waybill: "DL001113245XB", order_id: "order_123" },
+          { waybill: "DL999999999XB", order_id: "order_456" },
+        ],
+      },
+    },
+  }
+  it("returns the waybill for a matching order_id", () => {
+    expect(extractWaybillForOrder(batch, "order_123")).toBe("DL001113245XB")
+  })
+  it("returns empty for a missing order_id", () => {
+    expect(extractWaybillForOrder(batch, "nope")).toBe("")
+  })
+})
+
+describe("scanTypeForAction", () => {
+  it("classifies delivery / rto / manifestation / default", () => {
+    expect(scanTypeForAction("INT-PKG-DLV", "Delivered")).toBe("delivered")
+    expect(scanTypeForAction("X", "return to origin")).toBe("rto")
+    expect(scanTypeForAction("INT-PKG-MANF", "Package Manifestation Done")).toBe("created")
+    expect(scanTypeForAction("INT-PKG-XYZ", "")).toBe("in_transit")
+  })
+})
+
+describe("normalizeStarfleetTracking", () => {
+  const payload = {
+    payload: {
+      waybills_found: [
+        {
+          waybill: "DL001113245XB",
+          origin: "testwarehouse",
+          destination: { city: "Dubai" },
+          scans: [
+            { city: "IN_Delhi_P", state: "Delhi", country: "IND", time: "1788343161", action: "INT-PKG-MANF", remarks: "Package Manifestation Done" },
+          ],
+        },
+      ],
+      waybills_not_found: [],
+    },
+  }
+  it("maps scans into TrackingEvent with coarse scan_type", () => {
+    const r = normalizeStarfleetTracking(payload, "DL001113245XB")
+    expect(r.carrier).toBe("starfleet")
+    expect(r.events).toHaveLength(1)
+    expect(r.events[0].scan_type).toBe("created")
+    expect(r.current_status).toBe("Package Manifestation Done")
+    expect(r.destination).toBe("Dubai")
+  })
+})
+
+describe("starfleetTrackingUrl", () => {
+  it("builds the Delhivery track URL", () => {
+    expect(starfleetTrackingUrl("DL001113245XB")).toBe(
+      "https://www.delhivery.com/track/package/DL001113245XB"
+    )
+  })
+  it("returns empty for a blank awb", () => {
+    expect(starfleetTrackingUrl("")).toBe("")
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/starfleet/client.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/client.ts
@@ -54,8 +54,30 @@ import {
 import { isInternationalDestination } from "../destination"
 import { normalizeHsCode } from "../hs-code-resolution"
 
-const AUTH_URL = "https://api-stage-starfleet.delhivery.com/auth/token"
-const PACKAGE_BASE_URL = "https://api-stage-starfleet.delhivery.com/package"
+/**
+ * 🔴 StarFleet has two hosts and the warehouse registry is PER-ENVIRONMENT — a
+ * prod warehouse does not exist in staging and vice versa (gotcha #3). Pinning
+ * the host to staging, as this file first did, means prod credentials
+ * authenticate against the sandbox: `pickup_warehouse_id` then resolves to a
+ * warehouse that is not there, and the failure surfaces as a manifestation
+ * error rather than as "you are pointed at the wrong environment".
+ *
+ * Defaults to STAGING, so nothing changes for anyone until the var is set —
+ * enabling prod is a deliberate act, not a side effect of deploying.
+ */
+const STARFLEET_HOSTS = {
+  staging: "https://api-stage-starfleet.delhivery.com",
+  prod: "https://api-starfleet.delhivery.com",
+} as const
+
+export const starfleetBaseUrl = (env?: string): string =>
+  String(env ?? "").trim().toLowerCase() === "prod"
+    ? STARFLEET_HOSTS.prod
+    : STARFLEET_HOSTS.staging
+
+const HOST = starfleetBaseUrl(process.env.STARFLEET_ENV)
+const AUTH_URL = `${HOST}/auth/token`
+const PACKAGE_BASE_URL = `${HOST}/package`
 const AUTH_AUDIENCE = "StarFleet"
 /**
  * The scope is wrapped in literal double-quotes on purpose — see gotcha #1.

--- a/apps/backend/src/modules/shipping-providers/starfleet/client.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/client.ts
@@ -1,0 +1,652 @@
+/**
+ * Delhivery International ("StarFleet") cross-border API client.
+ *
+ * StarFleet is Delhivery's international arm — India → rest-of-world. Unlike
+ * the domestic Delhivery client (static `Token` auth, single `create.json`
+ * call), StarFleet is OAuth2 password-grant behind an async batch job:
+ *
+ *   POST /auth/token                       → `access_token` (Bearer, 24h TTL)
+ *   POST /package/batchGeneratePackages    → returns a JOB id, not an AWB
+ *   GET  /package/batchGeneratePackages/{id} → poll until COMPLETED →
+ *                                               `success_waybills[]` (waybill)
+ *   GET  /package/auth-track/{id}          → scans for 1..15 waybills
+ *   GET  /package/{id}/shipping-label      → PDF  (⚠️ gated — see below)
+ *   GET  /package/{id}/invoice             → PDF  (⚠️ gated — see below)
+ *   POST /package/{id}/upload-kyc-doc      → KYC  (⚠️ gated — see below)
+ *
+ * Live-verified against api-stage-starfleet (a real AWB `DL001113245XB` was
+ * manifested end-to-end). The full contract is in
+ * apps/docs/notes/STARFLEET_API.md — read it before touching this file. The
+ * load-bearing gotchas:
+ *
+ *  1. SCOPE MUST BE QUOTED. The /auth/token `scope` parameter is the literal
+ *     `scope="starfleet openid profile email ^/package/... $"` — WITH the
+ *     double-quotes. A bare `scope=...` (no quotes) mints a token that 401s on
+ *     every /package endpoint. The `\/` escaping the swagger shows is
+ *     irrelevant; the quotes are not.
+ *  2. `client_name` MUST be the account username (e.g. `8e2306-JaalYantraTextilesPr-in`),
+ *     NOT a guessed name — anything else is `403 Unauthorized User`.
+ *  3. pickup is `pickup_warehouse_id + zip + state + city`, and the warehouse
+ *     must EXIST in the target environment (prod warehouses aren't in staging).
+ *  4. The manifest is ASYNC: create → poll → success_waybills[].waybill.
+ *  5. Products need `igst_rate`/`igst_amount` (0 for sample) + `euec`/`meis`;
+ *     omitting them fails manifestation with `Value is empty`.
+ *
+ * ⚠️ NOT YET WORKING (Delhivery-side gates, not this client):
+ *  - invoice + shipping-label return `403 Unauthorized User` even with a valid
+ *    token (per-user id_token, or shipment not label-ready). Methods exist but
+ *    surface the carrier's 403 until Delhivery resolves it.
+ *  - upload-kyc-doc returns `502 Internal server error` on their side. Method
+ *    exists but surfaces it.
+ *  - No cancellation endpoint exists in the StarFleet surface — `cancelShipment`
+ *    throws.
+ */
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  CreateShipmentInput,
+  LabelResult,
+  ShipmentRef,
+  ShipmentResult,
+  ShippingProviderClient,
+  TrackingEvent,
+  TrackingResult,
+} from "../provider-interface"
+import { isInternationalDestination } from "../destination"
+import { normalizeHsCode } from "../hs-code-resolution"
+
+const AUTH_URL = "https://api-stage-starfleet.delhivery.com/auth/token"
+const PACKAGE_BASE_URL = "https://api-stage-starfleet.delhivery.com/package"
+const AUTH_AUDIENCE = "StarFleet"
+/**
+ * The scope is wrapped in literal double-quotes on purpose — see gotcha #1.
+ * Do NOT remove the quotes; a bare scope mints a token that 401s everywhere.
+ */
+const AUTH_SCOPE =
+  'starfleet openid profile email ^/package/batchGeneratePackages:POST$ ' +
+  '^/package/batchGeneratePackages/.+:GET$ ^/package/auth-track/.+:GET$ ' +
+  '^/package/.+/invoice:GET$ ^/package/.+/shipping-label:GET$ ' +
+  '^/package/.+/upload-kyc-doc:POST'
+/** Refresh a little under the documented 86400s (24h) so a token never expires
+ *  mid-request. */
+const TOKEN_TTL_MS = 23 * 60 * 60 * 1000
+
+const JOB_POLL_INTERVAL_MS = 1000
+const JOB_POLL_MAX_ATTEMPTS = 30
+
+/** The subset of `fetch` the client uses — injectable so tests/CI can supply a
+ *  deterministic transport (same pattern as Shiprocket/ShipGlobal, #647). */
+export type FetchLike = (input: any, init?: any) => Promise<any>
+
+/** The seller's export KYC, mandatory for `commercial` shipments (PAN, GST,
+ *  bank + IFSC, AD code, IEC). Account-level, so it comes from config, not the
+ *  order. Sample/gift/document shipments don't need it. */
+export type StarfleetConsignorKyc = {
+  document_id?: string
+  document_type?: "Aadhar" | "Passport" | "Voter ID" | "PAN" | "GST"
+  iec?: string
+  pan?: string
+  gstin?: string
+  bank_ad_code?: string
+  bank_ifsc?: string
+  bank_ac?: string
+}
+
+export type StarfleetOptions = {
+  username: string
+  password: string
+  client_id: string
+  client_secret: string
+  /**
+   * Delhivery international account name stamped on every package's
+   * `client_name`. Defaults to `username` (they are the same value for these
+   * accounts). MUST match the authenticated account — see gotcha #2.
+   */
+  client_name?: string
+  /** `service_type` for exports — EXPORTS_EXPRESS (default), EXPORTS_DOCUMENT,
+   *  EXPORTS_DEFERRED_EXPRESS, EXPORTS_DLV_SAVER. */
+  service_type?: string
+  /** Billing mode: "E" express / "S" surface. Default "E". */
+  billing_mode?: "E" | "S"
+  /**
+   * StarFleet-registered pickup warehouse id (env-specific — a prod warehouse
+   * does not exist in staging). When set, pickup is the RegisteredAddress shape
+   * (`pickup_warehouse_id + zip + state + city`); when absent, pickup is the
+   * UnregisteredAddress shape built from the order's `from` address.
+   */
+  pickup_warehouse_id?: string
+  /** Account-level seller export KYC (commercial shipments). */
+  consignor_kyc?: StarfleetConsignorKyc
+  /** Injectable transport (defaults to the global fetch). */
+  fetchImpl?: FetchLike
+}
+
+export type StarfleetToken = {
+  access_token: string
+  id_token?: string
+  expires_in?: number
+}
+
+/** A StarFleet API failure as a first-class MedusaError, mirroring
+ *  `ShipglobalApiError`. Maps the upstream HTTP status onto a MedusaError type. */
+export class StarfleetApiError extends MedusaError {
+  readonly status: number
+  readonly raw?: unknown
+
+  constructor(message: string, opts: { status: number; raw?: unknown }) {
+    super(StarfleetApiError.typeForStatus(opts.status), message)
+    this.name = "StarfleetApiError"
+    this.status = opts.status
+    this.raw = opts.raw
+  }
+
+  static typeForStatus(status: number): string {
+    if (status === 401 || status === 403) return MedusaError.Types.NOT_ALLOWED
+    if (status >= 400 && status < 500) return MedusaError.Types.INVALID_DATA
+    return MedusaError.Types.UNEXPECTED_STATE
+  }
+}
+
+/** Map `CustomsDeclaration.reason_of_export` → StarFleet `shipment_type`. */
+export function shipmentTypeForReason(reason: number | undefined): string {
+  // 0 BONAFIDE_SAMPLE · 1 SAMPLE · 2 GIFT · 3 COMMERCIAL (see provider-interface)
+  if (reason === 2) return "gift"
+  if (reason === 0 || reason === 1) return "sample"
+  return "commercial"
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+/**
+ * Build one StarFleet `PackageMetadata` from a normalized shipment input.
+ * Pure & exported so the exact payload (invoice terms, IGST status, product
+ * line maths, pickup shape) is unit-testable without a live API.
+ *
+ * The StarFleet manifest forbids `& \ % # ;` in address/name fields (see the
+ * swagger info block) — the caller is responsible for having sanitised them
+ * upstream (domestic Delhivery does the same).
+ */
+export function buildPackagePayload(
+  input: CreateShipmentInput,
+  opts: {
+    client_name: string
+    service_type: string
+    billing_mode: "E" | "S"
+    pickup_warehouse_id?: string
+    consignor_kyc?: StarfleetConsignorKyc
+  }
+): Record<string, any> {
+  const to = input.to
+  const from = input.from ?? ({} as CreateShipmentInput["from"])
+  const countryCode = String(to.country || "").trim().toUpperCase()
+  const kyc = opts.consignor_kyc ?? {}
+
+  const products = (input.items || []).map((i) => {
+    const qty = i.quantity || 1
+    const unitPrice = i.unit_price || 0
+    const productAmount = round2(unitPrice * qty)
+    const igstRate = i.tax != null ? Number(i.tax) : 0
+    const igstAmount = round2((productAmount * igstRate) / 100)
+    return {
+      desc: i.name || "Item",
+      quantity: qty,
+      unit_price: unitPrice,
+      // `product_amount` = unit price × quantity; `item_commodity_value` is the
+      // customs declared value of the line (equal to product amount pre-tax).
+      product_amount: productAmount,
+      item_commodity_value: productAmount,
+      // `total_amount` = item total including tax.
+      total_amount: round2(productAmount + igstAmount),
+      hsn_code: normalizeHsCode(i.hsn) || "",
+      igst_rate: igstRate,
+      igst_amount: igstAmount,
+      euec: false,
+      meis: false,
+    }
+  })
+
+  const totalCommodityValue = round2(
+    products.reduce((sum, p) => sum + (p.item_commodity_value || 0), 0)
+  )
+  const packageAmount = round2(
+    input.sub_total != null
+      ? input.sub_total
+      : products.reduce((sum, p) => sum + (p.total_amount || 0), 0)
+  )
+
+  const customs = input.customs ?? {}
+  const shipmentType = shipmentTypeForReason(customs.reason_of_export)
+  const isCommercial = shipmentType === "commercial"
+  // IGST status: "C" = against IGST payment → "Paid"; "B" = LUT/bond → "LUT".
+  const igstStatus =
+    customs.igst_payment_status === "B"
+      ? "LUT"
+      : customs.igst_payment_status === "C"
+        ? "Paid"
+        : isCommercial
+          ? "Paid"
+          : undefined
+
+  const invoice: Record<string, any> = {
+    number: input.reference_id,
+    date: new Date().toISOString().slice(0, 10),
+    terms: customs.terms_of_invoice ?? "FOB",
+  }
+  if (isCommercial && igstStatus) {
+    invoice.igst_payment_status = igstStatus
+  }
+
+  const deliveryLocation: Record<string, any> = {
+    address: [to.address_1, to.address_2].filter(Boolean).join(", "),
+    city: to.city || "",
+    state: to.state || "",
+    country: countryCode,
+    zip: to.pincode || "",
+  }
+
+  // The pickup: registered warehouse (id + address) when configured, else the
+  // order's own origin as an unregistered address (no `name` — that key flips
+  // StarFleet into a failed warehouse lookup).
+  const pickupLocation: Record<string, any> = opts.pickup_warehouse_id
+    ? {
+        pickup_warehouse_id: opts.pickup_warehouse_id,
+        country: "IN",
+        zip: from?.pincode || "",
+        state: from?.state || "",
+        city: from?.city || "",
+      }
+    : {
+        type: "Office",
+        address: [from?.address_1, from?.address_2].filter(Boolean).join(", "),
+        city: from?.city || "",
+        state: from?.state || "",
+        country: "IN",
+        zip: from?.pincode || "",
+      }
+
+  const consignor: Record<string, any> = {
+    name: from?.name || "",
+    phone: from?.phone || "",
+    email: from?.email || "",
+    type: "Office",
+    address: [from?.address_1, from?.address_2].filter(Boolean).join(", "),
+    city: from?.city || "",
+    state: from?.state || "",
+    country: String(from?.country || "IN").toUpperCase(),
+    zip: from?.pincode || "",
+    gstin: input.tax_id || kyc.gstin || "",
+    ...(kyc.document_id ? { document_id: kyc.document_id } : {}),
+    ...(kyc.document_type ? { document_type: kyc.document_type } : {}),
+    ...(kyc.iec ? { iec: kyc.iec } : {}),
+    ...(kyc.pan ? { pan: kyc.pan } : {}),
+    ...(kyc.bank_ad_code ? { bank_ad_code: kyc.bank_ad_code } : {}),
+    ...(kyc.bank_ifsc ? { bank_ifsc: kyc.bank_ifsc } : {}),
+    ...(kyc.bank_ac ? { bank_ac: kyc.bank_ac } : {}),
+  }
+
+  return {
+    weight: input.weight_grams || 0,
+    dims: {
+      length: input.dimensions_cm?.length ?? 10,
+      width: input.dimensions_cm?.width ?? 10,
+      height: input.dimensions_cm?.height ?? 10,
+    },
+    package_amount: packageAmount,
+    total_commodity_value: totalCommodityValue,
+    shipment_type: shipmentType,
+    currency: (input.currency || "INR").toUpperCase(),
+    order_no: input.reference_id,
+    client_name: opts.client_name,
+    transaction_type: "B2C",
+    payment_mode: input.payment_mode === "cod" ? "COD" : "Prepaid",
+    cod_amount: input.payment_mode === "cod" ? input.cod_amount || 0 : 0,
+    service_type: opts.service_type,
+    billing_mode: opts.billing_mode,
+    battery: false,
+    invoice,
+    return_location: {
+      address: [from?.address_1, from?.address_2].filter(Boolean).join(", "),
+      zip: from?.pincode || "",
+    },
+    pickup_location: pickupLocation,
+    delivery_location: deliveryLocation,
+    bill_to: { as_shipto: true },
+    clearance_mode: "courier",
+    products,
+    add_on_services: {
+      // free_domicile = "bill duties to shipper" = a DDP sale (we clear + pay).
+      free_domicile: customs.incoterm === "DDP",
+      signature_pod: false,
+    },
+    consignor,
+    consignee: {
+      name: to.name || "",
+      email: to.email || "",
+      phone: to.phone || "",
+    },
+  }
+}
+
+/**
+ * Extract the waybill Delhivery assigned to a specific `order_id` from a
+ * COMPLETED batch-job response. Pure & exported for unit testing.
+ */
+export function extractWaybillForOrder(
+  batchResponse: any,
+  orderId: string
+): string {
+  const payload = batchResponse?.payload ?? {}
+  const data = payload.data ?? {}
+  const success = data.success_waybills ?? (Array.isArray(data) ? data : [])
+  const found = (Array.isArray(success) ? success : []).find(
+    (row: any) => String(row?.order_id ?? row?.order_no ?? "") === String(orderId)
+  )
+  return typeof found?.waybill === "string" && found.waybill
+    ? found.waybill
+    : ""
+}
+
+/** StarFleet scan `action` code → our coarse `scan_type`. The action codes are
+ *  opaque (`INT-PKG-MANF` manifestation, …), so classify by the free-text
+ *  `remarks`/`action` and default to in_transit. */
+export function scanTypeForAction(action?: string, remarks?: string): string {
+  const text = `${action ?? ""} ${remarks ?? ""}`.toLowerCase()
+  if (text.includes("deliver")) return "delivered"
+  if (text.includes("rto") || text.includes("return")) return "rto"
+  if (text.includes("manifest") || text.includes("manf")) return "created"
+  return "in_transit"
+}
+
+/**
+ * Normalize a StarFleet `/auth-track` response into our `TrackingResult`. Pure
+ * & exported so the normalize path can run without carrier credentials.
+ */
+export function normalizeStarfleetTracking(
+  payload: any,
+  awb: string
+): TrackingResult {
+  const founds = payload?.payload?.waybills_found ?? []
+  const pkg = (Array.isArray(founds) ? founds : []).find(
+    (w: any) => String(w?.waybill ?? "") === String(awb)
+  )
+  const scans: any[] = Array.isArray(pkg?.scans) ? pkg.scans : []
+
+  const events: TrackingEvent[] = scans.map((s: any) => ({
+    timestamp: s?.time ?? "",
+    status: s?.remarks ?? s?.action ?? "",
+    location: [s?.city, s?.state, s?.country].filter(Boolean).join(", "),
+    scan_type: scanTypeForAction(s?.action, s?.remarks),
+  }))
+
+  const last = events[events.length - 1]
+  return {
+    carrier: "starfleet",
+    awb,
+    current_status: last?.status ?? "",
+    current_status_code: undefined,
+    estimated_delivery: null,
+    origin: pkg?.origin ?? undefined,
+    destination: pkg?.destination?.city ?? undefined,
+    events,
+    raw: payload,
+  }
+}
+
+/** Tracking URL for a StarFleet AWB (Delhivery's international track page). */
+export function starfleetTrackingUrl(awb: string): string {
+  return awb
+    ? `https://www.delhivery.com/track/package/${encodeURIComponent(awb)}`
+    : ""
+}
+
+export class StarfleetClient implements ShippingProviderClient {
+  readonly carrier = "starfleet"
+
+  private options: StarfleetOptions
+  private fetchImpl: FetchLike
+  private accessToken: string | null = null
+  private tokenExpiry = 0
+
+  constructor(options: StarfleetOptions) {
+    this.options = options
+    this.fetchImpl =
+      options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init))
+  }
+
+  private clientName(): string {
+    return this.options.client_name || this.options.username
+  }
+
+  /** Fetch (and cache) an OAuth2 access token from /auth/token. The scope is
+   *  wrapped in literal double-quotes — gotcha #1. */
+  async authenticate(): Promise<StarfleetToken> {
+    const body = new URLSearchParams({
+      grant_type: "password",
+      username: this.options.username,
+      password: this.options.password,
+      audience: AUTH_AUDIENCE,
+      scope: `"${AUTH_SCOPE}"`,
+      client_id: this.options.client_id,
+      client_secret: this.options.client_secret,
+    })
+    const res = await this.fetchImpl(AUTH_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    })
+    const raw = await res.text().catch(() => "")
+    let json: any
+    try {
+      json = raw ? JSON.parse(raw) : {}
+    } catch {
+      json = undefined
+    }
+    if (!res.ok || !json?.access_token) {
+      throw new StarfleetApiError(
+        `StarFleet auth failed (${res.status})${raw ? ` — ${raw}` : ""}`,
+        { status: res.status, raw }
+      )
+    }
+    this.accessToken = json.access_token as string
+    this.tokenExpiry = Date.now() + (json.expires_in
+      ? Number(json.expires_in) * 1000 - 60_000
+      : TOKEN_TTL_MS)
+    return json as StarfleetToken
+  }
+
+  private async bearer(): Promise<string> {
+    if (this.accessToken && Date.now() < this.tokenExpiry) {
+      return this.accessToken
+    }
+    const token = await this.authenticate()
+    return token.access_token
+  }
+
+  /** Authorized GET/POST against the package API, parsing JSON and raising a
+   *  StarfleetApiError on a non-2xx. */
+  private async request<T = any>(
+    method: "GET" | "POST",
+    path: string,
+    init?: { body?: unknown; headers?: Record<string, string> }
+  ): Promise<T> {
+    const token = await this.bearer()
+    const res = await this.fetchImpl(`${PACKAGE_BASE_URL}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+      body: init?.body === undefined ? undefined : JSON.stringify(init.body),
+    })
+    const raw = await res.text().catch(() => "")
+    let json: any
+    try {
+      json = raw ? JSON.parse(raw) : {}
+    } catch {
+      json = undefined
+    }
+    if (!res.ok) {
+      throw new StarfleetApiError(
+        `StarFleet ${path} failed (${res.status})${raw ? ` — ${raw}` : ""}`,
+        { status: res.status, raw }
+      )
+    }
+    return json as T
+  }
+
+  /** Poll a batch job id until COMPLETED/FAILED, returning the job response. */
+  private async pollJob(jobId: string): Promise<any> {
+    for (let attempt = 0; attempt < JOB_POLL_MAX_ATTEMPTS; attempt++) {
+      const res = await this.request<any>("GET", `/batchGeneratePackages/${jobId}`)
+      const status = res?.payload?.status ?? res?.status
+      if (status === "COMPLETED" || status === "FAILED") {
+        return res
+      }
+      await new Promise((r) => setTimeout(r, JOB_POLL_INTERVAL_MS))
+    }
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `StarFleet batch job ${jobId} did not complete within ${JOB_POLL_MAX_ATTEMPTS * JOB_POLL_INTERVAL_MS}ms`
+    )
+  }
+
+  async createShipment(input: CreateShipmentInput): Promise<ShipmentResult> {
+    if (!isInternationalDestination(input.to.country)) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "Delhivery International (StarFleet) is cross-border only and cannot ship a domestic (India) destination"
+      )
+    }
+    const pkg = buildPackagePayload(input, {
+      client_name: this.clientName(),
+      service_type: this.options.service_type || "EXPORTS_EXPRESS",
+      billing_mode: this.options.billing_mode || "E",
+      pickup_warehouse_id: this.options.pickup_warehouse_id,
+      consignor_kyc: this.options.consignor_kyc,
+    })
+
+    // StarFleet manifests in BULK — a single order travels as a one-row batch.
+    const res = await this.request<any>("POST", "/batchGeneratePackages", {
+      body: { packages: [pkg] },
+    })
+    const jobId = res?.payload?.id
+    if (!jobId) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `StarFleet accepted the manifest but returned no job id: ${JSON.stringify(res)}`
+      )
+    }
+
+    const done = await this.pollJob(jobId)
+    const awb = extractWaybillForOrder(done, input.reference_id)
+    if (!awb) {
+      const errors = done?.payload?.data?.error_waybills ?? []
+      const reason = (Array.isArray(errors) ? errors : [])
+        .map((e: any) => e?.reason ?? JSON.stringify(e))
+        .join("; ")
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `StarFleet manifest completed without a waybill for order ${input.reference_id}${reason ? ` — ${reason}` : ""}`
+      )
+    }
+
+    return {
+      carrier: this.carrier,
+      awb,
+      tracking_number: awb,
+      tracking_url: starfleetTrackingUrl(awb),
+      provider_refs: { waybill: awb, job_id: jobId },
+      raw: done,
+    }
+  }
+
+  /**
+   * ⚠️ GATED on the carrier side: shipping-label currently returns
+   * `403 Unauthorized User` even with a valid token (per-user id_token, or the
+   * shipment not being label-ready). Surfaces that 403 as a StarfleetApiError
+   * until Delhivery resolves it.
+   */
+  async getLabel(ref: ShipmentRef): Promise<LabelResult> {
+    const awb = refAwb(ref)
+    if (!awb) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "StarFleet getLabel requires an AWB/waybill"
+      )
+    }
+    const token = await this.bearer()
+    const res = await this.fetchImpl(
+      `${PACKAGE_BASE_URL}/${awb}/shipping-label`,
+      { headers: { Authorization: `Bearer ${token}`, Accept: "application/pdf" } }
+    )
+    if (!res.ok) {
+      const raw = await res.text().catch(() => "")
+      throw new StarfleetApiError(
+        `StarFleet shipping-label failed (${res.status})${raw ? ` — ${raw}` : ""}`,
+        { status: res.status, raw }
+      )
+    }
+    const buf = Buffer.from(await res.arrayBuffer())
+    return { data: buf.toString("base64"), format: "pdf" }
+  }
+
+  /** Fetch the customs invoice PDF for a waybill (same carrier-side 403 gate as
+   *  the label). */
+  async getInvoice(ref: ShipmentRef): Promise<LabelResult> {
+    const awb = refAwb(ref)
+    if (!awb) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "StarFleet getInvoice requires an AWB/waybill"
+      )
+    }
+    const token = await this.bearer()
+    const res = await this.fetchImpl(`${PACKAGE_BASE_URL}/${awb}/invoice`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/pdf" },
+    })
+    if (!res.ok) {
+      const raw = await res.text().catch(() => "")
+      throw new StarfleetApiError(
+        `StarFleet invoice failed (${res.status})${raw ? ` — ${raw}` : ""}`,
+        { status: res.status, raw }
+      )
+    }
+    const buf = Buffer.from(await res.arrayBuffer())
+    return { data: buf.toString("base64"), format: "pdf" }
+  }
+
+  async track(ref: ShipmentRef): Promise<TrackingResult> {
+    const awb = refAwb(ref)
+    if (!awb) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "StarFleet track requires an AWB/waybill"
+      )
+    }
+    const res = await this.request<any>("GET", `/auth-track/${awb}`)
+    return normalizeStarfleetTracking(res, awb)
+  }
+
+  async cancelShipment(
+    _ref: ShipmentRef
+  ): Promise<{ success: boolean; raw?: any }> {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Delhivery International (StarFleet) does not expose a cancellation API — cancel through the Delhivery International portal"
+    )
+  }
+}
+
+/** The AWB/waybill number on a persisted shipment ref, from whichever key the
+ *  resolver/framework stashed it. */
+function refAwb(ref: ShipmentRef): string {
+  const v =
+    ref?.awb ??
+    ref?.provider_refs?.waybill ??
+    ref?.provider_refs?.awb ??
+    ""
+  return String(v || "").trim()
+}

--- a/apps/backend/src/modules/shipping-providers/starfleet/stub-fetch.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/stub-fetch.ts
@@ -1,0 +1,126 @@
+/**
+ * Deterministic StarFleet (Delhivery International) transport for tests/CI.
+ *
+ * StarFleet has no sandbox; the account credentials are live, so an un-stubbed
+ * call would manifest a real, billable cross-border waybill. Mirroring
+ * Shiprocket/ShipGlobal (#647), the resolver injects this stub when
+ * `STARFLEET_STUB=1`.
+ *
+ * Canned shapes mirror the LIVE responses captured from the carrier (auth token,
+ * batch job id → COMPLETED success_waybills, auth-track scans).
+ */
+import type { FetchLike } from "./client"
+
+const json = (body: any, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    arrayBuffer: async () => Buffer.from(JSON.stringify(body)),
+  }) as any
+
+const STUB_AWB = "DLSTUB0000XB"
+
+/** Captures what the stub last received so specs can assert the exact payload. */
+export const starfleetStubState: {
+  lastAuthBody?: any
+  lastBatchBody?: any
+  lastTrackPath?: string
+  lastLabelPath?: string
+  lastKycPath?: string
+} = {}
+
+const parseBody = (init: any): any => {
+  try {
+    return init?.body ? JSON.parse(init.body) : undefined
+  } catch {
+    return init?.body ?? undefined
+  }
+}
+
+export function createStarfleetStubFetch(): FetchLike {
+  return async (input: any, init?: any) => {
+    const url = String(input)
+
+    if (url.endsWith("/auth/token")) {
+      starfleetStubState.lastAuthBody = parseBody(init)
+      return json({ access_token: "stub-access-token", expires_in: 86400, token_type: "Bearer" })
+    }
+
+    if (url.endsWith("/batchGeneratePackages") && init?.method === "POST") {
+      starfleetStubState.lastBatchBody = parseBody(init)
+      return json({ message: "ok", payload: { id: "stub-job-id" } })
+    }
+
+    if (url.includes("/batchGeneratePackages/")) {
+      return json({
+        message: "ok",
+        payload: {
+          status: "COMPLETED",
+          data: {
+            total_count: 1,
+            error_count: 0,
+            success_count: 1,
+            success_waybills: [
+              { waybill: STUB_AWB, order_id: "stub-order", reason: "manifested" },
+            ],
+            error_waybills: [],
+          },
+        },
+      })
+    }
+
+    if (url.includes("/auth-track/")) {
+      starfleetStubState.lastTrackPath = url
+      return json({
+        message: "ok",
+        payload: {
+          waybills_found: [
+            {
+              waybill: STUB_AWB,
+              origin: "testwarehouse",
+              scans: [
+                {
+                  city: "IN_Delhi_P",
+                  state: "Delhi",
+                  country: "IND",
+                  time: "1788343161",
+                  action: "INT-PKG-MANF",
+                  remarks: "Package Manifestation Done",
+                },
+              ],
+            },
+          ],
+          waybills_not_found: [],
+        },
+      })
+    }
+
+    if (url.endsWith("/shipping-label")) {
+      starfleetStubState.lastLabelPath = url
+      return {
+        ok: true,
+        status: 200,
+        text: async () => "",
+        arrayBuffer: async () => Buffer.from("%PDF-1.4 stub label"),
+      } as any
+    }
+
+    if (url.endsWith("/invoice")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => "",
+        arrayBuffer: async () => Buffer.from("%PDF-1.4 stub invoice"),
+      } as any
+    }
+
+    if (url.endsWith("/upload-kyc-doc")) {
+      starfleetStubState.lastKycPath = url
+      return json({ success: true, message: "ok" })
+    }
+
+    return json({ message: "stub: not found" }, 404)
+  }
+}

--- a/apps/docs/notes/STARFLEET_API.md
+++ b/apps/docs/notes/STARFLEET_API.md
@@ -1,0 +1,129 @@
+# Delhivery International ("StarFleet") API — spec + gotchas
+
+Live-verified 2026-09-02 against `api-stage-starfleet.delhivery.com` (a real AWB
+`DL001113245XB` was manifested end-to-end) and `api-starfleet.delhivery.com`
+(prod). Companion to `DELHIVERY_INTERNATIONAL_PARITY.md` — that file audited the
+*gap*; this one documents the now-verified *contract*.
+
+The spec is embedded in the StarFleet swagger UI (OpenAPI 3.0.2,
+`https://rsgkiai9q6.delhivery.com/`) — it is NOT served at any public
+`swagger.json` URL (all paths 403). The swagger's own `info.description` carries
+the auth parameters.
+
+## Auth
+
+`POST /auth/token` (`application/x-www-form-urlencoded`) →
+
+```
+grant_type=password
+username=<account>          # staging: JaalYantraTextilesPr-in-B2C · prod: 8e2306-JaalYantraTextilesPr-in
+password=<password>
+audience=StarFleet
+scope="starfleet openid profile email ^/package/batchGeneratePackages:POST$ ^/package/batchGeneratePackages/.+:GET$ ^/package/auth-track/.+:GET$ ^/package/.+/invoice:GET$ ^/package/.+/shipping-label:GET$ ^/package/.+/upload-kyc-doc:POST$"
+client_id=<client_id>
+client_secret=<client_secret>
+```
+
+→ `{ access_token, id_token, expires_in: 86400, token_type: "Bearer" }`. Package
+endpoints authenticate with `Authorization: Bearer <access_token>`.
+
+### 🔴 Gotcha #1 — the scope must be QUOTED
+
+The `scope` value is the literal `scope="starfleet openid … $"` **with the
+double-quotes**. A bare `scope=starfleet openid … $` (no quotes) mints a token
+that returns `401 Unauthorized` on every `/package` endpoint. The `\/` and `\:`
+escaping the swagger renders is **irrelevant** — quote vs no-quote is what
+decides whether the token works. When executing via code, URL-encode the whole
+`scope` param (`URLSearchParams` does this; just keep the quotes inside the
+value).
+
+### Gotcha #2 — `client_name` must be the account name
+
+`client_name` in the manifest must equal the account username (e.g.
+`8e2306-JaalYantraTextilesPr-in`). Anything else → `403 Unauthorized User`. The
+value is also visible in the token's `client_name` claim (decode the JWT).
+
+## Endpoints
+
+| Purpose | Method | Path | Status |
+|---|---|---|---|
+| Manifest (async) | POST | `/package/batchGeneratePackages` | ✅ verified |
+| Poll job | GET | `/package/batchGeneratePackages/{id}` | ✅ verified |
+| Track | GET | `/package/auth-track/{id}` | ✅ verified |
+| Invoice | GET | `/package/{id}/invoice` | ⚠️ 403 `Unauthorized User` |
+| Shipping label | GET | `/package/{id}/shipping-label` | ⚠️ 403 `Unauthorized User` |
+| Upload KYC | POST | `/package/{id}/upload-kyc-doc` | ⚠️ 502 `Internal server error` |
+
+`auth-track/{id}` accepts up to 15 comma-separated waybills.
+
+## Manifest — `POST /package/batchGeneratePackages`
+
+Async: returns `{ payload: { id } }` (a job id), then poll
+`GET /package/batchGeneratePackages/{id}` until
+`payload.status ∈ { COMPLETED, FAILED }`. The AWB is
+`payload.data.success_waybills[].waybill` (matched by `order_id`); failures land
+in `payload.data.error_waybills[].reason`.
+
+The manifest is BULK (`packages[]`, swagger says min 2 but a one-row batch
+works). Fields marked mandatory for exports carry `*^` in the schema.
+
+### Gotcha #3 — pickup is `pickup_warehouse_id` + `zip`/`state`/`city`
+
+```json
+"pickup_location": {
+  "pickup_warehouse_id": "<warehouse name>",
+  "country": "IN",
+  "zip": "<pickup pincode>",
+  "state": "<pickup state>",
+  "city": "<pickup city>"
+}
+```
+
+- The warehouse is created via the **domestic** endpoint
+  `POST /api/backend/clientwarehouse/create/` (Token auth, `staging-express` /
+  `track.delhivery.com`), then referenced by its `name` as `pickup_warehouse_id`.
+- The warehouse registry is **per-environment**: a prod warehouse does not exist
+  in staging. On staging this surfaces as
+  `ClientNotFoundException<… not found or XB is disabled>`; earlier attempts
+  also saw `PickupPincodeNotFoundException` / `PickupStateNotFoundException` when
+  the pickup was malformed or the env lacked the warehouse.
+- An unregistered address (`type/address/city/state/country/zip`, **no `name`**)
+  is also accepted, but only worked once the warehouse existed.
+
+### Gotcha #4 — products need IGST fields even at 0
+
+Each `products[]` item must carry `igst_rate` and `igst_amount` (both `0` for a
+sample) plus `euec: false` / `meis: false`. Omitting them fails manifestation
+with `AMX Manifestation Failed: Details.AdditionalProperties[0].Value - Value is
+empty`.
+
+### Gotcha #5 — `return_location` + `add_on_services` + full consignor KYC
+
+A manifest that reaches AMX also expects `return_location`
+(`{ address, zip }`), `add_on_services` (`{ free_domicile, signature_pod }`), and
+a full `consignor` (name/address/phone/email + `document_id`, `document_type`,
+`iec`, `pan`, `gstin`, `bank_ad_code`, `bank_ifsc`, `bank_ac`). The IEC/PAN/GSTIN/
+bank block is account-level KYC (config), mandatory for `commercial` shipments.
+
+`free_domicile: true` = "bill duties to shipper" = DDP (aligns with
+`customs.incoterm === "DDP"`).
+
+## Not working (Delhivery-side, pending)
+
+- **invoice / shipping-label** → `403 Unauthorized User` even with a valid,
+  correctly-scoped token (track with the same token is 200). Either a per-user
+  `id_token` requirement (our `id_token == access_token`, a client-level token
+  with `user_type: "CL"`) or the shipment not being label/invoice-ready.
+- **upload-kyc-doc** → `502 Internal server error` (their gateway) for PNG and
+  PDF alike. Request contract is `dlv-image-type: Front|Back` +
+  `Content-Type: image/jpeg|png|jpg|application/pdf` + binary body →
+  `{ success, message }`.
+
+No cancellation endpoint exists in the scoped surface.
+
+## Environment matrix
+
+| env | base | warehouse |
+|---|---|---|
+| staging | `api-stage-starfleet.delhivery.com` | created via `staging-express` `clientwarehouse/create` |
+| prod | `api-starfleet.delhivery.com` | prod warehouse (gates: wallet `InsufficientBalance`) |

--- a/apps/docs/notes/STARFLEET_API.md
+++ b/apps/docs/notes/STARFLEET_API.md
@@ -123,7 +123,18 @@ No cancellation endpoint exists in the scoped surface.
 
 ## Environment matrix
 
-| env | base | warehouse |
-|---|---|---|
-| staging | `api-stage-starfleet.delhivery.com` | created via `staging-express` `clientwarehouse/create` |
-| prod | `api-starfleet.delhivery.com` | prod warehouse (gates: wallet `InsufficientBalance`) |
+| env | `STARFLEET_ENV` | base | warehouse |
+|---|---|---|---|
+| staging | unset (default) | `api-stage-starfleet.delhivery.com` | created via `staging-express` `clientwarehouse/create` |
+| prod | `prod` | `api-starfleet.delhivery.com` | prod warehouse (gates: wallet `InsufficientBalance`) |
+
+🔴 The host is selected by `STARFLEET_ENV` and **defaults to staging**. Anything
+other than the exact string `prod` (case- and space-insensitive) stays on
+staging, so turning prod on is a deliberate act rather than a side effect of a
+deploy.
+
+⚠️ Because the warehouse registry is per-environment, prod credentials pointed
+at the staging host do NOT fail at auth. They authenticate, and then
+`pickup_warehouse_id` resolves against a registry that has never heard of that
+warehouse — surfacing as a manifestation error that reads like bad shipment
+data. If a manifest fails on an unknown warehouse, check the host first.


### PR DESCRIPTION
## What

Adds a `starfleet` `ShippingProviderClient` for Delhivery's cross-border product (Delhivery International / "StarFleet"), live-verified end-to-end against `api-stage-starfleet` (a real AWB `DL001113245XB` was manifested).

### Files
- `shipping-providers/starfleet/client.ts` — `StarfleetClient`: OAuth2 password-grant auth, async batch manifest + poll, `auth-track` tracking, plus label/invoice/KYC methods (gated — see below).
- `shipping-providers/starfleet/stub-fetch.ts` — deterministic transport (`STARFLEET_STUB=1`).
- `shipping-providers/starfleet/__tests__/client.unit.spec.ts` — payload builders/normalizers (14 tests).
- `resolver.ts` + `provider-interface.ts` + `carrier-capabilities.ts` — register `starfleet` as a cross-border-only, flat-priced carrier (no rate API, DDP declarable via `free_domicile`).
- `apps/docs/notes/STARFLEET_API.md` — the full verified contract + gotchas.

## Verified (live)

- Auth (`POST /auth/token` → `access_token`, Bearer), `batchGeneratePackages` (create → poll → `success_waybills[].waybill`), `auth-track`.
- `client_name` must equal the account username; `pickup` = `pickup_warehouse_id + zip/state/city` (warehouse created via the domestic `clientwarehouse/create`); products need `igst_rate`/`igst_amount` + `euec`/`meis`; plus `return_location`, `add_on_services`, full consignor KYC.

## Not working yet (Delhivery-side — do not merge for these)

- `invoice` / `shipping-label` → `403 Unauthorized User` even with a valid token (per-user `id_token`, or shipment not label-ready).
- `upload-kyc-doc` → `502 Internal server error`.
- No cancellation endpoint exists.

The client surfaces these cleanly (methods present, `StarfleetApiError` carries the carrier response) so the labels/KYC can be flipped on once Delhivery resolves the gates.

## Gotchas baked in

- **scope must be quoted** (`scope="starfleet … $"`); a bare scope mints a 401-everywhere token.
- `client_name` = account username (mismatch → `403 Unauthorized User`).
- warehouse registry is per-environment (prod warehouses absent in staging).