### PR TITLE
fix(quotes): a guesstimate cost can no longer become a firm quoted price (#1454)

### DIFF
--- a/apps/backend/src/modules/partner-quote/__tests__/design-quote-price.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/design-quote-price.unit.spec.ts
@@ -69,6 +69,42 @@ describe("designQuoteUnitPrice", () => {
       expect(result.unit_price).toBeNull()
     })
 
+    /**
+     * #1454 — a guesstimate is a guess, and a quote is a firm price the buyer
+     * can accept and pay.
+     *
+     * It used to price like any other estimate: FX-converted, marked up, minted
+     * as the variant's listed price and FROZEN onto the quote. The buyer saw a
+     * firm number with nothing marking it as a guess — there is no `confidence`
+     * anywhere on `QuoteViewLine`, the frozen line, or the storefront. The only
+     * disclosure was a NON-BLOCKING partner-facing warning, which is a control
+     * only for the partner who reads it.
+     */
+    it("🔴 refuses a guesstimate — a guess must not become a firm quoted price (#1454)", () => {
+      const result = designQuoteUnitPrice({
+        total_estimated: 1000,
+        confidence: "guesstimate",
+      })
+      expect(result.unit_price).toBeNull()
+      expect(result.reason).toMatch(/guesstimate/i)
+      // Says what to DO about it, or the partner has a refusal and no path.
+      expect(result.reason).toMatch(/dial in/i)
+    })
+
+    it("does NOT refuse 'estimated' or 'exact' — the gate is between roughly-worked-out and guessed", () => {
+      // Guards the gate: a check written as `confidence !== "exact"` would pass
+      // the case above and silently block every ordinary design quote.
+      for (const confidence of ["estimated", "exact"]) {
+        const result = designQuoteUnitPrice({
+          total_estimated: 1000,
+          confidence,
+          markup_percent: 0,
+        })
+        expect(result.unit_price).toBe(1000)
+        expect(result.reason).toBeNull()
+      }
+    })
+
     it("refuses a FAILED conversion, and does not treat it as 'no conversion'", () => {
       const result = designQuoteUnitPrice({
         total_estimated: 1000,

--- a/apps/backend/src/modules/partner-quote/lib/design-lines.ts
+++ b/apps/backend/src/modules/partner-quote/lib/design-lines.ts
@@ -631,7 +631,10 @@ export async function resolveDesignLinesForReadiness(
         message:
           `"${r.design_name ?? r.design_id}" has no product yet, so it will be quoted as made-to-order at ` +
           `${preview.unit_price} ${String(input.currency_code).toUpperCase()} per unit. ` +
-          `That figure is a ${preview.confidence ?? "guesstimate"} — dial it in if you know better.`,
+          // Only `exact` and `estimated` can reach this branch now — a
+          // guesstimate refuses to price and falls through to the BLOCKING
+          // case below (#1454). So the fallback word must not say "guesstimate".
+          `That figure is an ${preview.confidence ?? "estimate"} — dial it in if you know better.`,
         design_id: r.design_id,
         data: {
           candidates: r.candidates,

--- a/apps/backend/src/modules/partner-quote/lib/design-quote-price.ts
+++ b/apps/backend/src/modules/partner-quote/lib/design-quote-price.ts
@@ -42,7 +42,13 @@ export const DEFAULT_CUSTOM_DESIGN_MARKUP_PERCENT = 20
 export type DesignQuotePriceInput = {
   /** `total_estimated` from the estimator. Per finished unit (#1554). */
   total_estimated: number | null | undefined
-  /** The estimator's confidence. `none` is not an estimate at all. */
+  /**
+   * The estimator's confidence: `exact` | `estimated` | `guesstimate` | `none`.
+   *
+   * Two of the four refuse. `none` is the ABSENCE of an estimate (#1564);
+   * `guesstimate` is a guess, and a quote is a firm price the buyer can accept
+   * and pay (#1454). `exact` and `estimated` price normally.
+   */
   confidence?: string | null
   /**
    * Multiplier from the design's cost currency to the quote's. 1 when they
@@ -112,6 +118,31 @@ export function designQuoteUnitPrice(
   if (input.confidence === "none") {
     return refuse(
       "The cost estimate for this design has no basis, so it cannot be quoted."
+    )
+  }
+
+  /**
+   * 🔴 A `guesstimate` must not become a firm quoted price (#1454).
+   *
+   * It used to be priced like any other estimate — FX-converted, marked up,
+   * minted as the variant's listed price and FROZEN onto the quote. The buyer
+   * then saw a firm number with nothing on the page marking it as a guess:
+   * there is no `confidence` field on `QuoteViewLine`, on the frozen line, or
+   * anywhere in the storefront quotes module.
+   *
+   * The only disclosure was a partner-facing readiness WARNING — non-blocking,
+   * and therefore a control only for the partner who reads it. A warning is
+   * not a gate; the decision (#1454) was that this is a gate.
+   *
+   * Refused here rather than at the mint route because this is the one place
+   * every design price passes through, and a check at a route is a check the
+   * next route has to remember. `estimated` and `exact` still price normally —
+   * the line is between "we worked it out roughly" and "we guessed".
+   */
+  if (input.confidence === "guesstimate") {
+    return refuse(
+      "This design's cost is a guesstimate, and a quote is a firm price the buyer can accept and pay. " +
+        "Dial in a real cost for the design — a bill of materials, or a completed run to compare against — then quote it."
     )
   }
 


### PR DESCRIPTION
`estimateDesignCostWorkflow` reports confidence as `exact | estimated |
guesstimate | none`. `none` was refused. `guesstimate` was priced like any
other estimate: FX-converted, +20% markup, minted as the made-to-order
variant's listed price, and FROZEN onto the quote.

The buyer then saw a firm number with nothing marking it as a guess. There is
no `confidence` field on `QuoteViewLine`, on the frozen line model, or anywhere
in the storefront quotes module — the only disclosure was a partner-facing
readiness WARNING, non-blocking, which is a control only for the partner who
reads it. A quote is a firm price the buyer can accept and pay against.

The decision (#1454) was that this is a gate, not a warning. `guesstimate` now
refuses alongside `none`.

Refused in `designQuoteUnitPrice` rather than at the mint route because that is
the one place every design price passes through — a check at a route is a check
the next route has to remember, and there are two mint routes.

The refusal says what to DO ("dial in a real cost — a bill of materials, or a
completed run to compare against"), because a partner given a refusal and no
path just retries it.

## What follows on its own

`resolveDesignLineIssues` already branches on `unit_price != null`, so a
refused price falls out of the `warning` branch into the **blocking** one
carrying this reason. Readiness therefore now reports a guesstimate design as
blocking with the same message, and no separate change was needed to make the
preflight agree with the mint. Its stale fallback wording is corrected: only
`exact` and `estimated` can reach the warning branch now, so it no longer says
"That figure is a guesstimate".

## Tests

Two cases. The refusal, asserting both the reason and that it names the fix;
and a guard on the gate itself — `estimated` and `exact` must still price. That
second one is the one worth having: a check written as `confidence !== "exact"`
passes the first test and silently blocks every ordinary design quote.

Red/green: disabling the branch turns the guesstimate case red, alone. 12 green
in the file; 361 green across the 23 partner-quote suites.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 3 decision, taken: hard-gate it like `none`, rather than a recorded override or buyer-facing disclosure. Addresses the pricing gap in #1454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4