### PR TITLE
fix(inventory-orders): an admin status edit notified nobody (#771)

### DIFF
--- a/apps/backend/src/workflows/inventory_orders/__tests__/admin-status-change-emits.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/admin-status-change-emits.unit.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * #771 — the ADMIN edit path must emit the status-changed event.
+ *
+ * The sibling spec `status-changed-event.unit.spec.ts` tests
+ * `buildStatusChangedEvent` in isolation, and passed happily for months while
+ * this path never called it. A pure helper with tests and no caller is not a
+ * feature — so these assert the wiring, on the mock's recorded calls.
+ */
+import { applyInventoryOrderFieldUpdate } from "../update-inventory-orders"
+import { INVENTORY_ORDER_STATUS_CHANGED_EVENT } from "../update-inventory-order"
+import { Modules } from "@medusajs/framework/utils"
+
+const makeContainer = (opts: {
+  currentStatus?: string
+  updatedStatus?: string
+  emitThrows?: boolean
+}) => {
+  const emit = jest.fn(async (_event: unknown) => undefined)
+  const updateInventoryOrders = jest.fn(async (_args: unknown) => [
+    { id: "io_1", status: opts.updatedStatus },
+  ])
+  const retrieveInventoryOrder = jest.fn(async (_id: string, _config?: unknown) => ({
+    id: "io_1",
+    status: opts.currentStatus,
+  }))
+
+  const container = {
+    resolve: jest.fn((key: string) => {
+      if (key === Modules.EVENT_BUS) {
+        return { emit: opts.emitThrows ? jest.fn(async () => { throw new Error("bus down") }) : emit }
+      }
+      return { updateInventoryOrders, retrieveInventoryOrder }
+    }),
+  }
+  return { container, emit, updateInventoryOrders, retrieveInventoryOrder }
+}
+
+describe("admin inventory-order edit emits status-changed (#771)", () => {
+  it("emits when an admin moves the status", async () => {
+    const { container, emit } = makeContainer({
+      currentStatus: "Processing",
+      updatedStatus: "Shipped",
+    })
+
+    await applyInventoryOrderFieldUpdate({ id: "io_1", data: { status: "Shipped" } }, container)
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    const event = emit.mock.calls[0][0] as any
+    expect(event.name).toBe(INVENTORY_ORDER_STATUS_CHANGED_EVENT)
+    expect(event.data).toEqual({
+      id: "io_1",
+      previous_status: "Processing",
+      status: "Shipped",
+    })
+  })
+
+  it("stays silent on a metadata-only edit, and does not pay for the extra read", async () => {
+    const { container, emit, retrieveInventoryOrder } = makeContainer({
+      currentStatus: "Processing",
+      updatedStatus: "Processing",
+    })
+
+    await applyInventoryOrderFieldUpdate(
+      { id: "io_1", data: { metadata: { note: "hello" } } },
+      container
+    )
+
+    expect(emit).not.toHaveBeenCalled()
+    expect(retrieveInventoryOrder).not.toHaveBeenCalled()
+  })
+
+  it("stays silent when the status is written but did not actually move", async () => {
+    const { container, emit } = makeContainer({
+      currentStatus: "Shipped",
+      updatedStatus: "Shipped",
+    })
+
+    await applyInventoryOrderFieldUpdate({ id: "io_1", data: { status: "Shipped" } }, container)
+
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it("still applies the update when the event bus is down", async () => {
+    const { container, updateInventoryOrders } = makeContainer({
+      currentStatus: "Pending",
+      updatedStatus: "Processing",
+      emitThrows: true,
+    })
+
+    await expect(
+      applyInventoryOrderFieldUpdate({ id: "io_1", data: { status: "Processing" } }, container)
+    ).resolves.toBeDefined()
+
+    expect(updateInventoryOrders).toHaveBeenCalledTimes(1)
+  })
+
+  it("emits with a null previous status when the prior read fails", async () => {
+    const { container, emit } = makeContainer({ updatedStatus: "Delivered" })
+    const svc = { 
+      updateInventoryOrders: jest.fn(async () => [{ id: "io_1", status: "Delivered" }]),
+      retrieveInventoryOrder: jest.fn(async () => { throw new Error("gone") }),
+    }
+    container.resolve = jest.fn((key: string) =>
+      key === Modules.EVENT_BUS ? { emit } : svc
+    ) as any
+
+    await applyInventoryOrderFieldUpdate({ id: "io_1", data: { status: "Delivered" } }, container)
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect((emit.mock.calls[0][0] as any).data.previous_status).toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
@@ -15,9 +15,21 @@ import { mirrorUnifiedOrderStatusStep } from "./dual-write-unified-order";
  * generic `inventory_orders.inventory-orders.updated` on every write —
  * including metadata-only ones — which is too noisy to trigger partner
  * notification visual flows on. This fires only when the status actually
- * changes, carrying previous → new so a flow can branch/guard cleanly. Every
- * status transition (admin edit, partner start, partner complete) routes
- * through `updateInventoryOrderStep`, so this is the single choke point.
+ * changes, carrying previous → new so a flow can branch/guard cleanly.
+ *
+ * ⚠️ There is NO single choke point, and this comment used to claim there was.
+ * Two sibling files export a step AND a workflow under the SAME names:
+ *
+ *   update-inventory-order.ts  (this file) → partner start, ready-for-delivery,
+ *                                            cancel, tracking sync
+ *   update-inventory-orders.ts (plural)    → the generic admin PUT
+ *                                            /admin/inventory-orders/:id
+ *
+ * The plural one emitted nothing, so an admin status edit silently skipped the
+ * partner notification flow — no event, no error, nothing to notice. It now
+ * emits this same event via `buildStatusChangedEvent`. A third writer must emit
+ * too: importing "the" update workflow tells you nothing about which one you
+ * got. (#771)
  */
 export const INVENTORY_ORDER_STATUS_CHANGED_EVENT =
   "inventory_orders.inventory-order.status-changed";

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -8,13 +8,16 @@ import {
 } from "@medusajs/framework/workflows-sdk";
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils";
 import type { Link } from "@medusajs/modules-sdk";
-import type { RemoteQueryFunction, UpdateInventoryLevelInput } from "@medusajs/types";
+import type { IEventBusModuleService, RemoteQueryFunction, UpdateInventoryLevelInput } from "@medusajs/types";
 import { createInventoryLevelsWorkflow, updateInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows";
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import { FULLFILLED_ORDERS_MODULE } from "../../modules/fullfilled_orders";
 import type Fullfilled_ordersService from "../../modules/fullfilled_orders/service";
 import { mirrorUnifiedOrderStatusStep } from "./dual-write-unified-order";
+// #771 — reuse the singular file's pure event builder rather than restating the
+// delta rule; two copies of "did the status change" is how they drift apart.
+import { buildStatusChangedEvent } from "./update-inventory-order";
 import { reprojectInventoryMirrorItemsStep } from "./reproject-inventory-mirror-items";
 import { resolveExistingLevelsStep } from "./partner-complete-inventory-order";
 import inventoryOrdersStockLocations from "../../links/inventory-orders-stock-locations";
@@ -111,18 +114,78 @@ export const fetchOriginalOrderStep = createStep(
 );
 
 // Step 2: Update inventory order fields
+/**
+ * ⚠️ This is NOT the same step as `updateInventoryOrderStep` in the sibling file
+ * `update-inventory-order.ts` (singular). Both files export a step AND a
+ * workflow under identical names — importing from the wrong one silently gets
+ * you different behaviour. The admin PUT `/admin/inventory-orders/:id` resolves
+ * to THIS file.
+ *
+ * #771 — that duplication is how the generic admin edit came to skip the partner
+ * notification flow entirely: the singular file carried a comment claiming
+ * "every status transition routes through updateInventoryOrderStep, so this is
+ * the single choke point", which was false for this path. This step emitted
+ * nothing at all, so an admin moving an order to Shipped or Delivered notified
+ * nobody, with no event and no error to notice.
+ */
+/**
+ * The step body, exported so the WIRING is testable and not just the pure event
+ * builder beside it. #771's gap survived precisely because
+ * `buildStatusChangedEvent` had unit tests while nothing asserted that this path
+ * ever called it.
+ */
+export const applyInventoryOrderFieldUpdate = async (
+  input: { id: string; data: any },
+  container: any
+) => {
+  const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
+
+  // Capture the prior status only when a status change is intended, so a
+  // metadata-only edit costs no extra read. Mirrors the singular step. #771
+  let previousStatus: string | undefined;
+  if (input.data?.status !== undefined) {
+    try {
+      const existing = await inventoryOrderService.retrieveInventoryOrder(input.id, {
+        select: ["id", "status"],
+      });
+      previousStatus = (existing as any)?.status;
+    } catch {
+      /* best-effort — fall back to emitting without a previous_status */
+    }
+  }
+
+  const updatedOrder = await inventoryOrderService.updateInventoryOrders({
+    selector: { id: input.id },
+    data: { ...input.data },
+  });
+
+  // #771 — the status-changed event the partner notification flow triggers on.
+  // Guarded on an actual delta by `buildStatusChangedEvent`, so a metadata-only
+  // write stays silent. Best-effort: an event-bus failure must never fail an
+  // admin edit.
+  const rows = Array.isArray(updatedOrder) ? updatedOrder : updatedOrder ? [updatedOrder] : [];
+  const event = buildStatusChangedEvent(
+    input.id,
+    previousStatus,
+    (rows[0] as any)?.status,
+    input.data?.status !== undefined
+  );
+  if (event) {
+    try {
+      const eventBus = container.resolve(Modules.EVENT_BUS) as IEventBusModuleService;
+      await eventBus.emit(event);
+    } catch {
+      /* best-effort — never block the update if event emit fails */
+    }
+  }
+
+  return updatedOrder;
+};
+
 export const updateInventoryOrderStep = createStep(
   "update-inventory-order-fields-step",
   async (input: { id: string; data: any }, { container }) => {
-    const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
-    const updatedOrder = await inventoryOrderService.updateInventoryOrders({
-      selector: {
-        id: input.id
-      },
-      data: {
-        ...input.data
-      }
-    });
+    const updatedOrder = await applyInventoryOrderFieldUpdate(input, container);
     return new StepResponse(updatedOrder, null);
   },
   // Compensation: restore original order fields


### PR DESCRIPTION
Closes the code half of #771. The notification flow itself was already built; what was missing is that **one writer never emitted**, and a comment said otherwise.

## The false choke point

`update-inventory-order.ts` claimed:

> Every status transition (admin edit, partner start, partner complete) routes through `updateInventoryOrderStep`, so this is the single choke point.

There is no single choke point. Two sibling files export a step **and** a workflow under identical names:

| file | used by |
|---|---|
| `update-inventory-order.ts` (singular) | partner start, ready-for-delivery, cancel, tracking sync |
| `update-inventory-orders.ts` (**plural**) | the generic admin `PUT /admin/inventory-orders/:id` |

The admin route imports the plural one. It emitted nothing — no `status-changed`, no error. **An admin moving an order to Shipped or Delivered notified nobody**, and the comment above the event definition would have stopped anyone from looking.

Severity, honestly: **latent, not active.** The shipped edit form doesn't send `status`, so no notification is being lost today. It is one form field away from being live, and the misleading comment is the part that would have made it expensive to find.

## The fix

The plural path now emits the same event via the shared `buildStatusChangedEvent` — reused, not restated, since two copies of "did the status change" is how they drift. Guarded on an actual delta, so a metadata-only edit stays silent and doesn't pay for the extra status read.

The comment is replaced with the real topology plus a warning that a third writer must emit too, because *importing "the" update workflow tells you nothing about which one you got*.

## Why the step body was extracted

`applyInventoryOrderFieldUpdate` is exported so the **wiring** is testable, not just the pure helper.

That distinction is the whole point of this issue: `status-changed-event.unit.spec.ts` has tested `buildStatusChangedEvent` in isolation since #771 shipped, and passed happily for months while this path never called it. A pure helper with tests and no caller is not a feature — and a green suite said nothing about it.

## Verification

Red run — removing the emit fails exactly the cases that should:

```
Tests: 2 failed, 3 passed   (without the emit)
Tests: 5 passed             (with it)
```

The new cases assert the event on `emit.mock.calls` after the call, and cover: an admin status move emits with the correct previous→new; a metadata-only edit stays silent *and* skips the extra read; a status write that doesn't move stays silent; a dead event bus still applies the update; and a failed prior read still emits with `previous_status: null`.

`164 passed` across the inventory-orders unit suite. `check:prod-build` fails only on the pre-existing `@jest/core` error, reproduced on a clean tree.

## Corrections to the issue body

Three claims in #771 don't hold, found while auditing and confirmed here:

1. **"complete — Processing→Shipped/Delivered"** — the complete workflow sets `fullyFulfilled ? "Shipped" : "Partial"` and **never** sets `Delivered`. That arrives via admin edits or the carrier tracking sync.
2. **`submit-payment` does not mutate the order** and emits no inventory-order event — it creates an internal payment plus a link. So scope 3's "confirm start/complete/submit-payment each mutate the order and emit `…updated`" was never possible as written, and its verification was never done. Re-scope to `start` and `complete`.
3. The status enum also contains **"Ready for Delivery"** (#790), which the flow notifies on.

Scope 2 was satisfied by a different and better mechanism than asked: rather than a status-delta guard on the noisy `…updated` event, a dedicated `status-changed` event was added. Same intent, cleaner.

## Still open on #771

The flow ships as a **DRAFT seed** — inert until Meta template approval and a draft→active flip, neither of which is verifiable from source. "Built" and "firing in prod" remain different questions, and only the first is settled here.

Refs #771, #776, #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
