### PR TITLE
fix(quotes): the ordinary checkout charged 100% of a deposit cart (#1787)

### DIFF
--- a/apps/backend/src/api/store/carts/[id]/quote-terms/lib.ts
+++ b/apps/backend/src/api/store/carts/[id]/quote-terms/lib.ts
@@ -1,0 +1,179 @@
+import { planCartCollection, type CollectionPlan } from "../../../../../lib/payments/deposit-collection"
+
+/**
+ * What a buyer needs to be TOLD about a quote-bound cart, for
+ * `GET /store/carts/:id/quote-terms` (#1787).
+ *
+ * ## Why this exists
+ *
+ * A cart minted by `acceptQuoteWorkflow` is not an ordinary basket: its prices
+ * are frozen, its freight was rated in one lane, and — usually — only a deposit
+ * is collected now. The storefronts rendered none of that. A buyer landed on
+ * `/cart`, saw the full total with no mention of a deposit, and the first hint
+ * that she owed 30% today appeared at the Review step, if at all.
+ *
+ * 🔴 The deposit shown here is computed by `planCartCollection`, the SAME
+ * function that decides what the payment collection is actually created for.
+ * Advertising a number derived any other way is how a page comes to promise
+ * one figure and a gateway to charge another — which is exactly the class of
+ * defect that made this quote unpayable in the first place.
+ *
+ * Kept pure so the arithmetic is testable without a container.
+ */
+export type QuoteCartTerms = {
+  /** False for an ordinary cart; everything below is then null. */
+  is_quote_cart: boolean
+  quote_id: string | null
+  currency_code: string | null
+  /** The cart's own total — what is owed in the end, deposit or not. */
+  total: number | null
+  /**
+   * Null when the whole total is due now. A number here means the buyer is
+   * asked for THIS today and the rest later.
+   */
+  deposit_due_now: number | null
+  balance_due_later: number | null
+  deposit_pct: number | null
+  deposit_status: string | null
+  balance_status: string | null
+  /** `payu` | `stripe` | `manual` — which rail will take it. */
+  rail: string | null
+  /**
+   * 🔴 Present when the cart is bound to a quote but the terms could NOT be
+   * stated confidently — a schedule that names no usable deposit, or one that
+   * disagrees with the cart. The storefront must fall back to showing the plain
+   * total rather than inventing a split, and this says why.
+   *
+   * Not an error: the cart is still perfectly payable in full.
+   */
+  unavailable_reason: string | null
+}
+
+const NOT_A_QUOTE_CART: QuoteCartTerms = {
+  is_quote_cart: false,
+  quote_id: null,
+  currency_code: null,
+  total: null,
+  deposit_due_now: null,
+  balance_due_later: null,
+  deposit_pct: null,
+  deposit_status: null,
+  balance_status: null,
+  rail: null,
+  unavailable_reason: null,
+}
+
+const num = (v: unknown): number | null => {
+  if (v === null || v === undefined || v === "") return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+export function deriveQuoteCartTerms(
+  cart:
+    | {
+        id?: string
+        currency_code?: string | null
+        total?: number | string | null
+        metadata?: Record<string, unknown> | null
+      }
+    | null
+    | undefined,
+  schedule:
+    | {
+        deposit_pct?: number | string | null
+        deposit_amount?: number | string | null
+        deposit_status?: string | null
+        balance_status?: string | null
+        rail?: string | null
+        total_due?: number | string | null
+        currency_code?: string | null
+      }
+    | null
+    | undefined
+): QuoteCartTerms {
+  const quoteId = cart?.metadata?.quote_id
+
+  /**
+   * `metadata.quote_id` is the marker `acceptQuoteWorkflow` stamps, and it is
+   * the same marker the storefronts use to refuse a re-region. One definition
+   * of "this is a quote cart", not two.
+   */
+  if (!quoteId) {
+    return NOT_A_QUOTE_CART
+  }
+
+  const total = num(cart?.total)
+  const base = {
+    ...NOT_A_QUOTE_CART,
+    is_quote_cart: true,
+    quote_id: String(quoteId),
+    currency_code: cart?.currency_code ?? null,
+    total,
+    deposit_status: schedule?.deposit_status ?? null,
+    balance_status: schedule?.balance_status ?? null,
+    rail: schedule?.rail ?? null,
+    deposit_pct: num(schedule?.deposit_pct),
+  }
+
+  if (!schedule) {
+    return {
+      ...base,
+      unavailable_reason:
+        "This cart came from a quote but carries no payment schedule, so the whole total is due now.",
+    }
+  }
+
+  let plan: CollectionPlan
+  try {
+    plan = planCartCollection({
+      cartTotal: cart?.total,
+      cartCurrency: cart?.currency_code,
+      schedule,
+    })
+  } catch (e) {
+    return {
+      ...base,
+      unavailable_reason: e instanceof Error ? e.message : String(e),
+    }
+  }
+
+  /**
+   * A refused plan is reported, never guessed around. `planCartCollection`
+   * refuses a deposit it cannot name confidently — a zero amount, a deposit
+   * larger than the cart, a currency that does not match. In every one of those
+   * cases the honest thing to show a buyer is the plain total.
+   */
+  if (plan.basis === "refuse") {
+    return { ...base, unavailable_reason: plan.reason }
+  }
+
+  if (plan.basis !== "deposit") {
+    // A legitimate "pay in full" quote — `deposit_pct: 100`, or a waived
+    // deposit. It IS a quote cart (frozen prices still worth saying), it just
+    // has no split to advertise.
+    return { ...base, unavailable_reason: null }
+  }
+
+  const depositDue = num(plan.amount)
+  const balance =
+    depositDue !== null && total !== null
+      ? Math.round((total - depositDue) * 100) / 100
+      : null
+
+  /**
+   * 🔴 A `deposit` basis whose amount IS the whole total is `deposit_pct: 100`
+   * — "pay in full", which `planCartCollection` accepts deliberately. Rendering
+   * it as a split would show the buyer "Pay now A$314.77, balance A$0.00",
+   * which is noise dressed as a payment plan. There is no split to advertise.
+   */
+  if (balance === null || balance <= 0) {
+    return base
+  }
+
+  return {
+    ...base,
+    deposit_due_now: depositDue,
+    balance_due_later: balance,
+  }
+}

--- a/apps/backend/src/api/store/carts/[id]/quote-terms/lib.ts
+++ b/apps/backend/src/api/store/carts/[id]/quote-terms/lib.ts
@@ -1,4 +1,8 @@
-import { planCartCollection, type CollectionPlan } from "../../../../../lib/payments/deposit-collection"
+import {
+  planCartCollection,
+  type CollectionPlan,
+  type CollectionSchedule,
+} from "../../../../../lib/payments/deposit-collection"
 
 /**
  * What a buyer needs to be TOLD about a quote-bound cart, for
@@ -79,16 +83,18 @@ export function deriveQuoteCartTerms(
       }
     | null
     | undefined,
+  /**
+   * Extends `CollectionSchedule` — the exact shape the pricer reads — rather
+   * than restating it. A hand-written copy is how the two come to disagree
+   * about which fields are optional, and the pricer's opinion is the one that
+   * decides what the buyer is charged.
+   */
   schedule:
-    | {
+    | (CollectionSchedule & {
         deposit_pct?: number | string | null
-        deposit_amount?: number | string | null
-        deposit_status?: string | null
         balance_status?: string | null
         rail?: string | null
-        total_due?: number | string | null
-        currency_code?: string | null
-      }
+      })
     | null
     | undefined
 ): QuoteCartTerms {

--- a/apps/backend/src/api/store/carts/[id]/quote-terms/route.ts
+++ b/apps/backend/src/api/store/carts/[id]/quote-terms/route.ts
@@ -1,0 +1,56 @@
+/**
+ * GET /store/carts/:id/quote-terms
+ *
+ * What the storefront needs in order to render a quote-bound cart honestly
+ * (#1787): that its prices are held from a quote, and — when there is one —
+ * that only a deposit is collected today.
+ *
+ * A cart minted by `acceptQuoteWorkflow` is not an ordinary basket, and neither
+ * storefront said so. The buyer saw the full total on `/cart` with no mention
+ * of the 30% she was actually being asked for, and the split appeared, if at
+ * all, at the Review step.
+ *
+ * 🔴 The deposit reported here comes from `planCartCollection` — the same
+ * function `ensureCartPaymentCollection` uses to decide what the payment
+ * collection is created for. One pricer. A page that advertises a figure
+ * computed some other way is how the promise and the charge come to disagree.
+ *
+ * Reads only. Safe on an ordinary cart, which gets `is_quote_cart: false` and
+ * nulls throughout.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PAYMENT_SCHEDULE_MODULE } from "../../../../../modules/payment_schedule"
+import { deriveQuoteCartTerms } from "./lib"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const cartId = req.params.id
+
+  const { data: carts } = await query.graph({
+    entity: "cart",
+    fields: ["id", "currency_code", "total", "metadata"],
+    filters: { id: cartId },
+  })
+
+  const cart = carts?.[0] as any
+  if (!cart) {
+    return res.status(404).json({ message: "Cart not found" })
+  }
+
+  /**
+   * Best-effort. A schedule lookup that throws must not take down the cart
+   * page: the derivation below reports "terms unavailable" and the storefront
+   * falls back to the plain total, which is always a correct thing to show.
+   */
+  let schedule: any = null
+  try {
+    const schedules: any = req.scope.resolve(PAYMENT_SCHEDULE_MODULE)
+    schedule = await schedules.findByCartId(cartId)
+  } catch {
+    schedule = null
+  }
+
+  return res.json({ quote_terms: deriveQuoteCartTerms(cart, schedule) })
+}

--- a/apps/backend/src/api/store/carts/__tests__/quote-terms.unit.spec.ts
+++ b/apps/backend/src/api/store/carts/__tests__/quote-terms.unit.spec.ts
@@ -14,6 +14,7 @@ const AU_CART = {
 }
 
 const AU_SCHEDULE = {
+  id: "sched_au",
   currency_code: "aud",
   total_due: "314.77",
   deposit_pct: 30,

--- a/apps/backend/src/api/store/carts/__tests__/quote-terms.unit.spec.ts
+++ b/apps/backend/src/api/store/carts/__tests__/quote-terms.unit.spec.ts
@@ -1,0 +1,122 @@
+import { deriveQuoteCartTerms } from "../[id]/quote-terms/lib"
+
+/**
+ * #1787 — what a buyer is TOLD about a quote cart must be what she is CHARGED.
+ *
+ * The figures below are the live AUD quote that could not be paid:
+ * total A$314.77, deposit A$94.43 (30%), balance A$220.34.
+ */
+const AU_CART = {
+  id: "cart_au",
+  currency_code: "aud",
+  total: 314.77,
+  metadata: { quote_id: "01M1BPV6TMK0SVH32HX6SMQ25Z", partner_id: "p_1" },
+}
+
+const AU_SCHEDULE = {
+  currency_code: "aud",
+  total_due: "314.77",
+  deposit_pct: 30,
+  deposit_amount: "94.43",
+  deposit_status: "pending",
+  balance_status: "not_due",
+  rail: "stripe",
+}
+
+describe("deriveQuoteCartTerms", () => {
+  it("splits the cart into what is due now and what is due later", () => {
+    const terms = deriveQuoteCartTerms(AU_CART, AU_SCHEDULE)
+
+    expect(terms.is_quote_cart).toBe(true)
+    expect(terms.quote_id).toBe("01M1BPV6TMK0SVH32HX6SMQ25Z")
+    expect(terms.deposit_due_now).toBe(94.43)
+    expect(terms.balance_due_later).toBe(220.34)
+    expect(terms.deposit_pct).toBe(30)
+    expect(terms.rail).toBe("stripe")
+    expect(terms.unavailable_reason).toBeNull()
+  })
+
+  it("the two halves add back up to the cart total", () => {
+    const terms = deriveQuoteCartTerms(AU_CART, AU_SCHEDULE)
+
+    // 🔴 The assertion that catches a rounding split which quietly loses or
+    // invents a cent — the buyer would be shown a balance that never squares.
+    expect(
+      Math.round(
+        ((terms.deposit_due_now as number) +
+          (terms.balance_due_later as number)) *
+          100
+      )
+    ).toBe(Math.round((terms.total as number) * 100))
+  })
+
+  it("says nothing about a cart that did not come from a quote", () => {
+    const terms = deriveQuoteCartTerms(
+      { ...AU_CART, metadata: null },
+      AU_SCHEDULE
+    )
+
+    // An ordinary cart must look exactly as it did before, even if some
+    // schedule row happens to exist for it.
+    expect(terms.is_quote_cart).toBe(false)
+    expect(terms.deposit_due_now).toBeNull()
+    expect(terms.quote_id).toBeNull()
+  })
+
+  it("reports a quote cart with no schedule rather than inventing a split", () => {
+    const terms = deriveQuoteCartTerms(AU_CART, null)
+
+    expect(terms.is_quote_cart).toBe(true)
+    expect(terms.deposit_due_now).toBeNull()
+    expect(terms.unavailable_reason).toMatch(/no payment schedule/i)
+  })
+
+  it("advertises no split for a pay-in-full quote", () => {
+    const terms = deriveQuoteCartTerms(AU_CART, {
+      ...AU_SCHEDULE,
+      deposit_pct: 100,
+      deposit_amount: "314.77",
+    })
+
+    // `deposit_pct: 100` is legitimate — it is "pay in full", not a defect, so
+    // there is nothing to advertise and nothing to apologise for.
+    expect(terms.is_quote_cart).toBe(true)
+    expect(terms.deposit_due_now).toBeNull()
+    expect(terms.unavailable_reason).toBeNull()
+  })
+
+  it("refuses to advertise a deposit larger than the cart", () => {
+    const terms = deriveQuoteCartTerms(AU_CART, {
+      ...AU_SCHEDULE,
+      deposit_amount: "9999.00",
+    })
+
+    expect(terms.deposit_due_now).toBeNull()
+    expect(terms.unavailable_reason).toBeTruthy()
+  })
+
+  it("treats a stored zero deposit as no deposit, not a free one", () => {
+    // 🔑 `> 0`, not `!= null` — `Number(null)` is 0 and a stored 0 would
+    // otherwise advertise "pay nothing today".
+    const terms = deriveQuoteCartTerms(AU_CART, {
+      ...AU_SCHEDULE,
+      deposit_amount: "0",
+    })
+
+    expect(terms.deposit_due_now).toBeNull()
+    expect(terms.unavailable_reason).toBeTruthy()
+  })
+
+  it("carries the deposit status through, so a PAID deposit is not re-advertised", () => {
+    const terms = deriveQuoteCartTerms(AU_CART, {
+      ...AU_SCHEDULE,
+      deposit_status: "paid",
+    })
+
+    expect(terms.deposit_status).toBe("paid")
+    // The plan refuses a second collection on a paid deposit; the page must
+    // therefore not show "pay 94.43 now" again.
+    expect(terms.deposit_due_now).toBeNull()
+    expect(terms.unavailable_reason).toMatch(/paid/i)
+  })
+})

--- a/apps/backend/src/api/store/payment-collections/__tests__/route.unit.spec.ts
+++ b/apps/backend/src/api/store/payment-collections/__tests__/route.unit.spec.ts
@@ -1,0 +1,174 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+const mockCoreRefresh = jest.fn(async () => ({ result: {} }))
+const mockDeleteSessions = jest.fn(async () => ({ result: {} }))
+const mockCreateCollectionForCart = jest.fn(async () => ({
+  result: { id: "pc_full" },
+}))
+
+jest.mock("@medusajs/medusa/core-flows", () => ({
+  createPaymentCollectionForCartWorkflow: () => ({
+    run: mockCreateCollectionForCart,
+  }),
+  deletePaymentSessionsWorkflow: () => ({ run: mockDeleteSessions }),
+  refreshPaymentCollectionForCartWorkflow: () => ({ run: mockCoreRefresh }),
+}))
+
+jest.mock("../../../../modules/payment_schedule", () => ({
+  PAYMENT_SCHEDULE_MODULE: "payment_schedule",
+}))
+
+const mockRefetchEntity = jest.fn(async () => ({ id: "pc_x", amount: 0 }))
+
+jest.mock("@medusajs/framework/http", () => ({
+  refetchEntity: (...args: any[]) => mockRefetchEntity(...(args as [])),
+}))
+
+import { POST } from "../route"
+
+/**
+ * #1787 — the storefront's OWN checkout door.
+ *
+ * The deposit seam (#1451) was wired into the hosted Stripe page and the PayU
+ * rail, and both were verified. Neither is the door the ordinary checkout uses:
+ * `sdk.store.payment.initiatePaymentSession` POSTs `{ cart_id }` to
+ * `/store/payment-collections` first, and with no route file there it fell
+ * through to core, whose workflow hardcodes `amount: cart.raw_total`.
+ *
+ * A live AUD quote reached checkout with no deposit line and a demand for the
+ * full A$314.77 against a promised A$94.43.
+ *
+ * 🔑 These assert the AMOUNT the buyer would be charged, not that some helper
+ * was called. A test that only checks `ensureCartPaymentCollection` ran would
+ * pass against a mock of the very decision under test.
+ */
+const DEPOSIT_SCHEDULE = {
+  id: "sched_au",
+  deposit_amount: "94.43",
+  total_due: "314.77",
+  deposit_status: "pending",
+  currency_code: "aud",
+}
+
+const buildScope = (cart: any, schedule: any) => {
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  const paymentService = {
+    createPaymentCollections: jest.fn(async (input: any[]) => [
+      { id: "pc_deposit", ...input[0] },
+    ]),
+  }
+  const link = { create: jest.fn(async () => undefined) }
+  const schedules = { findByCartId: jest.fn(async () => schedule) }
+  const query = {
+    graph: jest.fn(async () => ({ data: cart ? [cart] : [] })),
+  }
+
+  const scope = {
+    resolve: (key: string) => {
+      if (key === ContainerRegistrationKeys.QUERY) return query
+      if (key === ContainerRegistrationKeys.LOGGER) return logger
+      if (key === ContainerRegistrationKeys.LINK) return link
+      if (key === Modules.PAYMENT) return paymentService
+      if (key === "payment_schedule") return schedules
+      throw new Error(`unexpected resolve(${key})`)
+    },
+  }
+
+  return { scope, paymentService, link, query }
+}
+
+const buildReq = (scope: any, body: any = { cart_id: "cart_au" }) =>
+  ({ scope, body, params: {}, queryConfig: {} } as any)
+
+const buildRes = () => {
+  const res: any = {}
+  res.status = jest.fn(() => res)
+  res.json = jest.fn(() => res)
+  return res
+}
+
+const AU_CART = {
+  id: "cart_au",
+  currency_code: "aud",
+  total: 314.77,
+  completed_at: null,
+}
+
+beforeEach(() => {
+  mockCreateCollectionForCart.mockClear()
+  mockRefetchEntity.mockClear()
+})
+
+describe("POST /store/payment-collections", () => {
+  it("mints the collection at the DEPOSIT, not the cart total", async () => {
+    const { scope, paymentService, link } = buildScope(AU_CART, DEPOSIT_SCHEDULE)
+
+    await POST(buildReq(scope), buildRes())
+
+    // 🔴 The assertion that fails against core's workflow: it would have been
+    // asked for 314.77, which is what the buyer was actually shown.
+    expect(paymentService.createPaymentCollections).toHaveBeenCalledWith([
+      { currency_code: "aud", amount: 94.43 },
+    ])
+    // Core's full-total workflow must not run at all on a deposit cart.
+    expect(mockCreateCollectionForCart).not.toHaveBeenCalled()
+    // Without the link, `cart.payment_collection` never resolves and the next
+    // request mints a SECOND collection.
+    expect(link.create).toHaveBeenCalledTimes(1)
+  })
+
+  it("leaves an ordinary cart on core's workflow, untouched", async () => {
+    const { scope, paymentService } = buildScope(
+      { ...AU_CART, id: "cart_plain" },
+      null
+    )
+
+    await POST(buildReq(scope, { cart_id: "cart_plain" }), buildRes())
+
+    expect(mockCreateCollectionForCart).toHaveBeenCalledTimes(1)
+    expect(paymentService.createPaymentCollections).not.toHaveBeenCalled()
+  })
+
+  it("refuses a completed cart rather than minting a second charge", async () => {
+    const { scope } = buildScope(
+      { ...AU_CART, completed_at: "2026-09-04T00:00:00.000Z" },
+      DEPOSIT_SCHEDULE
+    )
+
+    await expect(POST(buildReq(scope), buildRes())).rejects.toThrow(
+      /already completed/i
+    )
+  })
+
+  it("refuses a body with no cart_id", async () => {
+    const { scope } = buildScope(AU_CART, DEPOSIT_SCHEDULE)
+
+    await expect(POST(buildReq(scope, {}), buildRes())).rejects.toThrow(
+      /cart_id is required/i
+    )
+  })
+
+  it("404s an unknown cart", async () => {
+    const { scope } = buildScope(null, DEPOSIT_SCHEDULE)
+
+    await expect(POST(buildReq(scope), buildRes())).rejects.toThrow(/not found/i)
+  })
+
+  it("returns the collection under the key the SDK reads", async () => {
+    const { scope } = buildScope(AU_CART, DEPOSIT_SCHEDULE)
+    mockRefetchEntity.mockResolvedValueOnce({
+      id: "pc_deposit",
+      amount: 94.43,
+    } as any)
+    const res = buildRes()
+
+    await POST(buildReq(scope), res)
+
+    // 🔴 `initiatePaymentSession` reads `.payment_collection.id` off this
+    // response and passes it straight into the session URL. A wrong key is a
+    // confident nothing: the SDK would throw on `undefined.id`.
+    expect(res.json).toHaveBeenCalledWith({
+      payment_collection: { id: "pc_deposit", amount: 94.43 },
+    })
+  })
+})

--- a/apps/backend/src/api/store/payment-collections/route.ts
+++ b/apps/backend/src/api/store/payment-collections/route.ts
@@ -1,0 +1,108 @@
+import {
+  MedusaRequest,
+  MedusaResponse,
+  refetchEntity,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { ensureCartPaymentCollection } from "../../../lib/payments/ensure-cart-collection"
+
+const DEFAULT_FIELDS = ["id", "currency_code", "amount", "*payment_sessions"]
+
+/**
+ * Override of the core store payment-collection route
+ * (POST /store/payment-collections).
+ *
+ * ## Why this exists — the third door (#1787)
+ *
+ * #1451 established that a deposit cannot be expressed through core's
+ * `createPaymentCollectionForCartWorkflow`, which hardcodes
+ * `amount: cart.raw_total`, and replaced it with `ensureCartPaymentCollection`
+ * — in the two places that were known to create a collection: the hosted Stripe
+ * payment page and the PayU rail.
+ *
+ * 🔴 It was never fixed at the door the ORDINARY STOREFRONT CHECKOUT uses. The
+ * starter's `initiatePaymentSession` calls `sdk.store.payment
+ * .initiatePaymentSession(cart, …)`, which POSTs here first to make the
+ * collection, and only then creates the session. There was no route file under
+ * `api/store/payment-collections/`, so that POST fell through to core and every
+ * quote cart entering checkout the normal way had a collection minted for the
+ * FULL total.
+ *
+ * The buyer-visible symptom is exactly what was reported on a live AUD quote:
+ * the checkout shows no "Pay now (deposit)" line and asks for the whole amount.
+ * The storefront's `Review` panel derives that line from
+ * `payment_collection.amount < cart.total`, so a full-total collection does not
+ * render a broken deposit — it renders no deposit at all, which reads like a
+ * product decision rather than a defect.
+ *
+ * ⚠️ Two green rails are not a covered money path. The deposit was verified end
+ * to end on the hosted page and on PayU, and the conclusion drawn was that "the
+ * deposit works". Both verifications went through the two doors that had been
+ * fixed. Enumerate the callers of the thing you replaced, not the ones you
+ * remember replacing.
+ *
+ * ## Behaviour
+ *
+ * Identical to core for an ordinary cart: `planCartCollection` returns a `full`
+ * basis and `ensureCartPaymentCollection` runs core's own workflow untouched.
+ * Only a cart carrying a payment schedule with a usable deposit takes the
+ * bespoke path, and that path refuses rather than guesses (see
+ * `deposit-collection.ts`).
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req as any).validatedBody ?? req.body ?? {}
+  const cartId = String((body as { cart_id?: string }).cart_id || "")
+
+  if (!cartId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "cart_id is required to create a payment collection"
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: "cart",
+    fields: [
+      "id",
+      "completed_at",
+      "currency_code",
+      "total",
+      "payment_collection.id",
+      // The seam refuses to reuse a collection whose amount disagrees with the
+      // schedule, so it must be able to see the amount (#1451).
+      "payment_collection.amount",
+    ],
+    filters: { id: cartId },
+  })
+
+  const cart = data?.[0] as any
+
+  if (!cart) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Cart ${cartId} not found`)
+  }
+
+  /**
+   * Core does not check this here, but minting a collection against a completed
+   * cart can only lead to a second charge on an order that is already paid.
+   */
+  if (cart.completed_at) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Cart ${cartId} is already completed`
+    )
+  }
+
+  const { id } = await ensureCartPaymentCollection(req.scope, cart)
+
+  const paymentCollection = await refetchEntity({
+    entity: "payment_collection",
+    idOrFilter: id,
+    scope: req.scope,
+    fields: req.queryConfig?.fields ?? DEFAULT_FIELDS,
+  })
+
+  res.status(200).json({ payment_collection: paymentCollection })
+}

--- a/apps/storefront/src/app/[countryCode]/(checkout)/checkout/cart/[cartId]/route.ts
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/checkout/cart/[cartId]/route.ts
@@ -1,6 +1,8 @@
 import { cookies } from "next/headers"
 import { NextRequest, NextResponse } from "next/server"
 
+import { retrieveCart } from "@lib/data/cart"
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ countryCode: string; cartId: string }> }
@@ -18,7 +20,39 @@ export async function GET(
     path: "/",
   })
 
-  const redirectTo = `/${countryCode}/checkout?step=address`
+  /**
+   * 🔴 The CART's country, not the URL's (#1787).
+   *
+   * This is the abandoned-cart recovery link, and the recovery flow builds it
+   * with no country segment at all (`STORE_URL + "/checkout/cart/" + cart.id`).
+   * The middleware therefore fills in `NEXT_PUBLIC_DEFAULT_REGION`, so the
+   * buyer is handed to a checkout in the DEFAULT region regardless of what
+   * their cart is priced in. For an AUD quote cart that means payment providers
+   * resolve from India — PayU, never Stripe — and the address form's
+   * region-scoped country select offers only `in` against an `au` address,
+   * which blocks submit with no error anywhere.
+   *
+   * The cart already knows where it belongs, so ask it. Best-effort: a failed
+   * lookup falls back to the old behaviour rather than stranding a buyer who
+   * clicked a recovery mail.
+   */
+  let checkoutCountry = countryCode
+
+  try {
+    const cart = await retrieveCart(cartId, "id,region.countries.iso_2")
+    const cartCountry = cart?.region?.countries?.[0]?.iso_2?.toLowerCase()
+
+    if (cartCountry && cartCountry !== countryCode) {
+      console.log(
+        `[Cart Checkout Route] cart region country=${cartCountry} overrides url countryCode=${countryCode}`
+      )
+      checkoutCountry = cartCountry
+    }
+  } catch (e) {
+    console.log(`[Cart Checkout Route] region lookup failed, keeping ${countryCode}`, e)
+  }
+
+  const redirectTo = `/${checkoutCountry}/checkout?step=address`
   console.log(`[Cart Checkout Route] → Redirecting to ${redirectTo}`)
 
   return NextResponse.redirect(

--- a/apps/storefront/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -1,4 +1,4 @@
-import { retrieveCart } from "@lib/data/cart"
+import { retrieveCart, retrieveQuoteTerms } from "@lib/data/cart"
 import { retrieveCustomer } from "@lib/data/customer"
 import PaymentWrapper from "@modules/checkout/components/payment-wrapper"
 import CheckoutForm from "@modules/checkout/templates/checkout-form"
@@ -18,14 +18,18 @@ export default async function Checkout() {
     return notFound()
   }
 
-  const customer = await retrieveCustomer()
+  // #1787 — the deposit must be visible here, not first met at Review.
+  const [customer, quoteTerms] = await Promise.all([
+    retrieveCustomer(),
+    retrieveQuoteTerms(cart.id),
+  ])
 
   return (
     <div className="grid grid-cols-1 small:grid-cols-[1fr_416px] content-container gap-x-40 py-12">
       <PaymentWrapper cart={cart}>
         <CheckoutForm cart={cart} customer={customer} />
       </PaymentWrapper>
-      <CheckoutSummary cart={cart} />
+      <CheckoutSummary cart={cart} quoteTerms={quoteTerms} />
     </div>
   )
 }

--- a/apps/storefront/src/app/[countryCode]/(main)/cart/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/cart/page.tsx
@@ -1,4 +1,4 @@
-import { retrieveCart } from "@lib/data/cart"
+import { retrieveCart, retrieveQuoteTerms } from "@lib/data/cart"
 import { retrieveCustomer } from "@lib/data/customer"
 import CartTemplate from "@modules/cart/templates"
 import { Metadata } from "next"
@@ -15,7 +15,15 @@ export default async function Cart() {
     return notFound()
   })
 
-  const customer = await retrieveCustomer()
+  const [customer, quoteTerms] = await Promise.all([
+    retrieveCustomer(),
+    // #1787 — a quote cart must say so, and say what is due TODAY. Null for an
+    // ordinary cart, and null if the lookup fails: the plain total is always a
+    // correct thing to render.
+    retrieveQuoteTerms(cart?.id),
+  ])
 
-  return <CartTemplate cart={cart} customer={customer} />
+  return (
+    <CartTemplate cart={cart} customer={customer} quoteTerms={quoteTerms} />
+  )
 }

--- a/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from "next"
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 
 import { retrieveQuote } from "@lib/data/quotes"
+import { getRegion } from "@lib/data/regions"
 import { parseDialledLines } from "@lib/util/quote-lines"
 import QuoteTemplate from "@modules/quotes/templates"
 
@@ -89,8 +90,48 @@ export default async function QuotePage({ params, searchParams }: Props) {
     notFound()
   }
 
-  // 🔑 `countryCode` comes from the route segment, not from the quote. The
-  // storefront routes every page under it, so a checkout link built from the
-  // quote's DESTINATION would leave the locale the buyer is actually browsing.
-  return <QuoteTemplate quote={quote} token={token} countryCode={countryCode} />
+  /**
+   * 🔴 The quote decides the prefix, not the URL (#1787).
+   *
+   * This used to read: *"a checkout link built from the quote's DESTINATION
+   * would leave the locale the buyer is actually browsing"* — treating the
+   * route segment as authoritative. It is not, and a live buyer could not pay
+   * because of it. `buildQuoteBuyerUrl` mints the link under the quote's own
+   * country, but the middleware falls back to `NEXT_PUBLIC_DEFAULT_REGION` for
+   * any path whose first segment is not a known country, so a single
+   * un-prefixed internal link (the abandoned-cart recovery mail sends one) is
+   * enough to put an AU buyer on `/in`. From there the accept pushes to
+   * `/in/checkout`, the cart resolves payment providers from India — PayU, never
+   * Stripe — and the address form's region-scoped country select offers only
+   * `in` against her `au` address, silently refusing to submit.
+   *
+   * A quote is a document about one destination. There is no locale to preserve.
+   *
+   * ⚠️ Only redirect where the destination actually HAS a region: a prefix with
+   * no region would be rewritten by the middleware to the default one, which is
+   * the very state this is here to prevent.
+   */
+  const destination = quote.destination_country_code?.toLowerCase() || null
+  const destinationRegion = destination ? await getRegion(destination) : null
+
+  if (destinationRegion && destination && destination !== countryCode) {
+    // The dialled basket is part of what the buyer is looking at — dropping it
+    // on the redirect would reset their quantities to the quoted ones without
+    // saying so.
+    const dial = Array.isArray(lines) ? lines[0] : lines
+    const query = dial ? `?lines=${encodeURIComponent(dial)}` : ""
+    redirect(`/${destination}/quotes/${token}${query}`)
+  }
+
+  return (
+    <QuoteTemplate
+      quote={quote}
+      token={token}
+      countryCode={countryCode}
+      // Normally identical to `countryCode` — the redirect above has already
+      // agreed them. It differs only in the un-redirectable case: a destination
+      // this storefront has no region for.
+      checkoutCountryCode={destinationRegion && destination ? destination : countryCode}
+    />
+  )
 }

--- a/apps/storefront/src/lib/data/cart.ts
+++ b/apps/storefront/src/lib/data/cart.ts
@@ -16,6 +16,7 @@ import {
 } from "./cookies"
 import { getRegion } from "./regions"
 import { getLocale } from "@lib/data/locale-actions"
+import type { QuoteCartTerms } from "types/quote-terms"
 
 /**
  * Retrieves a cart by its ID. If no ID is provided, it will use the cart ID from the cookies.
@@ -75,6 +76,47 @@ export async function retrieveCart(cartId?: string, fields?: string) {
  */
 const isQuoteBoundCart = (cart?: { metadata?: Record<string, unknown> | null } | null) =>
   Boolean(cart?.metadata?.quote_id)
+
+/**
+ * The quote terms behind a cart, or null (#1787).
+ *
+ * 🔴 Never computes a deposit here. The backend derives it with the same
+ * function that creates the payment collection, so what the page promises and
+ * what the gateway charges cannot drift apart.
+ *
+ * Swallows failures on purpose: this decorates a cart page, and a cart must
+ * still render — at its plain total, which is always correct — if the lookup
+ * fails.
+ */
+export async function retrieveQuoteTerms(
+  cartId?: string
+): Promise<QuoteCartTerms | null> {
+  const id = cartId || (await getCartId())
+
+  if (!id) {
+    return null
+  }
+
+  const headers = {
+    ...(await getAuthHeaders()),
+  }
+
+  const next = {
+    ...(await getCacheOptions("carts")),
+  }
+
+  return sdk.client
+    .fetch<{ quote_terms: QuoteCartTerms }>(`/store/carts/${id}/quote-terms`, {
+      method: "GET",
+      headers,
+      // Tagged with the cart, so paying the deposit revalidates it. NOT
+      // force-cached: `deposit_status` flips from `pending` to `paid` and a
+      // stale copy would keep asking a buyer for money she has already sent.
+      next,
+    })
+    .then(({ quote_terms }) => quote_terms ?? null)
+    .catch(() => null)
+}
 
 export async function getOrSetCart(countryCode: string) {
   const region = await getRegion(countryCode)

--- a/apps/storefront/src/lib/data/cart.ts
+++ b/apps/storefront/src/lib/data/cart.ts
@@ -52,6 +52,30 @@ export async function retrieveCart(cartId?: string, fields?: string) {
     .catch(() => null)
 }
 
+/**
+ * Is this cart bound to a quote, and therefore NOT free to be re-regioned?
+ *
+ * 🔴 #1787. A browsing cart should follow the URL prefix — that is what the
+ * locale switcher is for. A quote cart must not: `acceptQuoteWorkflow` mints it
+ * against frozen prices, a fixed currency and a freight option rated in one
+ * specific lane, and stamps `metadata.quote_id` on it. Moving that cart to the
+ * region of whatever prefix the buyer happens to be under is not a locale
+ * preference, it is a silent re-pricing of an agreement they already accepted.
+ *
+ * A live example: an AUD quote opened under `/in/` was dragged into the
+ * India/INR region, which offered PayU instead of Stripe and scoped the
+ * checkout's country select to `in` — a required select with no option matching
+ * her `au` address, so the form refused to submit with nothing in any log.
+ *
+ * ⚠️ This file is a FORK of `apps/storefront-starter/src/lib/data/cart.ts` and
+ * carried the same defect. A fix here has two homes; change both.
+ *
+ * Not exported: this file is `"use server"`, where every export must be an
+ * async server action.
+ */
+const isQuoteBoundCart = (cart?: { metadata?: Record<string, unknown> | null } | null) =>
+  Boolean(cart?.metadata?.quote_id)
+
 export async function getOrSetCart(countryCode: string) {
   const region = await getRegion(countryCode)
 
@@ -59,7 +83,9 @@ export async function getOrSetCart(countryCode: string) {
     throw new Error(`Region not found for country code: ${countryCode}`)
   }
 
-  let cart = await retrieveCart(undefined, "id,region_id")
+  // `metadata` is fetched for the quote-cart guard below — without it the
+  // marker reads `undefined` on every cart and the guard is dead code.
+  let cart = await retrieveCart(undefined, "id,region_id,metadata")
 
   const headers = {
     ...(await getAuthHeaders()),
@@ -80,7 +106,7 @@ export async function getOrSetCart(countryCode: string) {
     revalidateTag(cartCacheTag)
   }
 
-  if (cart && cart?.region_id !== region.id) {
+  if (cart && cart?.region_id !== region.id && !isQuoteBoundCart(cart)) {
     await sdk.store.cart.update(cart.id, { region_id: region.id }, {}, headers)
     const cartCacheTag = await getCacheTag("carts")
     revalidateTag(cartCacheTag)
@@ -477,9 +503,18 @@ export async function updateRegion(countryCode: string, currentPath: string) {
   }
 
   if (cartId) {
-    await updateCart({ region_id: region.id })
-    const cartCacheTag = await getCacheTag("carts")
-    revalidateTag(cartCacheTag)
+    // #1787 — the locale switcher moves the STOREFRONT, and normally the cart
+    // with it. It must not move a quote cart: the prices, currency and freight
+    // on that cart were agreed, not browsed. The buyer still gets the locale
+    // they asked for; the quote they accepted simply does not follow them into
+    // it. See `isQuoteBoundCart`.
+    const cart = await retrieveCart(cartId, "id,region_id,metadata")
+
+    if (!isQuoteBoundCart(cart)) {
+      await updateCart({ region_id: region.id })
+      const cartCacheTag = await getCacheTag("carts")
+      revalidateTag(cartCacheTag)
+    }
   }
 
   const regionCacheTag = await getCacheTag("regions")

--- a/apps/storefront/src/modules/cart/components/quote-cart-notice/index.tsx
+++ b/apps/storefront/src/modules/cart/components/quote-cart-notice/index.tsx
@@ -1,0 +1,110 @@
+import { Text, clx } from "@medusajs/ui"
+
+import { convertToLocale } from "@lib/util/money"
+import type { QuoteCartTerms } from "types/quote-terms"
+
+/**
+ * What a quote-bound cart is, said plainly (#1787).
+ *
+ * A cart minted by accepting a quote looked exactly like an ordinary basket.
+ * A live buyer therefore saw A$314.77 on the cart page, was told nothing about
+ * the 30% she was actually being asked for today, and met the split for the
+ * first time at the Review step — if she got that far.
+ *
+ * Two things are worth saying, and this says only those two:
+ *
+ *   1. **These prices are held.** They came from a quote, they are not the
+ *      current shop prices, and they will not move under her.
+ *   2. **This is what you pay today, and this is what comes later** — when the
+ *      cart is on a deposit.
+ *
+ * 🔴 Every figure is rendered from the server's `quote_terms`, computed by the
+ * same function that decides what the payment collection is created for. This
+ * component does no arithmetic beyond formatting. A page that computes its own
+ * deposit is how the promise and the charge come to disagree — see the
+ * A$94.43-vs-A$314.77 defect this shipped with.
+ *
+ * ⚠️ Renders nothing at all unless the cart is quote-bound AND there is a real
+ * split to show. A quote whose deposit is 100%, or whose deposit has already
+ * been paid, has nothing to advertise, and an unavailable/refused plan must
+ * fall back to the plain total rather than invent one.
+ */
+const QuoteCartNotice = ({
+  terms,
+  className,
+}: {
+  terms: QuoteCartTerms | null
+  className?: string
+}) => {
+  if (!terms?.is_quote_cart) {
+    return null
+  }
+
+  const currency = terms.currency_code ?? undefined
+  const money = (amount: number | null) =>
+    amount === null || !currency
+      ? null
+      : convertToLocale({ amount, currency_code: currency })
+
+  const depositDue = money(terms.deposit_due_now)
+  const balanceLater = money(terms.balance_due_later)
+  const hasSplit = Boolean(depositDue && balanceLater)
+
+  const depositPaid = terms.deposit_status === "paid"
+
+  return (
+    <div
+      className={clx(
+        "rounded-lg border border-ui-border-base bg-ui-bg-subtle p-4",
+        className
+      )}
+      data-testid="quote-cart-notice"
+    >
+      <Text className="txt-medium-plus text-ui-fg-base">
+        Priced from your quote
+      </Text>
+      <Text className="txt-small text-ui-fg-subtle mt-1">
+        These prices, and the shipping on them, are the ones you were quoted.
+        They are held for this order and will not change here.
+      </Text>
+
+      {hasSplit && !depositPaid && (
+        <div className="mt-4 flex flex-col gap-y-2 border-t border-ui-border-base pt-4">
+          <div className="flex items-center justify-between">
+            <Text className="txt-small text-ui-fg-subtle">
+              Due today
+              {terms.deposit_pct ? ` (${terms.deposit_pct}%)` : ""}
+            </Text>
+            <Text
+              className="txt-medium-plus text-ui-fg-base"
+              data-testid="quote-deposit-due"
+            >
+              {depositDue}
+            </Text>
+          </div>
+          <div className="flex items-center justify-between">
+            <Text className="txt-small text-ui-fg-subtle">Due later</Text>
+            <Text className="txt-small text-ui-fg-base" data-testid="quote-balance-later">
+              {balanceLater}
+            </Text>
+          </div>
+          {/* The balance starts `not_due` on purpose — it is raised on a
+              production or delivery event, not at checkout. Saying so stops a
+              buyer expecting a second charge tonight. */}
+          <Text className="txt-small text-ui-fg-muted mt-1">
+            You are charged the amount due today at checkout. The balance is
+            requested later, when your order is ready — not now.
+          </Text>
+        </div>
+      )}
+
+      {depositPaid && (
+        <Text className="txt-small text-ui-fg-subtle mt-3" data-testid="quote-deposit-paid">
+          Your deposit has been received.
+        </Text>
+      )}
+    </div>
+  )
+}
+
+export default QuoteCartNotice

--- a/apps/storefront/src/modules/cart/templates/index.tsx
+++ b/apps/storefront/src/modules/cart/templates/index.tsx
@@ -4,13 +4,18 @@ import EmptyCartMessage from "../components/empty-cart-message"
 import SignInPrompt from "../components/sign-in-prompt"
 import Divider from "@modules/common/components/divider"
 import { HttpTypes } from "@medusajs/types"
+import QuoteCartNotice from "../components/quote-cart-notice"
+import type { QuoteCartTerms } from "types/quote-terms"
 
 const CartTemplate = ({
   cart,
   customer,
+  quoteTerms,
 }: {
   cart: HttpTypes.StoreCart | null
   customer: HttpTypes.StoreCustomer | null
+  /** #1787 — null for an ordinary cart. */
+  quoteTerms?: QuoteCartTerms | null
 }) => {
   return (
     <div className="py-12">
@@ -18,6 +23,11 @@ const CartTemplate = ({
         {cart?.items?.length ? (
           <div className="grid grid-cols-1 small:grid-cols-[1fr_360px] gap-x-40">
             <div className="flex flex-col bg-white py-6 gap-y-6">
+              {/* Above the line items on purpose: "these prices are held, and
+                  this is what you pay today" is context for everything below
+                  it, and a buyer who scrolls past the basket to the total has
+                  already formed an expectation by then. */}
+              <QuoteCartNotice terms={quoteTerms ?? null} />
               {!customer && (
                 <>
                   <SignInPrompt />

--- a/apps/storefront/src/modules/checkout/templates/checkout-summary/index.tsx
+++ b/apps/storefront/src/modules/checkout/templates/checkout-summary/index.tsx
@@ -4,8 +4,17 @@ import ItemsPreviewTemplate from "@modules/cart/templates/preview"
 import DiscountCode from "@modules/checkout/components/discount-code"
 import CartTotals from "@modules/common/components/cart-totals"
 import Divider from "@modules/common/components/divider"
+import QuoteCartNotice from "@modules/cart/components/quote-cart-notice"
+import type { QuoteCartTerms } from "types/quote-terms"
 
-const CheckoutSummary = ({ cart }: { cart: any }) => {
+const CheckoutSummary = ({
+  cart,
+  quoteTerms,
+}: {
+  cart: any
+  /** #1787 — null for an ordinary cart. */
+  quoteTerms?: QuoteCartTerms | null
+}) => {
   return (
     <div className="sticky top-0 flex flex-col-reverse small:flex-col gap-y-8 py-8 small:py-0 ">
       <div className="w-full bg-white flex flex-col">
@@ -17,6 +26,10 @@ const CheckoutSummary = ({ cart }: { cart: any }) => {
           In your Cart
         </Heading>
         <Divider className="my-6" />
+        {/* Directly under the totals: the buyer has just read the full
+            amount, and this is the moment the "due today" figure has to
+            appear — not two steps later at Review. */}
+        <QuoteCartNotice terms={quoteTerms ?? null} className="mb-6" />
         <CartTotals totals={cart} />
         <ItemsPreviewTemplate cart={cart} />
         <div className="my-6">

--- a/apps/storefront/src/modules/quotes/components/quote-accept/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-accept/index.tsx
@@ -40,6 +40,14 @@ const QuoteAcceptPanel = ({
 }: {
   token: string
   acceptance: QuoteAcceptance
+  /**
+   * 🔴 The QUOTE's destination country, not the route segment (#1787). The
+   * caller resolves it; this panel must not fall back to `useParams`. Pushing
+   * to the segment the buyer happens to be under sent an AU buyer to
+   * `/in/checkout`, where payment providers resolve from India (PayU, never
+   * Stripe) and the address form's country select — scoped to the region —
+   * offered only `in` against her `au` address and silently refused to submit.
+   */
   countryCode: string
   /**
    * Outer spacing, owned by the LAYOUT rather than by this panel (#1439 S14).

--- a/apps/storefront/src/modules/quotes/templates/index.tsx
+++ b/apps/storefront/src/modules/quotes/templates/index.tsx
@@ -29,11 +29,22 @@ const QuoteTemplate = ({
   quote,
   token,
   countryCode,
+  checkoutCountryCode,
 }: {
   quote: QuoteView
   token: string
   countryCode: string
+  /**
+   * The prefix CHECKOUT must run under (#1787) — the quote's own destination,
+   * not the segment the buyer arrived on. Normally equal to `countryCode`,
+   * since the page redirects to agree them; they diverge only where the
+   * storefront has no region for the destination.
+   */
+  checkoutCountryCode?: string
 }) => {
+  // Links WITHIN the quote document stay on the current prefix; only the
+  // hand-off to checkout is forced to the quote's country.
+  const checkoutCountry = checkoutCountryCode ?? countryCode
   const {
     compare,
     recipient,
@@ -162,7 +173,7 @@ const QuoteTemplate = ({
             <QuoteAcceptPanel
               token={token}
               acceptance={acceptance}
-              countryCode={countryCode}
+              countryCode={checkoutCountry}
               /* 🔴 The basket AS PRICED ABOVE, not the quoted one. `quote.lines`
              already carries the buyer's dial — the backend re-priced the whole
              document through it — so handing these straight to the accept call

--- a/apps/storefront/src/types/quote-terms.ts
+++ b/apps/storefront/src/types/quote-terms.ts
@@ -1,0 +1,37 @@
+/**
+ * The terms a quote-bound cart carries, from
+ * `GET /store/carts/:id/quote-terms` (#1787).
+ *
+ * A cart minted by accepting a quote is not an ordinary basket — its prices are
+ * held, and usually only a deposit is collected today. The storefront said none
+ * of that, so a buyer saw the full total on `/cart` and met the 30% for the
+ * first time at the Review step, if at all.
+ *
+ * 🔴 Every figure here is computed by the backend's `planCartCollection`, the
+ * same function that decides what the payment collection is actually created
+ * for. Do not re-derive a deposit in the browser: a page that computes its own
+ * split is how the promise and the charge come to disagree.
+ *
+ * Lives outside `lib/data/cart.ts` because that file is `"use server"`, where
+ * exports must be async functions.
+ */
+export type QuoteCartTerms = {
+  /** False for an ordinary cart; every other field is then null. */
+  is_quote_cart: boolean
+  quote_id: string | null
+  currency_code: string | null
+  total: number | null
+  /** Null when the whole total is due now — including a legitimate `deposit_pct: 100`. */
+  deposit_due_now: number | null
+  balance_due_later: number | null
+  deposit_pct: number | null
+  deposit_status: string | null
+  balance_status: string | null
+  rail: string | null
+  /**
+   * Set when the cart came from a quote but no split could be stated
+   * confidently. Not an error — the cart is payable in full, and the storefront
+   * should show the plain total rather than invent a split.
+   */
+  unavailable_reason: string | null
+}


### PR DESCRIPTION
Closes part of #1787. Found by the founder on the live AUD quote: the checkout showed **no deposit line and asked for the whole A$314.77** against a promised A$94.43.

## The third door

#1451 established that a deposit cannot be expressed through core's `createPaymentCollectionForCartWorkflow`, which hardcodes `amount: cart.raw_total`, and routed both known collection-creating paths through `ensureCartPaymentCollection`: the hosted Stripe payment page and the PayU rail. Both were verified end to end.

🔴 **Neither is the door the ordinary storefront checkout uses.** The SDK's `initiatePaymentSession` POSTs `{ cart_id }` to `/store/payment-collections` to mint the collection, and only then creates the session:

```js
// @medusajs/js-sdk — store/index.js
let paymentCollectionId = cart.payment_collection?.id
if (!paymentCollectionId) {
  paymentCollectionId = (await this.client.fetch(`/store/payment-collections`, {
    method: "POST", body: { cart_id: cart.id },
  })).payment_collection.id
}
```

There was no route file under `api/store/payment-collections/`, so that POST fell through to core and **every quote cart entering checkout the normal way got a collection for the full total.**

The symptom reads like a product decision rather than a defect: the storefront's `Review` panel derives its deposit line from `payment_collection.amount < cart.total`, so a full-total collection does not render a *broken* deposit — it renders **no deposit at all**.

> ⚠️ Two green rails are not a covered money path. Enumerate the callers of the thing you replaced, not the ones you remember replacing.

## Behaviour

Ordinary carts are unaffected — `planCartCollection` returns a `full` basis and core's own workflow runs untouched. Only a cart carrying a payment schedule with a usable deposit takes the bespoke path, and that path refuses rather than guesses. The route additionally refuses a **completed** cart, which core does not check here and where a second collection could only lead to a second charge.

## Also: the #1787 region fix, carried into `apps/storefront`

`apps/storefront` is a **fork** of `apps/storefront-starter` and carried the same three defects (fixed in the submodule by [nextjs-starter-medusa#31](https://github.com/Jaal-Yantra-Textiles/nextjs-starter-medusa/pull/31)), plus one of its own:

- `getOrSetCart` / `updateRegion` no longer re-region a cart minted against a quote (gated on `metadata.quote_id`, now actually fetched — the guard would otherwise read `undefined` on every cart and be dead code);
- the quote page redirects to its own destination country instead of accepting whichever prefix it was opened under;
- **the abandoned-cart recovery route** (`/[countryCode]/checkout/cart/[cartId]`, which adopts a cart id from the URL) now sends the buyer to the **cart's** country rather than the URL's. The recovery flow builds that link with *no country segment at all* (`STORE_URL + "/checkout/cart/" + cart.id`), so the middleware filled in `NEXT_PUBLIC_DEFAULT_REGION` and handed an AUD cart to an India/INR checkout — PayU instead of Stripe, and an address form that silently refused to submit.

## Tests

Six cases in `api/store/payment-collections/__tests__/route.unit.spec.ts`, asserting the **amount the buyer would be charged**, not that a helper ran:

```
✓ mints the collection at the DEPOSIT, not the cart total
✓ leaves an ordinary cart on core's workflow, untouched
✓ refuses a completed cart rather than minting a second charge
✓ refuses a body with no cart_id
✓ 404s an unknown cart
✓ returns the collection under the key the SDK reads
```

🔴 Verified **red against the old behaviour** before going green: swapping the handler back to `createPaymentCollectionForCartWorkflow` fails `mints the collection at the DEPOSIT` (1 failed, 5 passed) — a test that only checked `ensureCartPaymentCollection` ran would have passed against a mock of the very decision under test.

## Verify

- `TEST_TYPE=unit npx jest --testPathPattern="payment-collections|ensure-cart-collection|deposit-collection"` → 3 suites, 26 tests green
- `pnpm check:prod-build` → exit 0
- `apps/storefront` `next build` → exit 0

## Still open on #1787

The submodule pointer is **not** bumped in this PR — [nextjs-starter-medusa#31](https://github.com/Jaal-Yantra-Textiles/nextjs-starter-medusa/pull/31) must merge first, or the pointer would reference a commit that is not on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4