### PR TITLE
chore(agent-daemon): a watchdog on every delegate run, and a sentinel to chain audit waves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ scripts/agent-daemon/delegate-logs/
 
 # 🔴 Vendor credentials, endpoints and correspondence. This repo is PUBLIC.
 .audit/private/
+
+# Wave sentinels — process state, written so a chained batch can wait on a FILE
+# rather than on `pgrep`, which matches the waiter's own command line and hangs.
+.audit/batches/

--- a/scripts/agent-daemon/DELEGATION.md
+++ b/scripts/agent-daemon/DELEGATION.md
@@ -37,8 +37,17 @@ node scripts/agent-daemon/delegate.mjs \
   `cloudflare-workers-ai/@cf/moonshotai/kimi-k2.7-code`, `kimi-for-coding/k3-256k`.
   Still-free tier: `opencode/nemotron-3-ultra-free`, `opencode/mimo-v2.5-free`,
   `opencode/muse-spark-1.3-contributor-free`.
-- Exit `0` = ran clean **and** stayed in scope; `1` = errored, self-reported
-  `DRAFT_BLOCKED`, or strayed out of scope.
+- `--timeout <minutes>` (default **40**, or `$DELEGATE_TIMEOUT_MIN`): a hard
+  wall-clock ceiling, SIGKILL. 🔴 Not optional comfort — eight audit runs in one
+  session hung at **0.0% CPU for 20-40 minutes** each and had to be found with
+  `ps` and killed by PID, which a headless batch cannot do. A killed run reports
+  `⏱ TIMED OUT`, sets `timed_out: true` in the result JSON, and exits 1. Whatever
+  the agent had written is still on disk — a PARTIAL, untested draft. Lower it
+  for read-only `audit` waves; leave it high for `implement`, where a real
+  typecheck + jest run can honestly take 15+ minutes and killing good work is
+  worse than waiting.
+- Exit `0` = ran clean **and** stayed in scope; `1` = errored, timed out,
+  self-reported `DRAFT_BLOCKED`, or strayed out of scope.
 
 ## The verifier's job (always — a clean exit is NOT a correct result)
 1. `cat scripts/agent-daemon/delegate-logs/last-result.json` → `changed[]` / `out_of_scope[]`.

--- a/scripts/agent-daemon/audit-batch.sh
+++ b/scripts/agent-daemon/audit-batch.sh
@@ -16,14 +16,36 @@
 # Sequential on purpose: two agents in one checkout each see the other's writes
 # as OUT-OF-SCOPE, because the change detector snapshots one shared git status.
 # Parallelism here needs a worktree per issue, which the issue dumps would then
-# have to be copied into. Not worth it for a read-only pass.
+# have to be copied into. Not worth it for a read-only pass. To parallelise a
+# WAVE, run this script in several checkouts at once (see ../jyt-audit-{b,c,d}).
+#
+# ── Chaining waves ────────────────────────────────────────────────────────────
+# Every run writes a sentinel at .audit/batches/<AUDIT_BATCH_NAME>.done when it
+# finishes, so a later wave can wait on it:
+#
+#   AUDIT_BATCH_NAME=wave1 bash scripts/agent-daemon/audit-batch.sh 1420 772 &
+#   while [ ! -f .audit/batches/wave1.done ]; do sleep 60; done
+#   AUDIT_BATCH_NAME=wave2 bash scripts/agent-daemon/audit-batch.sh 940 943
+#
+# 🔴 Do NOT chain with `pgrep -f "audit-batch.sh <N>"`. That pattern matches the
+# WAITER'S OWN command line — the shell running the pgrep loop has the string in
+# its argv — so the waiter sees itself, concludes the previous wave is still
+# running, and waits forever. It deadlocked a whole overnight run. A file on
+# disk cannot match itself.
 set -uo pipefail   # NOT -e: one bad issue must not kill the batch
 
 cd "$(dirname "$0")/../.."
 MODEL="${AUDIT_MODEL:-cloudflare-workers-ai/@cf/zai-org/glm-5.3}"
 REPORT=".audit/BATCH-REPORT.md"
 
-mkdir -p .audit/issues .audit/verdicts
+BATCH_NAME="${AUDIT_BATCH_NAME:-batch-$$}"
+SENTINEL=".audit/batches/${BATCH_NAME}.done"
+
+mkdir -p .audit/issues .audit/verdicts .audit/batches
+# Clear a stale sentinel from a previous run of the same name FIRST — otherwise a
+# waiter started before this script gets going sees the old one and proceeds
+# immediately, which is the deadlock's mirror image and harder to spot.
+rm -f "$SENTINEL"
 {
   echo "# Batch audit — $(date -u '+%Y-%m-%d %H:%M UTC')"
   echo
@@ -84,3 +106,9 @@ done
 
 echo
 cat "$REPORT"
+
+# Written LAST, after the report is complete on disk, so a chained wave that
+# starts the moment it appears cannot read a half-written report.
+date -u '+%Y-%m-%dT%H:%M:%SZ' > "$SENTINEL"
+echo
+echo "batch '$BATCH_NAME' finished — sentinel: $SENTINEL"

--- a/scripts/agent-daemon/delegate.mjs
+++ b/scripts/agent-daemon/delegate.mjs
@@ -53,14 +53,34 @@ let mode = "draft"
 // REQUIRED for `implement`, and the only safe way to run two delegates at once —
 // two runs in one workspace each see the other's writes as OUT-OF-SCOPE.
 let worktreeSlug = ""
+/**
+ * --timeout <minutes>: hard wall-clock ceiling on the opencode run.
+ *
+ * 🔴 Not optional comfort. Eight audit runs in one session hung at 0.0% CPU for
+ * 20-40 minutes each and had to be found with `ps` and killed by PID — a
+ * headless batch script has no way to notice, so an unattended wave silently
+ * stops making progress and looks like it is still working. `spawnSync` takes a
+ * `timeout`, so the fix is a parameter, not a supervisor process.
+ *
+ * The default is generous on purpose: a real `implement` run that typechecks and
+ * runs jest can legitimately take 15+ minutes, and killing honest work is worse
+ * than waiting. Lower it for read-only `audit` waves, where nothing should take
+ * anywhere near that long.
+ */
+let timeoutMin = Number(process.env.DELEGATE_TIMEOUT_MIN || 40)
 const rest = []
 for (let i = 0; i < argv.length; i++) {
   if (argv[i] === "--model") model = argv[++i]
   else if (argv[i] === "--mode") mode = argv[++i]
   else if (argv[i] === "--worktree") worktreeSlug = argv[++i]
+  else if (argv[i] === "--timeout") timeoutMin = Number(argv[++i])
   else if (argv[i] === "--files")
     scope = argv[++i].split(",").map((s) => s.trim()).filter(Boolean)
   else rest.push(argv[i])
+}
+if (!Number.isFinite(timeoutMin) || timeoutMin <= 0) {
+  console.error(`delegate: --timeout must be a positive number of minutes (got '${timeoutMin}')`)
+  process.exit(2)
 }
 if (!["draft", "analysis", "audit", "implement", "review"].includes(mode)) {
   console.error(`delegate: --mode must be 'draft', 'analysis', 'audit', 'implement' or 'review' (got '${mode}')`)
@@ -71,7 +91,8 @@ if (!task) {
   console.error(
     'delegate: missing task prompt.\n' +
     '  node delegate.mjs [--mode draft|analysis|audit|implement|review] [--worktree <slug>] [--model <m>] [--files "a,b"] "<task>"\n' +
-    '  --mode implement REQUIRES --worktree; it is the only mode whose agent can run commands.'
+    '  --mode implement REQUIRES --worktree; it is the only mode whose agent can run commands.\n' +
+    '  --timeout <minutes> (default 40, or $DELEGATE_TIMEOUT_MIN) kills a hung run instead of waiting forever.'
   )
   process.exit(2)
 }
@@ -392,7 +413,7 @@ const ts = git(["rev-parse", "--short", "HEAD"]).slice(0, 7) + "-" + process.pid
 const logPath = join(LOG_DIR, `${ts}.log`)
 
 console.log(`[delegate] mode=${mode} model=${model} agent=jyt-drafter scope=${scope.join("|") || "(task-named)"}`)
-console.log(`[delegate] running opencode (free) — verifier owns correctness…`)
+console.log(`[delegate] running opencode (free) — verifier owns correctness… (watchdog ${timeoutMin}m)`)
 
 const run = spawnSync(
   "opencode",
@@ -411,6 +432,10 @@ const run = spawnSync(
     cwd: WORKDIR,
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
+    // The watchdog. SIGKILL, not the default SIGTERM: the runs that hang here
+    // hang at 0.0% CPU and have already stopped responding to anything polite.
+    timeout: timeoutMin * 60 * 1000,
+    killSignal: "SIGKILL",
     env: {
       ...process.env,
       OPENCODE_CONFIG: CONFIG, // restricted agent lives here, not in the repo root
@@ -438,7 +463,16 @@ const inScope = (p) =>
 const outOfScope = scope.length ? changed.filter((p) => !inScope(p)) : []
 
 const blocked = /(^|\n)\s*DRAFT_BLOCKED:/.test(run.stdout || "")
-const ranClean = run.status === 0 && !blocked
+/**
+ * A watchdog kill is its own outcome, not a failed run. `spawnSync` reports it
+ * as `error.code === "ETIMEDOUT"` with `status === null`, which would otherwise
+ * read as an ordinary non-zero exit and tell the caller nothing about WHY.
+ * Whatever the agent had written by then is still in the workspace — the kill
+ * ends the run, it does not undo the edits — so the diff below is still worth
+ * reading, and may be a usable partial draft.
+ */
+const timedOut = run.error?.code === "ETIMEDOUT"
+const ranClean = run.status === 0 && !blocked && !timedOut
 
 /**
  * 🔴 In `implement` mode the required trailer is not paperwork — it is the only
@@ -458,7 +492,7 @@ const missingTrailer =
 const ok = ranClean && outOfScope.length === 0 && missingTrailer.length === 0
 
 const resultJson = JSON.stringify(
-  { ok, mode, model, changed, out_of_scope: outOfScope, blocked, missing_trailer: missingTrailer, log: logPath, status: run.status },
+  { ok, mode, model, changed, out_of_scope: outOfScope, blocked, timed_out: timedOut, timeout_min: timeoutMin, missing_trailer: missingTrailer, log: logPath, status: run.status },
   null, 2
 )
 // `last-result.json` is a SHARED name: a second delegate running concurrently in
@@ -469,6 +503,13 @@ writeFileSync(join(LOG_DIR, `result-${ts}.json`), resultJson)
 
 console.log(`\n[delegate] ── result ───────────────────────────────`)
 console.log(`[delegate] exit=${run.status} blocked=${blocked} changed=${changed.length} out_of_scope=${outOfScope.length}`)
+if (timedOut)
+  console.log(
+    `[delegate] ⏱ TIMED OUT after ${timeoutMin}m and was KILLED. This is the 0.0%-CPU hang, not slow work.\n` +
+    `[delegate]   Nothing it had already written was rolled back — the files below are a PARTIAL draft, and the\n` +
+    `[delegate]   trailer is missing because the run never reached it, so NOTHING here was tested. Re-run, or\n` +
+    `[delegate]   raise --timeout if the task genuinely needs longer.`
+  )
 if (missingTrailer.length)
   console.log(`[delegate] ⚠ MISSING REPORT SECTIONS: ${missingTrailer.join(" ")} — the agent did not say what it ran. Treat every claim of testing as UNPROVEN.`)
 if (changed.length) {


### PR DESCRIPTION
The two harness gaps the last audit session paid for, and neither is cosmetic —
both cost real time and both silently stop an unattended wave.

## 1. `delegate.mjs` had no timeout

Eight audit runs hung at **0.0% CPU for 20-40 minutes each** and had to be
found with `ps` and killed by PID. A headless batch script cannot do that, so an
overnight wave stops making progress while looking exactly like a wave still
working — the same "a run that did nothing reads as a run that worked" shape the
other eight harness fixes were about.

`spawnSync` takes a `timeout`, so this is a parameter, not a supervisor process:
`--timeout <minutes>` / `$DELEGATE_TIMEOUT_MIN`, default 40, **SIGKILL** rather
than the default SIGTERM (a process hung at 0% CPU has already stopped
answering anything polite).

A kill is reported as its own outcome, not as a failed run: `⏱ TIMED OUT`,
`timed_out: true` in the result JSON, exit 1. It says explicitly that whatever
the agent wrote is still on disk as a PARTIAL draft and that **nothing was
tested**, because the run never reached its report trailer — otherwise the
missing trailer reads as an agent that forgot rather than a run that died.

The default is deliberately generous: an honest `implement` run that typechecks
and runs jest can take 15+ minutes, and killing good work is worse than waiting.
Lower it for read-only audit waves.

Proven both ways, not just the failure half:
- `--timeout 0.05` → killed, `timed_out: true`, `ok: false`, **exit 1**.
- `--timeout 10`, same task → **exit 0**, `timed_out: false`, file written.

## 2. `audit-batch.sh` had no safe way to chain waves

🔴 Chaining with `pgrep -f "audit-batch.sh <N>"` **deadlocks**: the pattern
matches the WAITER'S OWN command line — the shell running the pgrep loop has
that string in its argv — so the waiter sees itself, concludes the previous wave
is still running, and waits forever. It ate an overnight run.

Each batch now writes `.audit/batches/<AUDIT_BATCH_NAME>.done` and the header
documents the wait loop. A file on disk cannot match itself.

Two ordering details that are the whole point of a sentinel:
- it is written **last**, after the report is complete on disk, so a wave that
  starts the instant it appears cannot read a half-written report;
- a stale sentinel of the same name is removed **first**, or a waiter that
  started early sees the previous run's file and proceeds immediately — the
  deadlock's mirror image, and much harder to notice.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

The two harness fixes named under Tier 5 of the #1745 work list, done before the next audit wave rather than after it pays for them again. Refs #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4