### PR TITLE
fix(delhivery): the hourly tracking poll called a method the resolved provider does not have (#1758)

### DIFF
--- a/apps/backend/src/jobs/__tests__/poll-delhivery-tracking.unit.spec.ts
+++ b/apps/backend/src/jobs/__tests__/poll-delhivery-tracking.unit.spec.ts
@@ -1,0 +1,227 @@
+import pollDelhiveryTracking, { config } from "../poll-delhivery-tracking"
+
+/**
+ * #1758 — the hourly Delhivery poll had never run once.
+ *
+ * The job resolved its provider through `resolveShippingProvider`, which
+ * returns a `ShippingProviderClient` adapter whose tracking method is
+ * `track(ref)` — but the capability guard tested `trackShipment`, a method
+ * that only exists on the RAW DelhiveryClient. The guard tripped on every
+ * run, the job returned before querying anything, and a Delhivery parcel sat
+ * at "Awaiting shipping" forever no matter what the carrier knew — while the
+ * scheduler showed a healthy, quiet hourly job.
+ *
+ * These cases pin the properties that decide whether that can recur: the
+ * poll must actually CALL the adapter and feed its result to the tracking
+ * sync, and a provider that cannot track must be reported as the
+ * misconfiguration it is rather than swallowed as a no-op.
+ */
+
+const mockResolveProvider = jest.fn()
+const mockTrack = jest.fn()
+const mockInventoryRun = jest.fn()
+const mockOrderRun = jest.fn()
+
+jest.mock("../../modules/shipping-providers/resolver", () => ({
+  resolveShippingProvider: (...args: any[]) => mockResolveProvider(...args),
+}))
+
+jest.mock(
+  "../../workflows/inventory_orders/sync-inventory-shipment-tracking",
+  () => ({
+    syncInventoryShipmentTrackingWorkflow: () => ({ run: mockInventoryRun }),
+  })
+)
+
+jest.mock("../../workflows/orders/sync-order-shipment-tracking", () => ({
+  syncOrderShipmentTrackingWorkflow: () => ({ run: mockOrderRun }),
+}))
+
+const logger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+})
+
+/** What DelhiveryProviderAdapter.track returns for a parcel mid-journey. */
+const trackingResult = () => ({
+  carrier: "delhivery",
+  awb: "10053849125307",
+  current_status: "In Transit",
+  current_status_code: "UD",
+  estimated_delivery: "2026-09-05 23:00:00",
+  origin: "New Delhi (OKHLA)",
+  destination: "Bengaluru (Bommasandra)",
+  events: [
+    {
+      timestamp: "2026-09-01T21:41:00+05:30",
+      status: "Shipment booked",
+      location: "Gurgaon_Bilaspur_H (Haryana)",
+      scan_type: "PP",
+    },
+  ],
+  raw: {
+    ShipmentData: [
+      {
+        Shipment: {
+          AWB: "10053849125307",
+          Status: { Status: "In Transit", StatusType: "UD", StatusCode: "UD" },
+          Scans: [],
+        },
+      },
+    ],
+  },
+})
+
+const fulfillment = (over: Record<string, any> = {}) => ({
+  id: "ful_1",
+  data: { carrier: "delhivery", waybill: "10053849125307" },
+  shipped_at: "2026-09-01T16:08:00Z",
+  delivered_at: null,
+  canceled_at: null,
+  ...over,
+})
+
+const containerWith = (fulfillments: any[], log = logger()) => {
+  const graph = jest.fn().mockResolvedValue({ data: fulfillments })
+  const container = {
+    resolve: (key: string) => {
+      if (key === "logger") return log
+      if (key === "query") return { graph }
+      throw new Error(`unexpected resolve(${key})`)
+    },
+  } as any
+  return { container, log, graph }
+}
+
+const providerWithTrack = () => ({
+  carrier: "delhivery",
+  track: mockTrack,
+})
+
+describe("poll-delhivery-tracking", () => {
+  beforeEach(() => {
+    mockResolveProvider.mockReset()
+    mockTrack.mockReset()
+    mockInventoryRun.mockReset()
+    mockOrderRun.mockReset()
+  })
+
+  it("is scheduled hourly — a poll that never runs is the whole defect", () => {
+    expect(config.name).toBe("poll-delhivery-tracking")
+    expect(config.schedule).toBe("0 * * * *")
+  })
+
+  it("tracks the carrier and feeds the result to the inventory tracking sync", async () => {
+    const tracking = trackingResult()
+    mockResolveProvider.mockResolvedValue(providerWithTrack())
+    mockTrack.mockResolvedValue(tracking)
+    mockInventoryRun.mockResolvedValue({
+      result: { matched: true, shipment_status_changed: true },
+    })
+
+    // Noise the in-memory narrowing must skip: another carrier, and a
+    // delhivery row with no waybill yet.
+    const { container, log } = containerWith([
+      fulfillment(),
+      fulfillment({
+        id: "ful_2",
+        data: { carrier: "shiprocket", waybill: "SR-9" },
+      }),
+      fulfillment({ id: "ful_3", data: { carrier: "delhivery" } }),
+    ])
+
+    await pollDelhiveryTracking(container)
+
+    expect(mockTrack).toHaveBeenCalledTimes(1)
+    expect(mockTrack).toHaveBeenCalledWith({ awb: "10053849125307" })
+    expect(mockInventoryRun).toHaveBeenCalledTimes(1)
+    expect(mockInventoryRun).toHaveBeenCalledWith({ input: { tracking } })
+    expect(mockOrderRun).not.toHaveBeenCalled()
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("checked=1/1 advanced=1")
+    )
+  })
+
+  it("falls through to the core-order sync when no inventory shipment matches", async () => {
+    const tracking = trackingResult()
+    mockResolveProvider.mockResolvedValue(providerWithTrack())
+    mockTrack.mockResolvedValue(tracking)
+    mockInventoryRun.mockResolvedValue({ result: { matched: false } })
+    mockOrderRun.mockResolvedValue({
+      result: { matched: true, status_changed: true },
+    })
+
+    const { container } = containerWith([fulfillment()])
+
+    await pollDelhiveryTracking(container)
+
+    expect(mockInventoryRun).toHaveBeenCalledTimes(1)
+    expect(mockOrderRun).toHaveBeenCalledTimes(1)
+    expect(mockOrderRun).toHaveBeenCalledWith({ input: { tracking } })
+  })
+
+  it("warns and polls nothing when the configured provider has no track method", async () => {
+    mockResolveProvider.mockResolvedValue({ carrier: "delhivery" })
+
+    const { container, log, graph } = containerWith([fulfillment()])
+
+    await pollDelhiveryTracking(container)
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "[delhivery-poll] configured delhivery provider lacks a track method — misconfiguration, skipping poll"
+    )
+    expect(graph).not.toHaveBeenCalled()
+    expect(mockTrack).not.toHaveBeenCalled()
+    expect(mockInventoryRun).not.toHaveBeenCalled()
+    expect(mockOrderRun).not.toHaveBeenCalled()
+  })
+
+  it("stays at debug when delhivery is simply not configured — a no-op, not a misconfiguration", async () => {
+    mockResolveProvider.mockRejectedValue(
+      new Error("Delhivery credentials not configured")
+    )
+
+    const { container, log, graph } = containerWith([fulfillment()])
+
+    await pollDelhiveryTracking(container)
+
+    expect(log.debug).toHaveBeenCalledWith(
+      "[delhivery-poll] provider unavailable: Delhivery credentials not configured"
+    )
+    expect(log.warn).not.toHaveBeenCalled()
+    expect(graph).not.toHaveBeenCalled()
+  })
+
+  it("keeps polling when one AWB fails — one dead waybill must not stop the batch", async () => {
+    const tracking = trackingResult()
+    mockResolveProvider.mockResolvedValue(providerWithTrack())
+    mockTrack
+      .mockRejectedValueOnce(new Error("Delhivery tracking failed (502)"))
+      .mockResolvedValueOnce(tracking)
+    mockInventoryRun.mockResolvedValue({
+      result: { matched: true, shipment_status_changed: false },
+    })
+
+    const { container, log } = containerWith([
+      fulfillment({
+        id: "ful_a",
+        data: { carrier: "delhivery", waybill: "111" },
+      }),
+      fulfillment({
+        id: "ful_b",
+        data: { carrier: "delhivery", waybill: "222" },
+      }),
+    ])
+
+    await pollDelhiveryTracking(container)
+
+    expect(mockTrack).toHaveBeenCalledTimes(2)
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("AWB 111 failed")
+    )
+    expect(mockInventoryRun).toHaveBeenCalledTimes(1)
+    expect(mockInventoryRun).toHaveBeenCalledWith({ input: { tracking } })
+  })
+})

--- a/apps/backend/src/jobs/poll-delhivery-tracking.ts
+++ b/apps/backend/src/jobs/poll-delhivery-tracking.ts
@@ -2,7 +2,7 @@ import { MedusaContainer } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 import { resolveShippingProvider } from "../modules/shipping-providers/resolver"
-import { normalizeDelhiveryWebhook } from "../modules/shipping-providers/delhivery/client"
+import type { ShippingProviderClient } from "../modules/shipping-providers/provider-interface"
 import { syncOrderShipmentTrackingWorkflow } from "../workflows/orders/sync-order-shipment-tracking"
 import { syncInventoryShipmentTrackingWorkflow } from "../workflows/inventory_orders/sync-inventory-shipment-tracking"
 
@@ -14,11 +14,12 @@ import { syncInventoryShipmentTrackingWorkflow } from "../workflows/inventory_or
  * by their account team, so until that happens a Delhivery parcel would sit at
  * "Awaiting shipping" in the UI forever no matter what the carrier knows.
  *
- * This closes that gap with the API we already have (`trackShipment`) and feeds
- * the SAME sync workflows the webhook uses, so both paths converge on identical
- * state. When the push is eventually enabled the webhook just gets there first
- * and this job finds nothing to change — the sync is forward-only and
- * idempotent, so the two never fight.
+ * This closes that gap with the resolved provider's `track` — the adapter
+ * returns the same normalized `TrackingResult` the webhook normalizers produce —
+ * and feeds the SAME sync workflows the webhook uses, so both paths converge on
+ * identical state. When the push is eventually enabled the webhook just gets
+ * there first and this job finds nothing to change — the sync is forward-only
+ * and idempotent, so the two never fight.
  *
  * Only open shipments are polled: anything already delivered or canceled is
  * terminal, and re-asking the carrier about it is pure quota burn.
@@ -31,7 +32,7 @@ export default async function pollDelhiveryTracking(container: MedusaContainer) 
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
   const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
 
-  let provider: any
+  let provider: ShippingProviderClient
   try {
     provider = await resolveShippingProvider(container, "delhivery")
   } catch (e: any) {
@@ -40,8 +41,13 @@ export default async function pollDelhiveryTracking(container: MedusaContainer) 
     logger.debug?.(`[delhivery-poll] provider unavailable: ${e?.message}`)
     return
   }
-  if (!provider?.trackShipment) {
-    logger.debug?.("[delhivery-poll] provider has no trackShipment — skipping")
+  if (typeof provider?.track !== "function") {
+    // Every ShippingProviderClient implements `track`, so a resolved provider
+    // without it is a misconfiguration, not a no-op — warn rather than debug, or
+    // the poll goes silently dead while looking like there was nothing to do.
+    logger.warn?.(
+      "[delhivery-poll] configured delhivery provider lacks a track method — misconfiguration, skipping poll"
+    )
     return
   }
 
@@ -70,22 +76,17 @@ export default async function pollDelhiveryTracking(container: MedusaContainer) 
   for (const fulfillment of open) {
     const awb = String(fulfillment.data.waybill)
     try {
-      const raw = await provider.trackShipment(awb)
-      // The pull response and the push payload share Delhivery's `Shipment`
-      // envelope, so one normalizer serves both. `ShipmentData` is the pull's
-      // outer array.
-      const shipment = raw?.ShipmentData?.[0] ?? raw
-      const tracking = normalizeDelhiveryWebhook(shipment)
-      if (!tracking.awb) {
-        tracking.awb = awb
-      }
+      // The adapter takes a ShipmentRef and returns the normalized
+      // TrackingResult directly — the exact shape the webhook normalizers
+      // emit — so no client-envelope unpacking happens here.
+      const tracking = await provider.track({ awb })
       checked++
 
       // Try inventory shipments first, then core orders — same order as the
       // webhook, so a given AWB always resolves the same way.
       const { result: inv } = await syncInventoryShipmentTrackingWorkflow(
         container
-      ).run({ input: { tracking: { ...tracking, raw: shipment } } })
+      ).run({ input: { tracking } })
       if (inv.matched) {
         if (inv.shipment_status_changed) advanced++
         continue
@@ -93,7 +94,7 @@ export default async function pollDelhiveryTracking(container: MedusaContainer) 
 
       const { result: order } = await syncOrderShipmentTrackingWorkflow(
         container
-      ).run({ input: { tracking: { ...tracking, raw: shipment } } })
+      ).run({ input: { tracking } })
       if (order.matched && order.status_changed) {
         advanced++
       }


### PR DESCRIPTION
`resolveShippingProvider(container, "delhivery")` returns
`DelhiveryProviderAdapter`, whose tracking method is `track(ref)`.
`trackShipment` belongs to the RAW client, which the adapter calls internally.
The job was written against the client and resolves the adapter, so
`if (!provider?.trackShipment)` tripped on EVERY run: the poll returned before
querying anything, and no Delhivery shipment has ever had its status refreshed
by it. Delhivery's push webhook is not enabled either, so nothing else writes
those statuses — a parcel sat at "Awaiting shipping" forever while the
scheduler showed a healthy, quiet hourly job.

Three changes, and the second two are why it went unnoticed for so long:

1. The guard and the call site now use `track({ awb })`. The adapter returns a
   normalized `TrackingResult` — the same shape the webhook normalizers emit —
   so the client-envelope unpacking (`ShipmentData[0]`, `normalizeDelhiveryWebhook`,
   the manual `awb` backfill) is deleted rather than adapted. The adapter
   already falls back to the requested waybill when the response omits one.
2. `provider` is typed `ShippingProviderClient` instead of `any`. That is what
   makes the next rename a compile error instead of a silent hourly return.
3. The guard logs at `warn`, not `debug`. A configured carrier whose provider
   lacks the method it needs is a misconfiguration. The "delhivery is simply
   not configured" catch above it stays at `debug` — that one is a real no-op,
   and conflating the two is what made a job that had never worked look
   identical to a job with nothing to do.

Tests assert the EFFECT, not the exit code: that `track` is called and its
result reaches the inventory sync, that an unmatched AWB falls through to the
core-order sync, that a provider without `track` warns and polls NOTHING (no
graph query, no sync), that the not-configured case stays at debug, and that
one failing waybill does not stop the batch. A spec asserting the job returns
cleanly passes against the broken code — none of these do.

Red/green: restoring the `trackShipment` guard and call turns 3 of 6 red.

⚠️ `tracking.raw` is now the adapter's full client response rather than the
inner `Shipment` envelope. It is stored as `last_webhook`, overwritten each
poll rather than appended, so this is a debug-payload shape change only.

Drafted by the opencode implementer agent in an isolated worktree; the verifier
re-read the adapter and the two sync workflows, confirmed `TrackingResult`
carries `raw`, typechecked, and ran both halves of the red/green before push.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 1 item 1 out of the #1745 backlog audit — the one flagged "has never run once". Closes #1758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4