### PR TITLE
fix(email): consult the suppression ledger where mail actually leaves the platform (#1339)

### DIFF
--- a/apps/backend/medusa-config.dev.ts
+++ b/apps/backend/medusa-config.dev.ts
@@ -139,6 +139,10 @@ module.exports = defineConfig({
 
     {
       resolve: "@medusajs/medusa/notification",
+      // #1339 — puts the suppression ledger's service into the provider
+      // container. Without this the guard in each email provider degrades to
+      // "not enforced" (it logs [email-suppression-unavailable] and sends).
+      dependencies: ["email_suppression"],
       options: {
         providers: [
           {

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -207,6 +207,10 @@ module.exports = defineConfig({
 
     {
       resolve: "@medusajs/medusa/notification",
+      // #1339 — puts the suppression ledger's service into the provider
+      // container. Without this the guard in each email provider degrades to
+      // "not enforced" (it logs [email-suppression-unavailable] and sends).
+      dependencies: ["email_suppression"],
       options: {
         providers: [
           {

--- a/apps/backend/src/api/admin/email-suppressions/route.ts
+++ b/apps/backend/src/api/admin/email-suppressions/route.ts
@@ -1,0 +1,62 @@
+/**
+ * GET /admin/email-suppressions — read the suppression ledger (#1339).
+ *
+ * The ledger had no read surface at all: the only admin route touching it was
+ * the write-only `suppress-bounced-subscribers` maintenance job. That opacity is
+ * part of why it rotted into a write-only store — nobody could see that it was
+ * being populated correctly and consulted nowhere.
+ *
+ * Returns the rows plus a `by_reason` roll-up, because the first question anyone
+ * asks of this table is "how many hard bounces are we carrying".
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { EMAIL_SUPPRESSION_MODULE } from "../../../modules/email_suppression"
+
+/** Max rows per page. Explicit, and echoed in the response, because a silent
+ * clamp is how a list route hides most of its data (#1552). */
+const MAX_LIMIT = 200
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(EMAIL_SUPPRESSION_MODULE)
+
+  const q = req.query as Record<string, string | undefined>
+  const requestedLimit = Number(q.limit ?? 50)
+  const limit = Number.isFinite(requestedLimit)
+    ? Math.min(Math.max(requestedLimit, 1), MAX_LIMIT)
+    : 50
+  const offset = Math.max(Number(q.offset ?? 0) || 0, 0)
+
+  const filters: Record<string, unknown> = {}
+  if (q.email) {
+    filters.email = String(q.email).trim().toLowerCase()
+  }
+  if (q.reason) {
+    filters.reason = String(q.reason).trim()
+  }
+
+  const [suppressions, count] = await service.listAndCountEmailSuppressions(
+    filters,
+    { take: limit, skip: offset, order: { created_at: "DESC" } }
+  )
+
+  // Roll-up over the WHOLE ledger, not the current page — a per-page count
+  // would answer a question nobody asked.
+  const all = await service.listEmailSuppressions(filters, {
+    select: ["reason"],
+    take: null,
+  })
+  const byReason: Record<string, number> = {}
+  for (const row of all ?? []) {
+    const reason = (row as any)?.reason ?? "unknown"
+    byReason[reason] = (byReason[reason] ?? 0) + 1
+  }
+
+  res.json({
+    suppressions,
+    count,
+    offset,
+    limit,
+    limit_max: MAX_LIMIT,
+    by_reason: byReason,
+  })
+}

--- a/apps/backend/src/lib/__tests__/email-suppression-lookup.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/email-suppression-lookup.unit.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * #1339 — the provider-side guard: reading the ledger and applying the policy.
+ *
+ * The behaviours that matter most here are the failure ones. A guard that
+ * cannot run must SEND and must SAY SO — "not enforced" and "nothing to
+ * suppress" look identical otherwise, which is the exact ambiguity that let
+ * this ledger sit unread for months.
+ */
+import {
+  createSuppressionGuard,
+  createSuppressionLookup,
+  partitionSuppressedRecipients,
+  SUPPRESSION_CACHE_TTL_MS,
+} from "../email-suppression-lookup"
+
+const makeLogger = () => ({
+  warn: jest.fn((_msg: string) => undefined),
+  error: jest.fn((_msg: string) => undefined),
+  info: jest.fn((_msg: string) => undefined),
+  debug: jest.fn((_msg: string) => undefined),
+})
+
+const pgReturning = (...reasons: string[]) => ({
+  raw: jest.fn(async (_sql: string, _bindings?: unknown[]) => ({
+    rows: reasons.map((reason) => ({ reason })),
+  })),
+})
+
+describe("email suppression guard", () => {
+  it("suppresses a hard bounce on the transactional channel", async () => {
+    const logger = makeLogger()
+    const guard = createSuppressionGuard({
+      pg: pgReturning("hard_bounce"),
+      logger: logger as any,
+      provider: "resend",
+      channel: "email",
+    })
+
+    const verdict = await guard("dead@example.com", "order-shipment-delivered")
+
+    expect(verdict.suppress).toBe(true)
+    expect(verdict.id).toContain("suppressed")
+    // Assert on the recorded call, not inside the mock — an expect() thrown
+    // inside a mock can be swallowed by the code under test.
+    const lines = logger.warn.mock.calls.map((c) => String(c[0]))
+    expect(lines.some((l) => l.includes("[email-suppressed]"))).toBe(true)
+    expect(lines.some((l) => l.includes("reason=hard_bounce"))).toBe(true)
+  })
+
+  it("sends when the ledger has nothing on the address", async () => {
+    const logger = makeLogger()
+    const guard = createSuppressionGuard({
+      pg: pgReturning(),
+      logger: logger as any,
+      provider: "resend",
+      channel: "email",
+    })
+
+    const verdict = await guard("fine@example.com", "order-shipment-delivered")
+
+    expect(verdict.suppress).toBe(false)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  describe("the partner carve-out", () => {
+    it("delivers a partner's mail after their spam complaint, and raises an alert", async () => {
+      const logger = makeLogger()
+      const guard = createSuppressionGuard({
+        pg: pgReturning("spam_complaint"),
+        logger: logger as any,
+        provider: "maileroo",
+        channel: "email_partner",
+      })
+
+      const verdict = await guard("partner@example.com", "partner-quote-issued")
+
+      expect(verdict.suppress).toBe(false)
+      const lines = logger.warn.mock.calls.map((c) => String(c[0]))
+      expect(lines.some((l) => l.includes("[partner-spam-complaint]"))).toBe(true)
+    })
+
+    it("still blocks a partner address that hard-bounced", async () => {
+      const logger = makeLogger()
+      const guard = createSuppressionGuard({
+        pg: pgReturning("hard_bounce"),
+        logger: logger as any,
+        provider: "maileroo",
+        channel: "email_partner",
+      })
+
+      expect((await guard("gone@example.com", "partner-quote-issued")).suppress).toBe(true)
+    })
+  })
+
+  describe("failing open, loudly", () => {
+    it("sends and logs an error when the query throws", async () => {
+      const logger = makeLogger()
+      const pg = {
+        raw: jest.fn(async (_sql: string, _bindings?: unknown[]) => {
+          throw new Error("connection terminated")
+        }),
+      }
+      const guard = createSuppressionGuard({
+        pg,
+        logger: logger as any,
+        provider: "resend",
+        channel: "email",
+      })
+
+      const verdict = await guard("someone@example.com", "cart-abandoned")
+
+      expect(verdict.suppress).toBe(false)
+      const errors = logger.error.mock.calls.map((c) => String(c[0]))
+      expect(errors.some((l) => l.includes("[email-suppression-lookup-failed]"))).toBe(true)
+      expect(errors.some((l) => l.includes("sent without consulting the ledger"))).toBe(true)
+    })
+
+    it("sends and says the guard is not running when there is no connection", async () => {
+      const logger = makeLogger()
+      const guard = createSuppressionGuard({
+        pg: undefined,
+        logger: logger as any,
+        provider: "resend",
+        channel: "email",
+      })
+
+      expect((await guard("a@example.com")).suppress).toBe(false)
+      const errors = logger.error.mock.calls.map((c) => String(c[0]))
+      expect(errors.some((l) => l.includes("[email-suppression-unavailable]"))).toBe(true)
+      expect(errors.some((l) => l.includes("NOT being enforced"))).toBe(true)
+    })
+
+    it("does not repeat the missing-connection error on every send", async () => {
+      const logger = makeLogger()
+      const guard = createSuppressionGuard({
+        pg: null,
+        logger: logger as any,
+        provider: "resend",
+        channel: "email",
+      })
+
+      await guard("a@example.com")
+      await guard("b@example.com")
+      await guard("c@example.com")
+
+      expect(logger.error).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("caching", () => {
+    it("reuses a result within the TTL and re-queries after it", async () => {
+      const logger = makeLogger()
+      const pg = pgReturning("hard_bounce")
+      let clock = 1_000
+      const lookup = createSuppressionLookup({
+        pg,
+        logger: logger as any,
+        provider: "resend",
+        now: () => clock,
+      })
+
+      await lookup("x@example.com")
+      await lookup("x@example.com")
+      expect(pg.raw).toHaveBeenCalledTimes(1)
+
+      clock += SUPPRESSION_CACHE_TTL_MS + 1
+      await lookup("x@example.com")
+      expect(pg.raw).toHaveBeenCalledTimes(2)
+    })
+
+    it("normalizes the address so casing and display names share a cache entry", async () => {
+      const logger = makeLogger()
+      const pg = pgReturning()
+      const lookup = createSuppressionLookup({
+        pg,
+        logger: logger as any,
+        provider: "resend",
+      })
+
+      await lookup("Foo@Example.com")
+      await lookup("  foo@example.com ")
+      await lookup("Foo Bar <foo@example.com>")
+
+      expect(pg.raw).toHaveBeenCalledTimes(1)
+    })
+
+    it("never queries for an empty address", async () => {
+      const logger = makeLogger()
+      const pg = pgReturning()
+      const lookup = createSuppressionLookup({ pg, logger: logger as any, provider: "resend" })
+
+      expect(await lookup("")).toEqual([])
+      expect(pg.raw).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("bulk", () => {
+    it("splits a batch into sendable and suppressed", async () => {
+      const logger = makeLogger()
+      const pg = {
+        raw: jest.fn(async (_sql: string, bindings?: unknown[]) => {
+          const email = String((bindings ?? [])[0] ?? "")
+          return { rows: email === "dead@example.com" ? [{ reason: "hard_bounce" }] : [] }
+        }),
+      }
+      const guard = createSuppressionGuard({
+        pg,
+        logger: logger as any,
+        provider: "mailjet",
+        channel: "email_bulk",
+      })
+
+      const entries = [
+        { to: "ok@example.com" },
+        { to: "dead@example.com" },
+        { to: "also-ok@example.com" },
+      ]
+      const { send, suppressed } = await partitionSuppressedRecipients(
+        entries,
+        (e) => e.to,
+        guard
+      )
+
+      expect(send.map((e) => e.to)).toEqual(["ok@example.com", "also-ok@example.com"])
+      expect(suppressed.map((e) => e.to)).toEqual(["dead@example.com"])
+    })
+  })
+})

--- a/apps/backend/src/lib/__tests__/email-suppression-lookup.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/email-suppression-lookup.unit.spec.ts
@@ -20,17 +20,18 @@ const makeLogger = () => ({
   debug: jest.fn((_msg: string) => undefined),
 })
 
-const pgReturning = (...reasons: string[]) => ({
-  raw: jest.fn(async (_sql: string, _bindings?: unknown[]) => ({
-    rows: reasons.map((reason) => ({ reason })),
-  })),
+const serviceReturning = (...reasons: string[]) => ({
+  listEmailSuppressions: jest.fn(
+    async (_filters: Record<string, unknown>, _config?: unknown) =>
+      reasons.map((reason) => ({ reason }))
+  ),
 })
 
 describe("email suppression guard", () => {
   it("suppresses a hard bounce on the transactional channel", async () => {
     const logger = makeLogger()
     const guard = createSuppressionGuard({
-      pg: pgReturning("hard_bounce"),
+      suppressionService: serviceReturning("hard_bounce"),
       logger: logger as any,
       provider: "resend",
       channel: "email",
@@ -50,7 +51,7 @@ describe("email suppression guard", () => {
   it("sends when the ledger has nothing on the address", async () => {
     const logger = makeLogger()
     const guard = createSuppressionGuard({
-      pg: pgReturning(),
+      suppressionService: serviceReturning(),
       logger: logger as any,
       provider: "resend",
       channel: "email",
@@ -66,7 +67,7 @@ describe("email suppression guard", () => {
     it("delivers a partner's mail after their spam complaint, and raises an alert", async () => {
       const logger = makeLogger()
       const guard = createSuppressionGuard({
-        pg: pgReturning("spam_complaint"),
+        suppressionService: serviceReturning("spam_complaint"),
         logger: logger as any,
         provider: "maileroo",
         channel: "email_partner",
@@ -82,7 +83,7 @@ describe("email suppression guard", () => {
     it("still blocks a partner address that hard-bounced", async () => {
       const logger = makeLogger()
       const guard = createSuppressionGuard({
-        pg: pgReturning("hard_bounce"),
+        suppressionService: serviceReturning("hard_bounce"),
         logger: logger as any,
         provider: "maileroo",
         channel: "email_partner",
@@ -95,13 +96,13 @@ describe("email suppression guard", () => {
   describe("failing open, loudly", () => {
     it("sends and logs an error when the query throws", async () => {
       const logger = makeLogger()
-      const pg = {
-        raw: jest.fn(async (_sql: string, _bindings?: unknown[]) => {
+      const service = {
+        listEmailSuppressions: jest.fn(async () => {
           throw new Error("connection terminated")
         }),
       }
       const guard = createSuppressionGuard({
-        pg,
+        suppressionService: service,
         logger: logger as any,
         provider: "resend",
         channel: "email",
@@ -118,7 +119,7 @@ describe("email suppression guard", () => {
     it("sends and says the guard is not running when there is no connection", async () => {
       const logger = makeLogger()
       const guard = createSuppressionGuard({
-        pg: undefined,
+        suppressionService: undefined,
         logger: logger as any,
         provider: "resend",
         channel: "email",
@@ -133,7 +134,7 @@ describe("email suppression guard", () => {
     it("does not repeat the missing-connection error on every send", async () => {
       const logger = makeLogger()
       const guard = createSuppressionGuard({
-        pg: null,
+        suppressionService: null,
         logger: logger as any,
         provider: "resend",
         channel: "email",
@@ -150,10 +151,10 @@ describe("email suppression guard", () => {
   describe("caching", () => {
     it("reuses a result within the TTL and re-queries after it", async () => {
       const logger = makeLogger()
-      const pg = pgReturning("hard_bounce")
+      const service = serviceReturning("hard_bounce")
       let clock = 1_000
       const lookup = createSuppressionLookup({
-        pg,
+        suppressionService: service,
         logger: logger as any,
         provider: "resend",
         now: () => clock,
@@ -161,18 +162,18 @@ describe("email suppression guard", () => {
 
       await lookup("x@example.com")
       await lookup("x@example.com")
-      expect(pg.raw).toHaveBeenCalledTimes(1)
+      expect(service.listEmailSuppressions).toHaveBeenCalledTimes(1)
 
       clock += SUPPRESSION_CACHE_TTL_MS + 1
       await lookup("x@example.com")
-      expect(pg.raw).toHaveBeenCalledTimes(2)
+      expect(service.listEmailSuppressions).toHaveBeenCalledTimes(2)
     })
 
     it("normalizes the address so casing and display names share a cache entry", async () => {
       const logger = makeLogger()
-      const pg = pgReturning()
+      const service = serviceReturning()
       const lookup = createSuppressionLookup({
-        pg,
+        suppressionService: service,
         logger: logger as any,
         provider: "resend",
       })
@@ -181,30 +182,30 @@ describe("email suppression guard", () => {
       await lookup("  foo@example.com ")
       await lookup("Foo Bar <foo@example.com>")
 
-      expect(pg.raw).toHaveBeenCalledTimes(1)
+      expect(service.listEmailSuppressions).toHaveBeenCalledTimes(1)
     })
 
     it("never queries for an empty address", async () => {
       const logger = makeLogger()
-      const pg = pgReturning()
-      const lookup = createSuppressionLookup({ pg, logger: logger as any, provider: "resend" })
+      const service = serviceReturning()
+      const lookup = createSuppressionLookup({ suppressionService: service, logger: logger as any, provider: "resend" })
 
       expect(await lookup("")).toEqual([])
-      expect(pg.raw).not.toHaveBeenCalled()
+      expect(service.listEmailSuppressions).not.toHaveBeenCalled()
     })
   })
 
   describe("bulk", () => {
     it("splits a batch into sendable and suppressed", async () => {
       const logger = makeLogger()
-      const pg = {
-        raw: jest.fn(async (_sql: string, bindings?: unknown[]) => {
-          const email = String((bindings ?? [])[0] ?? "")
-          return { rows: email === "dead@example.com" ? [{ reason: "hard_bounce" }] : [] }
+      const service = {
+        listEmailSuppressions: jest.fn(async (filters: Record<string, unknown>) => {
+          const email = String((filters ?? {}).email ?? "")
+          return email === "dead@example.com" ? [{ reason: "hard_bounce" }] : []
         }),
       }
       const guard = createSuppressionGuard({
-        pg,
+        suppressionService: service,
         logger: logger as any,
         provider: "mailjet",
         channel: "email_bulk",

--- a/apps/backend/src/lib/__tests__/email-suppression-policy.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/email-suppression-policy.unit.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * #1339 — the suppression policy table, both policies.
+ *
+ * The stakes are asymmetric: wrongly suppressing is worse than wrongly sending,
+ * because a dropped order confirmation is invisible to everyone. So the
+ * "still sends" cases are asserted as carefully as the blocking ones.
+ */
+import {
+  classifySuppression,
+  resolveSuppressionMode,
+  shouldAlertOnSuppression,
+  suppressionLog,
+  partnerComplaintAlertLog,
+  DEFAULT_SUPPRESSION_MODE,
+  EMAIL_SUPPRESSED_SEND_ID,
+  type SuppressionReason,
+} from "../email-suppression-policy"
+
+const blocked = (
+  reasons: SuppressionReason[],
+  channel: string,
+  mode?: "strict" | "partner-carve-out"
+) => classifySuppression(reasons, channel, mode ?? DEFAULT_SUPPRESSION_MODE).suppress
+
+describe("email suppression policy", () => {
+  describe("hard_bounce — the mailbox does not exist", () => {
+    it("blocks every channel under both policies", () => {
+      for (const mode of ["partner-carve-out", "strict"] as const) {
+        expect(blocked(["hard_bounce"], "email", mode)).toBe(true)
+        expect(blocked(["hard_bounce"], "email_bulk", mode)).toBe(true)
+        expect(blocked(["hard_bounce"], "email_partner", mode)).toBe(true)
+      }
+    })
+  })
+
+  describe("spam_complaint — where the two policies differ", () => {
+    it("blocks marketing and lifecycle under both", () => {
+      for (const mode of ["partner-carve-out", "strict"] as const) {
+        expect(blocked(["spam_complaint"], "email", mode)).toBe(true)
+        expect(blocked(["spam_complaint"], "email_bulk", mode)).toBe(true)
+      }
+    })
+
+    it("lets partner operational mail through under the carve-out", () => {
+      expect(blocked(["spam_complaint"], "email_partner", "partner-carve-out")).toBe(false)
+    })
+
+    it("blocks partner operational mail under strict", () => {
+      expect(blocked(["spam_complaint"], "email_partner", "strict")).toBe(true)
+    })
+
+    it("raises an alert on partner mail regardless of policy", () => {
+      expect(shouldAlertOnSuppression(["spam_complaint"], "email_partner")).toBe(true)
+      expect(shouldAlertOnSuppression(["spam_complaint"], "email")).toBe(false)
+      expect(shouldAlertOnSuppression(["hard_bounce"], "email_partner")).toBe(false)
+    })
+  })
+
+  describe("unsubscribe — consent for marketing, not for the order they paid for", () => {
+    it("blocks bulk only", () => {
+      for (const mode of ["partner-carve-out", "strict"] as const) {
+        expect(blocked(["unsubscribe"], "email_bulk", mode)).toBe(true)
+        expect(blocked(["unsubscribe"], "email", mode)).toBe(false)
+        expect(blocked(["unsubscribe"], "email_partner", mode)).toBe(false)
+      }
+    })
+  })
+
+  describe("soft_bounce — a decision, not an accident", () => {
+    it("blocks nothing: a full mailbox is a live human", () => {
+      for (const mode of ["partner-carve-out", "strict"] as const) {
+        expect(blocked(["soft_bounce"], "email", mode)).toBe(false)
+        expect(blocked(["soft_bounce"], "email_bulk", mode)).toBe(false)
+        expect(blocked(["soft_bounce"], "email_partner", mode)).toBe(false)
+      }
+    })
+  })
+
+  describe("manual — someone did this on purpose", () => {
+    it("blocks every channel", () => {
+      expect(blocked(["manual"], "email")).toBe(true)
+      expect(blocked(["manual"], "email_bulk")).toBe(true)
+      expect(blocked(["manual"], "email_partner")).toBe(true)
+    })
+  })
+
+  describe("multiple rows on one address", () => {
+    it("the strictest rule wins — a later unsubscribe cannot downgrade a hard bounce", () => {
+      expect(blocked(["unsubscribe", "hard_bounce"], "email")).toBe(true)
+      expect(blocked(["hard_bounce", "unsubscribe"], "email")).toBe(true)
+    })
+
+    it("an address with no rows is never suppressed", () => {
+      expect(blocked([], "email")).toBe(false)
+      expect(blocked([], "email_bulk")).toBe(false)
+      expect(blocked([], "email_partner")).toBe(false)
+    })
+  })
+
+  describe("non-email channels are none of this module's business", () => {
+    it("never suppresses whatsapp or feed, whatever is on file", () => {
+      expect(blocked(["hard_bounce", "manual"], "whatsapp")).toBe(false)
+      expect(blocked(["hard_bounce", "manual"], "feed")).toBe(false)
+      expect(blocked(["hard_bounce", "manual"], "sms")).toBe(false)
+    })
+  })
+
+  describe("mode resolution fails safe", () => {
+    it("defaults to the carve-out and only 'strict' switches it", () => {
+      expect(resolveSuppressionMode(undefined)).toBe("partner-carve-out")
+      expect(resolveSuppressionMode("")).toBe("partner-carve-out")
+      expect(resolveSuppressionMode("STRICT")).toBe("strict")
+      expect(resolveSuppressionMode(" strict ")).toBe("strict")
+      // A typo must not take email down, and must not silently harden either.
+      expect(resolveSuppressionMode("strictt")).toBe("partner-carve-out")
+      expect(resolveSuppressionMode("true")).toBe("partner-carve-out")
+    })
+  })
+
+  describe("a suppression is never silent", () => {
+    it("logs the address, template, channel, reason and policy", () => {
+      const verdict = classifySuppression(["hard_bounce"], "email", "strict")
+      const line = suppressionLog("resend", " Foo@Example.COM ", "order-shipment-delivered", "email", verdict)
+      expect(line).toContain("[email-suppressed]")
+      expect(line).toContain("provider=resend")
+      expect(line).toContain("to=foo@example.com")
+      expect(line).toContain("template=order-shipment-delivered")
+      expect(line).toContain("channel=email")
+      expect(line).toContain("reason=hard_bounce")
+      expect(line).toContain("policy=strict")
+    })
+
+    it("names the partner complaint that was deliberately delivered", () => {
+      const line = partnerComplaintAlertLog("maileroo", "p@partner.test", "partner-quote-issued")
+      expect(line).toContain("[partner-spam-complaint]")
+      expect(line).toContain("to=p@partner.test")
+    })
+
+    it("suppressed never reads as sent", () => {
+      expect(EMAIL_SUPPRESSED_SEND_ID).toContain("suppressed")
+    })
+  })
+})

--- a/apps/backend/src/lib/email-suppression-lookup.ts
+++ b/apps/backend/src/lib/email-suppression-lookup.ts
@@ -1,20 +1,27 @@
 /**
  * Reads the `email_suppression` ledger from inside a notification provider (#1339).
  *
- * ── Why this is a raw query and not a module service ──────────────────────────
+ * ── How the provider reaches another module ───────────────────────────────────
  *
  * Notification providers are constructed as `new klass(cradle, options)` where
- * `cradle` is the NOTIFICATION MODULE'S OWN container — not the app container.
- * Probed directly by dumping the keys at construction:
+ * `cradle` is the NOTIFICATION MODULE'S OWN container, not the app container. By
+ * default that container holds only six injected keys — MANAGER, CONFIG_MODULE,
+ * LOGGER, PG_CONNECTION, EVENT_BUS, CACHING — so `email_suppression` is absent
+ * and a naive `container.resolve` inside a provider fails.
  *
- *   event_bus, logger, manager, configModule, __pg_connection__, caching,
- *   __providers__…, notificationModuleService, baseRepository, …
+ * The supported fix is `dependencies` on the module registration:
  *
- * `email_suppression` is NOT there, and no amount of declaring it as a
- * dependency puts it there — other modules are simply not resolvable from a
- * provider (the same boundary that hides fulfillment providers from the app
- * container). What IS there is `__pg_connection__`, a connection to the same
- * database. So the provider reads the one indexed column it needs directly.
+ *   { resolve: "@medusajs/medusa/notification",
+ *     dependencies: ["email_suppression"], options: { providers: [...] } }
+ *
+ * `loadInternalProvider` registers every declared dependency into the module's
+ * local container before the providers are built, so the service arrives in the
+ * cradle as `email_suppression`. Verified by dumping the cradle keys at
+ * construction with and without the declaration.
+ *
+ * ⚠️ That declaration lives in `medusa-config.dev.ts` and `medusa-config.prod.ts`.
+ * Without it the service is simply absent and this guard degrades to "not
+ * enforced" — loudly, see below, but silently in effect. Do not remove it.
  *
  * ── Fail OPEN, and loudly ─────────────────────────────────────────────────────
  *
@@ -55,17 +62,17 @@ export const normalizeSuppressionEmail = (raw: unknown): string => {
 /**
  * Build a cached lookup bound to one provider.
  *
- * `pg` is whatever `cradle.__pg_connection__` holds (a knex instance). It is
- * typed loosely on purpose: the provider must keep working if the key is
- * missing, which is exactly the case this guards.
+ * `suppressionService` is whatever `cradle.email_suppression` holds. It is typed
+ * loosely on purpose: the provider must keep working if the dependency was never
+ * declared, which is exactly the case the missing-service branch guards.
  */
 export function createSuppressionLookup(opts: {
-  pg: any
+  suppressionService: any
   logger: Logger
   provider: string
   now?: () => number
 }): SuppressionLookup {
-  const { pg, logger, provider } = opts
+  const { suppressionService, logger, provider } = opts
   const now = opts.now ?? (() => Date.now())
   const cache = new Map<string, CacheEntry>()
   let warnedMissingConnection = false
@@ -81,14 +88,14 @@ export function createSuppressionLookup(opts: {
       return hit.reasons
     }
 
-    if (!pg || typeof pg.raw !== "function") {
+    if (!suppressionService || typeof suppressionService.listEmailSuppressions !== "function") {
       // Loud, but only once per provider instance — a per-send error line here
       // would bury the log without telling anyone anything new.
       if (!warnedMissingConnection) {
         warnedMissingConnection = true
         logger.error(
           `[email-suppression-unavailable] provider=${provider} ` +
-            `reason="no __pg_connection__ in provider container" ` +
+            `reason="email_suppression not in the provider container — is it declared in the notification module's dependencies?" ` +
             `impact="suppression ledger is NOT being enforced on this channel"`
         )
       }
@@ -96,16 +103,17 @@ export function createSuppressionLookup(opts: {
     }
 
     try {
-      const result = await pg.raw(
-        `select distinct reason
-           from email_suppression
-          where lower(email) = ?
-            and deleted_at is null`,
-        [email]
+      // Writers normalize to lowercase (`normalizeEmail` in suppress-core), so
+      // an exact match on the normalized address is correct here.
+      const rows = await suppressionService.listEmailSuppressions(
+        { email },
+        { select: ["reason"] }
       )
-      const reasons = (result?.rows ?? [])
-        .map((r: any) => r?.reason)
-        .filter(Boolean) as SuppressionReason[]
+      const reasons = Array.from(
+        new Set(
+          (rows ?? []).map((r: any) => r?.reason).filter(Boolean)
+        )
+      ) as SuppressionReason[]
 
       if (cache.size >= SUPPRESSION_CACHE_MAX_ENTRIES) {
         cache.clear()
@@ -136,7 +144,7 @@ export function createSuppressionLookup(opts: {
  * with the prod mapping as the fallback.
  */
 export function createSuppressionGuard(opts: {
-  pg: any
+  suppressionService: any
   logger: Logger
   provider: string
   channel: string

--- a/apps/backend/src/lib/email-suppression-lookup.ts
+++ b/apps/backend/src/lib/email-suppression-lookup.ts
@@ -1,0 +1,191 @@
+/**
+ * Reads the `email_suppression` ledger from inside a notification provider (#1339).
+ *
+ * ── Why this is a raw query and not a module service ──────────────────────────
+ *
+ * Notification providers are constructed as `new klass(cradle, options)` where
+ * `cradle` is the NOTIFICATION MODULE'S OWN container — not the app container.
+ * Probed directly by dumping the keys at construction:
+ *
+ *   event_bus, logger, manager, configModule, __pg_connection__, caching,
+ *   __providers__…, notificationModuleService, baseRepository, …
+ *
+ * `email_suppression` is NOT there, and no amount of declaring it as a
+ * dependency puts it there — other modules are simply not resolvable from a
+ * provider (the same boundary that hides fulfillment providers from the app
+ * container). What IS there is `__pg_connection__`, a connection to the same
+ * database. So the provider reads the one indexed column it needs directly.
+ *
+ * ── Fail OPEN, and loudly ─────────────────────────────────────────────────────
+ *
+ * If the lookup cannot run, we SEND. The asymmetry is the whole point: mailing a
+ * dead address costs reputation slowly, whereas silently dropping a customer's
+ * order confirmation is invisible and unrecoverable. Every failure is logged at
+ * error level with a stable prefix so "the guard is not running" can never look
+ * like "nothing was suppressed".
+ */
+import type { Logger } from "@medusajs/framework/types"
+import {
+  classifySuppression,
+  shouldAlertOnSuppression,
+  suppressionLog,
+  partnerComplaintAlertLog,
+  EMAIL_SUPPRESSED_SEND_ID,
+  type SuppressionReason,
+} from "./email-suppression-policy"
+
+/** How long a lookup result is reused. Short: a new hard bounce should take
+ * effect within a minute, and prod runs more than one instance, so a long TTL
+ * would let instances disagree for as long as it lasted. */
+export const SUPPRESSION_CACHE_TTL_MS = 60_000
+
+/** Hard ceiling so a burst of unique addresses cannot grow the cache unbounded. */
+export const SUPPRESSION_CACHE_MAX_ENTRIES = 5_000
+
+type CacheEntry = { reasons: SuppressionReason[]; expiresAt: number }
+
+export type SuppressionLookup = (email: string) => Promise<SuppressionReason[]>
+
+export const normalizeSuppressionEmail = (raw: unknown): string => {
+  const s = String(raw ?? "").trim().toLowerCase()
+  const angled = s.match(/<([^>]+)>\s*$/)
+  return (angled ? angled[1] : s).trim()
+}
+
+/**
+ * Build a cached lookup bound to one provider.
+ *
+ * `pg` is whatever `cradle.__pg_connection__` holds (a knex instance). It is
+ * typed loosely on purpose: the provider must keep working if the key is
+ * missing, which is exactly the case this guards.
+ */
+export function createSuppressionLookup(opts: {
+  pg: any
+  logger: Logger
+  provider: string
+  now?: () => number
+}): SuppressionLookup {
+  const { pg, logger, provider } = opts
+  const now = opts.now ?? (() => Date.now())
+  const cache = new Map<string, CacheEntry>()
+  let warnedMissingConnection = false
+
+  return async (rawEmail: string): Promise<SuppressionReason[]> => {
+    const email = normalizeSuppressionEmail(rawEmail)
+    if (!email) {
+      return []
+    }
+
+    const hit = cache.get(email)
+    if (hit && hit.expiresAt > now()) {
+      return hit.reasons
+    }
+
+    if (!pg || typeof pg.raw !== "function") {
+      // Loud, but only once per provider instance — a per-send error line here
+      // would bury the log without telling anyone anything new.
+      if (!warnedMissingConnection) {
+        warnedMissingConnection = true
+        logger.error(
+          `[email-suppression-unavailable] provider=${provider} ` +
+            `reason="no __pg_connection__ in provider container" ` +
+            `impact="suppression ledger is NOT being enforced on this channel"`
+        )
+      }
+      return []
+    }
+
+    try {
+      const result = await pg.raw(
+        `select distinct reason
+           from email_suppression
+          where lower(email) = ?
+            and deleted_at is null`,
+        [email]
+      )
+      const reasons = (result?.rows ?? [])
+        .map((r: any) => r?.reason)
+        .filter(Boolean) as SuppressionReason[]
+
+      if (cache.size >= SUPPRESSION_CACHE_MAX_ENTRIES) {
+        cache.clear()
+      }
+      cache.set(email, { reasons, expiresAt: now() + SUPPRESSION_CACHE_TTL_MS })
+      return reasons
+    } catch (e: any) {
+      // Fail OPEN — see the header. Never let a ledger outage stop real mail.
+      logger.error(
+        `[email-suppression-lookup-failed] provider=${provider} ` +
+          `to=${email} error="${String(e?.message ?? e).slice(0, 200)}" ` +
+          `impact="sent without consulting the ledger"`
+      )
+      return []
+    }
+  }
+}
+
+/**
+ * The whole guard, ready to drop into a provider's `send()`.
+ *
+ * ⚠️ `ProviderSendNotificationDTO` does NOT carry the channel — it has `to`,
+ * `from`, `template`, `data`, `content` and nothing else. So each provider must
+ * declare the channel it serves. That is safe here because prod maps channel to
+ * provider one to one (`email`→Resend, `email_bulk`→Mailjet,
+ * `email_partner`→Maileroo); the value is taken from the provider's own
+ * `options.channels[0]` when present so config stays the single source of truth,
+ * with the prod mapping as the fallback.
+ */
+export function createSuppressionGuard(opts: {
+  pg: any
+  logger: Logger
+  provider: string
+  channel: string
+}): (to: string, template?: string) => Promise<{ suppress: boolean; id: string }> {
+  const { logger, provider, channel } = opts
+  const lookup = createSuppressionLookup(opts)
+
+  return async (to: string, template?: string) => {
+    const reasons = await lookup(to)
+    if (!reasons.length) {
+      return { suppress: false, id: "" }
+    }
+
+    // Raised even when the mail is delivered: under the carve-out a partner's
+    // spam complaint does NOT suppress, and that only makes sense if a human
+    // finds out. Logged before the verdict so it survives either policy.
+    if (shouldAlertOnSuppression(reasons, channel)) {
+      logger.warn(partnerComplaintAlertLog(provider, to, template))
+    }
+
+    const verdict = classifySuppression(reasons, channel)
+    if (!verdict.suppress) {
+      return { suppress: false, id: "" }
+    }
+
+    logger.warn(suppressionLog(provider, to, template, channel, verdict))
+    return { suppress: true, id: EMAIL_SUPPRESSED_SEND_ID }
+  }
+}
+
+/**
+ * Bulk counterpart. A suppressed address inside a 50-address batch is the same
+ * damage as a single send, so the bulk paths get the same policy — this is the
+ * mistake `partitionBotRecipients` exists to avoid repeating.
+ *
+ * Returns the entries to send plus the dropped ones with their verdicts, so the
+ * caller can log each drop individually rather than a single opaque count.
+ */
+export async function partitionSuppressedRecipients<T>(
+  entries: readonly T[],
+  getEmail: (entry: T) => string,
+  guard: (to: string, template?: string) => Promise<{ suppress: boolean; id: string }>
+): Promise<{ send: T[]; suppressed: T[] }> {
+  const send: T[] = []
+  const suppressed: T[] = []
+  for (const entry of entries) {
+    const verdict = await guard(getEmail(entry))
+    if (verdict.suppress) suppressed.push(entry)
+    else send.push(entry)
+  }
+  return { send, suppressed }
+}

--- a/apps/backend/src/lib/email-suppression-policy.ts
+++ b/apps/backend/src/lib/email-suppression-policy.ts
@@ -1,0 +1,221 @@
+/**
+ * Email suppression policy — the ONE place we decide whether a suppressed
+ * address may still be mailed on a given channel (#1339).
+ *
+ * ── Why this exists ───────────────────────────────────────────────────────────
+ *
+ * `email_suppression` is a real ledger. Hard bounces, spam complaints and
+ * unsubscribes are written to it by the Mailjet/Resend/Kit webhooks and by the
+ * manual CSV job. But before this module it was consulted in exactly ONE place —
+ * the Kit newsletter sync — so an address that hard-bounced was removed from the
+ * *marketing* audience and kept receiving transactional and lifecycle mail
+ * forever.
+ *
+ * A ledger that is written and never read is worse than no ledger: it creates
+ * the impression the problem is handled while every send to a dead mailbox goes
+ * on damaging sender reputation, which degrades delivery for addresses that are
+ * perfectly valid.
+ *
+ * ── The channel IS the classification ─────────────────────────────────────────
+ *
+ * We do not have to classify templates. Prod maps channel to provider one to
+ * one, and the channel already says what kind of mail it is:
+ *
+ *   email          → Resend   → transactional / lifecycle
+ *   email_bulk     → Mailjet  → marketing / bulk
+ *   email_partner  → Maileroo → partner operational
+ *
+ * So the whole policy is a `(reason, channel)` table. No heuristics, nothing to
+ * drift.
+ *
+ * ── Why the guard lives at the provider ───────────────────────────────────────
+ *
+ * Same reason as the bot-recipient guard next to it (#1333): lifecycle mail
+ * reaches the wire through the visual-flow `send_email` op, the
+ * `send-notification-email` workflows, and direct `createNotifications` calls
+ * scattered across workflows. A guard on any one of those is not a guard — it
+ * just moves the leak. See `src/lib/bot-recipients.ts`.
+ *
+ * This module is PURE and has no Medusa imports, so the policy is testable
+ * without a container and cannot drift between the three providers.
+ */
+
+/** Reasons as stored on `email_suppression.reason`. */
+export type SuppressionReason =
+  | "hard_bounce"
+  | "soft_bounce"
+  | "spam_complaint"
+  | "unsubscribe"
+  | "manual"
+
+/** The three email channels; anything else is not email and is never suppressed here. */
+export type MailChannel = "email" | "email_bulk" | "email_partner"
+
+export const MAIL_CHANNELS: readonly MailChannel[] = [
+  "email",
+  "email_bulk",
+  "email_partner",
+]
+
+/**
+ * Two policies, both real, selectable at boot.
+ *
+ * `partner-carve-out` (DEFAULT) — a spam complaint blocks marketing and
+ *   lifecycle mail but NOT `email_partner`. Rationale: about a fifth of prod's
+ *   recent email volume is partner operational mail to 36 named partner admins.
+ *   Under `strict`, one partner hitting "spam" on a quote silently stops their
+ *   production-run and quote mail, and they would never know why. That is an
+ *   operational failure dressed up as a deliverability win. A partner marking us
+ *   as spam is a relationship problem a human should see — see
+ *   `shouldAlertOnSuppression` below, which is why the carve-out is not just
+ *   "ignore it".
+ *
+ * `strict` — a spam complaint blocks every channel including partner mail.
+ *   Maximum protection for sender reputation, at the cost above. Correct if
+ *   partner mail ever starts flowing through a shared reputation pool with
+ *   customer mail.
+ *
+ * ⚠️ A hard bounce blocks EVERY channel under BOTH policies. A mailbox that does
+ * not exist cannot receive partner mail either, and sending to it is pure waste.
+ */
+export type SuppressionMode = "partner-carve-out" | "strict"
+
+export const DEFAULT_SUPPRESSION_MODE: SuppressionMode = "partner-carve-out"
+
+/**
+ * Resolve the active policy. `EMAIL_SUPPRESSION_MODE=strict` switches it; any
+ * other value (including unset) uses the default. Deliberately fail-safe toward
+ * the default rather than throwing — a typo in an env var must not take email
+ * down.
+ */
+export function resolveSuppressionMode(
+  raw: unknown = process.env.EMAIL_SUPPRESSION_MODE
+): SuppressionMode {
+  return String(raw ?? "").trim().toLowerCase() === "strict"
+    ? "strict"
+    : DEFAULT_SUPPRESSION_MODE
+}
+
+/**
+ * The policy table. Each entry lists the channels the reason BLOCKS.
+ *
+ * `soft_bounce` blocks nothing — a soft bounce is a full mailbox or a temporary
+ * server fault, and suppressing on it would drop mail to live humans. It stays
+ * log-only, which is what the code already did; recorded here as a DECISION
+ * rather than left as an accident of the implementation.
+ *
+ * `manual` blocks everything: someone put the address in by hand, on purpose.
+ */
+const BLOCKED_CHANNELS: Record<
+  SuppressionMode,
+  Record<SuppressionReason, readonly MailChannel[]>
+> = {
+  "partner-carve-out": {
+    hard_bounce: ["email", "email_bulk", "email_partner"],
+    spam_complaint: ["email", "email_bulk"],
+    unsubscribe: ["email_bulk"],
+    soft_bounce: [],
+    manual: ["email", "email_bulk", "email_partner"],
+  },
+  strict: {
+    hard_bounce: ["email", "email_bulk", "email_partner"],
+    spam_complaint: ["email", "email_bulk", "email_partner"],
+    unsubscribe: ["email_bulk"],
+    soft_bounce: [],
+    manual: ["email", "email_bulk", "email_partner"],
+  },
+}
+
+export type SuppressionVerdict = {
+  /** true when this send must not go out. */
+  suppress: boolean
+  /** The reason that blocked it, for the log line. Empty when not suppressed. */
+  reason: SuppressionReason | ""
+  /** The policy that produced the verdict, for the log line. */
+  mode: SuppressionMode
+}
+
+const NOT_SUPPRESSED = (mode: SuppressionMode): SuppressionVerdict => ({
+  suppress: false,
+  reason: "",
+  mode,
+})
+
+/**
+ * PURE: given the reasons on file for an address and the channel being sent on,
+ * should this send be suppressed?
+ *
+ * Takes the full reason list rather than one reason because an address can
+ * accumulate several rows — an unsubscribe last month and a hard bounce today.
+ * The strictest applicable rule wins, so a later `unsubscribe` can never
+ * "downgrade" an earlier `hard_bounce`.
+ */
+export function classifySuppression(
+  reasons: readonly SuppressionReason[],
+  channel: string,
+  mode: SuppressionMode = resolveSuppressionMode()
+): SuppressionVerdict {
+  if (!MAIL_CHANNELS.includes(channel as MailChannel)) {
+    return NOT_SUPPRESSED(mode)
+  }
+  const table = BLOCKED_CHANNELS[mode]
+  for (const reason of reasons) {
+    const blocked = table[reason]
+    if (blocked && blocked.includes(channel as MailChannel)) {
+      return { suppress: true, reason, mode }
+    }
+  }
+  return NOT_SUPPRESSED(mode)
+}
+
+/**
+ * Should a human be told about this? A spam complaint from a partner is the
+ * case the carve-out deliberately does NOT suppress — which only makes sense if
+ * somebody sees it. Returns true exactly when a complaint lands on partner mail.
+ */
+export function shouldAlertOnSuppression(
+  reasons: readonly SuppressionReason[],
+  channel: string
+): boolean {
+  return channel === "email_partner" && reasons.includes("spam_complaint")
+}
+
+/**
+ * The log line every suppression emits. Suppression MUST be visible: a silent
+ * drop of a real customer's order mail would be far worse than the bug this
+ * fixes. One shared formatter so every provider is greppable by one prefix —
+ * the same contract as `[bot-recipient-suppressed]`.
+ */
+export function suppressionLog(
+  provider: string,
+  email: string,
+  template: string | undefined,
+  channel: string,
+  verdict: SuppressionVerdict
+): string {
+  return (
+    `[email-suppressed] provider=${provider} ` +
+    `to=${String(email ?? "").trim().toLowerCase()} template=${template || "-"} ` +
+    `channel=${channel} reason=${verdict.reason} policy=${verdict.mode}`
+  )
+}
+
+/** Emitted when a partner marks us as spam and the carve-out let the mail through. */
+export function partnerComplaintAlertLog(
+  provider: string,
+  email: string,
+  template: string | undefined
+): string {
+  return (
+    `[partner-spam-complaint] provider=${provider} ` +
+    `to=${String(email ?? "").trim().toLowerCase()} template=${template || "-"} ` +
+    `note="partner marked our mail as spam; delivered anyway under partner-carve-out policy"`
+  )
+}
+
+/**
+ * The synthetic provider id returned in place of a real message id, mirroring
+ * `BOT_SUPPRESSED_SEND_ID`. Prefixed so a suppressed notification row is
+ * distinguishable from a delivered one — "suppressed" must never read as "sent".
+ */
+export const EMAIL_SUPPRESSED_SEND_ID = "email-suppressed-no-send"

--- a/apps/backend/src/modules/__tests__/email-suppression-guard.unit.spec.ts
+++ b/apps/backend/src/modules/__tests__/email-suppression-guard.unit.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * #1339 — the suppression ledger must be consulted at EVERY provider, and the
+ * upstream API must genuinely not be called.
+ *
+ * Sibling of `bot-recipient-guard.unit.spec.ts`, and the same lesson behind it:
+ * a guard on one path is not a guard. Asserting the return value alone would be
+ * worthless here — a send that was suppressed and a send that succeeded look
+ * identical from the outside, so every case asserts the upstream mock.
+ */
+import { EMAIL_SUPPRESSED_SEND_ID } from "../../lib/email-suppression-policy"
+
+const SUPPRESSED = "dead.mailbox@example.com"
+const CLEAN = "real.customer@example.com"
+
+const makeLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  log: jest.fn(),
+})
+
+/** A pg double that returns rows only for the suppressed address. */
+const makePg = (reason: string) => ({
+  raw: jest.fn(async (_sql: string, bindings?: unknown[]) => {
+    const email = String((bindings ?? [])[0] ?? "")
+    return { rows: email === SUPPRESSED ? [{ reason }] : [] }
+  }),
+})
+
+const resendSend = jest.fn().mockResolvedValue({ data: { id: "re_real" }, error: null })
+jest.mock("resend", () => ({
+  Resend: jest.fn().mockImplementation(() => ({ emails: { send: resendSend } })),
+}))
+
+const mailjetRequest = jest.fn().mockResolvedValue({ body: { Messages: [] } })
+jest.mock("node-mailjet", () => ({
+  __esModule: true,
+  default: {
+    apiConnect: jest.fn().mockImplementation(() => ({
+      post: jest.fn().mockReturnValue({ request: mailjetRequest }),
+    })),
+  },
+}))
+
+describe("suppression ledger is enforced at every provider (#1339)", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe("resend — channel email (transactional/lifecycle)", () => {
+    const load = () => require("../resend/service").default
+
+    it("does not call Resend for a hard-bounced address", async () => {
+      const svc = new (load())(
+        { logger: makeLogger(), __pg_connection__: makePg("hard_bounce") },
+        { api_key: "re_test", from: "a@b.com", channels: ["email"] }
+      )
+
+      const res = await svc.send({ to: SUPPRESSED, template: "order-shipment-delivered", data: {} })
+
+      expect(resendSend).not.toHaveBeenCalled()
+      expect(res.id).toBe(EMAIL_SUPPRESSED_SEND_ID)
+    })
+
+    it("still sends to an address with nothing on file", async () => {
+      const svc = new (load())(
+        { logger: makeLogger(), __pg_connection__: makePg("hard_bounce") },
+        { api_key: "re_test", from: "a@b.com", channels: ["email"] }
+      )
+
+      await svc.send({ to: CLEAN, template: "order-shipment-delivered", data: {} })
+
+      expect(resendSend).toHaveBeenCalledTimes(1)
+    })
+
+    it("still sends to someone who only unsubscribed — they paid for the order", async () => {
+      const svc = new (load())(
+        { logger: makeLogger(), __pg_connection__: makePg("unsubscribe") },
+        { api_key: "re_test", from: "a@b.com", channels: ["email"] }
+      )
+
+      await svc.send({ to: SUPPRESSED, template: "order-shipment-delivered", data: {} })
+
+      expect(resendSend).toHaveBeenCalledTimes(1)
+    })
+
+    it("sends when the ledger is unreachable, rather than dropping real mail", async () => {
+      const logger = makeLogger()
+      const svc = new (load())(
+        { logger, __pg_connection__: undefined },
+        { api_key: "re_test", from: "a@b.com", channels: ["email"] }
+      )
+
+      await svc.send({ to: SUPPRESSED, template: "order-shipment-delivered", data: {} })
+
+      expect(resendSend).toHaveBeenCalledTimes(1)
+      const errors = logger.error.mock.calls.map((c: any[]) => String(c[0]))
+      expect(errors.some((l) => l.includes("[email-suppression-unavailable]"))).toBe(true)
+    })
+  })
+
+  describe("mailjet — channel email_bulk (marketing)", () => {
+    const load = () => require("../mailjet/service").default
+
+    it("does not call Mailjet for an unsubscribed address", async () => {
+      const svc = new (load())(
+        { logger: makeLogger(), __pg_connection__: makePg("unsubscribe") },
+        {
+          api_key: "k",
+          secret_key: "s",
+          from_email: "a@b.com",
+          channels: ["email_bulk"],
+        }
+      )
+
+      const res = await svc.send({ to: SUPPRESSED, template: "newsletter", data: {} })
+
+      expect(mailjetRequest).not.toHaveBeenCalled()
+      expect(res.id).toBe(EMAIL_SUPPRESSED_SEND_ID)
+    })
+
+    it("drops the suppressed address out of a bulk batch", async () => {
+      const svc = new (load())(
+        { logger: makeLogger(), __pg_connection__: makePg("hard_bounce") },
+        {
+          api_key: "k",
+          secret_key: "s",
+          from_email: "a@b.com",
+          channels: ["email_bulk"],
+        }
+      )
+
+      await svc.sendBulk([
+        { to: CLEAN, subject: "hi", html: "<p>hi</p>" },
+        { to: SUPPRESSED, subject: "hi", html: "<p>hi</p>" },
+      ])
+
+      // Mailjet batches into ONE request; the payload must carry only the
+      // survivor. Asserting the call count alone would pass with both in it.
+      const payloads = mailjetRequest.mock.calls.map((c: any[]) => JSON.stringify(c[0]))
+      const joined = payloads.join(" ")
+      expect(joined).toContain(CLEAN)
+      expect(joined).not.toContain(SUPPRESSED)
+    })
+  })
+})

--- a/apps/backend/src/modules/__tests__/email-suppression-guard.unit.spec.ts
+++ b/apps/backend/src/modules/__tests__/email-suppression-guard.unit.spec.ts
@@ -20,11 +20,11 @@ const makeLogger = () => ({
   log: jest.fn(),
 })
 
-/** A pg double that returns rows only for the suppressed address. */
-const makePg = (reason: string) => ({
-  raw: jest.fn(async (_sql: string, bindings?: unknown[]) => {
-    const email = String((bindings ?? [])[0] ?? "")
-    return { rows: email === SUPPRESSED ? [{ reason }] : [] }
+/** A suppression-service double that returns rows only for the suppressed address. */
+const makeSuppressionService = (reason: string) => ({
+  listEmailSuppressions: jest.fn(async (filters: Record<string, unknown>) => {
+    const email = String((filters ?? {}).email ?? "")
+    return email === SUPPRESSED ? [{ reason }] : []
   }),
 })
 
@@ -51,7 +51,7 @@ describe("suppression ledger is enforced at every provider (#1339)", () => {
 
     it("does not call Resend for a hard-bounced address", async () => {
       const svc = new (load())(
-        { logger: makeLogger(), __pg_connection__: makePg("hard_bounce") },
+        { logger: makeLogger(), email_suppression: makeSuppressionService("hard_bounce") },
         { api_key: "re_test", from: "a@b.com", channels: ["email"] }
       )
 
@@ -63,7 +63,7 @@ describe("suppression ledger is enforced at every provider (#1339)", () => {
 
     it("still sends to an address with nothing on file", async () => {
       const svc = new (load())(
-        { logger: makeLogger(), __pg_connection__: makePg("hard_bounce") },
+        { logger: makeLogger(), email_suppression: makeSuppressionService("hard_bounce") },
         { api_key: "re_test", from: "a@b.com", channels: ["email"] }
       )
 
@@ -74,7 +74,7 @@ describe("suppression ledger is enforced at every provider (#1339)", () => {
 
     it("still sends to someone who only unsubscribed — they paid for the order", async () => {
       const svc = new (load())(
-        { logger: makeLogger(), __pg_connection__: makePg("unsubscribe") },
+        { logger: makeLogger(), email_suppression: makeSuppressionService("unsubscribe") },
         { api_key: "re_test", from: "a@b.com", channels: ["email"] }
       )
 
@@ -86,7 +86,7 @@ describe("suppression ledger is enforced at every provider (#1339)", () => {
     it("sends when the ledger is unreachable, rather than dropping real mail", async () => {
       const logger = makeLogger()
       const svc = new (load())(
-        { logger, __pg_connection__: undefined },
+        { logger, email_suppression: undefined },
         { api_key: "re_test", from: "a@b.com", channels: ["email"] }
       )
 
@@ -103,7 +103,7 @@ describe("suppression ledger is enforced at every provider (#1339)", () => {
 
     it("does not call Mailjet for an unsubscribed address", async () => {
       const svc = new (load())(
-        { logger: makeLogger(), __pg_connection__: makePg("unsubscribe") },
+        { logger: makeLogger(), email_suppression: makeSuppressionService("unsubscribe") },
         {
           api_key: "k",
           secret_key: "s",
@@ -120,7 +120,7 @@ describe("suppression ledger is enforced at every provider (#1339)", () => {
 
     it("drops the suppressed address out of a bulk batch", async () => {
       const svc = new (load())(
-        { logger: makeLogger(), __pg_connection__: makePg("hard_bounce") },
+        { logger: makeLogger(), email_suppression: makeSuppressionService("hard_bounce") },
         {
           api_key: "k",
           secret_key: "s",

--- a/apps/backend/src/modules/maileroo/service.ts
+++ b/apps/backend/src/modules/maileroo/service.ts
@@ -18,6 +18,10 @@ import {
   botSuppressionLog,
   BOT_SUPPRESSED_SEND_ID,
 } from "../../lib/bot-recipients"
+import {
+  createSuppressionGuard,
+  partitionSuppressedRecipients,
+} from "../../lib/email-suppression-lookup"
 
 type InjectedDependencies = {
   logger: Logger
@@ -68,14 +72,22 @@ class MailerooNotificationProviderService extends AbstractNotificationProviderSe
   protected client_: MailerooClientType | null = null
   protected readonly options: MailerooOptions
   protected readonly logger: Logger
+  protected readonly suppressionGuard: ReturnType<typeof createSuppressionGuard>
 
   constructor(
-    { logger }: InjectedDependencies,
+    deps: InjectedDependencies,
     options: MailerooOptions
   ) {
     super()
+    const { logger } = deps
     this.options = options
     this.logger = logger
+    this.suppressionGuard = createSuppressionGuard({
+      pg: (deps as any).__pg_connection__,
+      logger,
+      provider: "maileroo",
+      channel: (options as any).channels?.[0] ?? "email_partner",
+    })
   }
 
   protected async getClient(): Promise<MailerooClientType> {
@@ -122,6 +134,17 @@ class MailerooNotificationProviderService extends AbstractNotificationProviderSe
         botSuppressionLog("maileroo", notification.to, notification.template, botVerdict)
       )
       return { id: BOT_SUPPRESSED_SEND_ID }
+    }
+
+    // Suppression ledger (#1339). Separate from the bot guard above: that one is
+    // a pure domain rule, this one asks what the ledger says about this address
+    // on THIS channel. Fails open and logs loudly — see the lookup module.
+    const suppression = await this.suppressionGuard(
+      notification.to,
+      notification.template
+    )
+    if (suppression.suppress) {
+      return { id: suppression.id }
     }
 
     const templateData = notification.data as any
@@ -204,6 +227,17 @@ class MailerooNotificationProviderService extends AbstractNotificationProviderSe
       return { email: entry.to, rule: verdict.rule, note: verdict.note }
     })
     entries = partitioned.send
+
+    // Suppression ledger (#1339). Same reasoning as the bot guard directly
+    // above: a hard-bounced address inside a 50-address batch damages sender
+    // reputation exactly as much as a single send, and bulk does not go through
+    // send(). Each drop is logged individually by the guard.
+    const ledgerPartitioned = await partitionSuppressedRecipients(
+      entries,
+      (e) => e.to,
+      this.suppressionGuard
+    )
+    entries = ledgerPartitioned.send
 
     const defaultFrom = this.options.from_email
     const defaultName = this.options.from_name || "Jaal Yantra Textiles"

--- a/apps/backend/src/modules/maileroo/service.ts
+++ b/apps/backend/src/modules/maileroo/service.ts
@@ -83,7 +83,7 @@ class MailerooNotificationProviderService extends AbstractNotificationProviderSe
     this.options = options
     this.logger = logger
     this.suppressionGuard = createSuppressionGuard({
-      pg: (deps as any).__pg_connection__,
+      suppressionService: (deps as any).email_suppression,
       logger,
       provider: "maileroo",
       channel: (options as any).channels?.[0] ?? "email_partner",

--- a/apps/backend/src/modules/mailjet/service.ts
+++ b/apps/backend/src/modules/mailjet/service.ts
@@ -80,7 +80,7 @@ class MailjetNotificationProviderService extends AbstractNotificationProviderSer
     this.options = options
     this.logger = logger
     this.suppressionGuard = createSuppressionGuard({
-      pg: (deps as any).__pg_connection__,
+      suppressionService: (deps as any).email_suppression,
       logger,
       provider: "mailjet",
       channel: (options as any).channels?.[0] ?? "email_bulk",

--- a/apps/backend/src/modules/mailjet/service.ts
+++ b/apps/backend/src/modules/mailjet/service.ts
@@ -11,6 +11,10 @@ import {
   botSuppressionLog,
   BOT_SUPPRESSED_SEND_ID,
 } from "../../lib/bot-recipients"
+import {
+  createSuppressionGuard,
+  partitionSuppressedRecipients,
+} from "../../lib/email-suppression-lookup"
 
 type InjectedDependencies = {
   logger: Logger
@@ -64,15 +68,23 @@ class MailjetNotificationProviderService extends AbstractNotificationProviderSer
   protected readonly mailjetClient: ReturnType<typeof Mailjet.apiConnect>
   protected readonly options: MailjetOptions
   protected readonly logger: Logger
+  protected readonly suppressionGuard: ReturnType<typeof createSuppressionGuard>
 
   constructor(
-    { logger }: InjectedDependencies,
+    deps: InjectedDependencies,
     options: MailjetOptions
   ) {
     super()
+    const { logger } = deps
     this.mailjetClient = Mailjet.apiConnect(options.api_key, options.secret_key)
     this.options = options
     this.logger = logger
+    this.suppressionGuard = createSuppressionGuard({
+      pg: (deps as any).__pg_connection__,
+      logger,
+      provider: "mailjet",
+      channel: (options as any).channels?.[0] ?? "email_bulk",
+    })
   }
 
   static validateOptions(options: Record<any, any>) {
@@ -112,6 +124,17 @@ class MailjetNotificationProviderService extends AbstractNotificationProviderSer
         botSuppressionLog("mailjet", notification.to, notification.template, botVerdict)
       )
       return { id: BOT_SUPPRESSED_SEND_ID }
+    }
+
+    // Suppression ledger (#1339). Separate from the bot guard above: that one is
+    // a pure domain rule, this one asks what the ledger says about this address
+    // on THIS channel. Fails open and logs loudly — see the lookup module.
+    const suppression = await this.suppressionGuard(
+      notification.to,
+      notification.template
+    )
+    if (suppression.suppress) {
+      return { id: suppression.id }
     }
 
     const templateData = notification.data as any
@@ -206,6 +229,17 @@ class MailjetNotificationProviderService extends AbstractNotificationProviderSer
       return { email: entry.to, rule: verdict.rule, note: verdict.note }
     })
     entries = partitioned.send
+
+    // Suppression ledger (#1339). Same reasoning as the bot guard directly
+    // above: a hard-bounced address inside a 50-address batch damages sender
+    // reputation exactly as much as a single send, and bulk does not go through
+    // send(). Each drop is logged individually by the guard.
+    const ledgerPartitioned = await partitionSuppressedRecipients(
+      entries,
+      (e) => e.to,
+      this.suppressionGuard
+    )
+    entries = ledgerPartitioned.send
 
     const fromEmail = this.options.from_email
     const fromName = this.options.from_name || "Jaal Yantra Textiles"

--- a/apps/backend/src/modules/resend/service.ts
+++ b/apps/backend/src/modules/resend/service.ts
@@ -42,9 +42,10 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
     this.options = options
     this.logger = logger
     this.suppressionGuard = createSuppressionGuard({
-      // `__pg_connection__` is in the provider container; the suppression MODULE
-      // is not (probed — see email-suppression-lookup.ts). #1339
-      pg: (deps as any).__pg_connection__,
+      // Arrives in the provider container because the notification module
+      // declares `dependencies: ["email_suppression"]` — see the lookup module
+      // and medusa-config.{dev,prod}.ts. #1339
+      suppressionService: (deps as any).email_suppression,
       logger,
       provider: "resend",
       channel: (options as any).channels?.[0] ?? "email",

--- a/apps/backend/src/modules/resend/service.ts
+++ b/apps/backend/src/modules/resend/service.ts
@@ -12,6 +12,9 @@ import {
   botSuppressionLog,
   BOT_SUPPRESSED_SEND_ID,
 } from "../../lib/bot-recipients"
+import {
+  createSuppressionGuard,
+} from "../../lib/email-suppression-lookup"
 
 type InjectedDependencies = {
   logger: Logger
@@ -27,15 +30,25 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
   protected readonly resendClient: Resend
   protected readonly options: ResendOptions
   protected readonly logger: Logger
+  protected readonly suppressionGuard: ReturnType<typeof createSuppressionGuard>
 
   constructor(
-    { logger }: InjectedDependencies,
+    deps: InjectedDependencies,
     options: ResendOptions
   ) {
     super()
+    const { logger } = deps
     this.resendClient = new Resend(options.api_key)
     this.options = options
     this.logger = logger
+    this.suppressionGuard = createSuppressionGuard({
+      // `__pg_connection__` is in the provider container; the suppression MODULE
+      // is not (probed — see email-suppression-lookup.ts). #1339
+      pg: (deps as any).__pg_connection__,
+      logger,
+      provider: "resend",
+      channel: (options as any).channels?.[0] ?? "email",
+    })
   }
 
   static validateOptions(options: Record<any, any>) {
@@ -65,6 +78,17 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
         botSuppressionLog("resend", notification.to, notification.template, botVerdict)
       )
       return { id: BOT_SUPPRESSED_SEND_ID }
+    }
+
+    // Suppression ledger (#1339). Separate from the bot guard above: that one is
+    // a pure domain rule, this one asks what the ledger says about this address
+    // on THIS channel. Fails open and logs loudly — see the lookup module.
+    const suppression = await this.suppressionGuard(
+      notification.to,
+      notification.template
+    )
+    if (suppression.suppress) {
+      return { id: suppression.id }
     }
 
     let template: string | null = null


### PR DESCRIPTION
Closes #1339. **Both policies are built** — the partner carve-out is the default, `strict` is one env var away, and each is tested.

## The bug

`email_suppression` is a real ledger, correctly populated by the Mailjet/Resend/Kit webhooks and the manual CSV job. It was consulted in **exactly one place** — the Kit newsletter sync. So a hard-bounced address was dropped from the *marketing* audience and kept receiving transactional and lifecycle mail indefinitely.

A ledger that is written and never read is worse than no ledger: it creates the impression the problem is handled while every send to a dead mailbox goes on damaging sender reputation — which degrades delivery for addresses that are perfectly valid.

## The channel already encodes the policy

The part I expected to be fiddly turned out to be free. Prod maps channel to provider one to one:

| channel | provider | carries |
|---|---|---|
| `email` | Resend | transactional / lifecycle |
| `email_bulk` | Mailjet | marketing / bulk |
| `email_partner` | Maileroo | partner operational |

So this is a flat `(reason, channel)` table — no template classification, no heuristics, nothing to drift.

| reason | `email` | `email_bulk` | `email_partner` |
|---|---|---|---|
| `hard_bounce` | block | block | block |
| `spam_complaint` | block | block | **carve-out: send + alert** · strict: block |
| `unsubscribe` | send | block | send |
| `soft_bounce` | send | send | send |
| `manual` | block | block | block |

**Why the carve-out is the default.** About a fifth of prod's recent email volume is `partner-*` operational mail to **36 named partner admins**. Under `strict`, one partner hitting "spam" on a quote silently stops their production-run and quote mail and they would never learn why — an operational failure dressed up as a deliverability win. So it delivers and raises a `[partner-spam-complaint]` alert instead: a partner marking us as spam is a relationship problem a human should see, not an address to quietly mute. `EMAIL_SUPPRESSION_MODE=strict` flips it.

A hard bounce blocks **every** channel under both policies — a mailbox that does not exist cannot receive partner mail either.

`soft_bounce` blocks nothing. That was already the behaviour; it is now written down as a decision rather than left as an accident of the implementation.

## How the provider reaches the ledger

Providers are constructed as `new klass(cradle, options)` where `cradle` is the *notification module's own* container. By default it holds six injected keys — `MANAGER`, `CONFIG_MODULE`, `LOGGER`, `PG_CONNECTION`, `EVENT_BUS`, `CACHING` — so a naive resolve of `email_suppression` inside a provider fails.

The supported fix is `dependencies` on the module registration, which `loadInternalProvider` registers into the local container *before* the providers are built:

```ts
{ resolve: "@medusajs/medusa/notification",
  dependencies: ["email_suppression"],
  options: { providers: [...] } }
```

Verified by dumping the cradle keys with and without it. The guard then calls `listEmailSuppressions({ email }, { select: ["reason"] })`, so soft deletes, typing and future schema changes stay the module's problem.

⚠️ That declaration is load-bearing and lives in `medusa-config.dev.ts` and `medusa-config.prod.ts`. Remove it and the guard degrades to "not enforced" — loudly logged, but no longer blocking.

## It fails open, and says so

Mailing a dead address costs reputation slowly. Silently dropping a customer's order confirmation is invisible and unrecoverable. So every failure path **sends** and logs at error level with a stable prefix — `[email-suppression-unavailable]`, `[email-suppression-lookup-failed]` — because "the guard is not running" must never look like "nothing was suppressed". The missing-connection error is logged once per provider instance rather than per send.

Suppressions themselves return `EMAIL_SUPPRESSED_SEND_ID`, mirroring the bot guard, so a suppressed notification row never reads as delivered.

## Read route

Adds `GET /admin/email-suppressions` with filters, explicit pagination (`limit_max` echoed, no silent clamp — cf. #1552) and a `by_reason` roll-up over the whole ledger. The table previously had **no read surface at all**; the only admin route touching it was the write-only `suppress-bounced-subscribers` job, which is part of how it rotted into a write-only store.

## Verification

**Red run** — removing the resend guard fails exactly the cases that should fail:

```
● does not call Resend for a hard-bounced address
● sends when the ledger is unreachable, rather than dropping real mail
Tests: 2 failed, 4 passed
```

Green with it in place: **73 passed** across the new suites and the existing bot-recipient guard.

Provider tests assert the **upstream mock**, not the return value — a suppressed send and a successful send are indistinguishable from the outside. The bulk case asserts the Mailjet payload contains the survivor and *not* the suppressed address, since Mailjet batches into one request and a call-count assertion would pass with both in it.

**End to end against the local DB**, not only in unit tests. With a `hard_bounce` row on file, a real `createNotifications` logged

```
[email-suppressed] provider=resend to=… channel=email reason=hard_bounce policy=partner-carve-out
```

returned `external_id=email-suppressed-no-send` and never called Resend, while a clean address in the same run did reach Resend.

`check:prod-build` fails only on the pre-existing `@jest/core` error in `generate-integration-test.e2e.spec.ts`, reproduced on a clean tree by stashing.

## Not covered

A suppressed notification row still records `status: "success"` — the marker that distinguishes it is `external_id`. That is the same contract the bot-recipient guard already ships; changing it means changing core notification behaviour, which is out of scope here.

Maileroo's `send()` has no functional test — its client loads lazily and the existing bot-recipient spec doesn't mock it either. Its channel is covered by the policy unit tests and its wiring is identical to the other two.

I could not size the ledger in prod — there was no read route until this PR. Worth checking `by_reason` right after deploy to see what this actually starts suppressing.

Refs #1339, #1333, #1552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
