### PR TITLE
fix(inventory-orders): a "compare-and-set" that read then wrote let two sends duplicate a partner assignment (#780)

### DIFF
--- a/apps/backend/integration-tests/http/send-to-partner-concurrent-claim.spec.ts
+++ b/apps/backend/integration-tests/http/send-to-partner-concurrent-claim.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * #780 H7c — two concurrent sends of one inventory order to the SAME partner.
+ *
+ * The route's pre-check is a read-then-act: both requests read "no partner
+ * tasks yet" and both proceed. Before the fix, both then created a full set of
+ * partner tasks, messaged the partner twice, and left two long-running workflow
+ * instances parked in `awaitOrderStart`.
+ *
+ * ⚠️ The cross-partner case is NOT what this covers — `Link.create` already
+ * refuses a second partner for one order (singular-side uniqueness, cf. #1775).
+ * The hole was the same partner twice, where the duplicate link is a silent
+ * no-op. Verified by probe before this test was written.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+const TEST_PARTNER_EMAIL = "partner@concurrent-claim-test.com"
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+const PARTNER_TASK_TITLES = [
+  "partner-order-sent",
+  "partner-order-received",
+  "partner-order-shipped",
+]
+
+setupSharedTestSuite(() => {
+  describe("Send to Partner — concurrent claim (#780 H7c)", () => {
+    let appContainer
+    let partnerId
+    let inventoryOrderId
+    let adminHeaders
+    const { api, getContainer } = getSharedTestEnv()
+
+    beforeEach(async () => {
+      appContainer = getContainer()
+
+      await createAdminUser(appContainer)
+      adminHeaders = await getAuthHeaders(api)
+
+      await api.post("/auth/partner/emailpass/register", {
+        email: TEST_PARTNER_EMAIL,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const login = await api.post("/auth/partner/emailpass", {
+        email: TEST_PARTNER_EMAIL,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      let partnerHeaders = { Authorization: `Bearer ${login.data.token}` }
+
+      const partnerResponse = await api.post(
+        "/partners",
+        {
+          name: "Concurrent Claim Partner",
+          handle: "concurrent-claim-partner",
+          admin: {
+            email: TEST_PARTNER_EMAIL,
+            first_name: "Partner",
+            last_name: "Admin",
+          },
+        },
+        { headers: partnerHeaders }
+      )
+      partnerId = partnerResponse.data.partner.id
+
+      // The workflow creates its partner tasks from templates; without these
+      // the send 400s before it ever reaches the claim (cost one red run).
+      for (const [name, step] of [
+        ["partner-order-sent", "sent"],
+        ["partner-order-received", "received"],
+        ["partner-order-shipped", "shipped"],
+      ]) {
+        const templateResponse = await api.post(
+          "/admin/task-templates",
+          {
+            name,
+            description: `Template for ${name}`,
+            priority: "medium",
+            estimated_duration: 30,
+            required_fields: {
+              order_id: { type: "string", required: true },
+              partner_id: { type: "string", required: true },
+            },
+            eventable: true,
+            notifiable: true,
+            message_template: `Order {{order_id}} — ${name}.`,
+            metadata: { workflow_type: "partner_assignment", workflow_step: step },
+          },
+          adminHeaders
+        )
+        expect(templateResponse.status).toBe(201)
+      }
+
+      const inventoryResponse = await api.post(
+        "/admin/inventory-items",
+        { title: "Concurrent Claim Fabric", description: "fabric" },
+        adminHeaders
+      )
+      const inventoryItemId = inventoryResponse.data.inventory_item.id
+
+      const stockLocationResponse = await api.post(
+        "/admin/stock-locations",
+        { name: "Concurrent Claim Warehouse" },
+        adminHeaders
+      )
+      const stockLocationId = stockLocationResponse.data.stock_location.id
+
+      const orderResponse = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 10, price: 20 },
+          ],
+          quantity: 10,
+          total_price: 200,
+          status: "Pending",
+          expected_delivery_date: new Date(
+            Date.now() + 7 * 24 * 60 * 60 * 1000
+          ).toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {
+            address_1: "1 Race St",
+            city: "Race City",
+            postal_code: "12345",
+            country_code: "US",
+          },
+          stock_location_id: stockLocationId,
+          is_sample: false,
+        },
+        adminHeaders
+      )
+      expect(orderResponse.status).toBe(201)
+      inventoryOrderId = orderResponse.data.inventoryOrder.id
+    })
+
+    const partnerTaskTitles = async (): Promise<string[]> => {
+      const query = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        fields: ["id", "tasks.*"],
+        filters: { id: inventoryOrderId },
+      })
+      const tasks: any[] = (data?.[0] as any)?.tasks ?? []
+      return tasks
+        .map((t) => t?.title)
+        .filter((title) => PARTNER_TASK_TITLES.includes(title))
+    }
+
+    it("claims the assignment exactly once when two identical sends race", async () => {
+      const send = () =>
+        api
+          .post(
+            `/admin/inventory-orders/${inventoryOrderId}/send-to-partner`,
+            { partnerId, notes: "racing" },
+            adminHeaders
+          )
+          .catch((err) => err.response)
+
+      // Fired together so both clear the route's read-then-act pre-check.
+      const [first, second] = await Promise.all([send(), send()])
+
+      const statuses = [first?.status, second?.status].sort()
+      // Exactly one winner. The loser is refused — 409 from the pre-check if it
+      // happened to read late, otherwise the claim step's CONFLICT.
+      expect(statuses.filter((s) => s === 200)).toHaveLength(1)
+      expect(statuses.filter((s) => s !== 200)).toHaveLength(1)
+
+      // The assertion that actually matters: the mutation, not the status code.
+      // A duplicated send is only visible as duplicated tasks.
+      const titles = await partnerTaskTitles()
+      expect(titles.sort()).toEqual([...PARTNER_TASK_TITLES].sort())
+    })
+
+    it("records the winning transaction id as the claim", async () => {
+      const response = await api.post(
+        `/admin/inventory-orders/${inventoryOrderId}/send-to-partner`,
+        { partnerId, notes: "single send" },
+        adminHeaders
+      )
+      expect(response.status).toBe(200)
+
+      const query = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        fields: ["id", "partner_assignment_id"],
+        filters: { id: inventoryOrderId },
+      })
+      expect((data?.[0] as any)?.partner_assignment_id).toEqual(
+        expect.any(String)
+      )
+    })
+  })
+})

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260904090000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260904090000.ts
@@ -1,0 +1,27 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #780 H7c — atomic claim for the partner assignment.
+ *
+ * Adds nullable `partner_assignment_id` to `inventory_orders`, holding the
+ * workflow transaction id that owns the current assignment. The send-to-partner
+ * workflow claims it with a conditional update (`where partner_assignment_id is
+ * null`), so two concurrent sends to the same partner can no longer both create
+ * tasks and both message the partner.
+ *
+ * Hand-written idempotent ALTER: the table exists on live DBs, and a generated
+ * migration here would re-emit columns owned by earlier hand-written ones.
+ */
+export class Migration20260904090000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" add column if not exists "partner_assignment_id" text null;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_inventory_orders_partner_assignment_id" ON "inventory_orders" (partner_assignment_id) WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_inventory_orders_partner_assignment_id";`);
+    this.addSql(`alter table if exists "inventory_orders" drop column if exists "partner_assignment_id";`);
+  }
+
+}

--- a/apps/backend/src/modules/inventory_orders/models/order.ts
+++ b/apps/backend/src/modules/inventory_orders/models/order.ts
@@ -38,6 +38,22 @@ const InventoryOrder = model.define("inventory_orders", {
   cancelled_at: model.dateTime().nullable(),
   cancellation_reason: model.text().nullable(),
   cancelled_by: model.text().nullable(),
+  /**
+   * #780 H7c — the workflow transaction id that currently owns this order's
+   * partner assignment, or null when unassigned.
+   *
+   * This is the claim a `send-to-partner` run takes atomically before it
+   * creates any task or messages the partner. A typed column rather than
+   * metadata for the same reason as the cancellation audit above: it is
+   * load-bearing state that must survive a later metadata replacement.
+   *
+   * The cross-partner case was never the hole — `Link.create` already refuses
+   * a second partner for one order (the singular-side uniqueness behind
+   * #1775). What this closes is two concurrent sends to the SAME partner,
+   * where the duplicate link is a silent no-op and both runs went on to
+   * duplicate the tasks, the partner notification, and the workflow.
+   */
+  partner_assignment_id: model.text().nullable(),
 }).cascades({
   delete: ['orderlines']
 });

--- a/apps/backend/src/workflows/inventory_orders/cancel-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/cancel-inventory-order.ts
@@ -174,6 +174,9 @@ export const cancelInventoryOrderWorkflow = createWorkflow(
         cancelled_at: new Date(),
         cancellation_reason: input.reason ?? null,
         cancelled_by: input.cancelledBy ?? null,
+        // #780 H7c — release the partner-assignment claim. Without this a
+        // cancelled order could never be sent to a partner again.
+        partner_assignment_id: null,
       },
     }))
     updateInventoryOrderWorkflow.runAsStep({ input: updateInput })

--- a/apps/backend/src/workflows/inventory_orders/send-to-partner.ts
+++ b/apps/backend/src/workflows/inventory_orders/send-to-partner.ts
@@ -70,6 +70,75 @@ const validateInventoryOrderStep = createStep(
     }
 )
 
+/**
+ * #780 H7c — take an exclusive claim on this order's partner assignment.
+ *
+ * Runs BEFORE the link, the tasks and the partner notification, so a request
+ * that loses the race stops before it can duplicate any of them.
+ *
+ * The claim is a conditional update: only a row whose `partner_assignment_id`
+ * is still null is updated, so two concurrent sends resolve to exactly one
+ * winner in a single atomic statement. The zero-row result is the loser's
+ * signal — the same compare-and-set shape already merged on the partner start
+ * route (#780 A4), which this deliberately mirrors.
+ *
+ * ⚠️ Do not "simplify" this into a read-then-write. That is what it replaces.
+ */
+const claimPartnerAssignmentStep = createStep(
+    "claim-partner-assignment",
+    async (input: { inventoryOrderId: string }, { container, context }) => {
+        const pg = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+        const transactionId = context.transactionId
+
+        // 🔴 This MUST be raw SQL. `updateInventoryOrders({ selector, data })`
+        // looks like a conditional update but is a read-then-write: two
+        // concurrent calls with the same `where ... is null` selector BOTH
+        // return a row (probed directly — 1 and 1, expected 1 and 0). A single
+        // UPDATE ... WHERE ... IS NULL is serialized by Postgres row locking,
+        // so the loser's predicate re-evaluates to false and it updates zero
+        // rows. See #780 — the same false-atomicity affects the A4 guard on the
+        // partner start route.
+        const claimed = await pg.raw(
+            `update inventory_orders
+                set partner_assignment_id = ?, updated_at = now()
+              where id = ?
+                and partner_assignment_id is null
+                and deleted_at is null
+             returning id`,
+            [transactionId, input.inventoryOrderId]
+        )
+        const rows = claimed?.rows ?? []
+
+        if (rows.length === 0) {
+            // Either another request claimed it microseconds ago, or the order
+            // was already assigned and the route pre-check did not see it.
+            throw new MedusaError(
+                MedusaError.Types.CONFLICT,
+                `Inventory order ${input.inventoryOrderId} is already assigned to a partner. Cancel the existing assignment before sending it again.`
+            )
+        }
+
+        return new StepResponse({ inventoryOrderId: input.inventoryOrderId, transactionId }, {
+            inventoryOrderId: input.inventoryOrderId,
+            transactionId,
+        })
+    },
+    async (claimed, { container }) => {
+        if (!claimed) {
+            return
+        }
+        const pg = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+        // Release only our own claim — the transaction id is in the predicate,
+        // so a rollback can never clear an assignment another run owns.
+        await pg.raw(
+            `update inventory_orders
+                set partner_assignment_id = null, updated_at = now()
+              where id = ? and partner_assignment_id = ?`,
+            [claimed.inventoryOrderId, claimed.transactionId]
+        )
+    }
+)
+
 const validatePartnerStep = createStep(
     "validate-partner",
     async (input: SendInventoryOrderToPartnerInput, { container }) => {
@@ -335,8 +404,15 @@ export const sendInventoryOrderToPartnerWorkflow = createWorkflow(
         
         // Step 2: Validate the partner
         const partner = validatePartnerStep(input)
-        
-        // Idempotency removed: always create/update the link
+
+        // #780 H7c — claim the assignment before anything observable happens.
+        // A concurrent duplicate send fails here, so it cannot duplicate the
+        // tasks, the partner notification, or the awaiting workflow instance.
+        claimPartnerAssignmentStep({ inventoryOrderId: input.inventoryOrderId })
+
+        // The link itself is NOT the guard: Link.create refuses a second
+        // *partner* for one order (singular-side uniqueness, cf. #1775) but is
+        // a silent no-op for the same partner twice. The claim above covers it.
         linkInventoryOrderWithPartnerStep({
             inventoryOrderId: input.inventoryOrderId,
             partnerId: input.partnerId

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
@@ -4,7 +4,7 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
-import { Modules, MedusaError } from "@medusajs/framework/utils";
+import { Modules, MedusaError, ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import type { IEventBusModuleService } from "@medusajs/types";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
@@ -71,6 +71,9 @@ type UpdateInventoryOrderStepInput = {
     cancelled_at?: Date | null;
     cancellation_reason?: string | null;
     cancelled_by?: string | null;
+    // #780 H7c — the partner-assignment claim. Cancelling an order releases it
+    // so the order can legitimately be sent to a partner again.
+    partner_assignment_id?: string | null;
   };
 };
 
@@ -96,20 +99,49 @@ export const updateInventoryOrderStep = createStep(
 
     let order: any;
     if (input.expectedCurrentStatus !== undefined) {
-      // #780 H7 — atomic compare-and-set: only rows still at the expected status
-      // are updated. Returns the updated rows (empty if none matched).
-      const updated = await inventoryOrderService.updateInventoryOrders({
-        selector: { id: input.id, status: input.expectedCurrentStatus },
-        data: { ...input.update },
-      });
-      const rows = Array.isArray(updated) ? updated : updated ? [updated] : [];
-      if (rows.length === 0) {
+      // #780 H7 — compare-and-set on the transition.
+      //
+      // 🔴 This is raw SQL on purpose, and it must stay that way. The original
+      // version of this guard used
+      //   updateInventoryOrders({ selector: { id, status: expected }, data })
+      // and its comment claimed that was atomic. It is not: the service reads
+      // the matching rows and then writes them, so two concurrent callers with
+      // the same selector BOTH match and BOTH write. Probed directly against
+      // the local DB — two racing claims returned 1 row and 1 row, where an
+      // atomic CAS returns 1 and 0. A single `UPDATE ... WHERE status =
+      // <expected>` is serialized by Postgres row locking, so the loser's
+      // predicate re-evaluates after the winner commits and it updates nothing.
+      if (input.update.status === undefined) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          "expectedCurrentStatus requires a status change — the status write is the gate."
+        );
+      }
+
+      const pg = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any;
+      const gated = await pg.raw(
+        `update inventory_orders
+            set status = ?, updated_at = now()
+          where id = ?
+            and status = ?
+            and deleted_at is null
+         returning id`,
+        [input.update.status, input.id, input.expectedCurrentStatus]
+      );
+      if ((gated?.rows ?? []).length === 0) {
         throw new MedusaError(
           MedusaError.Types.CONFLICT,
           `Inventory order ${input.id} is no longer in "${input.expectedCurrentStatus}" state (already updated by a concurrent request)`
         );
       }
-      order = rows[0];
+
+      // The transition is now owned by this caller. Apply the remaining fields
+      // through the service so serialisation and the returned shape are
+      // unchanged; re-writing the same status is a no-op.
+      order = await inventoryOrderService.updateInventoryOrders({
+        id: input.id,
+        ...input.update,
+      });
     } else {
       order = await inventoryOrderService.updateInventoryOrders({
         id: input.id,


### PR DESCRIPTION
Closes the last live defect in #780, and fixes a guard from the same issue that was merged in June and never actually worked.

## The primitive was lying

`updateInventoryOrders({ selector, data })` reads the rows matching the selector and then writes them. It is not a conditional `UPDATE`. Probed directly against the local DB — two concurrent claims with the same `where partner_assignment_id is null` predicate:

```
PROBE concurrent claim rows: 1 1   (an atomic CAS returns 1 and 0)
```

That makes the **#780 A4 guard on the partner start route false as written**. Its comment says *"atomic compare-and-set: only rows still at the expected status are updated"* — it is neither atomic nor a compare-and-set, and the TOCTOU it was merged to close has been open since. Replaced with a single `UPDATE ... WHERE status = <expected>`, which Postgres row locking serializes, so the loser's predicate re-evaluates after the winner commits and it updates nothing:

```
PROBE raw concurrent rows: 1 0
```

## What H7c actually was

The audit and the issue both say the `send-to-partner` race is about assignment. **It isn't** — verified by probe before writing any code:

| `Link.create` attempt | outcome |
|---|---|
| partner A | OK |
| partner **B**, same order | **REFUSED** — `Cannot create multiple links between 'partner' and 'inventory_orders'` |
| partner A again | OK — silent no-op |

Cross-partner assignment has always been guarded, by the singular-side uniqueness that caused #1775. The hole was **two sends to the same partner**, where the duplicate link is a no-op and both runs went on to create a second full set of partner tasks, message the partner twice, and park a second `store: true` workflow in `awaitOrderStart` forever.

## The fix

A typed `partner_assignment_id` column holding the workflow transaction id that owns the assignment — typed rather than metadata, following the #778 C4 precedent on this same model. The workflow claims it atomically **before** the link, the tasks or the notification, so a loser stops before anything observable happens. Compensation and the cancel path release it, keyed on the owning transaction id so a rollback can never clear another run's claim.

The route's existing pre-check stays as the friendly 409 on the common already-assigned path — the same belt-and-braces shape as A4.

## Verification

Red/green on the new spec, `send-to-partner-concurrent-claim.spec.ts`, which fires both sends with `Promise.all` so both clear the read-then-act pre-check:

| | statuses | partner tasks on the order |
|---|---|---|
| before | `200, 200` | **6** — two full sets |
| after | `200, 409` | **3** |

It asserts the mutation, not the return value: a duplicated send is only visible as duplicated tasks.

```
Test Suites: 2 passed  (new spec + send-to-partner-error-cases)
Tests:      14 passed
Test Suites: 3 passed  (partner-security, dual-write, status-flow-execution)
Tests:      12 passed
```

`check:prod-build` fails only on `src/scripts/__tests__/generate-integration-test.e2e.spec.ts` — `Cannot find module '@jest/core'`. Confirmed pre-existing by stashing to a clean tree and reproducing the identical single error.

## Honest gap

The A4 fix on the start route has **no test of its own** — it is covered by the direct concurrency probe above and shares the mechanism the new spec exercises. A concurrent-start integration test would need the full partner auth flow; worth adding, not done here.

Migration: one nullable column plus a partial index, hand-written and idempotent (a generated migration here would re-emit columns owned by earlier hand-written ones).

Refs #780, #778, #1775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
