### PR TITLE
fix(partner-mcp): name the settings tool what it returns; delete dead phaseTimer (#726, #1383)

### DIFF
--- a/apps/backend/src/api/partners/helpers.ts
+++ b/apps/backend/src/api/partners/helpers.ts
@@ -627,49 +627,10 @@ export const getPartnerSalesChannelId = async (
     return { partner, store, salesChannelId: store.default_sales_channel_id }
 }
 /**
- * Phase timing for partner write routes (#1370).
- *
- * These saves are slow in a way no single measurement has yet explained: a
- * `variants/batch` price save runs 14-50s with the write itself at ~700ms, and
- * a `POST .../products` create 504'd at the 60s edge while the product row
- * landed 1.3s in and the worker finished its subscribers and FX fanout
- * normally. Three theories have already died (the option graph, core's refetch
- * helper, inline subscribers), and phase timing is the one technique that has
- * actually moved the diagnosis — it is what identified the 97% response re-read
- * on variants/batch.
- *
- * Shared rather than copied because the create paths come in pairs: the legacy
- * `POST /partners/products` that the assistant's `create_product` tool posts to,
- * and the store-scoped `POST /partners/stores/:id/products` that the partner UI
- * actually calls. Instrumenting one and reasoning about the other is how the
- * partner-facing path stays unmeasured.
- *
- * Deliberately `info` and always on: the slow saves are intermittent, and a
- * flag we switch on after a partner complains is off during every occurrence
- * worth measuring.
- */
-export const phaseTimer = (logger: any, label: string, requestId: string) => {
-  const t0 = Date.now()
-  let last = t0
-  const marks: string[] = []
-  return {
-    mark(name: string) {
-      const now = Date.now()
-      marks.push(`${name}=${now - last}ms`)
-      last = now
-    },
-    done(suffix = "") {
-      logger?.info?.(
-        `[${label}] ${requestId} total=${Date.now() - t0}ms ${marks.join(" ")}${suffix}`
-      )
-    },
-  }
-}
-
-/**
- * Log the phase map a workflow returns in the same shape `phaseTimer` emits, so
- * the existing CloudWatch filter (`'"[partners/'`) keeps working now that the
- * post-create work lives in `create-partner-product` rather than in the routes.
+ * Log the phase map a workflow returns as one `logger.info` line —
+ * `[label] requestId total=<N>ms <phase>=<v>ms <phase>=<v> …` — so the existing
+ * CloudWatch filter (`'"[partners/'`) keeps working now that the post-create
+ * work lives in `create-partner-product` rather than in the routes.
  *
  * A branch that did not run reports `skipped`, never `0ms`.
  */

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -153,7 +153,7 @@ describe("partner-mcp registry + dispatch", () => {
       const names = new Set(PARTNER_MCP_TOOLS.map((t) => t.name))
       for (const n of [
         "get_storefront_status", "get_storefront_website",
-        "update_storefront_website", "get_storefront_analytics",
+        "update_storefront_website", "get_storefront_settings",
         "update_storefront_analytics", "list_storefront_pages",
         "get_storefront_page", "list_storefront_page_blocks",
         "add_storefront_page_blocks", "update_storefront_page_block",
@@ -180,6 +180,24 @@ describe("partner-mcp registry + dispatch", () => {
       expect(isSensitive(byName("add_storefront_page_blocks"))).toBe(false)
       expect(isSensitive(byName("update_storefront_page_block"))).toBe(false)
       expect(isSensitive(byName("delete_storefront_page_block"))).toBe(true)
+    })
+
+    it("get_storefront_settings returns analytics config, not traffic data (#726)", () => {
+      const names = new Set(PARTNER_MCP_TOOLS.map((t) => t.name))
+      expect(names.has("get_storefront_analytics")).toBe(false)
+      const t = PARTNER_MCP_TOOLS.find(
+        (x) => x.name === "get_storefront_settings"
+      )!
+      expect(t.method).toBe("GET")
+      expect(t.path).toBe("/partners/storefront/website/analytics")
+      // The old row pretended to be a time-ranged analytics query; the route
+      // reads no window, so the tool must not offer one.
+      expect(t.queryParams ?? []).toEqual([])
+      expect(t.inputSchema.properties).toEqual({})
+      // The description must say plainly what comes back: configuration,
+      // never a traffic report.
+      expect(t.description).toContain("configuration")
+      expect(t.description).toContain("NOT traffic")
     })
 
     it("covers store config (Tier 3) under /partners/stores/:id", () => {

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -1414,15 +1414,12 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     ),
   },
   {
-    name: "get_storefront_analytics",
-    description: "Get storefront analytics (traffic / visits) for the partner's storefront.",
+    name: "get_storefront_settings",
+    description:
+      "Get the storefront's analytics configuration — provider (in_house / custom / off), custom head and body-end script blocks, and the Google site verification token. Returns settings only, NOT traffic or visit data.",
     method: "GET",
     path: "/partners/storefront/website/analytics",
-    queryParams: ["start", "end"],
-    inputSchema: obj({
-      start: STR("Optional ISO start date for the analytics window."),
-      end: STR("Optional ISO end date for the analytics window."),
-    }),
+    inputSchema: obj({}),
   },
   {
     name: "update_storefront_analytics",


### PR DESCRIPTION
## #726 — a tool that answers the wrong question with no error

`get_storefront_analytics` was described as "Get storefront analytics (traffic /
visits)" and carried `start` / `end` window parameters. The route it points at
(`GET /partners/storefront/website/analytics`) returns the analytics
CONFIGURATION: provider (`in_house` / `custom` / `off`), the custom head and
body-end script blocks, and the Google site-verification token. It reads no
date window at all.

So a model asked "how much traffic did we get last month" called this, got
script tags, and answered from them. A confident non-answer with no error is
worse than a missing tool — a missing tool makes the model say it cannot.

- Renamed to `get_storefront_settings`, described as configuration and
  explicitly "NOT traffic or visit data".
- `start` / `end` removed from both `queryParams` and the input schema; the
  route never read them, so they only ever advertised a capability.
- Slice reachability is unaffected: `tool-slice.ts` maps by PATH prefix
  (`/partners/storefront` → `storefront`), not by tool name.
- `dispatch.unit.spec.ts` pins it: the old name is GONE from the registry, the
  new row takes no window, and the description says configuration.

⚠️ NOT-DONE: the partner-UI settings form was reviewed and left alone. Its
"Analytics" label describes a screen that genuinely configures analytics
scripts, so it is accurate; the false promise was only ever in the MCP row.
Changing it would mean touching ~20 locale files for no correction.

## #1383 — delete `phaseTimer`

Dead since the post-create work moved into `create-partner-product`. Proven
before deleting: zero references anywhere in `apps/`, `packages/` or `scripts/`
outside its own definition and one doc comment. The neighbouring helper's
comment said "the same shape `phaseTimer` emits" — rewritten to state the shape
directly rather than name a function that no longer exists.

Red/green: renaming the row back to `get_storefront_analytics` turns 2 of 31
red. 31 green restored.

Drafted by the opencode implementer agent in an isolated worktree; the verifier
re-read the analytics route to confirm it returns settings, checked the slice
map is path-keyed, re-ran the no-callers grep for `phaseTimer`, and ran both
halves of the red/green before push.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 1 items 9 and 10 out of the #1745 backlog audit. Closes #726, closes #1383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4