### PR TITLE
fix(mcp): a plan can no longer smuggle a write past the confirm card (#1757)

### DIFF
--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -379,7 +379,8 @@ export const POST = async (
 
   // Structured multi-step planning. The model can emit ONE plan instead of
   // chaining tool calls itself; every step still goes through dispatchAdminTool
-  // (dry_run / confirm / reason rails + scope checks). `resolve` steps consult
+  // (dry_run / reason rails + scope checks); a plan naming a tool that needs
+  // CONFIRMATION is refused whole, before anything runs (#1757). `resolve` steps consult
   // the entity-memory cache so "customer by email" skips the lookup tool.
   const resolveEntity = cacheService && adminUserId
     ? (type: string, by: string, value: string) =>

--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -281,7 +281,8 @@ export const POST = async (
 
   // Structured multi-step planning. The model can emit ONE plan instead of
   // chaining tool calls itself; every step still goes through dispatchPartnerTool
-  // (dry_run / confirm rails + write gating). `resolve` steps consult the
+  // (dry_run rails + write gating); a plan naming a tool that needs CONFIRMATION
+  // is refused whole, before anything runs (#1757). `resolve` steps consult the
   // entity-memory cache so "customer by email" skips the lookup tool.
   const resolveEntity = cacheService && partnerId
     ? (type: string, by: string, value: string) =>

--- a/apps/backend/src/lib/assistant-context/plan-tool.ts
+++ b/apps/backend/src/lib/assistant-context/plan-tool.ts
@@ -10,7 +10,13 @@
  * executor (lib/mcp-core/plan) runs it with reference substitution, map fan-out,
  * deterministic empty-result retry, and entity-memory `resolve` steps. Every
  * step still dispatches through the surface's real dispatcher, so the
- * dry_run / confirm / reason rails and scope checks apply per step.
+ * dry_run / reason rails and scope checks apply per step.
+ *
+ * 🔴 The CONFIRM rail is the exception, and it is handled by refusing the plan
+ * outright rather than per step (#1757): a plan naming a sensitive tool
+ * anywhere — including inside a map body or a resolve fallback — is rejected
+ * before anything runs. A confirm response is `ok: true` with `executed:
+ * false`, which the executor used to read as success and carry on past.
  *
  * Shared by the admin and partner assistants — a surface supplies its own
  * dispatcher and (optionally) its cache-backed entity resolver.
@@ -36,8 +42,14 @@ export const PLAN_TOOL_NAME = "run_plan"
 export const PLAN_TOOL_DESCRIPTION =
   "Run a MULTI-STEP plan over the tools you have, when a request needs several " +
   "calls chained together (look up an entity, then list/act on it; or repeat a " +
-  "tool for each item of a list). Each step still respects dry_run / confirm / " +
-  "reason rails. " +
+  "tool for each item of a list). Each step still respects the dry_run / reason " +
+  "rails and scope checks.\n" +
+  "🔴 A plan CANNOT contain a tool that needs confirmation (any sensitive or " +
+  "destructive write, e.g. minting a quote, cancelling, deleting). Naming one " +
+  "anywhere in the plan — including inside a map body or a resolve fallback — " +
+  "refuses the WHOLE plan and runs nothing. Call such a tool directly as a " +
+  "single call, so the confirmation can be shown and approved, and use a plan " +
+  "for the read steps around it. " +
   "A step is ONE of:\n" +
   "- Tool call: {\"tool\": name, \"args\": {...}, \"as\": name|null, \"extract\": \"path\"|null}. " +
   "\"as\" stores the full result under that name; \"extract\" pulls one value out of it " +

--- a/apps/backend/src/lib/mcp-core/__tests__/plan.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/plan.unit.spec.ts
@@ -339,7 +339,12 @@ describe("executeMcpPlan — sensitive steps are refused before anything runs (#
   })
 
   it("still runs a plan of ordinary writes and reads — the guard must not over-refuse", async () => {
-    const dispatch = jest.fn(async (name: string) => ok(name, { designs: [{ id: "d1" }] }))
+    // `_args` is declared even though it is unused: without it TS types
+    // `mock.calls` as a 1-tuple and the `[1][1]` assertion below does not
+    // COMPILE — which jest never notices but `check:prod-build` does.
+    const dispatch = jest.fn(async (name: string, _args: Record<string, unknown>) =>
+      ok(name, { designs: [{ id: "d1" }] })
+    )
 
     const r = await executeMcpPlan({
       ctx,
@@ -374,7 +379,7 @@ describe("executeMcpPlan — sensitive steps are refused before anything runs (#
    * them the two halves are related.
    */
   it("documents why `ok` was not a stop condition: a confirm response is ok:true and does not execute", async () => {
-    const dispatch = jest.fn(async (name: string) => {
+    const dispatch = jest.fn(async (name: string, _args: Record<string, unknown>) => {
       if (name === "mint_quote") {
         // Exactly what dispatchMcpTool returns for a sensitive, unconfirmed call.
         return { ok: true, tool: name, requires_confirmation: true } as any

--- a/apps/backend/src/lib/mcp-core/__tests__/plan.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/plan.unit.spec.ts
@@ -225,3 +225,198 @@ describe("executeMcpPlan", () => {
     expect(r.error).toContain("No cached customer")
   })
 })
+/**
+ * #1757 — a plan must not smuggle a write past the confirm card.
+ *
+ * The defect: `dispatchMcpTool` answers a sensitive, unconfirmed call with
+ * `{ ok: true, requires_confirmation: true }` and does NOT execute it. The
+ * executor's only stop condition was `ok`, so the plan skipped that step and
+ * RAN ON — every later step executing against `undefined` refs — while the
+ * flag ended up nested under `value`, where no UI reader looks, so no approval
+ * card ever rendered. `run_plan` is bound on every partner chat turn.
+ *
+ * The fix refuses the whole plan before anything runs. The load-bearing
+ * assertion in each case below is therefore **dispatch was never called** —
+ * "returned an error" would also be true of a plan that ran three writes first.
+ */
+const sensitiveTools = [
+  { name: "list_designs", method: "GET", path: "/x" },
+  { name: "mint_quote", method: "POST", path: "/x", write: true, sensitive: true },
+  { name: "delete_thing", method: "DELETE", path: "/x", write: true },
+  { name: "log_note", method: "POST", path: "/x", write: true },
+] as any[]
+
+describe("executeMcpPlan — sensitive steps are refused before anything runs (#1757)", () => {
+  it("refuses a plan naming a sensitive tool, executing NOTHING", async () => {
+    const dispatch = jest.fn(async (name: string) => ok(name, { id: "x" }))
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools: sensitiveTools,
+      dispatch,
+      plan: {
+        steps: [
+          { tool: "list_designs", as: "designs", extract: "designs.0.id" },
+          { tool: "mint_quote", args: { design_id: "$designs" } },
+          { tool: "log_note", args: { note: "quoted" } },
+        ],
+      },
+    })
+
+    expect(r.ok).toBe(false)
+    expect(r.error).toContain("mint_quote")
+    expect(r.error).toContain("cannot run inside a plan")
+    // 🔴 The point. Under the defect, step 1 ran, step 2 was skipped with
+    // ok:true, and step 3 ran anyway with an undefined ref.
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(r.toolCalls).toBe(0)
+  })
+
+  it("finds a sensitive tool inside a map body — a guard that only walks the top level is no guard", async () => {
+    const dispatch = jest.fn(async (name: string) => ok(name, { things: [{ id: "t1" }] }))
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools: sensitiveTools,
+      dispatch,
+      plan: {
+        steps: [
+          { tool: "list_designs", as: "designs" },
+          {
+            map: "designs",
+            item: "d",
+            steps: [{ tool: "delete_thing", args: { id: "$d.id" } }],
+          },
+        ],
+      },
+    })
+
+    expect(r.ok).toBe(false)
+    // DELETE is sensitive via isSensitive even without an explicit flag.
+    expect(r.error).toContain("delete_thing")
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it("finds a sensitive tool hiding in a resolve fallback", async () => {
+    const dispatch = jest.fn(async (name: string) => ok(name, { id: "x" }))
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools: sensitiveTools,
+      dispatch,
+      plan: {
+        steps: [
+          {
+            resolve: "quote",
+            by: "email",
+            value: "buyer@example.com",
+            as: "q",
+            fallback: { tool: "mint_quote", args: {} },
+          },
+        ],
+      },
+    })
+
+    expect(r.ok).toBe(false)
+    expect(r.error).toContain("mint_quote")
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it("names every sensitive tool, so the model does not fix them one refusal at a time", async () => {
+    const r = await executeMcpPlan({
+      ctx,
+      tools: sensitiveTools,
+      dispatch: jest.fn(async (name: string) => ok(name, {})),
+      plan: {
+        steps: [{ tool: "mint_quote" }, { tool: "delete_thing" }, { tool: "mint_quote" }],
+      },
+    })
+
+    expect(r.error).toContain("mint_quote")
+    expect(r.error).toContain("delete_thing")
+    // De-duplicated: the same tool twice is one name, not two.
+    expect(r.error!.match(/mint_quote/g)).toHaveLength(1)
+  })
+
+  it("still runs a plan of ordinary writes and reads — the guard must not over-refuse", async () => {
+    const dispatch = jest.fn(async (name: string) => ok(name, { designs: [{ id: "d1" }] }))
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools: sensitiveTools,
+      dispatch,
+      plan: {
+        steps: [
+          { tool: "list_designs", as: "designs", extract: "designs.0.id" },
+          { tool: "log_note", args: { design_id: "$designs" } },
+        ],
+      },
+    })
+
+    expect(r.ok).toBe(true)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch.mock.calls[1][1]).toEqual({ design_id: "d1" })
+  })
+
+  /**
+   * The mechanism the guard exists to make unreachable, pinned so it is
+   * documented rather than merely absent.
+   *
+   * `tools: []` deliberately bypasses the guard (an empty registry knows
+   * nothing about sensitivity) so the OLD executor behaviour is still
+   * reachable from a test. It shows why `ok` was never a sufficient stop
+   * condition: the confirm response is `ok: true` with `executed: false`, so
+   * the loop treats a step that did NOT run as a step that succeeded, stores
+   * `undefined` under its `as`, and carries on.
+   *
+   * If someone deletes the guard, the four cases above go red. If someone also
+   * "fixes" dispatch to return ok:false for a confirm, THIS goes red and tells
+   * them the two halves are related.
+   */
+  it("documents why `ok` was not a stop condition: a confirm response is ok:true and does not execute", async () => {
+    const dispatch = jest.fn(async (name: string) => {
+      if (name === "mint_quote") {
+        // Exactly what dispatchMcpTool returns for a sensitive, unconfirmed call.
+        return { ok: true, tool: name, requires_confirmation: true } as any
+      }
+      return ok(name, { designs: [{ id: "d1" }] })
+    })
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools: [], // no registry ⇒ no sensitivity known ⇒ the old path
+      dispatch,
+      plan: {
+        steps: [
+          { tool: "list_designs", as: "designs", extract: "designs.0.id" },
+          { tool: "mint_quote", args: { design_id: "$designs" }, as: "quote", extract: "quote.id" },
+          { tool: "log_note", args: { quote_id: "$quote" } },
+        ],
+      },
+    })
+
+    // The plan reports SUCCESS having never minted anything.
+    expect(r.ok).toBe(true)
+    expect(dispatch).toHaveBeenCalledTimes(3)
+    // And the step after the un-run write executed against an undefined ref.
+    expect(dispatch.mock.calls[2][1]).toEqual({ quote_id: undefined })
+    // The flag the UI would need is nested under `value`, not at the top level —
+    // which is the second half of #1757: no approval card could ever render.
+    expect((r as any).requires_confirmation).toBeUndefined()
+  })
+
+  it("does not treat an UNKNOWN tool as sensitive — dispatch refuses it by name, better than this guard could", async () => {
+    const dispatch = jest.fn(async (name: string) => fail(name, `Unknown tool: ${name}`))
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools: sensitiveTools,
+      dispatch,
+      plan: { steps: [{ tool: "mint_qoute" }] },
+    })
+
+    expect(r.ok).toBe(false)
+    expect(r.error).toContain("Unknown tool")
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/src/lib/mcp-core/plan.ts
+++ b/apps/backend/src/lib/mcp-core/plan.ts
@@ -16,9 +16,23 @@
  *   - deterministic retry: a list step that comes back empty is re-dispatched
  *     once with a broadened filter.
  *
- * Every step still goes through `dispatchMcpTool`, so the dry_run / confirm /
- * reason rails and scope checks apply per step — the plan cannot smuggle past
- * a guard that a single call could not.
+ * Every step still goes through `dispatchMcpTool`, so the dry_run / reason
+ * rails and scope checks apply per step.
+ *
+ * 🔴 The confirm rail was the exception, and this docblock used to claim
+ * otherwise (#1757). The rail WAS invoked and its answer thrown away: a
+ * sensitive step returns `{ ok: true, requires_confirmation: true }` without
+ * executing, and the executor's only stop condition was `ok`. So the sensitive
+ * step was skipped, the plan RAN ON, and every later step executed against
+ * `undefined` refs — while the `requires_confirmation` flag ended up nested
+ * under `value`, where no reader looks, so no approval card ever rendered.
+ *
+ * The fix is a refusal BEFORE anything runs (`findSensitivePlanSteps` below): a
+ * plan naming a sensitive tool is rejected whole, and the model is told to call
+ * that tool directly, where the confirm card already works. Deliberately not a
+ * mid-plan halt-and-resume — that needs plan state to survive an approval round
+ * trip, and it makes a partly-executed plan a thing that exists. A refusal
+ * cannot half-happen.
  *
  * Plan grammar (see McpPlanStep):
  *   {"tool": name, "args": {...}, "as": name|null, "extract": "path"|null}
@@ -31,6 +45,7 @@
  */
 import type { McpContext, McpToolDef, McpToolResult } from "./types"
 import { dispatchMcpTool } from "./dispatch"
+import { isSensitive } from "./schema"
 
 export type McpPlanStep = {
   tool?: string
@@ -148,7 +163,71 @@ export function broadenPlanArgs(args: Record<string, unknown>): Record<string, u
   return next
 }
 
+/**
+ * Every sensitive tool named anywhere in a plan, in step order, de-duplicated.
+ *
+ * 🔑 The recursion is the whole point. A guard that only walks the top-level
+ * steps is a guard a `map` body walks straight past, and `map` is exactly where
+ * a fan-out write would sit ("for each of these, cancel it"). Three places a
+ * tool name can hide:
+ *   - `steps[].tool`
+ *   - `steps[].steps[]` — a `map` body, arbitrarily nested
+ *   - `steps[].fallback.tool` — the tool a `resolve` runs on a memory miss
+ *
+ * An unknown tool name is NOT treated as sensitive: it is not in the registry,
+ * so dispatch will refuse it by name with a better message than this guard
+ * could give. Sensitivity is `isSensitive` — the same predicate the confirm
+ * rail uses — so this can never disagree with the gate it is standing in for.
+ */
+export function findSensitivePlanSteps(
+  steps: McpPlanStep[],
+  tools: McpToolDef[]
+): string[] {
+  const byName = new Map(tools.map((t) => [t.name, t]))
+  const found: string[] = []
+
+  const consider = (name?: string) => {
+    if (!name) return
+    const def = byName.get(name)
+    if (def && isSensitive(def) && !found.includes(name)) found.push(name)
+  }
+
+  const walk = (list: McpPlanStep[]) => {
+    for (const s of list ?? []) {
+      consider(s.tool)
+      consider(s.fallback?.tool)
+      if (s.steps?.length) walk(s.steps)
+    }
+  }
+
+  walk(steps)
+  return found
+}
+
+/** The refusal a plan containing a sensitive step gets, before anything runs. */
+export const sensitivePlanRefusal = (names: string[]): string =>
+  `${names.join(", ")} ${names.length > 1 ? "are sensitive tools" : "is a sensitive tool"} and cannot run inside a plan. ` +
+  `Nothing was executed. Call ${names.length > 1 ? "each of them" : "it"} directly as a single tool call, ` +
+  `so the confirmation can be shown and approved; use a plan for the read steps around it.`
+
 export async function executeMcpPlan(opts: ExecutePlanOptions): Promise<McpPlanResult> {
+  /**
+   * 🔴 Refuse before executing anything (#1757). This must sit ahead of the
+   * loop, not inside it: the defect was a plan that had already run steps by
+   * the time it met the gate, and a guard that stops mid-plan still leaves
+   * whatever ran behind it.
+   */
+  const sensitive = findSensitivePlanSteps(opts.plan.steps, opts.tools)
+  if (sensitive.length) {
+    return {
+      ok: false,
+      value: null,
+      toolCalls: 0,
+      retries: 0,
+      error: sensitivePlanRefusal(sensitive),
+    }
+  }
+
   const dispatch =
     opts.dispatch ??
     ((name: string, args: Record<string, unknown>) => dispatchMcpTool(opts.ctx, opts.tools, name, args))


### PR DESCRIPTION
`plan.ts` claimed "the plan cannot smuggle past a guard that a single call could
not." For the confirm rail that was false. The rail WAS invoked and its answer
thrown away.

`dispatchMcpTool` answers a sensitive, unconfirmed call with `ok: true`,
`executed: false` — it deliberately does not run the tool. The plan executor's
only stop condition was `ok`. So for a plan containing a sensitive step:

1. the sensitive step did not run (correct);
2. the plan KEPT GOING and executed every step after it (wrong);
3. `res.data` is undefined on a confirm response, so `store[step.as]` became
   `undefined` and the following steps ran against undefined refs.

And the second half: the executor wraps each result as `{ ok, value, ... }`, so
`requires_confirmation` landed at `value.requires_confirmation`, while every
reader — `chat-thread.tsx`, the admin assistant page — checks the top level. No
approval card could ever render. `run_plan` is bound and activated on EVERY
partner chat turn, and the SOPs steer the model to it for anything multi-step.

## The fix: refuse the plan, don't halt it

A plan naming a sensitive tool is rejected before anything runs, and the model
is told to call that tool directly, where the confirm card already works.

Chosen over stop-and-resume deliberately. Resuming needs plan state to survive
an approval round trip, and it makes a partly-executed plan a thing that exists
in the system. A refusal cannot half-happen. The cost is real and small: a
multi-step request ending in a write becomes a plan plus one direct call.

`findSensitivePlanSteps` walks the plan RECURSIVELY. A guard that only reads
top-level steps is one a `map` body walks straight past — and `map` is exactly
where a fan-out write would sit ("for each of these, cancel it"). Three hiding
places are covered: `steps[].tool`, `steps[].steps[]` (nested maps), and
`steps[].fallback.tool` (the tool a `resolve` runs on a memory miss). It uses
`isSensitive`, the same predicate the confirm rail uses, so the guard can never
disagree with the gate it stands in for. An UNKNOWN tool is not treated as
sensitive — dispatch refuses it by name, with a better message.

The model is told up front too: `PLAN_TOOL_DESCRIPTION` said "Each step still
respects dry_run / confirm / reason rails". It now says a plan cannot contain a
tool needing confirmation and what to do instead — otherwise the model would
discover this one refusal at a time. All sensitive names are reported at once,
de-duplicated, for the same reason.

## Tests

7 new cases, 19 green in the file. The load-bearing assertion in each refusal
case is **dispatch was never called** — "returned an error" would also be true
of a plan that ran three writes first.

One case reproduces the DEFECT rather than the fix: with an empty registry
(bypassing the guard) and a confirm-shaped dispatch, the plan reports `ok:
true`, dispatches all three steps, and the third runs with `quote_id:
undefined`, with no top-level `requires_confirmation`. That is the audit's claim
independently reproduced, and it documents why `ok` was never a sufficient stop
condition.

Red/green: neutralising the guard turns 4 of the 5 refusal cases red; the two
"must not over-refuse" cases correctly stay green.

The false claim is corrected in all four places it was written down: the
executor docblock, the plan-tool docblock, and both chat routes' comments.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 2 out of the #1745 backlog audit — the "refuse sensitive steps up front" option. Closes #1757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4