### PR TITLE
feat(quotes): introduce the partner in code before the quote email (#1486)

### DIFF
--- a/apps/backend/src/workflows/email/workflows/send-quote-introduction-email.ts
+++ b/apps/backend/src/workflows/email/workflows/send-quote-introduction-email.ts
@@ -1,0 +1,83 @@
+import {
+  createWorkflow,
+  transform,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { QUOTE_INTRODUCTION_TEMPLATE_KEY } from "../../../scripts/seed-quote-email-template"
+import { fetchEmailTemplateStep } from "../steps/fetch-email-template"
+import { sendNotificationEmailStep } from "../steps/send-notification-email"
+
+/**
+ * What the introduction template's `variables` block declares — see
+ * `QUOTE_INTRODUCTION_TEMPLATE_DEFINITION` in the seed. Nothing more and
+ * nothing less: a variable this type forgets is a silent blank in a buyer's
+ * inbox, and one it invents is a lie the template will never render.
+ */
+export type QuoteIntroductionEmailData = {
+  partner_name: string
+  recipient_name: string
+  recipient_company: string | null
+  line_count: number
+  total_quantity: number
+  destination: string
+  current_year: number
+}
+
+/**
+ * Deliver the partner introduction that precedes a quote (#1486 slice 1).
+ *
+ * ## Why this exists when a visual flow could have sent it
+ *
+ * 🔴 The introduction used to be delegated to a prod-configured visual flow
+ * listening on `partner_quote.minted` — and nothing in code ever sent it. The
+ * template existed, the event was emitted, the subscriber allowlisted it, and
+ * whether a buyer was introduced at all depended on infrastructure that may
+ * not exist in any given environment. The send now lives in code, on the
+ * quote-delivery path; a configured flow becomes an addition, not a
+ * precondition.
+ *
+ * ## Same mechanism as the quote email, deliberately
+ *
+ * `fetchEmailTemplateStep` + `sendNotificationEmailStep`, composed exactly as
+ * `send-quote-email.ts` composes them — a second template-fetch or send path
+ * is how two emails that must agree quietly diverge. `fetchEmailTemplateStep`
+ * throws when the template is missing, which is as correct here as it is for
+ * the quote: an introduction sent from a provider default would introduce
+ * nobody. The CALLER owns the consequence — a failed introduction is logged
+ * and must never stop the quote itself.
+ *
+ * ## Channel
+ *
+ * `email` → Resend, the brand channel, matching the quote email it precedes.
+ * This is BUYER-facing and the template's own `from` is
+ * `sales@jaalyantra.com`; an introduction arriving from a partner subdomain
+ * would read as internal mail to a procurement inbox.
+ */
+export const sendQuoteIntroductionEmailWorkflow = createWorkflow(
+  { name: "send-quote-introduction-email", store: true },
+  (input: { email: string; data: QuoteIntroductionEmailData }) => {
+    const templateData = fetchEmailTemplateStep({
+      templateKey: QUOTE_INTRODUCTION_TEMPLATE_KEY,
+      data: input.data as unknown as Record<string, any>,
+    })
+
+    const payload = transform({ input, templateData }, (d) => ({
+      to: d.input.email,
+      template: QUOTE_INTRODUCTION_TEMPLATE_KEY,
+      channel: "email",
+      data: d.input.data as unknown as Record<string, any>,
+      templateData: d.templateData,
+    }))
+
+    // Returned, not fired and forgotten: the caller has to be able to tell a
+    // real send from a SUPPRESSED one — a known crawler address makes every
+    // provider return a synthetic id without mailing anything (#1333), and
+    // "suppressed" must never read as "sent".
+    const sent = sendNotificationEmailStep(payload as any)
+
+    return new WorkflowResponse(sent)
+  }
+)
+
+export default sendQuoteIntroductionEmailWorkflow

--- a/apps/backend/src/workflows/partner-quote/__tests__/deliver-quote-email.unit.spec.ts
+++ b/apps/backend/src/workflows/partner-quote/__tests__/deliver-quote-email.unit.spec.ts
@@ -1,0 +1,242 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import { BOT_SUPPRESSED_SEND_ID } from "../../../lib/bot-recipients"
+import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
+import { deliverQuoteEmail } from "../deliver-quote-email"
+
+/**
+ * #1486 slice 1 — the partner introduction, sent in code before the quote.
+ *
+ * The audit's finding, restated as the property under test: the template
+ * existed, the mint event was emitted, the subscriber allowlisted it — and
+ * nothing in code ever sent the introduction. Whether a buyer was introduced
+ * at all was decided by a visual flow that may not exist in any given
+ * environment.
+ *
+ * These tests pin what slice 1 promises: the introduction goes FIRST and is
+ * awaited, a failed introduction never costs the buyer their quote, and the
+ * failure is logged loudly enough for a human to act on. The link resolution
+ * and the email payload builder run for real — they have their own specs
+ * (`quote-link.unit.spec.ts`, `quote-email.unit.spec.ts`) — but the two send
+ * workflows are mocked: this file is about sequencing and failure, not about
+ * Resend.
+ */
+
+const mockQuoteRun = jest.fn()
+const mockIntroductionRun = jest.fn()
+const mockResolveBuyerLink = jest.fn()
+
+jest.mock("../../email/workflows/send-quote-email", () => ({
+  sendQuoteEmailWorkflow: () => ({ run: mockQuoteRun }),
+}))
+
+jest.mock("../../email/workflows/send-quote-introduction-email", () => ({
+  sendQuoteIntroductionEmailWorkflow: () => ({ run: mockIntroductionRun }),
+}))
+
+jest.mock("../../../modules/partner-quote/lib/quote-link", () => ({
+  resolveQuoteBuyerLink: (...args: any[]) => mockResolveBuyerLink(...args),
+}))
+
+// The module index pulls in the whole service graph; only the key is needed.
+jest.mock("../../../modules/partner-quote", () => ({
+  PARTNER_QUOTE_MODULE: "partnerQuote",
+}))
+
+const BUYER_URL = "https://shop.marcha.test/de/quotes/raw_token_1"
+
+const QUOTE = {
+  id: "quote_1",
+  partner_id: "partner_1",
+  email_sent_to: "buyer@example.com",
+  recipient_name: "Meera",
+  recipient_company: "Meera Textiles",
+  quoted_landed_total: 360000,
+  currency_code: "inr",
+  destination_city: "Berlin",
+  destination_country_code: "de",
+  expires_at: new Date("2026-10-01T00:00:00.000Z"),
+}
+
+const deliveryInput = () => ({
+  quote: QUOTE,
+  token: "raw_token_1",
+  partnerName: "Marcha",
+  lineCount: 6,
+  totalQuantity: 10,
+  actorType: "partner" as const,
+  actorId: "partner_user_1",
+})
+
+const scopeWith = () => {
+  const log = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  const eventBus = { emit: jest.fn(async () => undefined) }
+  const quoteService = {
+    updatePartnerQuotes: jest.fn(async () => undefined),
+    recordEvent: jest.fn(async () => undefined),
+  }
+  const scope: any = {
+    resolve: (key: string) => {
+      if (key === ContainerRegistrationKeys.LOGGER) return log
+      if (key === Modules.EVENT_BUS) return eventBus
+      if (key === PARTNER_QUOTE_MODULE) return quoteService
+      throw new Error(`unexpected resolve(${key})`)
+    },
+  }
+  return { log, eventBus, quoteService, scope }
+}
+
+describe("deliverQuoteEmail — the partner introduction (#1486 slice 1)", () => {
+  beforeEach(() => {
+    mockQuoteRun.mockReset()
+    mockIntroductionRun.mockReset()
+    mockResolveBuyerLink.mockReset()
+    mockResolveBuyerLink.mockResolvedValue(BUYER_URL)
+    mockQuoteRun.mockResolvedValue({ result: { id: "noti_quote_1" } })
+    mockIntroductionRun.mockResolvedValue({ result: { id: "noti_intro_1" } })
+  })
+
+  it("sends the introduction BEFORE the quote — awaited, not fired and forgotten", async () => {
+    // A deferred this test controls. invocationCallOrder can only prove which
+    // call STARTED first, and a fire-and-forget introduction also starts
+    // first — so it cannot distinguish the two. A promise that stays pending
+    // until this test resolves it can: while it hangs, nothing later may run.
+    let resolveIntroduction!: (value: { result: { id: string } }) => void
+    mockIntroductionRun.mockImplementationOnce(
+      () =>
+        new Promise<{ result: { id: string } }>((resolve) => {
+          resolveIntroduction = resolve
+        })
+    )
+    const { scope, log } = scopeWith()
+
+    let settled = false
+    const delivering = deliverQuoteEmail(scope, deliveryInput()).then((v) => {
+      settled = true
+      return v
+    })
+
+    // Drain everything that can run without the introduction resolving.
+    // setImmediate is a macrotask, so every microtask queued before the
+    // pending await has settled by the time this resumes. If the quote send
+    // — or the return — happened here, the introduction was fired and
+    // forgotten, and its "your quote follows shortly" copy is a lie.
+    await new Promise<void>((ready) => setImmediate(ready))
+    expect(mockIntroductionRun).toHaveBeenCalledTimes(1)
+    expect(mockQuoteRun).not.toHaveBeenCalled()
+    expect(settled).toBe(false)
+
+    resolveIntroduction({ result: { id: "noti_intro_1" } })
+    const verdict = await delivering
+
+    expect(mockQuoteRun).toHaveBeenCalledTimes(1)
+
+    const introductionInput = mockIntroductionRun.mock.calls[0][0].input
+    expect(introductionInput.email).toBe("buyer@example.com")
+    expect(introductionInput.data).toEqual({
+      partner_name: "Marcha",
+      recipient_name: "Meera",
+      recipient_company: "Meera Textiles",
+      line_count: 6,
+      total_quantity: 10,
+      destination: "Berlin, Germany",
+      current_year: new Date().getUTCFullYear(),
+    })
+
+    // The quote send is untouched by the new one: same buyer, same link.
+    const quoteInput = mockQuoteRun.mock.calls[0][0].input
+    expect(quoteInput.email).toBe("buyer@example.com")
+    expect(quoteInput.data.quote_url).toBe(BUYER_URL)
+
+    expect(verdict).toEqual({
+      sent: true,
+      to: "buyer@example.com",
+      buyer_url: BUYER_URL,
+      reason: null,
+    })
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  it("🔴 still sends the quote when the introduction throws", async () => {
+    mockIntroductionRun.mockRejectedValueOnce(
+      new Error("Resend rejected the introduction")
+    )
+    const { scope } = scopeWith()
+
+    const verdict = await deliverQuoteEmail(scope, deliveryInput())
+
+    // The introduction was genuinely attempted. Without this, deleting the
+    // introduction entirely leaves the rejection unconsumed, the quote still
+    // sends, and every assertion below passes on the old code too.
+    expect(mockIntroductionRun).toHaveBeenCalledTimes(1)
+
+    // The quote email is the only durable copy of the token — a failed
+    // introduction is a lost courtesy, not a reason to lose the link.
+    expect(mockQuoteRun).toHaveBeenCalledTimes(1)
+    expect(verdict.sent).toBe(true)
+    expect(verdict.reason).toBeNull()
+  })
+
+  it("logs the failed introduction with the partner id, buyer email and error", async () => {
+    mockIntroductionRun.mockRejectedValueOnce(
+      new Error("Resend rejected the introduction")
+    )
+    const { scope, log } = scopeWith()
+
+    await deliverQuoteEmail(scope, deliveryInput())
+
+    // Exactly once, and exactly this: the three things a human needs to act.
+    // The quote send succeeded, so no other error line exists to satisfy a
+    // looser match.
+    expect(log.error).toHaveBeenCalledTimes(1)
+    expect(log.error).toHaveBeenCalledWith(
+      "[quote] introduction NOT delivered quote=quote_1 partner_id=partner_1 to=buyer@example.com: Resend rejected the introduction"
+    )
+  })
+
+  it("does not log a suppressed introduction as delivered", async () => {
+    // #1333 — a send to a known crawler address is a silent no-op that
+    // returns a synthetic id. "Delivered" would be a lie; the quote send
+    // right after reports the crawler address loudly as ITS own failure.
+    mockIntroductionRun.mockResolvedValueOnce({
+      result: { id: BOT_SUPPRESSED_SEND_ID },
+    })
+    const { scope, log } = scopeWith()
+
+    await deliverQuoteEmail(scope, deliveryInput())
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "[quote] introduction suppressed (known crawler address) quote=quote_1 to=buyer@example.com"
+    )
+    expect(log.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("introduction delivered")
+    )
+    expect(mockQuoteRun).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not introduce when no quote email can follow", async () => {
+    // The introduction promises "your quote follows shortly". When the
+    // delivery path already knows the quote cannot be sent — no buyer link —
+    // that promise is a lie the system is aware of, so nothing goes out.
+    mockResolveBuyerLink.mockResolvedValue(null)
+    const { scope } = scopeWith()
+
+    const verdict = await deliverQuoteEmail(scope, deliveryInput())
+
+    expect(mockIntroductionRun).not.toHaveBeenCalled()
+    expect(mockQuoteRun).not.toHaveBeenCalled()
+    expect(verdict.sent).toBe(false)
+  })
+
+  it("does not introduce a buyer with no email address", async () => {
+    const { scope } = scopeWith()
+
+    await deliverQuoteEmail(scope, {
+      ...deliveryInput(),
+      quote: { ...QUOTE, email_sent_to: null },
+    })
+
+    expect(mockIntroductionRun).not.toHaveBeenCalled()
+    expect(mockQuoteRun).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/workflows/partner-quote/deliver-quote-email.ts
+++ b/apps/backend/src/workflows/partner-quote/deliver-quote-email.ts
@@ -6,9 +6,11 @@ import { PARTNER_QUOTE_EVENTS } from "../../modules/partner-quote/events"
 import { buildQuoteEmailData } from "../../modules/partner-quote/lib/quote-email"
 import { resolveQuoteBuyerLink } from "../../modules/partner-quote/lib/quote-link"
 import { sendQuoteEmailWorkflow } from "../email/workflows/send-quote-email"
+import { sendQuoteIntroductionEmailWorkflow } from "../email/workflows/send-quote-introduction-email"
 
 /**
- * Send the minted quote to its buyer (#1420), and say honestly whether it went.
+ * Send the minted quote to its buyer (#1420), and say honestly whether it
+ * went. Introduce the partner first (#1486) — in code, not in a flow.
  *
  * ## Why this sits beside the mint rather than inside it
  *
@@ -157,18 +159,83 @@ export async function deliverQuoteEmail(
     )
   }
 
+  const quoteEmailData = buildQuoteEmailData({
+    quote,
+    partnerName: input.partnerName ?? null,
+    quoteUrl: buyerUrl,
+    lineCount: input.lineCount,
+    totalQuantity: input.totalQuantity,
+    now: new Date(),
+  })
+
+  /**
+   * Introduce the partner BEFORE the quote (#1486 slice 1).
+   *
+   * 🔴 This used to be delegated to a prod-configured visual flow listening on
+   * `partner_quote.minted` — and nothing in code ever sent it, so whether a
+   * buyer was introduced at all depended on infrastructure nobody had
+   * reviewed. It is sent here, in code, from the delivery path instead.
+   *
+   * ## Ordering is the point, and it is real
+   *
+   * Awaited, not fired and forgotten: the introduction's copy says "your
+   * quote follows shortly", and a quote that lands first — or concurrently —
+   * makes that a lie. Only after this resolves, one way or the other, does
+   * the quote send below run.
+   *
+   * ## A failed introduction must never cost the buyer their link
+   *
+   * The quote email is the only durable copy of the token; the introduction
+   * is a courtesy. So the failure is logged loudly — partner id, buyer email
+   * and the error, because "the introduction did not go" is a fact a human
+   * should be able to act on — and swallowed. The quote send then proceeds
+   * exactly as it would have.
+   *
+   * 🔑 No dedup yet (#1486 slice 1b, deliberately out of scope here): a visual
+   * flow configured on `partner_quote.minted` may still send its own
+   * introduction, and a buyer can be introduced once per quote. Making it
+   * once-per-(partner, buyer) needs a table this code does not have yet.
+   */
+  try {
+    const { result } = await sendQuoteIntroductionEmailWorkflow(scope).run({
+      input: {
+        email: to,
+        data: {
+          // The same builder as the quote email, so the two cannot disagree
+          // about who the partner is or how the destination reads.
+          partner_name: quoteEmailData.partner_name,
+          recipient_name: quoteEmailData.recipient_name,
+          recipient_company:
+            String(quote?.recipient_company ?? "").trim() || null,
+          line_count: quoteEmailData.line_count,
+          total_quantity: quoteEmailData.total_quantity,
+          destination: quoteEmailData.destination,
+          current_year: quoteEmailData.current_year,
+        },
+      },
+    })
+
+    if ((result as any)?.id === BOT_SUPPRESSED_SEND_ID) {
+      // Not an error: nothing was lost, and the quote send right after will
+      // report the crawler address loudly as ITS failure. But "delivered"
+      // would be a lie — a suppressed send must never read as sent (#1333).
+      logger.warn(
+        `[quote] introduction suppressed (known crawler address) quote=${quote.id} to=${to}`
+      )
+    } else {
+      logger.info(`[quote] introduction delivered quote=${quote.id} to=${to}`)
+    }
+  } catch (e: any) {
+    logger.error(
+      `[quote] introduction NOT delivered quote=${quote?.id} partner_id=${quote?.partner_id ?? null} to=${to}: ${e?.message ?? String(e)}`
+    )
+  }
+
   try {
     const { result } = await sendQuoteEmailWorkflow(scope).run({
       input: {
         email: to,
-        data: buildQuoteEmailData({
-          quote,
-          partnerName: input.partnerName ?? null,
-          quoteUrl: buyerUrl,
-          lineCount: input.lineCount,
-          totalQuantity: input.totalQuantity,
-          now: new Date(),
-        }),
+        data: quoteEmailData,
       },
     })
 


### PR DESCRIPTION
Closes part of #1486 (slice 1 only — see "Not in this PR").

## The problem

The partner-introduction email was **plumbing with no sender**. The template existed (`QUOTE_INTRODUCTION_TEMPLATE_KEY`), `partner_quote.minted` was emitted before the quote send, and the subscriber allowlisted the event — but **nothing in code ever sent the introduction**. The only references to the template key were inside its own seed script. Whether a buyer was introduced at all depended on a visual flow being configured in production, which nobody had verified.

## The change

The introduction is now sent **in code**, from the quote-delivery path:

- **Sent before the quote**, and genuinely `await`ed — not fire-and-forget. The introduction's copy says "your quote follows shortly"; a quote that lands first makes that a lie.
- **A failed introduction never costs the buyer their link.** The quote email is the only durable copy of the token, so the failure is logged at `error` with partner id, buyer email and the error, then swallowed. The quote send proceeds unchanged.
- `buildQuoteEmailData` is hoisted so both emails share one build and cannot disagree about who the partner is.
- Suppressed sends (a known crawler address returns a synthetic id without mailing, #1333) are logged as suppressed, never as delivered.
- The new workflow composes `fetchEmailTemplateStep` + `sendNotificationEmailStep` exactly as `send-quote-email.ts` does — a second template-fetch path is how two emails that must agree quietly diverge.

## Tests — and proof they can fail

6 unit tests, all green. Both load-bearing properties were verified by **breaking the feature and watching them go red**:

| neutralisation | result |
|---|---|
| remove the `await` on the introduction | **process crashes** — unhandled rejection |
| remove the introduction call entirely | **4 of 6 fail** |

That first row is worth noting: without the `await`, the `try/catch` cannot catch the async rejection, so a failed introduction takes down the worker. The `await` is load-bearing for "must never block the quote", not just for ordering.

The ordering test deliberately does **not** use `invocationCallOrder` — that proves which call *started* first, and a fire-and-forget also starts first, so it cannot distinguish the two. It uses a deferred the test controls, drains the microtask queue, and asserts the quote send has not happened while the introduction is still pending.

## Not in this PR

- **Slice 1b — once-per-(partner, buyer) dedup.** Needs a new table, so a migration. Today a buyer can be introduced once per quote, and a visual flow configured on `partner_quote.minted` may still send its own introduction alongside this one.
- **Slice 2 — the no-partner "house" quote.** `partner_id` is non-null on the model and required on both admin validators; making it optional needs a schema change.

## Known defect this PR does not fix

The introduction template declares `recipient_name` and `recipient_company` in its `variables` block but **never renders them** — `html_content` hardcodes `Hello,`. Every buyer gets a generic greeting while the payload carries their name. Fixing it is a one-line template change *plus* a prod run of the `quote` email-template seed job, since templates live in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
