### PR TITLE
docs(payments): direct charges are the decision, and the partner is told they carry the disputes (#838)

### DIFF
--- a/apps/backend/src/modules/stripe-connect-payment/README.md
+++ b/apps/backend/src/modules/stripe-connect-payment/README.md
@@ -16,7 +16,26 @@ cart.sales_channel_id
 ```
 
 `initiatePayment` creates the PaymentIntent **on** the connected account
-(`{ stripeAccount }`) with `application_fee_amount`. The fee % comes from the
+(`{ stripeAccount }`) with `application_fee_amount`.
+
+### 🔴 Direct, not destination — and that decides who answers a chargeback
+
+This is a **deliberate, settled** choice (#838, decided 2026-09-03), not an
+accident of implementation. The issue body words *destination* charges; the code
+ships *direct* ones and there is no `transfer_data` anywhere in the module.
+
+Economically the two are near-identical: the money settles to the partner and
+the platform takes a fee. **Liability is not.** With direct charges the charge
+exists on the partner's own account, so a dispute or chargeback is raised
+there and is the partner's to respond to — the platform has no standing to
+answer it and no dispute tooling here. With destination charges it would be the
+platform's.
+
+Keeping direct means the partner carries the fraud risk on their own sales.
+That is the intended split, and it is stated to the partner **before** they
+connect, on the Stripe Connect card in partner settings — a partner must not
+learn this from their first chargeback. If that trade is ever revisited, it is
+a payments migration on live connected accounts, not a config change. The fee % comes from the
 partner's active plan (`partner_subscription → plan.features.payment_processing_fee`,
 e.g. `"2%"`), falling back to `defaultFeePercent`. All later operations
 (authorize/capture/refund/cancel/update) re-scope to the same connected account
@@ -43,16 +62,27 @@ to partners.
 
 ## v1 limitations (follow-ups)
 
-- **Webhook wiring**: direct-charge `payment_intent.*` events are delivered to
-  the platform's **Connect** webhook endpoint. `getWebhookActionAndData` maps
-  them, but the `/webhooks/stripe/connect` route is not yet wired to dispatch
-  payment events into the Medusa payment module — the happy path relies on
-  client-side confirmation + `authorizePayment` on return. Wiring the webhook is
-  the recommended next step for robustness.
+- ~~**Webhook wiring**~~ — **DONE, and this bullet was stale.**
+  `apps/backend/src/api/webhooks/stripe/connect/route.ts` dispatches payment
+  events via `getWebhookActionAndData` → `processPaymentWorkflow`. The claim
+  that it "is not yet wired" survived the wiring by months; read the route, not
+  this file.
 - **Refunds**: `refund_application_fee: true` by default (platform fee handed
-  back so the partner isn't out-of-pocket). Disputes/chargebacks land on the
-  **partner's** account (Standard direct-charge semantics) — no platform-side
-  dispute tooling yet.
+  back so the partner isn't out-of-pocket).
+- **Dispute tooling**: none. Disputes land on the partner's account by design
+  (see "Direct, not destination" above) and are answered in the partner's own
+  Stripe dashboard. There is no platform-side surface for them, and given the
+  liability sits with the partner there is no obvious reason to build one — but
+  it does mean the platform cannot see a dispute happening.
+- **Admin surface**: unbuilt. The partner-facing card exists
+  (`apps/partner-ui/src/routes/settings/payment-providers/components/stripe-connect-card.tsx`);
+  there is no admin view of connected accounts or their state.
+- **Two fee sources**: this module resolves the fee from
+  `partner_subscription → plan.features.payment_processing_fee`. The #336 fee
+  engine (`modules/partner_billing/resolve-fee-rate.ts`) resolves from
+  `commission_bps` / `PLATFORM_TX_FEE_BPS` and is NOT called from here, despite
+  a comment on #838 claiming they were unified. One partner can therefore be
+  charged two different rates depending on which path books the money.
 - **INR/GST**: launch EUR-first. Stripe India Connect + GST handling is out of
   scope for this slice.
 - **Payouts**: handled by Stripe on the connected account's own schedule; not

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -3824,6 +3824,7 @@
     "stripeConnect": {
       "heading": "JYT Stripe Connect",
       "payoutsPending": "payouts pending",
+      "liability": "Payments are charged on your own Stripe account, so any disputes or chargebacks are raised there and are yours to respond to. JYT's fee is deducted from each charge.",
       "badge": {
         "active": "Active",
         "pending": "Setup incomplete"

--- a/apps/partner-ui/src/routes/settings/payment-providers/components/stripe-connect-card.tsx
+++ b/apps/partner-ui/src/routes/settings/payment-providers/components/stripe-connect-card.tsx
@@ -95,6 +95,21 @@ export const StripeConnectCard = () => {
                   "Skip entering API keys. Connect a Stripe account through JYT to get paid faster, with payouts and refunds handled for you."
                 )}
           </Text>
+          {/*
+            #838 — DIRECT charges: the payment is created ON the partner's own
+            connected account (the `stripeAccount` request option), with JYT's
+            cut taken as `application_fee_amount`. The consequence that is not
+            obvious from "get paid faster" is that disputes and chargebacks are
+            raised against THAT account and are the partner's to answer. Said
+            here, before they connect, because the alternative is a partner
+            learning it from their first chargeback.
+          */}
+          <Text size="xsmall" className="text-ui-fg-muted max-w-[560px] mt-1">
+            {t(
+              "partner.stripeConnect.liability",
+              "Payments are charged on your own Stripe account, so any disputes or chargebacks are raised there and are yours to respond to. JYT's fee is deducted from each charge."
+            )}
+          </Text>
           {isActive && stripe_connect?.account_id && (
             <Text size="xsmall" className="text-ui-fg-muted font-mono mt-1">
               {stripe_connect.account_id}


### PR DESCRIPTION
The issue body words **destination** charges; the module ships **direct** ones
(`{ stripeAccount }` on the PaymentIntent, no `transfer_data` anywhere). The
issue's own 2026-07-08 comment flagged the choice as an open decision and the
code simply picked one. It is now decided: **keep direct.** It is live on a
connected account and working; the alternative is a payments migration on live
accounts.

Economically the two are near-identical — money settles to the partner, the
platform takes `application_fee_amount`. **Liability is not.** With direct
charges the charge exists on the partner's own account, so a dispute or
chargeback is raised there and is theirs to answer; the platform has no standing
to answer it and no dispute tooling.

## The part that was actually missing

That trade was recorded only in a "v1 limitations" bullet, and **nowhere the
partner would see it**. The onboarding card said "get paid faster, with payouts
and refunds handled for you" and stopped. A partner should not learn about
chargeback liability from their first chargeback, so the card now says it —
before they connect, not after.

## Record corrections

- The README's webhook bullet claimed `/webhooks/stripe/connect` "is not yet
  wired to dispatch payment events". It has been wired for months
  (`getWebhookActionAndData` → `processPaymentWorkflow`). Marked done and
  pointed at the route, because the file outlived the fact.
- The direct-vs-destination trade is promoted from a limitations bullet to a
  stated decision beside the routing description, where someone reading how a
  charge works will actually meet it.
- **Two fee sources, written down.** A comment on #838 claims the fee engine is
  shared with #336. It is not: this module reads
  `partner_subscription → plan.features.payment_processing_fee`; #336 reads
  `commission_bps` / `PLATFORM_TX_FEE_BPS`, and nothing here calls it. One
  partner can be charged two different rates depending on which path books the
  money. Recorded as a limitation rather than fixed — unifying them is a
  separate piece of work with its own correctness questions.
- The missing admin surface and absent dispute tooling are listed honestly
  instead of being implied by silence.

No behaviour change. One partner is connected today (`acct_1TpEX5…`, since
2026-07-03), so this is the moment the record is cheap to correct.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Tier 3 decision, taken: keep direct charges and correct the record, rather than migrating to destination charges. Addresses the S2 open decision on #838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4