### PR TITLE
docs(quotes): correct the revoked-link claim, and stop mint_quote prescribing a revoke (#1418, #1452)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/quote-revoke-guidance.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/quote-revoke-guidance.unit.spec.ts
@@ -1,0 +1,48 @@
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { PARTNER_MCP_TOOLS } from "../../../../partners/mcp/lib/registry"
+
+/**
+ * The two quote rows must not contradict each other about revocation (#1452).
+ *
+ * `mint_quote`'s `sideEffects` told the model to "revoke the old quote first",
+ * while `revoke_quote`'s own description — three lines below it — said that is
+ * no longer needed because the mint supersedes the previous quote itself
+ * (#1435). A model reads the row for the tool it is about to CALL, so the
+ * stale half was on the write: it revoked a live buyer link for nothing, in
+ * the gap before the new quote was minted.
+ *
+ * A registry row is prose a model acts on, so nothing typechecks it and no
+ * route test can catch a sentence that has gone false. This spec is the check.
+ */
+const rows = [
+  ["admin", ADMIN_MCP_TOOLS],
+  ["partner", PARTNER_MCP_TOOLS],
+] as const
+
+describe.each(rows)("%s mint_quote — revocation guidance", (_surface, tools) => {
+  const mint = (tools as any[]).find((t) => t.name === "mint_quote")
+  const text = [
+    mint?.description,
+    mint?.sideEffects,
+    ...(Array.isArray(mint?.nextSteps) ? [] : []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  it("is registered", () => {
+    expect(mint).toBeTruthy()
+  })
+
+  it("never prescribes revoking the previous quote before re-minting", () => {
+    // The literal sentence that shipped, and the shape of it — a rephrase that
+    // still tells the model to revoke first is the same defect.
+    expect(text).not.toMatch(/revoke the old quote first/i)
+    expect(text).not.toMatch(/revoke[^.]{0,40}before (re-?)?(minting|quoting)/i)
+  })
+
+  it("says the mint supersedes the previous quote itself", () => {
+    // The positive half: removing the wrong sentence without stating what is
+    // actually true leaves the model to guess, and it guessed revoke before.
+    expect(text).toMatch(/supersede/i)
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -4391,7 +4391,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       ]
     ),
     sideEffects:
-      "Creates a customer-group-scoped price list with a real expiry, sends the buyer an email containing the only copy of the quote link, and makes the quote acceptable into a cart. Re-quoting the same buyer STACKS price lists — the cheapest active one wins (#1435), so revoke the old quote first.",
+      "Creates a customer-group-scoped price list with a real expiry, sends the buyer an email containing the only copy of the quote link, and makes the quote acceptable into a cart. Re-minting for the same buyer SUPERSEDES their previous quote itself (#1435) — you do NOT need to revoke it first, and revoking first only costs the buyer a live link in the gap. Revoke a quote when it should not stand at all, not as a step before re-quoting.",
     nextSteps: ["get_quote", "revoke_quote"],
   },
   {

--- a/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
+++ b/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
@@ -18,9 +18,17 @@ import { hashQuoteToken } from "../../../../../modules/partner-quote/lib/token"
  * deliberately MULTI-VIEW: forwarding it to procurement is the use case, not
  * an abuse of it.
  *
- * 🔑 An unknown token and a revoked one must be indistinguishable to a prober,
- * so both are 404. The row is looked up by sha256 — the raw token is never
- * stored, so a database read cannot reconstruct a working link.
+ * 🔑 An unknown token and a WRONG-STORE one are indistinguishable to a prober:
+ * both 404, with the same body. The row is looked up by sha256 — the raw token
+ * is never stored, so a database read cannot reconstruct a working link.
+ *
+ * ⚠️ A REVOKED token is NOT in that set, whatever earlier comments here said.
+ * It passes the lookup and the tenant guard and returns 200 with a `dead_link`
+ * document (`quoteUnusableReason` → "revoked"; `show_quoted`/`show_live` both
+ * false, acceptance refused), which is deliberate and kinder than a 404 —
+ * verified against a real revoked quote. Nothing actionable leaks: no price is
+ * rendered and the tokens are high-entropy. Do not "fix" it into a 404 without
+ * deciding that trade on purpose; do not write down that it already is one.
  */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)

--- a/apps/docs/docs/implementation/quotes/tenant-isolation.md
+++ b/apps/docs/docs/implementation/quotes/tenant-isolation.md
@@ -44,8 +44,22 @@ Nothing relied on any of the three hatches, so each is now a refusal.
 ## The shape of the refusal
 
 **404**, with the same body an unknown token gets. A prober must not learn a
-token is real by being told they are on the wrong shop. A revoked quote is
-deliberately indistinguishable from an unknown one for the same reason.
+token is real by being told they are on the wrong shop.
+
+> ⚠️ **This indistinguishability covers the wrong-store case only — not
+> revocation.** An earlier version of this page claimed a revoked quote 404s
+> too. It does not: `quoteUnusableReason` returns `"revoked"`
+> (`apps/backend/src/modules/partner-quote/lib/token.ts`), the view is built
+> with `show_quoted` and `show_live` both false, and the route still returns
+> **200** with a `dead_link` document saying the partner withdrew the quote —
+> verified against a real revoked quote (see
+> `apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx`).
+> That is deliberate and kinder than a 404, but it means a prober *can*
+> distinguish a revoked token from an unknown one. Nothing actionable leaks
+> either way — the tokens are high-entropy and no price is rendered — so this
+> is a curiosity, not a hole. It is written down here because a security
+> property a document asserts and the code does not hold is worse than no
+> document at all.
 
 The *keyless* case never reaches this code — core rejects a missing
 `x-publishable-api-key` with a 400 before the route runs. So the "no sales


### PR DESCRIPTION
Two stale sentences, both load-bearing, both contradicted by the code beside
them.

#1418 — `tenant-isolation.md` and the store route's own docblock both said a
revoked quote 404s like an unknown one. It does not: `quoteUnusableReason`
returns "revoked", the view is built with `show_quoted`/`show_live` false, and
the route returns 200 with a `dead_link` document. The storefront flagged this
twice, verified against a real revoked quote. A document asserting a security
property the code does not hold is worse than no document. The
indistinguishability that IS real — unknown vs wrong-store — is now stated as
exactly that.

#1452 — `mint_quote`'s `sideEffects` told the model to "revoke the old quote
first" while `revoke_quote`, three lines below, said that is no longer needed
because the mint supersedes the previous quote itself (#1435). The stale half
was on the WRITE, so it is the one a model acts on: it kills a live buyer link
for nothing in the gap before the new quote exists. The partner surface already
fixed this in #1517; the admin registry was the half left behind.

A registry row is prose a model acts on — nothing typechecks it and no route
test catches a sentence that has gone false. `quote-revoke-guidance.unit.spec.ts`
pins both surfaces: no revoke-first instruction, and the supersede fact stated
positively (removing the wrong sentence without stating the true one leaves the
model to guess, and it guessed revoke before). Red/green confirmed by restoring
the old sentence: 2 of 6 fail, admin only.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 1 items 6 and 7 out of the #1745 backlog audit ([work list](https://github.com/Jaal-Yantra-Textiles/v2/issues/1745#issuecomment-5522839216)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4