### PR TITLE
chore(deps): take DTDC plugin 0.1.2, so the free-shipping fix actually reaches the backend (#1422)

### DIFF
--- a/apps/backend/src/scripts/check-dtdc-calculated-refusal.ts
+++ b/apps/backend/src/scripts/check-dtdc-calculated-refusal.ts
@@ -1,0 +1,105 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+/**
+ * Does the DTDC provider Medusa actually RESOLVES refuse to price a calculated
+ * shipping option? (#1422)
+ *
+ * The unit spec in the plugin calls `DtdcFulfillmentService` directly, which
+ * proves the class is right and nothing about the wiring. Three things sit
+ * between that class and a buyer, and each has broken something here before:
+ *
+ *   1. the registration gate — both configs register dtdc only when
+ *      `DTDC_API_KEY` is set, so with no token the provider does not exist;
+ *   2. `ENABLE_CARRIER_FULFILLMENT=1`, without which the whole fulfillment
+ *      provider block is skipped in dev;
+ *   3. **which build is installed** — `apps/backend/package.json` takes the
+ *      plugin from npm (`"latest"`) and the lockfile pins an exact version, so
+ *      the class Medusa loads is whatever `pnpm-lock.yaml` says, NOT the source
+ *      in `packages/`. A fix merged to the repo and absent from the lockfile is
+ *      a fix that does not run.
+ *
+ * So this asks the container, not the source tree. It prints the version it
+ * actually loaded and calls the two methods through Medusa's own
+ * `fp_<provider_id>` registration.
+ *
+ * Read-only: it books nothing and writes nothing. Run it with the DTDC DEMO
+ * credentials (GL018) and `DTDC_SANDBOX=true`; do NOT set
+ * `DELHIVERY_API_TOKEN`, or you register a carrier with no sandbox.
+ *
+ *   ENABLE_CARRIER_FULFILLMENT=1 DTDC_SANDBOX=true \
+ *   DTDC_CUSTOMER_CODE=GL018 DTDC_API_KEY=<demo key> \
+ *   npx medusa exec ./src/scripts/check-dtdc-calculated-refusal.ts
+ */
+export default async function checkDtdcCalculatedRefusal({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  let installed = "(not resolvable)"
+  try {
+    installed = require("@jytextiles/medusa-plugin-dtdc-shipping/package.json").version
+  } catch {
+    /* the plugin is not installed at all — reported below */
+  }
+  logger.info(`[dtdc-check] plugin build Medusa will load: ${installed}`)
+  logger.info(
+    `[dtdc-check] env: ENABLE_CARRIER_FULFILLMENT=${process.env.ENABLE_CARRIER_FULFILLMENT ?? "(unset)"} ` +
+      `DTDC_API_KEY=${process.env.DTDC_API_KEY ? "set" : "(unset)"} ` +
+      `DTDC_SANDBOX=${process.env.DTDC_SANDBOX ?? "(unset)"}`
+  )
+
+  const fulfillment: any = container.resolve(Modules.FULFILLMENT)
+  const providers = await fulfillment.listFulfillmentProviders({}, { take: 100 })
+  const dtdc = providers.find((p: any) => String(p.id).includes("dtdc"))
+
+  logger.info(
+    `[dtdc-check] registered providers: ${providers.map((p: any) => p.id).join(", ") || "(none)"}`
+  )
+  if (!dtdc) {
+    logger.warn(
+      "[dtdc-check] NO dtdc provider registered — nothing to check. That is the " +
+        "correct state with no DTDC token, and it is also why this defect is latent " +
+        "in production rather than live."
+    )
+    return
+  }
+
+  /**
+   * Through the module's OWN entry points, not a hand-resolved class: these two
+   * are what core calls when it prices a calculated shipping option, so a pass
+   * here is a statement about the path a cart takes rather than about a class
+   * that happens to be importable. (Provider registrations live in the
+   * fulfillment module's private container as `fp_<provider_id>` — the app
+   * container cannot resolve them, which is itself worth knowing.)
+   */
+  let canCalculate: boolean | string
+  try {
+    const [answer] = await fulfillment.validateShippingOptionsForPriceCalculation([
+      { provider_id: dtdc.id, price_type: "calculated", name: "dtdc probe" },
+    ])
+    canCalculate = answer
+  } catch (e: any) {
+    canCalculate = `THREW "${e?.message ?? String(e)}"`
+  }
+  logger.info(`[dtdc-check] canCalculate -> ${canCalculate}`)
+
+  let priceOutcome: string
+  try {
+    const prices = await fulfillment.calculateShippingOptionsPrices([
+      { provider_id: dtdc.id, optionData: {}, data: {}, context: {} },
+    ])
+    // 🔴 The defect. Whatever comes back here is the buyer's shipping charge,
+    // and a zero is indistinguishable from a genuinely free lane.
+    priceOutcome = `RESOLVED ${JSON.stringify(prices)}`
+  } catch (e: any) {
+    priceOutcome = `THREW "${e?.message ?? String(e)}"`
+  }
+  logger.info(`[dtdc-check] calculatePrice -> ${priceOutcome}`)
+
+  const fixed = canCalculate === false && priceOutcome.startsWith("THREW")
+  logger.info(
+    fixed
+      ? `[dtdc-check] ✅ PASS — build ${installed} refuses to price a calculated dtdc option.`
+      : `[dtdc-check] 🔴 FAIL — build ${installed} still quotes a calculated dtdc option. ` +
+          `If canCalculate is true and calculatePrice resolved 0, this is the #1422 free-shipping build.`
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,7 +157,7 @@ importers:
         version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
       '@jytextiles/medusa-plugin-dtdc-shipping':
         specifier: latest
-        version: 0.1.1(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)(@medusajs/types@2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 0.1.2(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)(@medusajs/types@2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@jytextiles/medusa-plugin-etsy-sync':
         specifier: latest
         version: 0.1.6(d7461c732c552c3be1976fbfbbf1e7a7)
@@ -343,7 +343,7 @@ importers:
         version: 2.5.6
       '@uploadthing/react':
         specifier: 7.1.0
-        version: 7.1.0(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)))
+        version: 7.1.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)))
       '@xenova/transformers':
         specifier: ^2.17.2
         version: 2.17.2
@@ -544,7 +544,7 @@ importers:
         version: 1.2.1
       uploadthing:
         specifier: 7.2.0
-        version: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
+        version: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
       use-file-picker:
         specifier: ^2.1.2
         version: 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react@18.3.1)
@@ -1385,7 +1385,7 @@ importers:
         version: 2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)
       '@medusajs/medusa':
         specifier: 2.19.0
-        version: 2.19.0(0404c9f56e237f8cc3ef991f1df290ec)
+        version: 2.19.0(2ce18f9a0db051432298b951242a1b36)
       '@medusajs/types':
         specifier: 2.19.0
         version: 2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -1403,7 +1403,7 @@ importers:
         version: 20.19.34
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -1467,7 +1467,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -1531,7 +1531,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -5245,8 +5245,8 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@jytextiles/medusa-plugin-dtdc-shipping@0.1.1':
-    resolution: {integrity: sha512-dMJsY6dJhfZyYz1ERJkzL7mJSdNK0KctSquN6cdb2t6zfmOrQCU80jpjOzFZHugjwu5IGvcaEVVlHup2AvNAxA==}
+  '@jytextiles/medusa-plugin-dtdc-shipping@0.1.2':
+    resolution: {integrity: sha512-ZQ7CkzJI5JmQ/Tq7c7fXjAypWK0+urW8ywD8BaWaKbVNEHWA1UJXuA3MUp3Y63iAVjryRkLyJv1htIHU/f0jGg==}
     peerDependencies:
       '@medusajs/framework': 2.19.0
       '@medusajs/medusa': 2.19.0
@@ -26471,19 +26471,6 @@ snapshots:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.71.2(react@18.3.1)
 
-  '@hookform/resolvers@5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)':
-    dependencies:
-      '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.83.0(react@18.3.1)
-    optionalDependencies:
-      '@sinclair/typebox': 0.34.48
-      '@standard-schema/spec': 1.1.0
-      ajv: 8.13.0
-      ajv-formats: 2.1.1(ajv@8.13.0)
-      effect: 3.19.19
-      joi: 17.13.3
-      zod: 4.2.0
-
   '@hookform/resolvers@5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.18.0))(ajv@8.18.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -26758,41 +26745,6 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
-
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.34
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))':
     dependencies:
@@ -27142,7 +27094,7 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jytextiles/medusa-plugin-dtdc-shipping@0.1.1(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)(@medusajs/types@2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@jytextiles/medusa-plugin-dtdc-shipping@0.1.2(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)(@medusajs/types@2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@medusajs/framework': 2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)
       '@medusajs/medusa': 2.19.0(91a2f19d1744c07c9c0a55b6ae822462)
@@ -27456,7 +27408,7 @@ snapshots:
   '@medusajs/admin-bundler@2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/node@20.19.34)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(jiti@1.21.7)(joi@17.13.3)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)':
     dependencies:
       '@medusajs/admin-shared': 2.19.0
-      '@medusajs/admin-vite-plugin': 2.19.0(picomatch@4.0.5)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@medusajs/admin-vite-plugin': 2.19.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@medusajs/dashboard': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)
       '@vitejs/plugin-react': 5.2.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer: 10.4.27(postcss@8.5.26)
@@ -27511,11 +27463,11 @@ snapshots:
       - yaml
       - yup
 
-  '@medusajs/admin-bundler@2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/node@20.19.34)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(jiti@1.21.7)(joi@17.13.3)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)':
+  '@medusajs/admin-bundler@2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/node@20.19.34)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(jiti@1.21.7)(joi@17.13.3)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)':
     dependencies:
       '@medusajs/admin-shared': 2.19.0
-      '@medusajs/admin-vite-plugin': 2.19.0(picomatch@4.0.5)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@medusajs/dashboard': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)
+      '@medusajs/admin-vite-plugin': 2.19.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@medusajs/dashboard': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)
       '@vitejs/plugin-react': 5.2.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer: 10.4.27(postcss@8.5.26)
       compression: 1.8.1
@@ -27615,11 +27567,26 @@ snapshots:
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
       '@medusajs/admin-shared': 2.19.0
-      fdir: 6.1.1(picomatch@4.0.5)
+      fdir: 6.1.1(picomatch@4.0.4)
       magic-string: 0.30.5
       outdent: 0.8.0
       picocolors: 1.1.1
       vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+    transitivePeerDependencies:
+      - picomatch
+      - supports-color
+
+  '@medusajs/admin-vite-plugin@2.19.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/parser': 7.25.6
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.25.6
+      '@medusajs/admin-shared': 2.19.0
+      fdir: 6.1.1(picomatch@4.0.4)
+      magic-string: 0.30.5
+      outdent: 0.8.0
+      picocolors: 1.1.1
+      vite: 7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - picomatch
       - supports-color
@@ -27903,7 +27870,7 @@ snapshots:
       - vest
       - yup
 
-  '@medusajs/dashboard@2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)':
+  '@medusajs/dashboard@2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)':
     dependencies:
       '@ariakit/react': 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.29.7
@@ -27911,7 +27878,7 @@ snapshots:
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       '@hookform/error-message': 2.0.1(react-dom@18.3.1(react@18.3.1))(react-hook-form@7.83.0(react@18.3.1))(react@18.3.1)
-      '@hookform/resolvers': 5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)
+      '@hookform/resolvers': 5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)
       '@medusajs/admin-shared': 2.19.0
       '@medusajs/icons': 2.19.0(react@18.3.1)
       '@medusajs/js-sdk': 2.19.0
@@ -28055,11 +28022,11 @@ snapshots:
       - vest
       - yup
 
-  '@medusajs/draft-order@2.19.0(7b6c1d5e91336905aed7ef9ae6ca9ba3)':
+  '@medusajs/draft-order@2.19.0(9eee04df443ddaabee4d61ada18509cd)':
     dependencies:
       '@ariakit/react': 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.29.7
-      '@hookform/resolvers': 5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)
+      '@hookform/resolvers': 5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)
       '@medusajs/framework': 2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)
       '@medusajs/js-sdk': 2.19.0
       '@tanstack/react-query': 5.90.21(react@18.3.1)
@@ -28074,7 +28041,7 @@ snapshots:
     optionalDependencies:
       '@medusajs/admin-sdk': 2.19.0
       '@medusajs/cli': 2.19.0(@types/node@20.19.34)
-      '@medusajs/dashboard': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)
+      '@medusajs/dashboard': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)
       '@medusajs/icons': 2.19.0(react@18.3.1)
       '@medusajs/test-utils': 2.19.0(@medusajs/core-flows@2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)))(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)
       '@medusajs/ui': 4.2.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
@@ -28404,12 +28371,12 @@ snapshots:
       - yaml
       - yup
 
-  '@medusajs/medusa@2.19.0(0404c9f56e237f8cc3ef991f1df290ec)':
+  '@medusajs/medusa@2.19.0(2ce18f9a0db051432298b951242a1b36)':
     dependencies:
       '@inquirer/checkbox': 2.5.0
       '@inquirer/confirm': 2.0.17
       '@inquirer/input': 2.3.0
-      '@medusajs/admin-bundler': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/node@20.19.34)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(jiti@1.21.7)(joi@17.13.3)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+      '@medusajs/admin-bundler': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/node@20.19.34)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(jiti@1.21.7)(joi@17.13.3)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
       '@medusajs/analytics': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
       '@medusajs/analytics-local': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
       '@medusajs/analytics-posthog': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(posthog-node@5.41.0(rxjs@7.8.2))
@@ -28427,7 +28394,7 @@ snapshots:
       '@medusajs/core-flows': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
       '@medusajs/currency': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
       '@medusajs/customer': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
-      '@medusajs/draft-order': 2.19.0(7b6c1d5e91336905aed7ef9ae6ca9ba3)
+      '@medusajs/draft-order': 2.19.0(9eee04df443ddaabee4d61ada18509cd)
       '@medusajs/event-bus-local': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
       '@medusajs/event-bus-redis': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
       '@medusajs/file': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
@@ -29025,7 +28992,7 @@ snapshots:
       ulid: 2.4.0
     optionalDependencies:
       '@medusajs/core-flows': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
-      '@medusajs/medusa': 2.19.0(0404c9f56e237f8cc3ef991f1df290ec)
+      '@medusajs/medusa': 2.19.0(91a2f19d1744c07c9c0a55b6ae822462)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -29652,17 +29619,6 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
-
-  '@oclif/command@1.8.36(@oclif/config@1.18.17)':
-    dependencies:
-      '@oclif/config': 1.18.17
-      '@oclif/errors': 1.3.6
-      '@oclif/help': 1.0.15(supports-color@8.1.1)
-      '@oclif/parser': 3.8.17
-      debug: 4.4.3(supports-color@8.1.1)
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@oclif/command@1.8.36(@oclif/config@1.18.17)(supports-color@8.1.1)':
     dependencies:
@@ -38460,14 +38416,14 @@ snapshots:
 
   '@uploadthing/mime-types@0.3.1': {}
 
-  '@uploadthing/react@7.1.0(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)))':
+  '@uploadthing/react@7.1.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@uploadthing/shared': 7.1.0
       file-selector: 0.6.0
       react: 18.3.1
-      uploadthing: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
+      uploadthing: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
-      next: 16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
 
   '@uploadthing/shared@7.1.0':
     dependencies:
@@ -38813,11 +38769,6 @@ snapshots:
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
-
-  ajv-formats@2.1.1(ajv@8.13.0):
-    optionalDependencies:
-      ajv: 8.13.0
-    optional: true
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -40471,21 +40422,6 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
-
-  create-jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   create-jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
@@ -44066,25 +44002,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
@@ -44103,37 +44020,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-config@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.34
-      ts-node: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
@@ -44402,18 +44288,6 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
@@ -46097,7 +45971,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
+  next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -46106,7 +45980,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@8.0.1)(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -46788,7 +46662,7 @@ snapshots:
 
   pg-god@1.0.12:
     dependencies:
-      '@oclif/command': 1.8.36(@oclif/config@1.18.17)
+      '@oclif/command': 1.8.36(@oclif/config@1.18.17)(supports-color@8.1.1)
       '@oclif/config': 1.18.17
       '@oclif/plugin-help': 3.3.1
       cli-ux: 5.6.7(@oclif/config@1.18.17)
@@ -50315,12 +50189,12 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  styled-jsx@5.1.6(@babel/core@8.0.1)(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 8.0.1
+      '@babel/core': 7.29.7
     optional: true
 
   stylehacks@6.1.1(postcss@8.5.6):
@@ -50760,27 +50634,6 @@ snapshots:
   ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
-
-  ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.34
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.6.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.5.7(@swc/helpers@0.5.19)
-    optional: true
 
   ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3):
     dependencies:
@@ -51229,7 +51082,7 @@ snapshots:
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
 
-  uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)):
+  uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@effect/platform': 0.69.8(effect@3.19.19)
       '@uploadthing/mime-types': 0.3.1
@@ -51237,7 +51090,7 @@ snapshots:
       effect: 3.19.19
     optionalDependencies:
       express: 5.2.1
-      next: 16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
 
   upper-case-first@2.0.2:


### PR DESCRIPTION
#1767 fixed `canCalculate`/`calculatePrice` in `packages/medusa-plugin-dtdc-shipping`
and bumped it to 0.1.2, but the backend depends on that plugin from **npm**
(`"latest"` in `apps/backend/package.json`) and the lockfile still pinned
`0.1.1`. CI and Docker install with `--frozen-lockfile`, so the merge changed
the repo and not the running code: production kept quoting free shipping from
the 0.1.1 build.

Trusted Publishing (OIDC) is now configured, `publish-dtdc-plugin.yml` ran
green, and `0.1.2` is on the registry. This refreshes the lockfile onto it.

Verified in the installed package rather than by version string —
`.medusa/server/src/providers/dtdc/service.js` in the resolved 0.1.2 tarball has
`async canCalculate(_data) { return false; }` and a `calculatePrice` that
throws. A version number is not evidence that a build carries a fix.

🔴 The watch-out on #1767 is CLEARED. A read-only prod probe (one-off Fargate
task on the live task definition, `select` only) returned:

    dtdc_options = []
    all_options  = delhivery_delhivery/calculated 17,
                   shiprocket_shiprocket/calculated 22,
                   manual_manual/flat 48

There is no shipping option on any dtdc provider in production — calculated or
otherwise — so the new throw is unreachable there and no live listing can break
on it. (It also confirms why Shiprocket and Delhivery keep a flat fallback
instead: 39 calculated options between them, all of which a throw would take
down.)

⚠️ Worth deciding separately: `"latest"` as a dependency range means any
unrelated lockfile refresh silently upgrades this plugin. That is fine while
we own both sides, and a trap the day we don't.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

The second half of Tier 1 item 2. Closes #1422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4