### PR TITLE
fix(ci): prod-build has been red on main since #1788

### DIFF
--- a/apps/backend/src/modules/partner-quote/lib/resolve-region.ts
+++ b/apps/backend/src/modules/partner-quote/lib/resolve-region.ts
@@ -152,7 +152,17 @@ export async function resolveQuoteRegion(
 
   const resolved = pickQuoteRegion((regions ?? []) as RegionLike[], input)
 
-  if (opts.strict && !resolved.region_id) {
+  /**
+   * 🔴 Narrow on `source`, not on `!region_id`.
+   *
+   * `RegionResolution` is a union whose failure branch is the only one carrying
+   * `reason`, and `source` is its discriminant. TypeScript narrows a union by
+   * truthiness only when the property is a literal type — `region_id: string`
+   * is not, so `!resolved.region_id` narrowed nothing and `resolved.reason`
+   * did not compile. That failed CI's `prod-build` job on every push, on `main`
+   * included, from the moment #1788 landed.
+   */
+  if (opts.strict && resolved.source === "none") {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
       `Cannot determine the region for this quote: ${resolved.reason}. ` +


### PR DESCRIPTION
Found while merging #1790: CI's `prod-build` job fails on **every** push, `main` included.

```
src/modules/partner-quote/lib/resolve-region.ts:158:63 - error TS2339:
Property 'reason' does not exist on type 'RegionResolution'.
```

`RegionResolution` is a union whose failure branch alone carries `reason`, discriminated by `source`:

```ts
export type RegionResolution =
  | { region_id: string; source: "explicit" | "derived" }
  | { region_id: null; source: "none"; reason: string }
```

The strict guard narrowed on `!resolved.region_id`. TypeScript narrows a union by truthiness **only when the property is a literal type** — `region_id: string` is not, so nothing narrowed and `resolved.reason` did not compile. Narrowing on `source === "none"` fixes it and says what is actually meant.

### Why this survived a merge and a deploy

Two independent reasons, worth knowing:

1. **The prod deploy is not gated on this job**, so #1788 shipped and works.
2. **`pnpm check:prod-build` prints the error locally and still exits 0.** The local gate reads green while CI reads red — which is how I nearly filed it as "pre-existing, not mine" and moved on. I verified it was pre-existing (`git show main:…` has the line verbatim) but should have gone one step further and asked why CI was red at all.

### Verify

- `npx tsc --noEmit` → no error in `resolve-region.ts`
- `TEST_TYPE=unit jest --testPathPattern="resolve-region"` → 9/9 green

Behaviour is unchanged: the guard fires in exactly the same case, since `source === "none"` is precisely when `region_id` is null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4