### PR TITLE
fix(dtdc): stop quoting FREE shipping from a carrier with no rate API (#1422)

### DIFF
--- a/packages/medusa-plugin-dtdc-shipping/package.json
+++ b/packages/medusa-plugin-dtdc-shipping/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-dtdc-shipping",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-dtdc-shipping/src/__tests__/dtdc-service.spec.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/__tests__/dtdc-service.spec.ts
@@ -1,0 +1,63 @@
+import DtdcFulfillmentService from "../providers/dtdc/service"
+
+/**
+ * #1422 — a calculated DTDC option quoted FREE shipping.
+ *
+ * `canCalculate` returned `true` and `calculatePrice` returned
+ * `{ calculated_amount: 0 }`, on an integration with no rate API at all
+ * (`carrier-capabilities.ts` records dtdc as `can_rate: false`). A zero is
+ * indistinguishable from a genuinely free lane, so nothing downstream could
+ * tell "we cannot quote" from "shipping is free" — and the buyer was charged
+ * nothing to ship.
+ *
+ * These two cases are the whole contract, and the second one is deliberately
+ * NOT an amount assertion: asserting any number here would be re-asserting the
+ * bug in a different denomination.
+ */
+const logger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+} as any
+
+const service = () =>
+  new (DtdcFulfillmentService as any)(
+    { logger },
+    {
+      customer_code: "GL018",
+      api_key: "test-key",
+      tracking_username: "GL018_trk_json",
+      tracking_password: "test",
+    }
+  )
+
+describe("DtdcFulfillmentService — calculated pricing (#1422)", () => {
+  it("refuses to back a calculated shipping option", async () => {
+    // This is what stops a calculated dtdc option being created in the first
+    // place. DTDC has no rate API; there is nothing to calculate from.
+    await expect(service().canCalculate({} as any)).resolves.toBe(false)
+  })
+
+  it("throws rather than quoting a price it cannot know", async () => {
+    // Reachable only through an option created before this fix. A number here
+    // — zero or any invented flat rate — is a price nobody chose, shown to a
+    // buyer as though a carrier had said it.
+    await expect(
+      service().calculatePrice({}, {}, {})
+    ).rejects.toThrow(/no rate API/i)
+  })
+
+  it("never resolves to an amount", async () => {
+    // Guards the guard: a future 'helpful' fallback that returns a number
+    // reintroduces exactly the defect, and a rejects-toThrow test alone would
+    // still catch it — but only if someone remembers what it was for.
+    const result = await service()
+      .calculatePrice({}, {}, {})
+      .then(
+        (v: any) => ({ resolved: true, v }),
+        () => ({ resolved: false, v: undefined })
+      )
+    expect(result.resolved).toBe(false)
+  })
+})

--- a/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/service.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/service.ts
@@ -74,16 +74,52 @@ class DtdcFulfillmentService extends AbstractFulfillmentProviderService {
     return true
   }
 
-  async canCalculate(data: CreateShippingOptionDTO): Promise<boolean> {
-    return true
+  /**
+   * 🔴 DTDC can NEVER back a calculated shipping option (#1422).
+   *
+   * This integration has no rate API — `carrier-capabilities.ts` records dtdc
+   * as `can_rate: false` on both domestic and international, and the client
+   * exposes no `getRates`. There is nothing to calculate from.
+   *
+   * It used to answer `true` here and `{ calculated_amount: 0 }` below. A zero
+   * is not "we could not quote": it is indistinguishable from a genuinely free
+   * lane, so the cart, the order and every downstream report read it as free
+   * shipping and the buyer was charged nothing to ship. That is the same
+   * defect #1417 found on Shiprocket, whose header comment
+   * (`modules/shipping-providers/shiprocket/flat-fallback.ts`) is the fullest
+   * account of why a silent zero is the worst available answer.
+   *
+   * Refusing here is what stops a calculated dtdc option being created at all.
+   */
+  async canCalculate(_data: CreateShippingOptionDTO): Promise<boolean> {
+    return false
   }
 
+  /**
+   * Unreachable through a correctly-created option, because `canCalculate`
+   * refuses. It throws rather than returning a number for the one case that
+   * can still reach it: a calculated option created BEFORE this fix.
+   *
+   * ⚠️ The trade is deliberate and it is not the same trade Shiprocket made.
+   * Shiprocket falls back to a flat rate because its failures are transient —
+   * a live rate API having a bad day — and a throw would take the whole
+   * shipping-options listing with it, including the manual flat option. DTDC
+   * has no rate API at ALL, so a calculated dtdc option is a standing
+   * misconfiguration rather than an outage, and there is no honest number to
+   * substitute: any flat amount invented here would be a price nobody chose,
+   * quoted to a buyer as if a carrier had said it. Failing loudly is what gets
+   * the option corrected; quoting zero is what shipped freight for free.
+   */
   async calculatePrice(
-    optionData: Record<string, unknown>,
-    data: Record<string, unknown>,
-    context: any
+    _optionData: Record<string, unknown>,
+    _data: Record<string, unknown>,
+    _context: any
   ): Promise<CalculatedShippingOptionPrice> {
-    return { calculated_amount: 0, is_calculated_price_tax_inclusive: false }
+    throw new Error(
+      "DTDC cannot price a calculated shipping option: this integration has no rate API (can_rate: false). " +
+        "Use a flat-rate shipping option for DTDC, or rate the lane with a carrier that quotes. " +
+        "Returning 0 here would quote the buyer free shipping (#1422)."
+    )
   }
 
   async createFulfillment(


### PR DESCRIPTION
`DtdcFulfillmentService.canCalculate` returned `true` and `calculatePrice`
returned `{ calculated_amount: 0 }`. DTDC has no rate API in this integration —
`carrier-capabilities.ts` records dtdc as `can_rate: false` on both domestic and
international, and the client exposes no `getRates`. There was never anything
to calculate from.

A zero is not "we could not quote". It is indistinguishable from a genuinely
free lane, so the cart, the order and every downstream report read it as free
shipping and the buyer paid nothing to ship. That is the defect #1417 already
found on Shiprocket; `modules/shipping-providers/shiprocket/flat-fallback.ts`
carries the fullest account of why the silent zero is the worst answer
available.

- `canCalculate` → `false`. This is the half that matters: it stops a
  calculated dtdc option being created at all.
- `calculatePrice` throws, for the one case that can still reach it — an option
  created before this fix.

⚠️ The throw is a DIFFERENT trade from Shiprocket's flat fallback, on purpose.
Shiprocket falls back to a flat rate because its failures are transient (a live
rate API having a bad day) and a throw would take the whole shipping-options
listing down with it. DTDC has no rate API at all, so a calculated dtdc option
is a standing misconfiguration, not an outage, and there is no honest number to
substitute — any flat amount invented in the plugin is a price nobody chose,
shown to a buyer as though a carrier had said it. Failing loudly is what gets
the option corrected.

🔴 Before merging, check prod for a shipping option on provider `dtdc_dtdc`
with `price_type: calculated`. If one exists, the throw will break that
option's listing — which is the correct signal, but it should be a decision
someone makes rather than discovers. (The audit could not settle this from
source.)

Tests assert the contract, never an amount: `canCalculate` resolves false,
`calculatePrice` rejects, and a third case pins that it never RESOLVES to
anything — a future "helpful" numeric fallback is the same bug again.
Red/green: restoring `true` + `calculated_amount: 0` turns all 3 red.

⚠️ Two-step to reach production. `apps/backend/package.json` depends on this
plugin from npm (`"latest"`), so the fix does not reach the backend from this
merge alone. The version is bumped to 0.1.2 so `publish-dtdc-plugin.yml` fires
on merge; a follow-up PR must then refresh `pnpm-lock.yaml`, which currently
pins 0.1.1 and is installed with `--frozen-lockfile`. Until that lands, prod
still runs the free-shipping build.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 1 item 2 out of the #1745 backlog audit. Addresses #1422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4