### PR TITLE
fix(payouts): a partner's second payout to the same bank account was refused (#1636 fallout)

### DIFF
--- a/apps/backend/src/links/submission-paid-to-method-link.ts
+++ b/apps/backend/src/links/submission-paid-to-method-link.ts
@@ -26,9 +26,37 @@ import InternalPaymentModule from "../modules/internal_payments"
  *
  * Do not remove the override to "tidy up". Verify with:
  *   \dt *paid_to*
+ *
+ * ## 🔴 `isList` on the SUBMISSION side is load-bearing too
+ *
+ * One bank account receives MANY payouts. Without `isList: true` here, neither
+ * side of the link is a list, and Medusa validates uniqueness on BOTH foreign
+ * keys — `$or: [payment_submission_id, internal_payment_details_id]`
+ * (`@medusajs/modules-sdk` `Link.create`). The first approval to an account
+ * succeeds and **every later payout to that same account is refused** with
+ *
+ *   Cannot create multiple links between 'payment_submissions' and 'internal_payments'
+ *
+ * It read as a 400 on the review route with no mention of a bank account, so it
+ * looked like a validation problem with the submission being approved rather
+ * than a fact about one that had already been paid.
+ *
+ * `isList` marks the side that may be MANY: a payment method has many
+ * submissions. The method side stays singular on purpose — a submission is paid
+ * to exactly one account, and that is still enforced (Medusa then checks only
+ * that no OTHER method is linked to this submission).
+ *
+ * The table is unchanged: its primary key is already the composite
+ * `(payment_submission_id, internal_payment_details_id)`, so many-to-one was
+ * always expressible in the schema. Only the application-level uniqueness check
+ * was wrong, which is why no migration is needed and why nothing failed until a
+ * partner was paid a second time.
  */
 export default defineLink(
-  PaymentSubmissionsModule.linkable.paymentSubmission,
+  {
+    linkable: PaymentSubmissionsModule.linkable.paymentSubmission,
+    isList: true,
+  },
   {
     linkable: InternalPaymentModule.linkable.internalPaymentDetails,
     field: "paid_to",

--- a/apps/backend/src/scripts/check-paid-to-link-cardinality.ts
+++ b/apps/backend/src/scripts/check-paid-to-link-cardinality.ts
@@ -1,0 +1,92 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../modules/payment_submissions"
+import { INTERNAL_PAYMENTS_MODULE } from "../modules/internal_payments"
+
+/**
+ * Can ONE payment method be paid to by TWO submissions? (#1636 fallout)
+ *
+ * Approving a payout links the submission to the bank/wallet record it was paid
+ * to. If that link is defined with neither side a list, Medusa validates
+ * uniqueness on BOTH foreign keys — `$or: [submission_id, method_id]` — so the
+ * SECOND payout to the same bank account is refused with
+ * "Cannot create multiple links between 'payment_submissions' and
+ * 'internal_payments'". That is every partner's second payout onwards.
+ *
+ * This drives the real link registry with synthetic ids. Link tables carry no
+ * cross-module foreign keys, so the ids need not exist — which is what makes
+ * this checkable without inventing a partner, a run and a payout.
+ *
+ * Read-only in effect: both links are dismissed at the end, in a `finally`, so
+ * a failure part-way still cleans up.
+ *
+ *   npx medusa exec ./src/scripts/check-paid-to-link-cardinality.ts
+ */
+export default async function checkPaidToLinkCardinality({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+  const method = "ipd_cardinality_probe"
+  const subA = "psub_cardinality_probe_a"
+  const subB = "psub_cardinality_probe_b"
+
+  const def = (submissionId: string) => ({
+    [PAYMENT_SUBMISSIONS_MODULE]: { payment_submission_id: submissionId },
+    [INTERNAL_PAYMENTS_MODULE]: { internal_payment_details_id: method },
+  })
+
+  let first = "not attempted"
+  let second = "not attempted"
+
+  try {
+    await link.create([def(subA)])
+    first = "OK"
+
+    try {
+      // The real-world case: a second payout to the SAME bank account.
+      await link.create([def(subB)])
+      second = "OK"
+    } catch (e: any) {
+      second = `THREW "${e?.message ?? String(e)}"`
+    }
+  } catch (e: any) {
+    first = `THREW "${e?.message ?? String(e)}"`
+  } finally {
+    await link.dismiss([def(subA)]).catch(() => {})
+    await link.dismiss([def(subB)]).catch(() => {})
+  }
+
+  /**
+   * The other half, and the one a "just make it many-to-many" fix would quietly
+   * lose: a submission must still be paid to exactly ONE method. Approving a
+   * payout to two bank accounts is a worse bug than the one being fixed.
+   */
+  let twoMethods = "not attempted"
+  const otherMethod = "ipd_cardinality_probe_other"
+  const defOther = {
+    [PAYMENT_SUBMISSIONS_MODULE]: { payment_submission_id: subA },
+    [INTERNAL_PAYMENTS_MODULE]: { internal_payment_details_id: otherMethod },
+  }
+  try {
+    await link.create([def(subA)])
+    try {
+      await link.create([defOther])
+      twoMethods = "OK — 🔴 a submission was linked to TWO methods"
+    } catch (e: any) {
+      twoMethods = `refused (correct): "${e?.message ?? String(e)}"`
+    }
+  } finally {
+    await link.dismiss([def(subA)]).catch(() => {})
+    await link.dismiss([defOther]).catch(() => {})
+  }
+
+  logger.info(`[paid-to-link] first submission  -> ${first}`)
+  logger.info(`[paid-to-link] two methods on one submission -> ${twoMethods}`)
+  logger.info(`[paid-to-link] second submission -> ${second}`)
+  logger.info(
+    first === "OK" && second === "OK"
+      ? "[paid-to-link] ✅ PASS — one payment method can receive many payouts."
+      : "[paid-to-link] 🔴 FAIL — a payment method can only ever be paid once. Every partner's second payout is blocked."
+  )
+}

--- a/apps/backend/src/scripts/check-paid-to-read-shape.ts
+++ b/apps/backend/src/scripts/check-paid-to-read-shape.ts
@@ -1,0 +1,68 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../modules/payment_submissions"
+import { INTERNAL_PAYMENTS_MODULE } from "../modules/internal_payments"
+
+/**
+ * Does `submission.paid_to` come back as an OBJECT or an ARRAY?
+ *
+ * Changing a link's `isList` changes the read shape, and a to-one that becomes
+ * a to-many turns every `paid_to.id` into `undefined` and every `.filter` on it
+ * into a 500 — silently, because `query.graph` does not complain. Reasoning
+ * from the definition is not good enough here; this measures it.
+ *
+ *   npx medusa exec ./src/scripts/check-paid-to-read-shape.ts
+ */
+export default async function checkPaidToReadShape({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const submissionService: any = container.resolve(PAYMENT_SUBMISSIONS_MODULE)
+  const paymentService: any = container.resolve(INTERNAL_PAYMENTS_MODULE)
+
+  const [submission] = await submissionService.listPaymentSubmissions({}, { take: 1 })
+  const [method] = await paymentService.listPaymentDetails({}, { take: 1 })
+
+  if (!submission || !method) {
+    logger.warn(
+      `[shape] Need one payment_submission and one internal_payment_details row locally — found submission=${!!submission} method=${!!method}. Cannot measure.`
+    )
+    return
+  }
+
+  const def = {
+    [PAYMENT_SUBMISSIONS_MODULE]: { payment_submission_id: submission.id },
+    [INTERNAL_PAYMENTS_MODULE]: { internal_payment_details_id: method.id },
+  }
+
+  try {
+    await link.create([def])
+  } catch (e: any) {
+    logger.info(`[shape] (link already present or refused: ${e?.message})`)
+  }
+
+  try {
+    const { data } = await query.graph({
+      entity: "payment_submission",
+      fields: ["id", "paid_to.*"],
+      filters: { id: submission.id },
+    })
+    const row: any = (data || [])[0]
+    const paidTo = row?.paid_to
+    logger.info(
+      `[shape] submission.paid_to -> ${
+        paidTo === undefined
+          ? "UNDEFINED (no key returned)"
+          : Array.isArray(paidTo)
+            ? `ARRAY(${paidTo.length})`
+            : "OBJECT"
+      } :: ${JSON.stringify(paidTo)?.slice(0, 200)}`
+    )
+  } catch (e: any) {
+    logger.error(`[shape] read failed: ${e?.message}`)
+  } finally {
+    await link.dismiss([def]).catch(() => {})
+  }
+}


### PR DESCRIPTION
Approving `payment-submission/01M1DS8WXYVFR9JPTQA32D2DFP` returned a 400. The
route's message named neither a bank account nor an earlier payout, so it read
as a validation problem with the submission being approved. The real error, from
CloudWatch:

    Cannot create multiple links between 'payment_submissions' and 'internal_payments'
      at Link.create (@medusajs/modules-sdk/dist/link.js:361)
      at review-payment-submission.js:141   ← resolve-paid-to-method

## The mechanism

`submission-paid-to-method-link.ts` declared neither side a list. When both
sides are singular, `Link.create` validates uniqueness on BOTH foreign keys:

    $or: [ { payment_submission_id }, { internal_payment_details_id } ]

So the FIRST approval to a bank account succeeds and **every later payout to
that same account is refused** — every partner, from their second payout
onwards. The submission being approved was innocent: prod has no
`payment_submission_paid_to_method` row for it at all. Its partner's account had
been linked to submission `01M1DT0ZXHDT2ZVW6ES4YV1Z47` minutes earlier, and that
row is what the `$or` matched.

Only three payouts had ever taken this path, which is why it surfaced now: the
link replaced `internal_payments.paid_to_id` in #1636, and nobody had yet been
paid twice.

## The fix

`isList: true` on the SUBMISSION side — a payment method has many submissions.
`isList` marks the side that may be many, so the method side stays singular on
purpose: a submission is still paid to exactly one account, and Medusa still
enforces it (it then checks only that no OTHER method is linked to this
submission).

**No migration.** The table's primary key is already the composite
`(payment_submission_id, internal_payment_details_id)`, so many-to-one was
always expressible in the schema; only the application-level uniqueness check
was wrong. That is also why nothing failed until a second payout.

## Verified against the real link registry, both halves

`check-paid-to-link-cardinality.ts` drives `Link.create` with synthetic ids
(link tables carry no cross-module foreign keys) and dismisses them in a
`finally`. Before / after, locally:

    before   first submission -> OK
             second submission -> THREW "Cannot create multiple links…"   🔴
    after    first submission -> OK
             second submission -> OK                                       ✅
             two methods on one submission -> refused (correct)

That third line is the guard that matters: a "just make it many-to-many" fix
would silently allow one payout to two bank accounts, which is worse than the
bug being fixed.

## The read shape does NOT change

Changing a link's cardinality can flip a `query.graph` read from an object to an
array, turning `paid_to.id` into `undefined` silently. Measured rather than
reasoned about (`check-paid-to-read-shape.ts`): `submission.paid_to` returns
**no key at all**, on this branch AND on `main`. It was never readable from the
entity side — the long-table-name problem this link file's own docblock
documents — which is why the one reader,
`settle-payment-reconciliation.ts:193`, goes through `Link.entryPoint` and
indexes `data[0]`. Unaffected either way.

246 unit tests green across the 18 payment suites.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Found from a live approval failure on `payment-submission/01M1DS8WXYVFR9JPTQA32D2DFP`. Blocks every partner's second payout, so worth merging ahead of the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4