### PR TITLE
feat(engagement): backfill email_engagement from Kit subscriber stats, and recompute on a schedule (#1785)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-engagement-from-kit-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-engagement-from-kit-job.ts
@@ -1,0 +1,196 @@
+import { EMAIL_ENGAGEMENT_MODULE } from "../../../../modules/email_engagement"
+import { normalizeEmail } from "../../../../modules/email_suppression/suppress-core"
+import {
+  firstDeliveredAtFromSentCount,
+  mergeKitStats,
+} from "../../../../modules/email_engagement/kit-backfill-core"
+import { KIT_MODULE } from "../../../../modules/kit"
+import type KitService from "../../../../modules/kit/service"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Backfill `email_engagement` from Kit's per-subscriber stats (#1785).
+ *
+ * The engagement gate (#881) classifies almost nobody on the newsletter list —
+ * 211 rows against a 524-strong audience, 172 of them `unknown` — because
+ * nothing on the Kit path records a delivery or an open. Kit registers only
+ * bounce/complain/unsubscribe webhooks, `parseKitEngagement` can emit only
+ * `click`, and that rule is not auto-registered because Kit wants a URL per
+ * rule. Opens exist solely as broadcast AGGREGATES, which cannot be attributed
+ * to a person.
+ *
+ * `GET /v4/subscribers/{id}/stats` closes it as a pull. This job walks the
+ * broadcast tag — the true audience, including people carried over from earlier
+ * sends — pulls each subscriber's totals and folds them in as a DELTA against
+ * the stored `kit_*` snapshot, so a re-run is a no-op and the Mailjet/Resend
+ * history is never overwritten.
+ *
+ * It writes COUNTERS only. Classification is already free:
+ * `recompute-email-engagement-status` reads these counters and persists
+ * `engagement_status`, and the send-path gate classifies live regardless.
+ */
+
+const PER_PAGE = 100
+/** Kit allows 120 req / rolling 60s; each subscriber costs 1 stats call. */
+const PER_SUBSCRIBER_DELAY_MS = 550
+const WRITE_BATCH = 200
+/** Hard stop so a runaway tag can never spin forever against a rate limit. */
+const MAX_SUBSCRIBERS = 20_000
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+function numParam(raw: unknown, fallback: number): number {
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+export const backfillEngagementFromKitJob: MaintenanceJob = {
+  id: "backfill-engagement-from-kit",
+  label: "Backfill email engagement from Kit",
+  description:
+    "Walk the Kit broadcast tag, pull each subscriber's sent/opened/clicked totals, and fold them into the email_engagement ledger so newsletter contacts can be classified at all (#1785). Kit publishes no per-recipient delivery or open webhook, so this pull is the only route. Applies a DELTA against the last Kit snapshot, so re-running is a no-op and transactional history from the Mailjet/Resend webhooks is never overwritten; a lower total from Kit never claws counters back. Writes counters only — run recompute-email-engagement-status afterwards to persist the statuses. Dry-run reports what would change, including how many rows are new, and writes nothing.",
+  params: [
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Stop after this many subscribers (default: the whole tag).",
+    },
+    {
+      name: "delay_ms",
+      type: "number",
+      required: false,
+      description: "Pause between Kit stats calls. Default 550 (~2/s, under Kit's 120/60s).",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const kit = container.resolve(KIT_MODULE) as KitService
+    const service: any = container.resolve(EMAIL_ENGAGEMENT_MODULE)
+    const now = new Date()
+
+    const limit = numParam(params?.limit, MAX_SUBSCRIBERS)
+    const delayMs = numParam(params?.delay_ms, PER_SUBSCRIBER_DELAY_MS)
+
+    // Broadcast send times, newest first — `sent = N` means the last N of these,
+    // so the Nth from the end is the subscriber's first delivery. Exact, not a
+    // proxy: dating from the subscriber's `created_at` would predate their
+    // first send and overstate the dormancy span.
+    const broadcasts = await kit.listBroadcasts()
+    const broadcastSendsDesc: string[] = broadcasts
+      .map((b: any) => b?.send_at || b?.created_at)
+      .filter(Boolean)
+      .map((s: string) => new Date(s).toISOString())
+      .sort()
+      .reverse()
+
+    // 1. Walk the tag.
+    const subscribers: Array<{ id: string; email: string }> = []
+    let cursor: string | null = null
+    do {
+      const page = await kit.listTagSubscribers({
+        perPage: PER_PAGE,
+        after: cursor ?? undefined,
+      })
+      for (const s of page.subscribers) {
+        const email = normalizeEmail(s?.email_address ?? "")
+        if (email && s?.id) subscribers.push({ id: String(s.id), email })
+        if (subscribers.length >= limit) break
+      }
+      cursor = subscribers.length >= limit ? null : page.nextCursor
+    } while (cursor)
+
+    // 2. Existing rows, by email.
+    const emails = subscribers.map((s) => s.email)
+    const existingRows: any[] = emails.length
+      ? await service.listEmailEngagements({ email: emails }, { take: null })
+      : []
+    const byEmail = new Map<string, any>(
+      existingRows.map((r: any) => [normalizeEmail(r.email), r])
+    )
+
+    // 3. Pull stats and fold.
+    const toUpdate: any[] = []
+    const toCreate: any[] = []
+    let statsFailed = 0
+    let unchanged = 0
+    for (const sub of subscribers) {
+      let stats: any = null
+      try {
+        stats = await kit.getSubscriberStats(sub.id)
+      } catch {
+        statsFailed++
+        await sleep(delayMs)
+        continue
+      }
+      if (!stats) {
+        statsFailed++
+        await sleep(delayMs)
+        continue
+      }
+
+      const existing = byEmail.get(sub.email) ?? null
+      const merged = mergeKitStats(existing, stats, {
+        firstDeliveredAt: firstDeliveredAtFromSentCount(
+          Number(stats.sent ?? 0),
+          broadcastSendsDesc
+        ),
+        now,
+      })
+
+      if (existing) {
+        // `changed` covers the engagement counters; the snapshot moving on its
+        // own still has to be persisted or the next run recomputes the same
+        // delta forever.
+        const snapshotMoved =
+          merged.kit_sent !== Number(existing.kit_sent ?? 0) ||
+          merged.kit_opened !== Number(existing.kit_opened ?? 0) ||
+          merged.kit_clicked !== Number(existing.kit_clicked ?? 0)
+        if (!merged.changed && !snapshotMoved) {
+          unchanged++
+          await sleep(delayMs)
+          continue
+        }
+        const { changed, ...fields } = merged
+        toUpdate.push({ id: existing.id, ...fields })
+      } else {
+        const { changed, ...fields } = merged
+        toCreate.push({ email: sub.email, ...fields })
+      }
+      await sleep(delayMs)
+    }
+
+    if (!dry_run) {
+      for (let i = 0; i < toCreate.length; i += WRITE_BATCH) {
+        await service.createEmailEngagements(toCreate.slice(i, i + WRITE_BATCH))
+      }
+      for (let i = 0; i < toUpdate.length; i += WRITE_BATCH) {
+        await service.updateEmailEngagements(toUpdate.slice(i, i + WRITE_BATCH))
+      }
+    }
+
+    const changes: MaintenanceChange[] = [
+      { entity: "email_engagement", id: "created", field: "count", after: toCreate.length },
+      { entity: "email_engagement", id: "updated", field: "count", after: toUpdate.length },
+      { entity: "email_engagement", id: "unchanged", field: "count", after: unchanged },
+      { entity: "kit", id: "tag_subscribers", field: "count", after: subscribers.length },
+      { entity: "kit", id: "broadcasts", field: "count", after: broadcastSendsDesc.length },
+      { entity: "kit", id: "stats_failed", field: "count", after: statsFailed },
+    ]
+
+    const verb = dry_run ? "Would fold" : "Folded"
+    return {
+      job_id: backfillEngagementFromKitJob.id,
+      dry_run,
+      applied: !dry_run && (toCreate.length > 0 || toUpdate.length > 0),
+      summary:
+        `${verb} Kit stats for ${subscribers.length} tagged subscriber(s) across ` +
+        `${broadcastSendsDesc.length} broadcast(s): ${toCreate.length} new row(s), ` +
+        `${toUpdate.length} updated, ${unchanged} already current` +
+        (statsFailed ? `, ${statsFailed} stats call(s) failed` : "") +
+        `. Counters only — run recompute-email-engagement-status to persist statuses.`,
+      changes,
+    }
+  },
+}
+
+export default backfillEngagementFromKitJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -105,6 +105,7 @@ import { importLeadsToCrmJob } from "./import-leads-to-crm-job"
 import { crmEngagementSweepJob } from "./crm-engagement-sweep-job"
 import { backfillRetailPartnerFeesJob } from "./backfill-retail-partner-fees-job"
 import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-status-job"
+import { backfillEngagementFromKitJob } from "./backfill-engagement-from-kit-job"
 import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
 import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
@@ -5880,6 +5881,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   importLeadsToCrmJob,
   crmEngagementSweepJob,
   recomputeEmailEngagementStatusJob,
+  backfillEngagementFromKitJob,
   generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,
   repairInventoryOrderRouteJob,

--- a/apps/backend/src/jobs/recompute-email-engagement.ts
+++ b/apps/backend/src/jobs/recompute-email-engagement.ts
@@ -1,0 +1,99 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { EMAIL_ENGAGEMENT_MODULE } from "../modules/email_engagement"
+import {
+  classifyEngagement,
+  type EngagementStatus,
+} from "../modules/email_engagement/classifier"
+
+/**
+ * recompute-email-engagement — keep `engagement_status` current on its own.
+ *
+ * The classification existed only as a MANUAL maintenance job
+ * (`recompute-email-engagement-status`), so the persisted status was whatever
+ * the last human run left behind. Raw ingestion is automatic — the Mailjet and
+ * Resend webhooks fold every delivery/open/click as it arrives — but nothing
+ * ever re-derived the status from those counters.
+ *
+ * That is not a correctness bug: the send-path gate in `get-subscribers`
+ * classifies LIVE from the counters, so a stale status has never caused a wrong
+ * exclusion. What went stale is everything that READS the persisted value —
+ * the Marketing → Engagement view and win-back selection — which is exactly
+ * where an operator looks to decide whether the list is healthy.
+ *
+ * Deliberately thin: it reuses `classifyEngagement` with the default
+ * thresholds and writes only the rows whose status actually moved. The
+ * maintenance job stays the place to run an ad-hoc pass with tuned thresholds.
+ */
+const WRITE_BATCH = 500
+
+const ALL_STATUSES: EngagementStatus[] = [
+  "engaged",
+  "cooling",
+  "dormant",
+  "never_opened",
+  "unknown",
+]
+
+export default async function recomputeEmailEngagement(container: MedusaContainer) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const service: any = container.resolve(EMAIL_ENGAGEMENT_MODULE)
+
+  const rows: any[] = await service.listEmailEngagements(
+    {},
+    {
+      select: [
+        "id",
+        "email",
+        "delivered_count",
+        "opens_count",
+        "clicks_count",
+        "delivered_since_last_open",
+        "first_delivered_at",
+        "last_open_at",
+        "engagement_status",
+      ],
+      take: null,
+    }
+  )
+
+  const now = new Date()
+  const nowIso = now.toISOString()
+  const dist: Record<EngagementStatus, number> = {
+    engaged: 0,
+    cooling: 0,
+    dormant: 0,
+    never_opened: 0,
+    unknown: 0,
+  }
+  const toUpdate: Array<{
+    id: string
+    engagement_status: EngagementStatus
+    status_computed_at: string
+  }> = []
+
+  for (const r of rows) {
+    const { status } = classifyEngagement(r, { now })
+    dist[status]++
+    if (r.engagement_status !== status) {
+      toUpdate.push({ id: r.id, engagement_status: status, status_computed_at: nowIso })
+    }
+  }
+
+  for (let i = 0; i < toUpdate.length; i += WRITE_BATCH) {
+    await service.updateEmailEngagements(toUpdate.slice(i, i + WRITE_BATCH))
+  }
+
+  logger.info(
+    `[Engagement Recompute] ${rows.length} row(s), ${toUpdate.length} changed — ` +
+      ALL_STATUSES.map((s) => `${s}=${dist[s]}`).join(", ")
+  )
+}
+
+export const config = {
+  name: "recompute-email-engagement",
+  // 02:10 UTC daily — after the analytics rollups, before anyone reads the
+  // Marketing tab in IST business hours.
+  schedule: "10 2 * * *",
+}

--- a/apps/backend/src/modules/email_engagement/__tests__/kit-backfill-core.unit.spec.ts
+++ b/apps/backend/src/modules/email_engagement/__tests__/kit-backfill-core.unit.spec.ts
@@ -1,0 +1,156 @@
+import {
+  firstDeliveredAtFromSentCount,
+  mergeKitStats,
+} from "../kit-backfill-core"
+
+// Newest first, as the job passes them.
+const BROADCASTS = [
+  "2026-09-04T03:47:59Z",
+  "2026-08-10T10:37:37Z",
+  "2026-07-23T08:25:34Z",
+]
+
+describe("firstDeliveredAtFromSentCount", () => {
+  it("dates the first delivery as the Nth broadcast from the end", () => {
+    // Tagged before everything: three sends, first is the oldest broadcast.
+    expect(firstDeliveredAtFromSentCount(3, BROADCASTS)).toBe(
+      "2026-07-23T08:25:34.000Z"
+    )
+    // Tagged after the first: two sends.
+    expect(firstDeliveredAtFromSentCount(2, BROADCASTS)).toBe(
+      "2026-08-10T10:37:37.000Z"
+    )
+    // Tagged today: one send, the most recent broadcast.
+    expect(firstDeliveredAtFromSentCount(1, BROADCASTS)).toBe(
+      "2026-09-04T03:47:59.000Z"
+    )
+  })
+
+  it("returns null when nothing has been sent", () => {
+    expect(firstDeliveredAtFromSentCount(0, BROADCASTS)).toBeNull()
+  })
+
+  it("returns null rather than guessing when Kit claims more sends than we have broadcasts", () => {
+    // Better to leave the span unknown than to invent one — an invented early
+    // date is what makes someone wrongly `dormant`.
+    expect(firstDeliveredAtFromSentCount(5, BROADCASTS)).toBeNull()
+  })
+})
+
+describe("mergeKitStats", () => {
+  const now = new Date("2026-09-04T04:00:00.000Z")
+
+  it("adds Kit's totals to a row that has never been synced", () => {
+    const out = mergeKitStats(
+      { delivered_count: 4, opens_count: 2, clicks_count: 0 },
+      { sent: 3, opened: 1, clicked: 0, last_sent: "2026-09-04T03:48:02Z", last_opened: "2026-09-04T03:55:00Z", sends_since_last_open: 0 },
+      { now }
+    )
+    // Transactional history (4/2) is preserved, Kit's 3/1 added on top.
+    expect(out.delivered_count).toBe(7)
+    expect(out.opens_count).toBe(3)
+    expect(out.kit_sent).toBe(3)
+    expect(out.changed).toBe(true)
+  })
+
+  it("is a NO-OP on a re-run with unchanged stats — the whole point of the snapshot", () => {
+    const stats = { sent: 3, opened: 1, clicked: 0, last_sent: "2026-09-04T03:48:02Z", last_opened: "2026-09-04T03:55:00Z", sends_since_last_open: 0 }
+    const first = mergeKitStats({ delivered_count: 4, opens_count: 2 }, stats, { now })
+
+    const second = mergeKitStats(
+      {
+        delivered_count: first.delivered_count,
+        opens_count: first.opens_count,
+        clicks_count: first.clicks_count,
+        delivered_since_last_open: first.delivered_since_last_open,
+        first_delivered_at: first.first_delivered_at,
+        last_delivered_at: first.last_delivered_at,
+        last_open_at: first.last_open_at,
+        last_click_at: first.last_click_at,
+        last_event_at: first.last_event_at,
+        kit_sent: first.kit_sent,
+        kit_opened: first.kit_opened,
+        kit_clicked: first.kit_clicked,
+      },
+      stats,
+      { now }
+    )
+
+    expect(second.delivered_count).toBe(first.delivered_count)
+    expect(second.opens_count).toBe(first.opens_count)
+    expect(second.changed).toBe(false)
+  })
+
+  it("applies only the delta when Kit's totals grow", () => {
+    const out = mergeKitStats(
+      { delivered_count: 7, opens_count: 3, kit_sent: 3, kit_opened: 1 },
+      { sent: 4, opened: 1, sends_since_last_open: 1, last_sent: "2026-10-01T09:00:00Z" },
+      { now }
+    )
+    expect(out.delivered_count).toBe(8) // +1, not +4
+    expect(out.opens_count).toBe(3) // unchanged
+  })
+
+  it("never claws back deliveries when Kit reports LOWER totals", () => {
+    // A subscriber deleted and re-created in Kit resets their counters. That
+    // must not subtract from what our own webhooks recorded.
+    const out = mergeKitStats(
+      { delivered_count: 9, opens_count: 4, kit_sent: 5, kit_opened: 2 },
+      { sent: 1, opened: 0, sends_since_last_open: 1 },
+      { now }
+    )
+    expect(out.delivered_count).toBe(9)
+    expect(out.opens_count).toBe(4)
+    // The snapshot still tracks what Kit currently says, so later growth is
+    // measured from the new baseline.
+    expect(out.kit_sent).toBe(1)
+  })
+
+  it("takes the LOWER cold streak when Kit has seen engagement", () => {
+    // Neither counter is the whole truth; the smaller one keeps people on the
+    // list, matching the conservative bias of the webhook path.
+    const out = mergeKitStats(
+      { delivered_since_last_open: 6, kit_sent: 0 },
+      { sent: 2, opened: 1, sends_since_last_open: 1 },
+      { now }
+    )
+    expect(out.delivered_since_last_open).toBe(1)
+  })
+
+  it("grows the cold streak by the delivery delta when Kit has seen no engagement", () => {
+    const out = mergeKitStats(
+      { delivered_since_last_open: 2, kit_sent: 1 },
+      { sent: 3, opened: 0, clicked: 0, sends_since_last_open: 3 },
+      { now }
+    )
+    expect(out.delivered_since_last_open).toBe(4) // 2 + (3 - 1)
+  })
+
+  it("treats a click as engagement even with no open date", () => {
+    const out = mergeKitStats(
+      {},
+      { sent: 1, opened: 0, clicked: 1, last_clicked: "2026-09-04T03:59:00Z", sends_since_last_open: 0 },
+      { now }
+    )
+    expect(out.last_open_at).toBe("2026-09-04T03:59:00.000Z")
+    expect(out.last_click_at).toBe("2026-09-04T03:59:00.000Z")
+  })
+
+  it("keeps the EARLIER first_delivered_at when the row already has one", () => {
+    const out = mergeKitStats(
+      { first_delivered_at: "2026-01-01T00:00:00Z" },
+      { sent: 1, sends_since_last_open: 1 },
+      { firstDeliveredAt: "2026-07-23T08:25:34Z", now }
+    )
+    expect(out.first_delivered_at).toBe("2026-01-01T00:00:00.000Z")
+  })
+
+  it("adopts the derived first_delivered_at when the row has none", () => {
+    const out = mergeKitStats(
+      {},
+      { sent: 3, sends_since_last_open: 3 },
+      { firstDeliveredAt: "2026-07-23T08:25:34Z", now }
+    )
+    expect(out.first_delivered_at).toBe("2026-07-23T08:25:34.000Z")
+  })
+})

--- a/apps/backend/src/modules/email_engagement/kit-backfill-core.ts
+++ b/apps/backend/src/modules/email_engagement/kit-backfill-core.ts
@@ -1,0 +1,192 @@
+/**
+ * Folding Kit's absolute subscriber stats into the engagement aggregate (#1785).
+ *
+ * Kit is a broadcast platform: it reports per-subscriber TOTALS
+ * (`GET /v4/subscribers/{id}/stats`), never individual events. The aggregate in
+ * `email_engagement` is otherwise built by `applyEngagement`, which folds ONE
+ * webhook event at a time. The two cannot be mixed naively:
+ *
+ *   - overwriting destroys the Mailjet/Resend history already in the row
+ *   - adding the totals is right once and double-counts on every re-run
+ *   - taking the max is idempotent but undercounts anyone who receives BOTH
+ *     transactional mail and the newsletter
+ *
+ * So we keep the last snapshot Kit gave us (`kit_*` columns) and apply the
+ * DELTA. Re-running the backfill with unchanged stats is a no-op, and the two
+ * populations add up honestly.
+ *
+ * Everything here is pure so the arithmetic is testable without Kit or a DB.
+ */
+
+/** The subset of `GET /v4/subscribers/{id}/stats` we consume. */
+export type KitSubscriberStats = {
+  sent?: number | null
+  opened?: number | null
+  clicked?: number | null
+  last_sent?: string | null
+  last_opened?: string | null
+  last_clicked?: string | null
+  sends_since_last_open?: number | null
+}
+
+export type EngagementRowForMerge = {
+  delivered_count?: number | null
+  opens_count?: number | null
+  clicks_count?: number | null
+  delivered_since_last_open?: number | null
+  first_delivered_at?: string | Date | null
+  last_delivered_at?: string | Date | null
+  last_open_at?: string | Date | null
+  last_click_at?: string | Date | null
+  last_event_at?: string | Date | null
+  kit_sent?: number | null
+  kit_opened?: number | null
+  kit_clicked?: number | null
+}
+
+export type KitMergeResult = {
+  delivered_count: number
+  opens_count: number
+  clicks_count: number
+  delivered_since_last_open: number
+  first_delivered_at: string | null
+  last_delivered_at: string | null
+  last_open_at: string | null
+  last_click_at: string | null
+  last_event_at: string | null
+  kit_sent: number
+  kit_opened: number
+  kit_clicked: number
+  kit_synced_at: string
+  /** false when nothing moved — the caller skips the write entirely. */
+  changed: boolean
+}
+
+const num = (v: unknown): number => {
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0
+}
+
+const iso = (v: string | Date | null | undefined): string | null => {
+  if (!v) return null
+  const d = v instanceof Date ? v : new Date(v)
+  return Number.isNaN(d.getTime()) ? null : d.toISOString()
+}
+
+const laterIso = (a: string | null, b: string | null): string | null => {
+  if (!a) return b
+  if (!b) return a
+  return new Date(a) >= new Date(b) ? a : b
+}
+
+const earlierIso = (a: string | null, b: string | null): string | null => {
+  if (!a) return b
+  if (!b) return a
+  return new Date(a) <= new Date(b) ? a : b
+}
+
+/**
+ * The date of a subscriber's FIRST newsletter delivery, derived exactly.
+ *
+ * A tagged subscriber receives every broadcast from then on, so `sent = N`
+ * means their deliveries are the last N broadcasts — their first is the Nth
+ * from the end. This is not a proxy: no guessing from `created_at` (which
+ * predates their first send and would overstate the dormancy span) or from
+ * `tagged_at` (which is only a floor).
+ *
+ * @param broadcastSendsDesc every broadcast's send time, NEWEST FIRST.
+ * @returns null when they have received nothing, or when we have fewer
+ *          broadcasts on record than Kit says they were sent — in which case we
+ *          genuinely do not know, and a null keeps them out of `dormant`.
+ */
+export function firstDeliveredAtFromSentCount(
+  sent: number,
+  broadcastSendsDesc: string[]
+): string | null {
+  const n = num(sent)
+  if (n <= 0) return null
+  if (n > broadcastSendsDesc.length) return null
+  return iso(broadcastSendsDesc[n - 1])
+}
+
+/**
+ * Fold one Kit stats snapshot into an existing engagement row.
+ *
+ * Deltas are clamped at zero: Kit's totals should only grow, but a subscriber
+ * deleted and re-created there would report LOWER numbers, and a negative delta
+ * must never claw back deliveries the transactional webhooks recorded.
+ */
+export function mergeKitStats(
+  existing: EngagementRowForMerge | null | undefined,
+  stats: KitSubscriberStats,
+  opts: { firstDeliveredAt?: string | null; now?: Date } = {}
+): KitMergeResult {
+  const e = existing || {}
+  const now = opts.now ?? new Date()
+
+  const kitSent = num(stats.sent)
+  const kitOpened = num(stats.opened)
+  const kitClicked = num(stats.clicked)
+
+  const dSent = Math.max(0, kitSent - num(e.kit_sent))
+  const dOpened = Math.max(0, kitOpened - num(e.kit_opened))
+  const dClicked = Math.max(0, kitClicked - num(e.kit_clicked))
+
+  const lastSent = iso(stats.last_sent)
+  const lastOpened = iso(stats.last_opened)
+  const lastClicked = iso(stats.last_clicked)
+
+  const delivered_count = num(e.delivered_count) + dSent
+  const opens_count = num(e.opens_count) + dOpened
+  const clicks_count = num(e.clicks_count) + dClicked
+
+  // The cold streak is the one field we do NOT add: Kit computes it over its
+  // own sends and our counter covers ours, so neither is the whole truth. Take
+  // the LOWER of the two — a smaller streak keeps people on the list, matching
+  // the conservative bias the webhook path already documents.
+  const ourCold = num(e.delivered_since_last_open)
+  const kitCold = num(stats.sends_since_last_open)
+  const delivered_since_last_open =
+    kitOpened > 0 || kitClicked > 0 ? Math.min(ourCold, kitCold) : ourCold + dSent
+
+  const first_delivered_at = earlierIso(
+    iso(e.first_delivered_at),
+    iso(opts.firstDeliveredAt ?? null)
+  )
+  const last_delivered_at = laterIso(iso(e.last_delivered_at), lastSent)
+  // A click proves engagement even when the open never registered — same rule
+  // as applyEngagement.
+  const last_open_at = laterIso(laterIso(iso(e.last_open_at), lastOpened), lastClicked)
+  const last_click_at = laterIso(iso(e.last_click_at), lastClicked)
+  const last_event_at = laterIso(
+    iso(e.last_event_at),
+    laterIso(last_delivered_at, last_open_at)
+  )
+
+  const changed =
+    delivered_count !== num(e.delivered_count) ||
+    opens_count !== num(e.opens_count) ||
+    clicks_count !== num(e.clicks_count) ||
+    delivered_since_last_open !== ourCold ||
+    first_delivered_at !== iso(e.first_delivered_at) ||
+    last_delivered_at !== iso(e.last_delivered_at) ||
+    last_open_at !== iso(e.last_open_at) ||
+    last_click_at !== iso(e.last_click_at)
+
+  return {
+    delivered_count,
+    opens_count,
+    clicks_count,
+    delivered_since_last_open,
+    first_delivered_at,
+    last_delivered_at,
+    last_open_at,
+    last_click_at,
+    last_event_at,
+    kit_sent: kitSent,
+    kit_opened: kitOpened,
+    kit_clicked: kitClicked,
+    kit_synced_at: now.toISOString(),
+    changed,
+  }
+}

--- a/apps/backend/src/modules/email_engagement/migrations/Migration20260904040000.ts
+++ b/apps/backend/src/modules/email_engagement/migrations/Migration20260904040000.ts
@@ -1,0 +1,31 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1785 — the Kit snapshot columns on `email_engagement`.
+ *
+ * Kit reports ABSOLUTE per-subscriber totals; the existing counters are folded
+ * one webhook event at a time. Storing what Kit last told us makes the backfill
+ * idempotent (apply a delta, not the total) and keeps the transactional
+ * history from the Mailjet/Resend webhooks intact.
+ *
+ * HAND-WRITTEN, not generated. `db:generate` re-emits every model it sees for a
+ * module with no MikroORM snapshot, and its `down()` would drop columns these
+ * migrations never created.
+ */
+export class Migration20260904040000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "email_engagement" add column if not exists "kit_sent" integer not null default 0;`);
+    this.addSql(`alter table if exists "email_engagement" add column if not exists "kit_opened" integer not null default 0;`);
+    this.addSql(`alter table if exists "email_engagement" add column if not exists "kit_clicked" integer not null default 0;`);
+    this.addSql(`alter table if exists "email_engagement" add column if not exists "kit_synced_at" timestamptz null;`);
+  }
+
+  override async down(): Promise<void> {
+    // Only the four columns this migration added — nothing else in the table.
+    this.addSql(`alter table if exists "email_engagement" drop column if exists "kit_sent";`);
+    this.addSql(`alter table if exists "email_engagement" drop column if exists "kit_opened";`);
+    this.addSql(`alter table if exists "email_engagement" drop column if exists "kit_clicked";`);
+    this.addSql(`alter table if exists "email_engagement" drop column if exists "kit_synced_at";`);
+  }
+}

--- a/apps/backend/src/modules/email_engagement/models/email-engagement.ts
+++ b/apps/backend/src/modules/email_engagement/models/email-engagement.ts
@@ -39,6 +39,21 @@ const EmailEngagement = model.define("email_engagement", {
     .enum(["engaged", "cooling", "dormant", "never_opened", "unknown"])
     .default("unknown"),
   status_computed_at: model.dateTime().nullable(),
+  /**
+   * The last snapshot Kit reported for this address (#1785).
+   *
+   * Kit hands out ABSOLUTE totals (`GET /v4/subscribers/{id}/stats`), while the
+   * counters above are folded one webhook event at a time. Keeping the last
+   * snapshot lets the backfill apply a DELTA: re-running it is a no-op, and the
+   * Mailjet/Resend history already in the row is never overwritten.
+   *
+   * Typed columns rather than `metadata` on purpose — these decide who receives
+   * a newsletter, and load-bearing state does not belong in an untyped blob.
+   */
+  kit_sent: model.number().default(0),
+  kit_opened: model.number().default(0),
+  kit_clicked: model.number().default(0),
+  kit_synced_at: model.dateTime().nullable(),
   metadata: model.json().nullable(),
 })
 

--- a/apps/backend/src/modules/kit/service.ts
+++ b/apps/backend/src/modules/kit/service.ts
@@ -171,6 +171,48 @@ class KitService extends MedusaService({ KitBroadcast }) {
     return { id, raw }
   }
 
+  /**
+   * One page of the tag's subscribers. Cursor-paginated; pass the previous
+   * response's `pagination.end_cursor` as `after` to continue.
+   *
+   * This is the true broadcast audience — it includes people carried over from
+   * earlier sends who are no longer in our computed audience at all (#1782).
+   */
+  async listTagSubscribers(
+    opts: { tagId?: string; perPage?: number; after?: string } = {}
+  ): Promise<{ subscribers: any[]; nextCursor: string | null }> {
+    const tag = opts.tagId || this.blogTagId
+    if (!tag) {
+      throw new Error("No Kit tag id (pass tagId or set KIT_BLOG_TAG_ID)")
+    }
+    const qs = [`per_page=${opts.perPage ?? 100}`]
+    if (opts.after) qs.push(`after=${encodeURIComponent(opts.after)}`)
+    const res = await this.request("GET", `/tags/${tag}/subscribers?${qs.join("&")}`)
+    const subscribers: any[] = Array.isArray(res?.subscribers) ? res.subscribers : []
+    const nextCursor = res?.pagination?.has_next_page
+      ? String(res.pagination.end_cursor)
+      : null
+    return { subscribers, nextCursor }
+  }
+
+  /**
+   * Per-subscriber engagement totals: `sent`, `opened`, `clicked`, `bounced`,
+   * `last_sent` / `last_opened` / `last_clicked`, and `sends_since_last_open`
+   * — which is the cold streak our classifier otherwise derives from delivery
+   * events. Kit publishes no per-recipient open webhook, so this pull is the
+   * only route to engagement for newsletter contacts (#1785).
+   */
+  async getSubscriberStats(subscriberId: string): Promise<any | null> {
+    const res = await this.request("GET", `/subscribers/${subscriberId}/stats`)
+    return res?.subscriber?.stats ?? null
+  }
+
+  /** Every broadcast, newest first — the send dates the backfill dates deliveries from. */
+  async listBroadcasts(perPage = 50): Promise<any[]> {
+    const res = await this.request("GET", `/broadcasts?per_page=${perPage}`)
+    return Array.isArray(res?.broadcasts) ? res.broadcasts : []
+  }
+
   /** Poll aggregate stats for a broadcast (recipients/opens/clicks). */
   async getBroadcastStats(broadcastId: string): Promise<any> {
     return this.request("GET", `/broadcasts/${broadcastId}/stats`)


### PR DESCRIPTION
Closes #1785. Builds decision (1) as agreed — typed snapshot columns and a delta merge — plus the exact `first_delivered_at`, and answers the "does engagement land on its own?" question with a scheduled recompute.

## Does engagement land on its own?

**Ingestion: yes.** The Mailjet and Resend webhooks fold every delivery/open/click into the ledger as it arrives.

**Classification: no.** `recompute-email-engagement-status` existed only as a *manual* maintenance job, so the persisted `engagement_status` was whatever the last human run left behind.

That is not a correctness bug — `get-subscribers` classifies **live** from the counters, so a stale status has never caused a wrong exclusion. What went stale is everything that *reads* the persisted value: the Marketing → Engagement view and win-back selection, which is exactly where you look to judge whether the list is healthy. Now a daily job at 02:10 UTC writing only rows whose status moved. The maintenance job stays the place for an ad-hoc pass with tuned thresholds.

## The backfill

`GET /v4/subscribers/{id}/stats` — verified live before a line was written — returns `sent`, `opened`, `clicked`, the three timestamps, and `sends_since_last_open`, which **is** the cold streak `classifyEngagement` otherwise derives from delivery events.

**Idempotent by construction.** Kit reports absolute totals; our counters are folded one event at a time. Overwriting destroys the transactional history, adding double-counts on re-run, max undercounts anyone who gets both. So the last Kit snapshot lives in typed `kit_*` columns and the job applies the delta — re-running changes nothing. A *lower* total from Kit (a subscriber deleted and re-created there) clamps at zero rather than clawing back deliveries our webhooks recorded.

**`first_delivered_at` is exact.** `sent = N` means the last N broadcasts, so the first is the Nth from the end. `created_at` would predate their first send and overstate the dormancy span — the error that marks someone dormant too eagerly. If Kit claims more sends than we have broadcasts, the date stays null: not knowing keeps them out of `dormant`.

## Expectations — this will not shrink the list yet

`dormantColdStreak` is 5 and only **3** broadcasts have ever been sent, so no newsletter-only contact can reach the threshold under any dating scheme. The value here is turning the 172 `unknown` rows into `never_opened`/`engaged` — an honest picture instead of a blank one, with correctly dated history ready for when the 5th broadcast makes the gate bite.

## Verify

```
cd apps/backend
TEST_TYPE=unit npx jest --testPathPattern="kit-backfill-core"          # 12 passed
TEST_TYPE=unit npx jest --testPathPattern="kit-service|engagement"     # 85 passed
pnpm check:prod-build
```

`check:prod-build` is clean apart from the pre-existing `@jest/core` failure in `generate-integration-test.e2e.spec.ts`, which reproduces on a clean tree.

**After deploy**, dry-run first — it writes nothing and reports what it would change:

```
POST /admin/ops/maintenance-jobs/backfill-engagement-from-kit/run  {"dry_run":true}
```

⚠️ Paced at ~2 subscribers/sec against Kit's 120 req/60s, so a full pass over the 527-strong tag takes about 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
