### PR TITLE
fix(design-assistant): base64, not latin1, on the store reference-upload path (#1759)

### DIFF
--- a/apps/backend/src/api/store/custom/design-assistant/references/__tests__/encode-upload.unit.spec.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/references/__tests__/encode-upload.unit.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * #1759 — the reference-upload path must not corrupt image bytes.
+ *
+ * The route used to pass `file.buffer.toString("binary")` (latin1) into
+ * `uploadFilesWorkflow`. The Medusa file provider (local-file / file-s3)
+ * format-detects the content string by attempting a base64 round-trip; a
+ * latin1 string of raw bytes fails that check, so the provider falls back to
+ * `Buffer.from(content, "utf8")`, which UTF-8-re-encodes every byte >= 0x80.
+ * The upload still SUCCEEDS — a 200 with a mojibake file on the other end
+ * (magic bytes c3 bf c3 98 instead of ff d8 ff e0, browsers refuse to
+ * render). So a test that only asserts the route responds proves nothing:
+ * byte-identity of the round-trip is the only evidence that counts.
+ *
+ * The admin media routes were fixed the same way in #769; this spec pins the
+ * store route to the same base64 encoding.
+ */
+import { createHash } from "crypto"
+
+import { encodeUploadContent } from "../route"
+
+const sha256 = (buf: Buffer): string =>
+  createHash("sha256").update(buf).digest("hex")
+
+/**
+ * A fixture with the mess of a real image: JPEG magic bytes up front, then
+ * every byte value 0x00–0xff once — 132 of the 260 bytes are >= 0x80, the
+ * exact range latin1 + the utf8 fallback corrupts. Length 260 is not a
+ * multiple of 3, so base64 padding is exercised too.
+ */
+const imageLike = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, // JPEG magic (SOI + APP0 marker)
+  ...Array.from({ length: 256 }, (_, i) => i),
+])
+
+describe("encodeUploadContent (#1759)", () => {
+  it("round-trips every byte 0x00–0xff byte-identically", () => {
+    const encoded = encodeUploadContent(imageLike)
+    const decoded = Buffer.from(encoded, "base64")
+
+    expect(decoded.length).toBe(imageLike.length)
+    expect(sha256(decoded)).toBe(sha256(imageLike))
+  })
+
+  it("survives the file provider's base64 round-trip detection", () => {
+    // The provider only decodes content as base64 when the string re-encodes
+    // to itself; anything else takes the utf8 fallback and is corrupted.
+    const encoded = encodeUploadContent(imageLike)
+    expect(Buffer.from(encoded, "base64").toString("base64")).toBe(encoded)
+  })
+
+  it("round-trips a single 0xff byte (base64 padding edge)", () => {
+    const source = Buffer.from([0xff])
+    const decoded = Buffer.from(encodeUploadContent(source), "base64")
+
+    expect(decoded.length).toBe(1)
+    expect(sha256(decoded)).toBe(sha256(source))
+  })
+
+  /**
+   * The encoding this route used before #1759. Not the code under test —
+   * the documented failure mode it must never regress to: latin1 fails the
+   * provider's detection, and the utf8 fallback re-encodes every high byte.
+   */
+  it("proves the old latin1 encoding corrupts (the bug this fixes)", () => {
+    const latin1 = imageLike.toString("binary")
+
+    // Fails the provider's base64 detection → takes the utf8 fallback.
+    expect(Buffer.from(latin1, "base64").toString("base64")).not.toBe(latin1)
+
+    // And the utf8 fallback re-encodes: the 4 magic bytes + 128 high bytes
+    // each become two UTF-8 bytes → 392 bytes where 260 went in.
+    const utf8 = Buffer.from(latin1, "utf8")
+    expect(utf8.length).toBe(392)
+    expect(sha256(utf8)).not.toBe(sha256(imageLike))
+  })
+})

--- a/apps/backend/src/api/store/custom/design-assistant/references/route.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/references/route.ts
@@ -65,6 +65,22 @@ import { createDesignWorkflow } from "../../../../../workflows/designs/create-de
 const ALLOWED = /^image\/(png|jpe?g|webp|gif|avif|heic|heif)$/i
 const MAX_FILES = 8
 
+/**
+ * Encode a multer file's bytes for `uploadFilesWorkflow`.
+ *
+ * 🔴 base64, NOT "binary"/latin1 (#1759). The Medusa file provider
+ * (local-file / file-s3) format-detects the content string by attempting a
+ * base64 round-trip — if that succeeds it decodes as base64; otherwise it
+ * falls back to `Buffer.from(content, "utf8")`, which UTF-8-re-encodes every
+ * byte >= 0x80 and corrupts real images (magic bytes c3 bf c3 98 instead of
+ * ff d8 ff e0 — the upload still SUCCEEDS, the stored file is just mojibake,
+ * which is why no status assertion can catch it). Same failure mode #769
+ * fixed on the admin media routes; see
+ * workflows/whatsapp/whatsapp-media-helper.ts for the full autopsy.
+ */
+export const encodeUploadContent = (buffer: Buffer): string =>
+  buffer.toString("base64")
+
 export const POST = async (
   req: MedusaRequest & { files?: Express.Multer.File[] },
   res: MedusaResponse
@@ -166,7 +182,7 @@ export const POST = async (
           {
             filename: file.originalname,
             mimeType: file.mimetype,
-            content: file.buffer.toString("binary"),
+            content: encodeUploadContent(file.buffer),
             access: "public" as const,
           },
         ],


### PR DESCRIPTION
`apps/backend/src/api/store/custom/design-assistant/references/route.ts` passed
`file.buffer.toString("binary")` into `uploadFilesWorkflow`. That is latin1.
The Medusa file provider format-detects the content string with a base64
round-trip; a latin1 string of raw bytes fails that check, so it falls back to
`Buffer.from(content, "utf8")` and UTF-8-re-encodes every byte >= 0x80 — most
of a real image.

This is the exact construct #769 traced from prod CloudWatch and fixed on the
three admin media routes, which closed with "those were the only outliers".
This is a fourth, and it is CUSTOMER-facing: a maker's reference photos. The
encoding now matches `api/admin/medias/route.ts` — `buffer.toString("base64")`.

The upload SUCCEEDS either way, which is the whole problem: a 200 with a
mojibake file behind it. So the test asserts byte identity, not status —
length and sha256 across a round trip, over a fixture carrying JPEG magic bytes
plus every byte value 0x00–0xff (132 of 260 bytes in the corrupting range, and
a length that exercises base64 padding). A fourth case pins the OLD encoding as
corrupting, so the failure mode itself is documented rather than merely absent.

Red/green: the spec was run against the latin1 encoding first — 3 of 4 red,
including the byte-identity assertion — then against base64: 4 green.

⚠️ The encoding is now a small exported helper (`encodeUploadContent`) purely
so it can be tested; there is no other behaviour change on this route.

Drafted by the opencode implementer agent in an isolated worktree. 🔴 The agent
left the helper neutralised to latin1 with a "TEMPORARY for red/green proof"
comment directly under a docblock stating it was base64 — comment and code
disagreeing, tests red, reported as done. The verifier restored it and re-ran
both halves; that is the whole reason a human reads the diff.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 1 item 3 out of the #1745 backlog audit. Closes #1759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4