### PR TITLE
fix(visual-flows): subscribe the four crm.* sweep events, and extend the guard that would have caught it (#1355)

### DIFF
--- a/apps/backend/src/modules/partner-quote/events.ts
+++ b/apps/backend/src/modules/partner-quote/events.ts
@@ -1,5 +1,7 @@
 /**
- * Events the quote path emits (#1439).
+ * Events the quote path emits (#1439) — and, because the guard this file feeds
+ * is the only signal this failure mode ever produces, the CRM engagement-sweep
+ * names the subscriber must also carry (#1355).
  *
  * ## Why these are constants and not string literals at the emit site
  *
@@ -35,4 +37,37 @@ export const PARTNER_QUOTE_EVENTS = {
 
 export const PARTNER_QUOTE_EVENT_NAMES: readonly string[] = Object.values(
   PARTNER_QUOTE_EVENTS
+)
+
+/**
+ * CRM engagement-sweep events (#1355) — the same trap again, so the same guard
+ * covers them.
+ *
+ * `crm-engagement-sweep` (the maintenance job the daily `sweep-crm-engagement`
+ * schedule runs) is the sole emitter of these four names, and it emits only on
+ * a real engagement-state TRANSITION. They were emitted while absent from the
+ * subscriber's allowlist, so every flow triggering on `crm.*` sat inert — the
+ * exact failure the quote constants above were centralized to prevent.
+ *
+ * The emitter keeps its own local name map (`EVENT_BY_STATE` in
+ * `api/admin/ops/maintenance-jobs/crm-engagement-sweep-job.ts`) and is not
+ * coupled to this module, so these constants are the guard's copy, not the
+ * emitter's: `quote-events-are-subscribed.unit.spec.ts` asserts the subscriber
+ * carries every one of them. Adding a new crm.* event to the emitter means
+ * adding it here as well — that second line is the whole checklist, and
+ * skipping it is how #1355 happened.
+ */
+export const CRM_ENGAGEMENT_EVENTS = {
+  /** A contact's follow-up date passed with nobody having acted. */
+  FOLLOW_UP_DUE: "crm.follow_up_due",
+  /** A contact went quiet long enough to count as stalled. */
+  STALLED: "crm.contact_stalled",
+  /** An inbound reply moved the contact into `in_conversation`. */
+  REPLIED: "crm.contact_replied",
+  /** The contact asked not to be contacted (`do_not_contact`). */
+  OPTED_OUT: "crm.contact_opted_out",
+} as const
+
+export const CRM_ENGAGEMENT_EVENT_NAMES: readonly string[] = Object.values(
+  CRM_ENGAGEMENT_EVENTS
 )

--- a/apps/backend/src/subscribers/__tests__/quote-events-are-subscribed.unit.spec.ts
+++ b/apps/backend/src/subscribers/__tests__/quote-events-are-subscribed.unit.spec.ts
@@ -1,5 +1,8 @@
 import { config } from "../visual-flow-event-trigger"
-import { PARTNER_QUOTE_EVENT_NAMES } from "../../modules/partner-quote/events"
+import {
+  CRM_ENGAGEMENT_EVENT_NAMES,
+  PARTNER_QUOTE_EVENT_NAMES,
+} from "../../modules/partner-quote/events"
 
 /**
  * Every event the quote path emits must be one the visual-flow trigger is
@@ -25,12 +28,23 @@ import { PARTNER_QUOTE_EVENT_NAMES } from "../../modules/partner-quote/events"
  * 🔑 A manual flow run proves the FLOW works. It bypasses the subscriber
  * entirely, so it can never prove the flow will be triggered. Only this
  * pairing does.
+ *
+ * ## #1355 — the same trap, crm.* edition
+ *
+ * The CRM engagement sweep emitted `crm.follow_up_due`, `crm.contact_stalled`,
+ * `crm.contact_replied` and `crm.contact_opted_out` while none of them were in
+ * the allowlist, so step 6 of the flow feature — any flow triggering on
+ * `crm.*` — could not fire. The guard therefore covers those names too. The
+ * sweep's emitter keeps its own local name map and is not coupled to the
+ * events module, so `CRM_ENGAGEMENT_EVENT_NAMES` is the guard's copy: a new
+ * crm.* event must be added there as well, or it rides the same silent
+ * failure this file exists to make loud.
  */
-describe("quote events reach the visual-flow trigger", () => {
-  const subscribed = new Set(
-    (Array.isArray(config.event) ? config.event : [config.event]) as string[]
-  )
+const subscribed = new Set(
+  (Array.isArray(config.event) ? config.event : [config.event]) as string[]
+)
 
+describe("quote events reach the visual-flow trigger", () => {
   it.each(PARTNER_QUOTE_EVENT_NAMES)(
     "🔴 %s is in the subscriber's allowlist",
     (eventName) => {
@@ -44,5 +58,22 @@ describe("quote events reach the visual-flow trigger", () => {
    */
   it("has quote events to check in the first place", () => {
     expect(PARTNER_QUOTE_EVENT_NAMES.length).toBeGreaterThan(0)
+  })
+})
+
+describe("crm engagement events reach the visual-flow trigger", () => {
+  it.each(CRM_ENGAGEMENT_EVENT_NAMES)(
+    "🔴 %s is in the subscriber's allowlist",
+    (eventName) => {
+      expect(subscribed.has(eventName)).toBe(true)
+    }
+  )
+
+  /**
+   * Guards the guard, same as above: an emptied CRM list would silently
+   * assert nothing and pass.
+   */
+  it("has crm engagement events to check in the first place", () => {
+    expect(CRM_ENGAGEMENT_EVENT_NAMES.length).toBeGreaterThan(0)
   })
 })

--- a/apps/backend/src/subscribers/visual-flow-event-trigger.ts
+++ b/apps/backend/src/subscribers/visual-flow-event-trigger.ts
@@ -272,6 +272,18 @@ export const config: SubscriberConfig = {
     "person.person.deleted",
     "person_address.created",
     "person_address.updated",
+
+    // CRM engagement-sweep transitions (#1355). Sole emitter:
+    // api/admin/ops/maintenance-jobs/crm-engagement-sweep-job.ts (run daily by
+    // jobs/sweep-crm-engagement.ts); fires only on a real engagement-state
+    // transition — follow-up due, contact stalled, contact replied, contact
+    // opted out. Same allowlist trap as partner_quote above: these were
+    // emitted while absent here, so every flow triggering on crm.* sat inert.
+    // The names are also asserted by quote-events-are-subscribed.unit.spec.ts.
+    "crm.follow_up_due",
+    "crm.contact_stalled",
+    "crm.contact_replied",
+    "crm.contact_opted_out",
     
     // Agreements
     "agreements.agreement.created",


### PR DESCRIPTION
`crm-engagement-sweep` emits `crm.follow_up_due`, `crm.contact_stalled`,
`crm.contact_replied` and `crm.contact_opted_out` on every real
engagement-state transition. None of the four were in
`visual-flow-event-trigger`'s allowlist, so every flow triggering on `crm.*`
sat inert — step 6 of the flow feature could not fire at all. Nothing errored:
an event nobody is subscribed to is indistinguishable from an event that never
happened.

This is the THIRD occurrence of this exact shape, which is why the fix is two
parts and the second one is the point:

1. The four names are added to `config.event`, each verified against the sole
   emitter (`EVENT_BY_STATE` in `crm-engagement-sweep-job.ts:37-41`) rather
   than taken from the issue text — a name nothing emits is a dead
   subscription that looks identical to a live one.
2. `quote-events-are-subscribed.unit.spec.ts` — the guard that exists because
   the quote events hit this once already — now covers the crm names too. The
   emitter keeps its own local map and is not coupled to the events module, so
   `CRM_ENGAGEMENT_EVENT_NAMES` is deliberately the GUARD's copy: adding a new
   crm.* event means adding it there as well, and that second line is the whole
   checklist.

Both list-guards keep their "has events to check in the first place" case: an
emptied list would assert nothing and pass green.

Red/green: removing the four names from the allowlist turns exactly those four
cases red, the quote cases stay green. 8 pass restored.

Drafted by the opencode implementer agent in an isolated worktree; diff read,
every event name re-verified against the emitter, and the red/green run
independently by the verifier before push.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 1 item 4 out of the #1745 backlog audit. Closes #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4