### PR TITLE
fix(analytics): the weekly digest def followed Monday, prod has sent Friday since June (#1782)

### DIFF
--- a/apps/backend/src/scripts/__tests__/seed-partner-analytics-digest-flow.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/seed-partner-analytics-digest-flow.unit.spec.ts
@@ -11,8 +11,10 @@ describe("seed-partner-analytics-digest-flow FLOW_DEF", () => {
   it("is a weekly schedule-triggered draft flow", () => {
     expect(FLOW_DEF.status).toBe("draft")
     expect(FLOW_DEF.trigger_type).toBe("schedule")
-    // Weekly Monday cron (day-of-week field = 1, single value, not a range).
-    expect(FLOW_DEF.trigger_config.cron).toBe("30 3 * * 1")
+    // Weekly Friday cron (day-of-week field = 5, single value, not a range).
+    // Friday, not Monday: the live prod flow was moved to Friday on the canvas
+    // and the def now follows it (#1782).
+    expect(FLOW_DEF.trigger_config.cron).toBe("30 3 * * 5")
     expect(
       (FLOW_DEF.canvas_state.nodes[0].data as any).triggerConfig.cron
     ).toBe(FLOW_DEF.trigger_config.cron)

--- a/apps/backend/src/scripts/seed-partner-analytics-digest-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-analytics-digest-flow.ts
@@ -21,10 +21,10 @@
  * `active` once those are live.
  *
  * Cadence (locked decision):
- *   Cron `30 3 * * 1` = 09:00 IST Monday when the container runs UTC.
- *   If the container runs in IST, change to `0 9 * * 1`. Confirm via `date`
+ *   Cron `30 3 * * 5` = 09:00 IST Friday when the container runs UTC.
+ *   If the container runs in IST, change to `0 9 * * 5`. Confirm via `date`
  *   on the deployed host before activating. Period defaults to last_7_days,
- *   so a Monday run covers the previous calendar-ish week. The digest is
+ *   so a Friday run covers the previous calendar-ish week. The digest is
  *   compared against the equal-length window immediately before it (S1).
  *
  * Thresholds:
@@ -47,8 +47,11 @@ import VisualFlowService from "../modules/visual_flows/service"
 
 const FLOW_NAME = "Partner Storefront Analytics Digest — Weekly"
 
-// Cron: 09:00 IST Monday assuming a UTC container (03:30 UTC).
-const DIGEST_CRON = "30 3 * * 1"
+// Cron: 09:00 IST Friday assuming a UTC container (03:30 UTC). Friday, not
+// Monday: the installed prod flow was moved to Friday by hand on the canvas
+// (label and cron both), and that operator choice is the live cadence 28
+// partners already receive. The def follows prod here rather than the reverse.
+const DIGEST_CRON = "30 3 * * 5"
 
 // ─── Canvas positions ────────────────────────────────────────────────────────
 const X_CENTER = 500
@@ -68,13 +71,13 @@ export const FLOW_DEF = {
   status: "draft" as const,
   trigger_type: "schedule" as const,
   trigger_config: {
-    cron: DIGEST_CRON, // 09:00 IST Monday assuming UTC container
+    cron: DIGEST_CRON, // 09:00 IST Friday assuming UTC container
   },
 
   canvas_state: {
     viewport: { x: 0, y: 0, zoom: 0.85 },
     nodes: [
-      { id: "trigger",         type: "trigger",   position: { x: X_CENTER, y: -20 },        data: { label: "Schedule — 09:00 IST Monday", triggerType: "schedule", triggerConfig: { cron: DIGEST_CRON } } },
+      { id: "trigger",         type: "trigger",   position: { x: X_CENTER, y: -20 },        data: { label: "Schedule — 09:00 IST Friday", triggerType: "schedule", triggerConfig: { cron: DIGEST_CRON } } },
       { id: "compute_digests", type: "operation", position: { x: X_CENTER, y: Y_DIGEST },   data: { label: "Compute Partner Digests", operationKey: "compute_digests", operationType: "partner_analytics_digest", options: { period: "last_7_days", max_partners: 200, continue_on_error: true } } },
       { id: "send_digests",    type: "operation", position: { x: X_CENTER, y: Y_DISPATCH }, data: { label: "Send Digest Emails",      operationKey: "send_digests",    operationType: "bulk_trigger_workflow", options: { workflow_name: "send-partner-digest-email", items: "{{ compute_digests.digests }}", input_template: { digest: "{{ item }}" }, continue_on_error: true, max_items: 200 } } },
       { id: "log_summary",     type: "operation", position: { x: X_CENTER, y: Y_LOG },      data: { label: "Log Summary",            operationKey: "log_summary",     operationType: "log", options: { message: "Partner digest run — partners={{ compute_digests.count }} with_storefront={{ compute_digests.with_storefront }} with_suggestions={{ compute_digests.with_suggestions }} suggestions={{ compute_digests.suggestion_count }} failed_compute={{ compute_digests.failed }} emails_triggered={{ send_digests.triggered }} emails_failed={{ send_digests.failed }}", level: "info" } } },
@@ -202,7 +205,7 @@ export default async function seedPartnerAnalyticsDigestFlow({
   console.log(`     (active) and set MAILEROO_FROM_DOMAIN / PARTNER_DASHBOARD_URL`)
   console.log(`     / FRONTEND_URL (S2 ops tail).`)
   console.log(`  3. Confirm the deployed container's local time matches the cron`)
-  console.log(`     assumption. This seed uses "${DIGEST_CRON}" = 09:00 IST Monday`)
+  console.log(`     assumption. This seed uses "${DIGEST_CRON}" = 09:00 IST Friday`)
   console.log(`     assuming UTC. If the container is in IST, edit to "0 9 * * 1".`)
   console.log(`  4. Flip flow status: draft → active in the admin editor.`)
 }


### PR DESCRIPTION
Closes the last drift found by the #1782 sweep.

## What

The installed prod flow `vflow_01KVMY89Q8X87TMMY9C12K2QNP` runs on `30 3 * * 5` and its canvas trigger reads **"Schedule — 09:00 IST Friday"**. The definition on disk has said `30 3 * * 1` / Monday since #586, and `git log -p` shows the file **never** carried Friday — so the move was made by hand on the canvas, deliberately, with the cron and the label changed together.

## Why this direction

The def follows prod, not the reverse. Pushing Monday into the live flow would silently move a digest **28 partners already receive**, undoing a choice a human made on purpose. Nothing about Monday is load-bearing — the period is `last_7_days` either way, compared against the equal-length window immediately before it.

The two other flows in this sweep were fixed the other way (code → prod), because there the code was demonstrably newer and the prod copy was a stale snapshot. Here the prod copy is the newer, intentional one.

## Changes

- `DIGEST_CRON` → `30 3 * * 5`, with a comment recording why it is Friday
- Both "09:00 IST Monday" labels, the console hint, and the header cadence note
- The spec asserted the exact string `30 3 * * 1`; now asserts Friday

## Verify

```
cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern="seed-partner-analytics-digest-flow"
```
→ 7 passed. The def and the prod canvas now compare clean on trigger and on all three node option sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4