### PR TITLE
fix(quotes): a quote with no region checked out through the wrong country's gateway (#1787)

### DIFF
--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -2,6 +2,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
+import { resolveQuoteRegion } from "../../../modules/partner-quote/lib/resolve-region"
 import { buildQuoteListQuery } from "../../../modules/partner-quote/lib/list-query"
 import { withEffectiveStatus } from "../../../modules/partner-quote/lib/token"
 import { totalQuotedQuantity } from "../../../modules/partner-quote/lib/quote-email"
@@ -154,6 +155,20 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     partnerLabel: partner.name || partnerId,
   })
 
+  // #1787 — resolve the region BEFORE anything is frozen. Strict here: a
+  // quote is a commercial commitment, and one minted against the wrong
+  // region checks out through the wrong country's gateway. Refusing while
+  // the partner is present beats discovering it when the buyer is.
+  const mintRegion = await resolveQuoteRegion(
+    req.scope,
+    {
+      region_id: body.region_id ?? null,
+      currency_code: body.currency_code,
+      destination_country_code: body.destination_country_code,
+    },
+    { strict: true }
+  )
+
   const { result } = await mintQuoteWorkflow(req.scope).run({
     input: {
       partner_id: partner.id,
@@ -171,7 +186,11 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       destination_postal_code: body.destination_postal_code ?? null,
       destination_city: body.destination_city ?? null,
       currency_code: body.currency_code,
-      region_id: body.region_id ?? null,
+      // #1787 — derived when the caller did not name one, and REFUSED when
+      // currency and destination name no region (or two). The region decides
+      // which payment providers the buyer is offered; a quote frozen without
+      // one reached an Australian buyer as PayU-only and she could not pay.
+      region_id: mintRegion.region_id,
       carrier: body.carrier,
       duties_prepaid: body.duties_prepaid ?? false,
       // The number behind the promise (#1447). The validator has already

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -2,6 +2,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
+import { resolveQuoteRegion } from "../../../modules/partner-quote/lib/resolve-region"
 import { resolveQuoteDesignLines } from "../../../modules/partner-quote/lib/design-lines"
 import { buildQuoteListQuery } from "../../../modules/partner-quote/lib/list-query"
 import { withEffectiveStatus } from "../../../modules/partner-quote/lib/token"
@@ -110,6 +111,20 @@ export const POST = async (
     sales_channel_id: (store as any).default_sales_channel_id,
   })
 
+  // #1787 — resolve the region BEFORE anything is frozen. Strict here: a
+  // quote is a commercial commitment, and one minted against the wrong
+  // region checks out through the wrong country's gateway. Refusing while
+  // the partner is present beats discovering it when the buyer is.
+  const mintRegion = await resolveQuoteRegion(
+    req.scope,
+    {
+      region_id: body.region_id ?? null,
+      currency_code: body.currency_code,
+      destination_country_code: body.destination_country_code,
+    },
+    { strict: true }
+  )
+
   const { result } = await mintQuoteWorkflow(req.scope).run({
     input: {
       partner_id: partner.id,
@@ -127,7 +142,11 @@ export const POST = async (
       destination_postal_code: body.destination_postal_code ?? null,
       destination_city: body.destination_city ?? null,
       currency_code: body.currency_code,
-      region_id: body.region_id ?? null,
+      // #1787 — derived when the caller did not name one, and REFUSED when
+      // currency and destination name no region (or two). The region decides
+      // which payment providers the buyer is offered; a quote frozen without
+      // one reached an Australian buyer as PayU-only and she could not pay.
+      region_id: mintRegion.region_id,
       carrier: body.carrier,
       duties_prepaid: body.duties_prepaid ?? false,
       // The number behind the promise (#1447). The validator has already

--- a/apps/backend/src/modules/partner-quote/__tests__/resolve-region.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/resolve-region.unit.spec.ts
@@ -1,0 +1,124 @@
+import { pickQuoteRegion } from "../lib/resolve-region"
+
+// The prod shape that produced #1787: one AUD region covering au, one INR
+// region covering in, and two EUR regions so ambiguity is representable.
+const REGIONS = [
+  { id: "reg_in", currency_code: "inr", countries: [{ iso_2: "in" }] },
+  { id: "reg_au", currency_code: "aud", countries: [{ iso_2: "au" }] },
+  { id: "reg_eu", currency_code: "eur", countries: [{ iso_2: "de" }, { iso_2: "nl" }] },
+  { id: "reg_us", currency_code: "usd", countries: [{ iso_2: "us" }] },
+]
+
+describe("pickQuoteRegion", () => {
+  it("derives the AU region from aud + au — the case that broke", () => {
+    // The quote carried destination AU and currency AUD and stored no region,
+    // so accept fell back to the INR store default and offered PayU only.
+    expect(
+      pickQuoteRegion(REGIONS, {
+        region_id: null,
+        currency_code: "AUD",
+        destination_country_code: "AU",
+      })
+    ).toEqual({ region_id: "reg_au", source: "derived" })
+  })
+
+  it("keeps an explicit region_id", () => {
+    expect(
+      pickQuoteRegion(REGIONS, {
+        region_id: "reg_eu",
+        currency_code: "eur",
+        destination_country_code: "de",
+      })
+    ).toEqual({ region_id: "reg_eu", source: "explicit" })
+  })
+
+  it("refuses an explicit region whose currency contradicts the quote", () => {
+    // The rule `currency_code` already advertises — "must match the region's
+    // currency" — stated to callers and, until now, enforced against nobody.
+    const out = pickQuoteRegion(REGIONS, {
+      region_id: "reg_in",
+      currency_code: "aud",
+      destination_country_code: "au",
+    })
+    expect(out.region_id).toBeNull()
+    expect(out).toMatchObject({ source: "none" })
+    expect((out as any).reason).toMatch(/denominated in inr/)
+  })
+
+  it("refuses a region_id that does not exist", () => {
+    const out = pickQuoteRegion(REGIONS, {
+      region_id: "reg_nope",
+      currency_code: "aud",
+      destination_country_code: "au",
+    })
+    expect(out.region_id).toBeNull()
+    expect((out as any).reason).toMatch(/does not exist/)
+  })
+
+  it("requires BOTH currency and country to match, never either alone", () => {
+    // aud exists, but not for a German destination — matching on currency alone
+    // would have picked reg_au and quoted an Australian sale into Germany.
+    expect(
+      pickQuoteRegion(REGIONS, {
+        region_id: null,
+        currency_code: "aud",
+        destination_country_code: "de",
+      }).region_id
+    ).toBeNull()
+
+    // de exists, but the quote is priced in usd — matching on country alone
+    // would have put a USD quote in a EUR region.
+    expect(
+      pickQuoteRegion(REGIONS, {
+        region_id: null,
+        currency_code: "usd",
+        destination_country_code: "de",
+      }).region_id
+    ).toBeNull()
+  })
+
+  it("refuses rather than guessing when two regions claim the sale", () => {
+    const ambiguous = [
+      ...REGIONS,
+      { id: "reg_eu2", currency_code: "eur", countries: [{ iso_2: "de" }] },
+    ]
+    const out = pickQuoteRegion(ambiguous, {
+      region_id: null,
+      currency_code: "eur",
+      destination_country_code: "de",
+    })
+    expect(out.region_id).toBeNull()
+    expect((out as any).reason).toMatch(/2 regions claim EUR \+ DE/)
+    expect((out as any).reason).toMatch(/reg_eu, reg_eu2/)
+  })
+
+  it("says what is missing when there is nothing to derive from", () => {
+    const out = pickQuoteRegion(REGIONS, {
+      region_id: null,
+      currency_code: null,
+      destination_country_code: "au",
+    })
+    expect(out.region_id).toBeNull()
+    expect((out as any).reason).toMatch(/no currency \+ destination/)
+  })
+
+  it("is case- and whitespace-insensitive on both keys", () => {
+    expect(
+      pickQuoteRegion(REGIONS, {
+        region_id: null,
+        currency_code: " Aud ",
+        destination_country_code: " Au ",
+      })
+    ).toEqual({ region_id: "reg_au", source: "derived" })
+  })
+
+  it("reports no match instead of throwing when no region covers the pair", () => {
+    const out = pickQuoteRegion(REGIONS, {
+      region_id: null,
+      currency_code: "jpy",
+      destination_country_code: "jp",
+    })
+    expect(out.region_id).toBeNull()
+    expect((out as any).reason).toMatch(/no region covers JPY \+ JP/)
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/resolve-region.ts
+++ b/apps/backend/src/modules/partner-quote/lib/resolve-region.ts
@@ -1,0 +1,165 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * Which region a quote belongs to (#1787).
+ *
+ * ## The defect this closes
+ *
+ * `region_id` is optional on the mint and nothing ever derived it. The admin
+ * wizard has a selector; the MCP tool does not ask, its guidance never mentions
+ * a region, and the word appears three times in the whole mint tool schema. So
+ * a caller who says "Australia, in AUD" sends `destination_country_code: "AU"`
+ * and `currency_code: "aud"` — both of which name exactly one region — and the
+ * quote is stored with none.
+ *
+ * At accept, `quote.region_id ?? store.default_region_id` then sent the cart to
+ * the store default: **India / INR**. Payment providers are configured per
+ * region, so an Australian buyer holding an AUD 314.77 quote was offered PayU,
+ * an INR-only rail, and never Stripe. The buyer reported it as "I cannot pay".
+ *
+ * ## Why derive rather than default
+ *
+ * The store default is right for a domestic INR quote and actively wrong for
+ * every foreign-currency one — and wrong in a way nothing downstream notices,
+ * because a region mismatch produces no error, just the wrong gateway.
+ *
+ * A quote's currency and destination are not hints: `currency_code` is already
+ * documented to the caller as "must match the region's currency", a rule stated
+ * and never enforced. This enforces it.
+ */
+
+export type RegionLike = {
+  id: string
+  currency_code?: string | null
+  countries?: Array<{ iso_2?: string | null }> | null
+}
+
+export type RegionResolution =
+  | { region_id: string; source: "explicit" | "derived" }
+  | { region_id: null; source: "none"; reason: string }
+
+const lower = (v: unknown): string => String(v ?? "").trim().toLowerCase()
+
+/**
+ * PURE. Pick the region for a quote, or explain why none can be picked.
+ *
+ * An explicit `region_id` wins, but only if it is real AND its currency agrees
+ * with the quote's — a quote priced in one currency inside a region denominated
+ * in another is the same class of mismatch, just supplied by hand.
+ *
+ * Otherwise: the region whose currency matches AND whose countries include the
+ * destination. Both conditions, never either — currency alone would pick the
+ * wrong one the moment two regions share a currency (eur, most obviously), and
+ * country alone would ignore what the buyer was actually quoted in.
+ *
+ * **Ambiguity is not resolved by picking the first.** More than one match means
+ * a human configured two regions that both claim this sale, and guessing which
+ * is how a quote ends up on the wrong books.
+ */
+export function pickQuoteRegion(
+  regions: RegionLike[],
+  input: {
+    region_id?: string | null
+    currency_code?: string | null
+    destination_country_code?: string | null
+  }
+): RegionResolution {
+  const all = Array.isArray(regions) ? regions : []
+  const currency = lower(input.currency_code)
+  const country = lower(input.destination_country_code)
+
+  if (input.region_id) {
+    const named = all.find((r) => r.id === input.region_id)
+    if (!named) {
+      return {
+        region_id: null,
+        source: "none",
+        reason: `region_id ${input.region_id} does not exist`,
+      }
+    }
+    const named_currency = lower(named.currency_code)
+    if (currency && named_currency && named_currency !== currency) {
+      return {
+        region_id: null,
+        source: "none",
+        reason:
+          `region ${named.id} is denominated in ${named_currency}, ` +
+          `but the quote is priced in ${currency}`,
+      }
+    }
+    return { region_id: named.id, source: "explicit" }
+  }
+
+  if (!currency || !country) {
+    return {
+      region_id: null,
+      source: "none",
+      reason: "no region_id, and no currency + destination to derive one from",
+    }
+  }
+
+  const matches = all.filter(
+    (r) =>
+      lower(r.currency_code) === currency &&
+      (r.countries ?? []).some((c) => lower(c?.iso_2) === country)
+  )
+
+  if (matches.length === 1) {
+    return { region_id: matches[0].id, source: "derived" }
+  }
+  if (matches.length > 1) {
+    return {
+      region_id: null,
+      source: "none",
+      reason:
+        `${matches.length} regions claim ${currency.toUpperCase()} + ` +
+        `${country.toUpperCase()} (${matches.map((m) => m.id).join(", ")}) — ` +
+        `name one with region_id`,
+    }
+  }
+  return {
+    region_id: null,
+    source: "none",
+    reason: `no region covers ${currency.toUpperCase()} + ${country.toUpperCase()}`,
+  }
+}
+
+/**
+ * Container-driven wrapper: read the regions, then decide.
+ *
+ * `strict` is the mint's posture — a quote is a commercial commitment, and one
+ * frozen against the wrong region checks out through the wrong country's
+ * gateway. Better to refuse at mint, where the partner is present, than at
+ * accept, where the buyer is.
+ *
+ * Accept passes `strict: false`: those quotes are already minted, so the belt
+ * improves what it can and leaves the caller's own fallback in place.
+ */
+export async function resolveQuoteRegion(
+  scope: any,
+  input: {
+    region_id?: string | null
+    currency_code?: string | null
+    destination_country_code?: string | null
+  },
+  opts: { strict?: boolean } = {}
+): Promise<RegionResolution> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: regions } = await query.graph({
+    entity: "region",
+    fields: ["id", "currency_code", "countries.iso_2"],
+  })
+
+  const resolved = pickQuoteRegion((regions ?? []) as RegionLike[], input)
+
+  if (opts.strict && !resolved.region_id) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Cannot determine the region for this quote: ${resolved.reason}. ` +
+        `The region decides which payment providers the buyer is offered, so a ` +
+        `quote must not be frozen without one.`
+    )
+  }
+
+  return resolved
+}

--- a/apps/backend/src/modules/partner-quote/tool-schema.ts
+++ b/apps/backend/src/modules/partner-quote/tool-schema.ts
@@ -74,6 +74,7 @@ export const QUOTE_MINT_WRITE_GUIDANCE = [
   "Run the readiness preflight first (`check_quote_readiness`). It reports EVERY blocking problem at once; minting reports the same set but after the buyer's expectations have been set.",
   "Cross-border freight IS rated now (#1498): when the partner's own pickup pin cannot be carried, the rate is retried from one of our own export warehouses and the domestic first leg is added, so a real carrier number is quoted. Do NOT reach for `freight_override_amount` by reflex — hand-typed international rates have run 2-3x the rated route, and the buyer is charged the difference. Supply it only when readiness actually refuses for want of freight, and pass `freight_basis` saying where the number came from; it is shown to the buyer as quoted by hand.",
   "`duties_prepaid: true` is a promise that the buyer pays nothing at their border. It requires a duty figure alongside it — either `duty_rate_percent` (preferred, applied to the basket actually priced) or `duty_total`. Promising DDP with no amount funds it out of margin.",
+  "The region decides which payment gateway the buyer is offered, not just prices and tax. It is derived from `currency_code` + `destination_country_code`, so those two must name exactly one region — the mint refuses rather than guessing. An AUD quote that landed in the INR default region offered the buyer PayU, an INR-only rail, and she could not pay at all (#1787).",
   "Tax follows the SELLER's jurisdiction, never the buyer's. An export from India is zero-rated whatever the destination's VAT rate is; do not add destination VAT to the lines.",
   "A DESIGN line (`design_id`) is quoted before the garment exists as a product. Two things follow that a variant line never needs. (1) Send `unit_weight_grams` on it — the design has no weight of its own, and the freight estimate refuses the whole basket on the first line it cannot weigh, so one design line with no weight kills the quote. (2) The mint CREATES a made-to-order product for that design and adds it to the partner's catalogue; readiness reports this as a `design_catalogue_pending` warning, which is expected and not a problem to solve.",
   "`override_unit_amount` is read in the PARTNER STORE's default currency and converted at the live rate — it is not in the quote currency. On an INR store quoting in AUD, `40` means forty rupees, about A$0.58. Quote the price the seller means in their own currency, or state the buyer-facing figure and let a human convert it.",
@@ -167,7 +168,8 @@ export const quoteMintSchemaProps = () => ({
   },
   region_id: {
     type: "string",
-    description: "Region whose prices and tax basis apply, e.g. 'reg_...'.",
+    description:
+      "Region whose prices, tax basis AND PAYMENT PROVIDERS apply, e.g. 'reg_...'. Omit it and it is derived from `currency_code` + `destination_country_code`, which must name exactly one region; the mint is REFUSED when they name none or two. Pass one explicitly only to disambiguate, and only in the quote's own currency.",
   },
   carrier: {
     type: "string",

--- a/apps/backend/src/workflows/partner-quote/accept-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/accept-quote.ts
@@ -25,6 +25,7 @@ import {
   quoteFreightOptionName,
 } from "../../modules/partner-quote/lib/quote-freight-option"
 import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
+import { resolveQuoteRegion } from "../../modules/partner-quote/lib/resolve-region"
 import { PARTNER_QUOTE_EVENTS } from "../../modules/partner-quote/events"
 import { PAYMENT_SCHEDULE_MODULE } from "../../modules/payment_schedule"
 import { quoteUnusableReason } from "../../modules/partner-quote/lib/token"
@@ -402,9 +403,28 @@ const createQuoteCartStep = createStep(
       phone: input.shipping_address?.phone ?? null,
     }
 
+    // Not strict: this quote is already minted, so improve what we can and
+    // leave the existing fallback in place rather than refusing an accept
+    // the buyer is standing in front of.
+    const acceptRegionId =
+      quote.region_id ??
+      (
+        await resolveQuoteRegion(container, {
+          region_id: null,
+          currency_code: quote.currency_code,
+          destination_country_code: quote.destination_country_code,
+        })
+      ).region_id
+
     const { result: cart } = await createCartWorkflow(container).run({
       input: {
-        region_id: quote.region_id ?? store?.default_region_id ?? undefined,
+        // #1787 — the store default is right for a domestic INR quote and
+        // actively wrong for every foreign-currency one: payment providers
+        // are per region, so an AUD quote landing in the INR default region
+        // was offered PayU and never Stripe. Belt for the quotes already
+        // minted without a region (every one since 2026-08-24); the mint
+        // now refuses rather than storing null.
+        region_id: acceptRegionId ?? store?.default_region_id ?? undefined,
         currency_code: quote.currency_code,
         sales_channel_id: store.default_sales_channel_id,
         customer_id: quote.customer_id,


### PR DESCRIPTION
The fix for the live incident on #1787.

## What happened

A buyer in Australia could not pay. Her quote was **AUD 314.77 to an AU address** but carried `region_id: null`, so accept fell back to `store.default_region_id` — **India / INR**. Payment providers are per region: India has only PayU, an INR rail. She was never offered Stripe, which lives on the Australia region.

## Why it was possible

`region_id` was optional on the mint and nothing derived it. The admin wizard has a selector; the MCP tool does not ask. The word "region" appeared **three times in the entire mint tool schema** — the param name, its own one-line description, and a clause in `currency_code` saying it "must match the region's currency", a rule stated to callers and enforced against nobody.

So a caller saying "Australia, in AUD" sends a destination and a currency that name exactly one region, and the quote is stored with none. **Every quote minted since 2026-08-24 has `region_id: null`.**

## The change

- **`pickQuoteRegion`** (pure): an explicit region wins, but only if it exists **and** its currency agrees with the quote's. Otherwise the region matching currency **and** containing the destination — both, never either. Currency alone picks the wrong one the moment two regions share EUR; country alone puts a USD quote in a EUR region. Two matches **refuse** rather than take the first, because two regions claiming one sale is a human misconfiguration and guessing is how a quote lands on the wrong books.
- **Both mint routes** resolve strictly, before anything is frozen — refusing while the partner is present beats discovering it when the buyer is.
- **`accept-quote`** resolves as a non-strict belt for quotes already minted without one, keeping the store default as the last resort.
- **The tool schema** now states that the region decides the payment gateway, and the guidance says so too.

## Verify

```
cd apps/backend
TEST_TYPE=unit npx jest --testPathPattern="resolve-region"   # 9 passed
TEST_TYPE=unit npx jest --testPathPattern="quote"            # 463 passed
```

The first test is the exact case that broke: `aud` + `au` with no region → `reg_au`, `source: "derived"`.

`check:prod-build` is clean apart from the pre-existing `@jest/core` failure in `generate-integration-test.e2e.spec.ts`, which reproduces on a clean tree.

## Not in this PR

The buyer was unblocked by hand — AU GST zeroed (a founder tax decision, see the issue) and her cart moved to the AU region, totals unchanged at 314.77. The **other** open quotes with `region_id: null` are not repaired by this; the accept belt will resolve them at accept time, but a sweep to fill the column would be tidier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4