### PR TITLE
fix(ui): delete the phantom message-queue banner; close the approval gate on a lost response (#1549, #1371)

### DIFF
--- a/apps/backend/src/admin/routes/messaging/[conversationId]/page.tsx
+++ b/apps/backend/src/admin/routes/messaging/[conversationId]/page.tsx
@@ -195,16 +195,6 @@ const ConversationThreadModal = () => {
               </div>
             </div>
 
-            {/* Awaiting reply banner */}
-            {conversation.metadata?.awaiting_reply && (
-              <div className="flex items-center gap-2 px-6 py-2 bg-ui-bg-highlight border-b border-ui-border-base text-sm text-ui-fg-muted">
-                <span className="inline-block w-2 h-2 rounded-full bg-orange-400 animate-pulse" />
-                <Text size="small">
-                  Waiting for partner to reply. Messages are queued and will be sent automatically once they respond.
-                </Text>
-              </div>
-            )}
-
             {/* Messages */}
             <div ref={scrollRef} className="flex-1 overflow-y-auto px-6 py-4 bg-ui-bg-subtle">
               {messages.length === 0 ? (

--- a/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
+++ b/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
@@ -879,6 +879,23 @@ function ToolCard({
         toast.error(r.error || `Could not run ${label}`)
       }
     } catch (e: any) {
+      // Transport failed — but the POST may have already executed server-side
+      // (the failure was in the response, not necessarily the call), so the
+      // outcome is UNKNOWN, not "failed". Close the gate exactly like a
+      // resolved approval: a still-live Approve button here is the
+      // double-execution shape. Persisted too — a reopened chat must not
+      // re-offer an action whose attempt already happened, and the model must
+      // check state rather than assume nothing ran or blindly retry.
+      const unknownOutcome = {
+        ok: false,
+        tool: name,
+        error:
+          `Outcome unknown — the tool was submitted but the response did not arrive` +
+          ` (${e?.message || "transport error"}). It may have already run. Do not retry it blindly; check the current state first.`,
+      }
+      setResolved("approved")
+      setResult(unknownOutcome)
+      onResolved(unknownOutcome, "approved")
       toast.error(e?.message || `Could not run ${label}`)
     } finally {
       setConfirming(false)

--- a/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
+++ b/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
@@ -237,7 +237,11 @@ export const ChatThread = ({
   const transport = new DefaultChatTransport({
     api: `${backendUrl.replace(/\/$/, "")}/partners/assistant/chat`,
     credentials: "include",
-    headers: () => {
+    // Annotated: without it TS widens the ternary to
+    // `{ Authorization: string } | {}`, which is not assignable to the
+    // transport's `Record<string, string>` — a pre-existing error in this file
+    // that CI's changed-files typecheck attributes to whoever touches it next.
+    headers: (): Record<string, string> => {
       const token = authToken()
       return token ? { Authorization: `Bearer ${token}` } : {}
     },


### PR DESCRIPTION
## #1549 — "Messages are queued and will be sent automatically"

The messaging conversation page rendered that banner whenever
`conversation.metadata?.awaiting_reply` was set. Nothing in the codebase writes
`awaiting_reply` onto a messaging conversation's metadata, and there is no
queue and nothing that drains one. Verified before deleting: the only other
`awaiting_reply` in the repo is a CRM PERSON's `engagement_state`, a different
field on a different entity.

So the banner could never render — and if it ever did, it would tell an
operator their message will send later when nothing will send it. Deleted
rather than reworded: there is no true version of a sentence about a queue that
does not exist. (`<Text>` is still used elsewhere in the file; no import
becomes unused.)

## #1371 item 4 — a failed tool run left Approve live

In `ToolCard.onApprove`, the `catch` only raised a toast. `result` stayed null,
`resolved` stayed null, `onResolved` was never called — so the approval card
stayed pending and the partner could press Approve again.

But a transport failure is not a failed call. The POST may have already
executed server-side; what failed was the response. Pressing Approve again then
runs a write twice — the #1689 double-execution shape, on a card that looks
like nothing happened.

The catch now closes the gate the same way a resolved approval does, and
records the honest state: **outcome unknown**, not "failed". The message the
model receives says the tool was submitted, the response did not arrive, it may
already have run, and it must check current state rather than retry blindly.
Claiming failure would be a second lie in the other direction. It is persisted
through `onResolved` so a reopened chat does not re-offer an action whose
attempt already happened.

⚠️ NOT-DONE: no automated test for the catch path. `ToolCard` is internal to a
900-line component and testing it needs a full render harness partner-ui does
not have here. The change was typechecked (zero new errors against the
identical two pre-existing baseline errors in this file) and read line by line;
it is three state calls in an existing catch.

Drafted by the opencode implementer agent in an isolated worktree; the verifier
ran the no-writer grep behind the banner deletion and diffed tsc against
`main` before push.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 1 items 5 and 8 out of the #1745 backlog audit. Closes #1549; addresses item 4 of #1371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4