### PR TITLE
fix(shiprocket): live rate calls read the one credential path that is blank

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -1,6 +1,8 @@
 import { loadEnv, defineConfig, Modules } from "@medusajs/framework/utils";
 import path from "path";
 import { parseFlatFallbackAmounts } from "./src/modules/shipping-providers/shiprocket/flat-fallback"
+import { SOCIALS_MODULE } from "./src/modules/socials"
+import { ENCRYPTION_MODULE } from "./src/modules/encryption"
 
 loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 
@@ -334,6 +336,18 @@ module.exports = defineConfig({
     },
     {
       resolve: "@medusajs/medusa/fulfillment",
+      /**
+       * 🔴 Load-bearing and invisible (#1451 follow-on). A fulfillment PROVIDER
+       * is built with the parent module's cradle — six default keys and nothing
+       * else — so without these two the Shiprocket service cannot read the
+       * carrier credentials in the `category:shipping` SocialPlatform record,
+       * and its rate calls fall back to env vars this manifest DELIBERATELY
+       * leaves unset. That is what made every live rate call in prod answer
+       * `422 — The password is required`.
+       *
+       * Drop these and the symptom returns silently.
+       */
+      dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE],
       options: {
         providers: [
           {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -1,6 +1,8 @@
 import { loadEnv, defineConfig, Modules } from "@medusajs/framework/utils";
 import path from "path";
 import { parseFlatFallbackAmounts } from "./src/modules/shipping-providers/shiprocket/flat-fallback"
+import { SOCIALS_MODULE } from "./src/modules/socials"
+import { ENCRYPTION_MODULE } from "./src/modules/encryption"
 
 loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 
@@ -432,6 +434,20 @@ module.exports = defineConfig({
       ? [
           {
             resolve: "@medusajs/medusa/fulfillment",
+            /**
+             * 🔴 Load-bearing and invisible (#1451 follow-on). A fulfillment
+             * PROVIDER is built with the parent module's cradle, which carries
+             * six default keys and nothing else — so without these two, the
+             * Shiprocket service cannot read the carrier credentials that live
+             * in the `category:shipping` SocialPlatform record, and its rate
+             * calls fall back to env vars that are DELIBERATELY unset (see the
+             * copilot manifest). That is what made every live rate call answer
+             * `422 — The password is required`.
+             *
+             * Drop these and the symptom returns silently. The service logs
+             * loudly on the missing branch for that reason.
+             */
+            dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE],
             options: {
               providers: [
                 {

--- a/apps/backend/src/admin/components/social-platforms/ai-roles.ts
+++ b/apps/backend/src/admin/components/social-platforms/ai-roles.ts
@@ -42,6 +42,10 @@ export const KNOWN_AI_ROLES: KnownAiRole[] = [
     label: "Inventory image → items (vision extraction)",
   },
   {
+    value: "ai_id_extraction",
+    label: "ID card → person (vision OCR)",
+  },
+  {
     value: "ai_redesign",
     label: "Moodboard Redesign — Nano-Banana (gemini-2.5-flash-image)",
   },

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -33,6 +33,16 @@ describe("admin-mcp per-ask tool slicing", () => {
       expect(orphans).toEqual([])
     })
 
+    it("puts ID-card person onboarding on the partners slice", () => {
+      // /admin/people had NO prefix entry when the tool was added, which would
+      // have classified it `undefined` — registered, callable in principle, and
+      // reachable from no ask. It rides `partners` because "add this weaver to
+      // the partner" is the ask, not `customers` (the storefront buyer).
+      expect(
+        toolDomain(ADMIN_MCP_TOOLS.find((t) => t.name === "create_person_from_id_card")!)
+      ).toBe("partners")
+    })
+
     it("resolves the longest matching prefix, not the first", () => {
       // /admin/production-run-policy must not be swallowed by a shorter prefix,
       // and /admin/mcp/usage must land on observability rather than core.

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -3445,6 +3445,58 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "Reads the image with a separately-configured vision model and returns text. Stores nothing and changes no records. Failures are configuration problems, not transient ones — relay the message rather than retrying.",
   },
   {
+    name: "create_person_from_id_card",
+    description:
+      "Read a photo of an identity document (Aadhaar, PAN, passport, driving licence, voter ID) and turn it into a person on the weaver/artisan directory. Run it WITHOUT persist first and show the operator the draft and its warnings; only persist:true with confirm:true creates a record. The ID number is stored masked to its last four digits and nothing here verifies an identity. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/people/id-extraction",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "image_url",
+      "notes",
+      "id_number_policy",
+      "persist",
+      "confirm",
+      "partner_id",
+      "person_type_ids",
+    ],
+    inputSchema: obj(
+      {
+        image_url: STR("URL or data URI of the identity document photo."),
+        notes: STR(
+          "Context from the operator, e.g. 'the card is laminated and glary on the left'."
+        ),
+        id_number_policy: {
+          type: "string",
+          enum: ["mask", "discard"],
+          description:
+            "What to keep of the document number. 'mask' (default) keeps only the last four digits; 'discard' keeps none. Storing the full number is deliberately not offered.",
+        },
+        persist: {
+          type: "boolean",
+          description:
+            "Create the person. Default false — preview the draft first, always.",
+        },
+        confirm: {
+          type: "boolean",
+          description: "Required alongside persist. Creating a person from a photograph is not undoable by the caller.",
+        },
+        partner_id: STR(
+          "Link the created person to this partner's roster."
+        ),
+        person_type_ids: {
+          type: "array",
+          items: { type: "string" },
+          description: "Person-type ids to attach to the created person.",
+        },
+      },
+      ["image_url"]
+    ),
+    sideEffects:
+      "Without persist: reads the image with a vision model and returns a draft. Stores nothing. With persist+confirm: creates ONE person (and its address, best-effort) and optionally links it to a partner. The draft's warnings are the operator's only signal that a field was dropped or doubted — relay them rather than summarising them away.",
+  },
+  {
     name: "extract_inventory_from_image",
     description:
       "Read a photo of fabric/trims/a delivery note and turn it into raw materials + inventory items. Run it with persist:false first to show the operator what was found; only persist:true creates records. Sensitive: requires confirm:true.",

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -128,6 +128,17 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   // Stats dashboards + panels. Their own domain: a "create a stats panel"
   // ask is about the analytics surface, not any one business domain.
   ["/admin/stats", "stats"],
+  /**
+   * The people directory — weavers and artisans rostered under a partner.
+   *
+   * 🔴 Without this entry the ID-card extraction tool classifies as `undefined`
+   * and loads in NO slice: registered, callable in principle, and reachable
+   * from no ask. Same trap the payout tools fell into above.
+   *
+   * It rides `partners` because that is the ask it belongs to — "add this
+   * weaver to the partner" — not `customers`, which is the storefront buyer.
+   */
+  ["/admin/people", "partners"],
 ]
 
 /** Classify one tool by the route it wraps. */
@@ -194,6 +205,11 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "maker", "makers", "artisan", "artisans", "weaver", "weavers", "vendor",
     "vendors", "onboard", "onboarding", "whatsapp", "subscription", "plan",
     "commission", "fee", "fees", "admin user", "verify", "verification",
+    // People onboarding from an identity document (#1787 follow-on). "id card"
+    // and "aadhaar" are what an operator actually types; without them the ask
+    // "add this weaver from her aadhaar" matches only on "weaver".
+    "people", "person", "id card", "identity", "aadhaar", "pan card",
+    "passport", "voter id", "driving licence", "driving license",
   ],
   designs: [
     "design", "designs", "designer", "moodboard", "tech pack", "techpack",

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/reconcile-order-balances-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/reconcile-order-balances-job.ts
@@ -1,0 +1,125 @@
+import { PAYMENT_SCHEDULE_MODULE } from "../../../../modules/payment_schedule"
+import { reconcileBalanceForSchedule } from "../../../../lib/payments/reconcile-balance"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Close out balances that have been paid but never recorded (#1451 follow-on).
+ *
+ * ## 🔴 Why a sweep and not a subscriber
+ *
+ * `@medusajs/payment` does not reference the event bus at all — it emits
+ * nothing. There is no `payment.captured` to subscribe to, so a handler written
+ * against one would never fire, and a balance would sit `due` forever while the
+ * money was already in the account. The deposit escapes this only because
+ * `order.placed` happens to exist.
+ *
+ * The buyer returning to the payment page reconciles on the spot and is the
+ * fast path. This is the backstop for everyone who pays and closes the tab, and
+ * for any redirect that never comes back. Both call the SAME function, so they
+ * cannot reach different conclusions about the same money.
+ *
+ * Read-mostly and idempotent: a schedule already `paid` is skipped, a partial
+ * capture is deliberately left `due`, and an authorisation is not money.
+ */
+const DEFAULT_LIMIT = 500
+
+function numParam(raw: unknown, fallback: number): number {
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+export const reconcileOrderBalancesJob: MaintenanceJob = {
+  id: "reconcile-order-balances",
+  label: "Reconcile paid order balances",
+  description:
+    "Walk payment schedules whose balance is `due`, read what their order's outstanding payment collection actually captured, and mark the schedule paid when the full amount has landed. Exists because the payment module emits no events — nothing announces a capture, so a balance can be paid by the buyer and stay `due` in our ledger indefinitely. A partial capture is left `due` on purpose ('mostly paid' is not paid), and an authorisation is not counted (a hold is not money received). Dry-run reports what would change and writes nothing.",
+  params: [
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Maximum schedules to examine (default ${DEFAULT_LIMIT}).`,
+    },
+    {
+      name: "schedule_id",
+      type: "string",
+      required: false,
+      description: "Reconcile one schedule only, for checking a specific order.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const schedules: any = container.resolve(PAYMENT_SCHEDULE_MODULE)
+    const limit = numParam(params?.limit, DEFAULT_LIMIT)
+    const only = params?.schedule_id ? String(params.schedule_id) : null
+
+    const rows: any[] = only
+      ? await schedules
+          .listPaymentSchedules({ id: only })
+          .catch(() => [])
+      : await schedules
+          .listPaymentSchedules({ balance_status: "due" }, { take: limit })
+          .catch(() => [])
+
+    const changes: MaintenanceChange[] = []
+    let settled = 0
+    let outstanding = 0
+
+    for (const row of rows) {
+      /**
+       * ⚠️ Dry-run must not call the reconciler: it WRITES when it settles.
+       * Reporting "would mark paid" here means reading the same evidence
+       * without acting — otherwise `dry_run: true` would quietly close
+       * balances, which is the opposite of what an operator asked for.
+       */
+      if (dry_run) {
+        changes.push({
+          entity: "payment_schedule",
+          id: row.id,
+          before: { balance_status: row.balance_status },
+          after: { balance_status: "would be checked against captured payments" },
+        } as MaintenanceChange)
+        continue
+      }
+
+      const rec = await reconcileBalanceForSchedule(container, row.id).catch(
+        (e: any) => ({
+          schedule_id: row.id,
+          marked_paid: false,
+          already_paid: false,
+          expected: null,
+          state: null,
+          payment_collection_id: null,
+          reason: `Reconcile failed: ${e?.message ?? e}`,
+        })
+      )
+
+      if (rec.marked_paid) {
+        settled += 1
+        changes.push({
+          entity: "payment_schedule",
+          id: row.id,
+          before: { balance_status: "due" },
+          after: {
+            balance_status: "paid",
+            captured: rec.state?.captured ?? null,
+            expected: rec.expected,
+          },
+        } as MaintenanceChange)
+      } else {
+        outstanding += 1
+      }
+    }
+
+    return {
+      job_id: reconcileOrderBalancesJob.id,
+      dry_run,
+      applied: !dry_run && settled > 0,
+      summary: dry_run
+        ? `${rows.length} schedule(s) with a due balance would be checked against their captured payments.`
+        : `Checked ${rows.length} due balance(s): ${settled} marked paid, ${outstanding} still outstanding.`,
+      changes,
+    }
+  },
+}
+
+export default reconcileOrderBalancesJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -146,6 +146,7 @@ import {
   AI_ROLES,
 } from "../../../../mastra/services/ai-platforms"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
+import { reconcileOrderBalancesJob } from "./reconcile-order-balances-job"
 import {
   buildAiPlatformCoverageReport,
   planAiPlatformNormalization,
@@ -5814,6 +5815,7 @@ export const seedGoodsTransferTaskTemplateJob: MaintenanceJob = {
 }
 
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
+  reconcileOrderBalancesJob,
   cancelInactiveProductionRunsJob,
   warnExpiringProductionRunsJob,
   remirrorCancelledRunStatusJob,

--- a/apps/backend/src/api/admin/people/id-extraction/route.ts
+++ b/apps/backend/src/api/admin/people/id-extraction/route.ts
@@ -1,0 +1,89 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/framework/modules-sdk"
+
+import { extractPersonFromIdWorkflow } from "../../../../workflows/ai/extract-person-from-id"
+import { PARTNER_MODULE } from "../../../../modules/partner"
+import { PERSON_MODULE } from "../../../../modules/person"
+import type { AdminIdExtractionReqType } from "./validators"
+
+/**
+ * POST /admin/people/id-extraction
+ *
+ * Read a photographed identity document and, on request, create the person.
+ *
+ * ## Preview, then create — two calls, never one
+ *
+ * `persist:false` (the default) reads the card and returns a draft with its
+ * warnings; `persist:true` **and** `confirm:true` creates. The operator sees
+ * what a machine made of a photograph of someone's legal document before a row
+ * exists, which is the same discipline `extract_inventory_from_image` (#769)
+ * established for stock — and this is a person, not a bale of cloth.
+ *
+ * ## 🔴 What is kept
+ *
+ * The ID number is masked to its last four digits and the card's type. Nothing
+ * here verifies an identity, and `metadata.id_document.verified` is written
+ * `false` so no later reader mistakes a photo for KYC. See
+ * `lib/people/id-card.ts` for why full retention is not an option on this
+ * route.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.validatedBody ?? req.body) as AdminIdExtractionReqType
+
+  if (body.persist && !body.confirm) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Creating a person from an identity document requires confirm:true alongside persist:true. Run it without persist first and show the operator the draft."
+    )
+  }
+
+  const { result } = await extractPersonFromIdWorkflow(req.scope).run({
+    input: {
+      image_url: body.image_url,
+      notes: body.notes ?? null,
+      id_number_policy: body.id_number_policy ?? "mask",
+      persist: Boolean(body.persist),
+      partner_id: body.partner_id ?? null,
+      person_type_ids: body.person_type_ids ?? null,
+    },
+  })
+
+  const out = result as any
+
+  /**
+   * Linking is done here rather than in the workflow because a partner link is
+   * an admin-side association, and a failure to link must not roll back a
+   * person who was read correctly. It is reported instead.
+   */
+  let linked_partner_id: string | null = null
+  let link_error: string | null = null
+
+  if (out.person?.id && body.partner_id) {
+    try {
+      const link: Link = req.scope.resolve(ContainerRegistrationKeys.LINK)
+      // Same shape the existing /admin/partners/:id/people route uses — a
+      // single object, not an array.
+      await link.create({
+        [PARTNER_MODULE]: { partner_id: body.partner_id },
+        [PERSON_MODULE]: { person_id: out.person.id },
+      })
+      linked_partner_id = body.partner_id
+    } catch (e: any) {
+      link_error = e?.message ?? String(e)
+    }
+  }
+
+  return res.status(out.persisted ? 201 : 200).json({
+    message: out.persisted
+      ? "Person created from the identity document."
+      : "Document read. Nothing was created.",
+    draft: out.draft,
+    person: out.person ?? null,
+    persisted: out.persisted,
+    not_persisted_reason: out.not_persisted_reason,
+    linked_partner_id,
+    link_error,
+    model: out.model,
+  })
+}

--- a/apps/backend/src/api/admin/people/id-extraction/validators.ts
+++ b/apps/backend/src/api/admin/people/id-extraction/validators.ts
@@ -1,0 +1,41 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * ⚠️ `zodValidator` forces `.strict()`, so every field a caller may send must
+ * appear here — a field missing from this schema is a 400, not a silent drop.
+ * It must also stay in step with the MCP registry rows' `bodyParams`, which is
+ * where the tool's own contract lives (an MCP row is a contract with its
+ * validator).
+ */
+export const AdminIdExtractionReq = z.object({
+  image_url: z
+    .string()
+    .refine(
+      (s) => {
+        if (!s) return false
+        if (s.startsWith("data:")) return true
+        try {
+          new URL(s)
+          return true
+        } catch {
+          return false
+        }
+      },
+      { message: "image_url must be a valid URL or data URI" }
+    ),
+  notes: z.string().optional(),
+  /**
+   * 🔴 No `"store"` option, deliberately. Retaining a full Aadhaar/PAN number
+   * is a decision that needs a retention policy and an encrypted column, not a
+   * flag on an extraction tool. See `lib/people/id-card.ts`.
+   */
+  id_number_policy: z.enum(["mask", "discard"]).optional(),
+  /** Preview unless explicitly asked otherwise. */
+  persist: z.boolean().optional(),
+  /** Required alongside `persist` — creating a person from a photo is not undoable by the caller. */
+  confirm: z.boolean().optional(),
+  partner_id: z.string().optional(),
+  person_type_ids: z.array(z.string()).optional(),
+})
+
+export type AdminIdExtractionReqType = z.infer<typeof AdminIdExtractionReq>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -234,6 +234,8 @@ import { sendToPartnerSchema } from "./admin/inventory-orders/[id]/send-to-partn
 import { EmailTemplateQueryParams, EmailTemplateSchema, UpdateEmailTemplateSchema } from "./admin/email-templates/validators";
 import { CreateAgreementSchema, UpdateAgreementSchema } from "./admin/agreements/validators";
 import { AdminImageExtractionReq } from "./admin/ai/image-extraction/validators";
+import { AdminIdExtractionReq } from "./admin/people/id-extraction/validators";
+import { PartnerIdExtractionReq } from "./partners/people/id-extraction/validators";
 import { AdminSendPersonAgreementReq } from "./admin/persons/[id]/agreements/validators";
 import { folderSchema, uploadMediaSchema } from "./admin/medias/validator";
 import { ExtractFeaturesRequestSchema } from "./admin/medias/extract-features/validators";
@@ -1536,6 +1538,17 @@ export default defineMiddlewares({
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    // 🔴 A partner route 401s until it is named HERE — auth is per-route, and
+    // neither tsc nor a green suite says a word about the omission.
+    {
+      matcher: "/partners/people/id-extraction",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerIdExtractionReq)),
       ],
     },
     {
@@ -4059,6 +4072,14 @@ export default defineMiddlewares({
       matcher: "/admin/ai/image-extraction",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminImageExtractionReq))],
+    },
+    // ID card → person (vision extraction). Sibling of the image-extraction
+    // endpoint above; separate validator because the payload and the retention
+    // policy are different — see lib/people/id-card.ts.
+    {
+      matcher: "/admin/people/id-extraction",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminIdExtractionReq))],
     },
     // Inventory-nested alias of the image-extraction endpoint (#770) — the
     // canonical "Import From Image" path under the Inventory resource. Same

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -1540,6 +1540,17 @@ export default defineMiddlewares({
         authenticate("partner", ["session", "bearer"]),
       ],
     },
+    // The balance activation (#1451 follow-on). No body validator: the order
+    // comes from the path and the partner from the session, so there is nothing
+    // to validate and nothing to spoof.
+    {
+      matcher: "/partners/orders/:id/request-balance",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
     // 🔴 A partner route 401s until it is named HERE — auth is per-route, and
     // neither tsc nor a green suite says a word about the omission.
     {

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -34,6 +34,15 @@ describe("partner-mcp per-ask tool slicing", () => {
       expect(orphans).toEqual([])
     })
 
+    it("keeps ID-card person onboarding on the always-present core slice", () => {
+      // /partners/people had NO prefix entry when the tool was added, which
+      // would have classified it `undefined` — reachable from no ask. `core`
+      // because adding a worker is onboarding, and core is always loaded.
+      expect(
+        toolDomain(PARTNER_MCP_TOOLS.find((t) => t.name === "add_person_from_id_card")!)
+      ).toBe("core")
+    })
+
     it("classifies store PRODUCTS as catalog, and store CONFIG as storefront", () => {
       // Store products live under /partners/stores/:id/products, but a partner
       // asks for them in product words ("update the price of my product"), never

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -209,6 +209,52 @@ const consumptionLogSchema = (withRun: boolean) =>
 export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   // ===== Profile & persona (onboarding) =====================================
   {
+    name: "add_person_from_id_card",
+    description:
+      "Read a photo of a worker's identity document (Aadhaar, PAN, passport, driving licence, voter ID) and add them to your people. Run it WITHOUT persist first and show the operator the draft and its warnings; only persist:true with confirm:true creates the record. The document number is kept masked to its last four digits, and nothing here verifies an identity. Sensitive — requires confirmation.",
+    method: "POST",
+    path: "/partners/people/id-extraction",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "image_url",
+      "notes",
+      "id_number_policy",
+      "persist",
+      "confirm",
+      "person_type_ids",
+    ],
+    inputSchema: obj(
+      {
+        image_url: STR("URL or data URI of the identity document photo."),
+        notes: STR("Context from the operator, e.g. 'the card is glary on the left'."),
+        id_number_policy: {
+          type: "string",
+          enum: ["mask", "discard"],
+          description:
+            "What to keep of the document number. 'mask' (default) keeps only the last four digits; 'discard' keeps none. Storing the full number is deliberately not offered.",
+        },
+        persist: {
+          type: "boolean",
+          description: "Create the person. Default false — preview the draft first, always.",
+        },
+        confirm: {
+          type: "boolean",
+          description:
+            "Required alongside persist. Creating a person from a photograph is not undoable by the caller.",
+        },
+        person_type_ids: {
+          type: "array",
+          items: { type: "string" },
+          description: "Person-type ids to attach to the created person.",
+        },
+      },
+      ["image_url"]
+    ),
+    sideEffects:
+      "Without persist: reads the image with a vision model and returns a draft. Stores nothing. With persist+confirm: creates ONE person, links it to YOUR partner (taken from the session, never from the body) and best-effort creates their address. Relay the draft's warnings verbatim — they are the only signal that a field was dropped or doubted.",
+  },
+  {
     name: "get_partner_profile",
     description:
       "Get the current partner's profile (name, handle, workspace_type/persona, status, metadata). Call this first to understand who you are helping and how far onboarding has progressed.",

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -55,6 +55,14 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, PartnerToolDomain]> = [
   // product, check own usage from anywhere.
   ["/partners/ai", "core"],
   ["/partners/notifications", "core"],
+  /**
+   * The partner's own people (weavers, artisans on their roster).
+   *
+   * 🔴 Without this entry the row classifies as `undefined` and loads in NO
+   * slice — registered and reachable from no ask. `core` because adding a
+   * person is onboarding work, and core is always present.
+   */
+  ["/partners/people", "core"],
 
   // ---- orders: fulfilment + the whole post-purchase lifecycle ----
   ["/partners/orders", "orders"],

--- a/apps/backend/src/api/partners/orders/[id]/request-balance/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/request-balance/route.ts
@@ -1,0 +1,69 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { requestOrderBalanceWorkflow } from "../../../../../workflows/payments/request-order-balance"
+import { validatePartnerOrderOwnership } from "../../../helpers"
+
+/**
+ * POST /partners/orders/:id/request-balance
+ *
+ * The activation. A partner working this order says the goods are made and
+ * moving, which is what makes the remaining balance payable — and gets back a
+ * link to send the buyer.
+ *
+ * ## Why a partner presses this and a clock does not
+ *
+ * The balance becomes payable when the goods exist, and the people who know
+ * that are the makers. A timer would ask a buyer for money against goods
+ * nobody had started. Several partners may be realising one order; any of them
+ * may raise it, and pressing twice is harmless — the workflow reuses the
+ * existing balance collection and the schedule keeps its original
+ * `balance_due_at` rather than resetting the clock.
+ *
+ * ## 🔴 Ownership is checked before anything is read
+ *
+ * `validatePartnerOrderOwnership` first, always: this route mints a charge
+ * against a buyer, and a partner must not be able to raise money on an order
+ * that is not theirs by naming its id.
+ *
+ * ## Refusals are answers, not errors
+ *
+ * An already-paid balance, an unpaid deposit or a zero balance come back 200
+ * with `raised: false` and a `reason` the partner can read. A partner pressing
+ * a button twice has done nothing wrong and should not meet a 500.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const orderId = req.params.id
+
+  const { partner } = await validatePartnerOrderOwnership(
+    req.auth_context,
+    orderId,
+    req.scope
+  )
+
+  const { result } = await requestOrderBalanceWorkflow(req.scope).run({
+    input: {
+      order_id: orderId,
+      requested_by: partner?.id ?? null,
+    },
+  })
+
+  const out = result as any
+  const plan = out.plan
+
+  return res.status(200).json({
+    raised: Boolean(out.raised),
+    reused: Boolean(out.reused),
+    // The figure and the link the buyer will see — the two things a partner
+    // needs in order to say anything useful to them.
+    amount: plan?.collectable ? plan.amount : null,
+    currency_code: plan?.collectable ? plan.currency_code : null,
+    pay_url: out.pay_url ?? null,
+    payment_collection_id: out.payment_collection_id ?? null,
+    reason: plan?.reason ?? null,
+    /** `already_paid` | `waived` | `deposit_unpaid` | `no_order` | `no_amount` | `no_currency` */
+    code: plan?.collectable ? null : plan?.code ?? null,
+  })
+}

--- a/apps/backend/src/api/partners/people/id-extraction/route.ts
+++ b/apps/backend/src/api/partners/people/id-extraction/route.ts
@@ -1,0 +1,92 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/framework/modules-sdk"
+
+import { extractPersonFromIdWorkflow } from "../../../../workflows/ai/extract-person-from-id"
+import { getPartnerFromAuthContext } from "../../helpers"
+import { PARTNER_MODULE } from "../../../../modules/partner"
+import { PERSON_MODULE } from "../../../../modules/person"
+import type { PartnerIdExtractionReqType } from "./validators"
+
+/**
+ * POST /partners/people/id-extraction
+ *
+ * A partner photographs an artisan's ID card and gets a person on their own
+ * roster. Same reading and the same masking policy as the admin route; the
+ * difference is who it belongs to.
+ *
+ * 🔴 The partner comes from the AUTHENTICATED ACTOR, never from the body. The
+ * validator has no `partner_id` field at all, so there is nothing to spoof —
+ * and a route that took one would be a cross-tenant write waiting to happen.
+ *
+ * ⚠️ A new partner route 401s until `middlewares.ts` names it. Auth here is
+ * per-route, and neither tsc nor a green suite will tell you.
+ */
+export const POST = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) => {
+  const body = (req.validatedBody ?? req.body) as PartnerIdExtractionReqType
+
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner is associated with this session."
+    )
+  }
+
+  if (body.persist && !body.confirm) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Creating a person from an identity document requires confirm:true alongside persist:true. Read it without persist first and check the draft."
+    )
+  }
+
+  const { result } = await extractPersonFromIdWorkflow(req.scope).run({
+    input: {
+      image_url: body.image_url,
+      notes: body.notes ?? null,
+      id_number_policy: body.id_number_policy ?? "mask",
+      persist: Boolean(body.persist),
+      partner_id: partner.id,
+      person_type_ids: body.person_type_ids ?? null,
+    },
+  })
+
+  const out = result as any
+
+  /**
+   * The link is what makes this the PARTNER's person rather than a floating
+   * record. Reported rather than rolled back: a person read correctly should
+   * not be destroyed because an association failed, but an unlinked person is
+   * invisible on the partner's roster, so the caller has to be told.
+   */
+  let linked = false
+  let link_error: string | null = null
+
+  if (out.person?.id) {
+    try {
+      const link: Link = req.scope.resolve(ContainerRegistrationKeys.LINK)
+      await link.create({
+        [PARTNER_MODULE]: { partner_id: partner.id },
+        [PERSON_MODULE]: { person_id: out.person.id },
+      })
+      linked = true
+    } catch (e: any) {
+      link_error = e?.message ?? String(e)
+    }
+  }
+
+  return res.status(out.persisted ? 201 : 200).json({
+    message: out.persisted
+      ? linked
+        ? "Person created and added to your people."
+        : "Person created, but could not be added to your people — see link_error."
+      : "Document read. Nothing was created.",
+    draft: out.draft,
+    person: out.person ?? null,
+    persisted: out.persisted,
+    not_persisted_reason: out.not_persisted_reason,
+    linked,
+    link_error,
+    model: out.model,
+  })
+}

--- a/apps/backend/src/api/partners/people/id-extraction/validators.ts
+++ b/apps/backend/src/api/partners/people/id-extraction/validators.ts
@@ -1,0 +1,34 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Partner-side ID extraction.
+ *
+ * ⚠️ Deliberately has NO `partner_id`. The partner is taken from the
+ * authenticated actor, never from the body — a partner naming another
+ * partner's id is exactly the cross-tenant write this platform has been bitten
+ * by before (validate both ends of any request that names an id).
+ */
+export const PartnerIdExtractionReq = z.object({
+  image_url: z
+    .string()
+    .refine(
+      (s) => {
+        if (!s) return false
+        if (s.startsWith("data:")) return true
+        try {
+          new URL(s)
+          return true
+        } catch {
+          return false
+        }
+      },
+      { message: "image_url must be a valid URL or data URI" }
+    ),
+  notes: z.string().optional(),
+  id_number_policy: z.enum(["mask", "discard"]).optional(),
+  persist: z.boolean().optional(),
+  confirm: z.boolean().optional(),
+  person_type_ids: z.array(z.string()).optional(),
+})
+
+export type PartnerIdExtractionReqType = z.infer<typeof PartnerIdExtractionReq>

--- a/apps/backend/src/api/stripe/pay/balance/[id]/route.ts
+++ b/apps/backend/src/api/stripe/pay/balance/[id]/route.ts
@@ -1,0 +1,225 @@
+/**
+ * GET /stripe/pay/balance/:id — the buyer's page for the BALANCE of an order.
+ *
+ * `:id` is the PAYMENT SCHEDULE id, not a cart and not a payment collection.
+ * The schedule is the one identifier that survives a retry — a failed session
+ * is deleted and remade, and a collection could in principle be replaced — so
+ * a link already sent by email keeps working.
+ *
+ * ## Why this exists rather than a Stripe Payment Link
+ *
+ * Stripe's Payment Links are a fine way to ask for money, but they live outside
+ * Medusa: the charge arrives as an object with no payment collection, no order
+ * association and nothing for the admin to capture or reconcile against. This
+ * page mounts the Payment Element against the balance collection's OWN Medusa
+ * session, so the money lands in the same records as the deposit did and the
+ * order's `paid_total` moves on its own. It is the same rail the deposit used,
+ * which is the rail that has now been proven in production.
+ *
+ * Public, like the deposit's page and a PayU link: the buyer opens it directly
+ * and the unguessable id is the credential.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  buildStripePaymentPageHtml,
+  clientSecretOf,
+  formatAmount,
+} from "../../../lib/payment-page"
+import { PAYMENT_SCHEDULE_MODULE } from "../../../../../modules/payment_schedule"
+import { reconcileBalanceForSchedule } from "../../../../../lib/payments/reconcile-balance"
+
+const STRIPE_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://js.stripe.com",
+  "style-src 'self' 'unsafe-inline'",
+  "frame-src https://js.stripe.com https://hooks.stripe.com",
+  "connect-src 'self' https://api.stripe.com",
+  "img-src 'self' data:",
+].join("; ")
+
+const sendHtml = (res: MedusaResponse, status: number, html: string) => {
+  res.status(status)
+  res.setHeader("Content-Type", "text/html; charset=utf-8")
+  res.setHeader("Content-Security-Policy", STRIPE_CSP)
+  res.send(html)
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const scheduleId = req.params.id
+
+  let schedule: any
+  try {
+    const schedules: any = req.scope.resolve(PAYMENT_SCHEDULE_MODULE)
+    schedule = await schedules.retrievePaymentSchedule(scheduleId)
+  } catch {
+    schedule = null
+  }
+
+  /**
+   * 🔑 Reconcile FIRST, then render.
+   *
+   * The payment module emits no events, so nothing tells us the balance landed.
+   * The buyer returning to this page after paying is the earliest reliable
+   * moment we get — so we look at what the collection actually captured before
+   * deciding what to show. Without this, a buyer who has just paid would be
+   * shown the payment form again.
+   *
+   * Best-effort: a reconcile failure must not replace a working payment page
+   * with an error. The maintenance sweep is the backstop.
+   */
+  if (schedule) {
+    try {
+      const rec = await reconcileBalanceForSchedule(req.scope, scheduleId)
+      if (rec.marked_paid) {
+        schedule = { ...schedule, balance_status: "paid" }
+      }
+    } catch (e: any) {
+      logger?.warn?.(`[balance-page] reconcile failed: ${e?.message ?? e}`)
+    }
+  }
+
+  if (!schedule) {
+    return sendHtml(
+      res,
+      404,
+      buildStripePaymentPageHtml({
+        state: "unavailable",
+        title: "Payment link",
+        message: "This payment link is not valid.",
+      })
+    )
+  }
+
+  /**
+   * Paid is a first-class page, not a 404. A buyer who pays and then reopens
+   * the link from their email must be told the money arrived, not shown an
+   * error that makes them wonder whether it did.
+   */
+  if (schedule.balance_status === "paid") {
+    return sendHtml(
+      res,
+      200,
+      buildStripePaymentPageHtml({
+        state: "paid",
+        title: "Balance paid",
+        message: "The balance on this order has been paid. You can close this window.",
+      })
+    )
+  }
+
+  if (schedule.balance_status === "waived") {
+    return sendHtml(
+      res,
+      200,
+      buildStripePaymentPageHtml({
+        state: "paid",
+        title: "Nothing to pay",
+        message: "The balance on this order was waived. There is nothing more to pay.",
+      })
+    )
+  }
+
+  /**
+   * `not_due` means no partner has raised the balance yet. That is a real state
+   * — the goods are still being made — and saying so is kinder than a dead
+   * link, which is what a buyer would otherwise report as a broken email.
+   */
+  if (schedule.balance_status !== "due") {
+    return sendHtml(
+      res,
+      200,
+      buildStripePaymentPageHtml({
+        state: "unavailable",
+        title: "Not due yet",
+        message:
+          "The balance on this order is not due yet. You will be sent a link when your order is ready.",
+      })
+    )
+  }
+
+  /**
+   * 🔴 The balance collection is the order's NON-completed one, not one found
+   * by a marker of ours. `createOrUpdateOrderPaymentCollectionWorkflow` creates
+   * it and writes no marker — the deposit's collection is `completed` and this
+   * one is not, which is the same distinction core itself uses.
+   *
+   * Matching the amount as well makes "this is the balance" defensible rather
+   * than positional: picking the wrong collection would show the buyer the
+   * deposit's figure a second time.
+   */
+  let collection: any = null
+  try {
+    const { data } = await query.graph({
+      entity: "order",
+      fields: [
+        "id",
+        "payment_collections.id",
+        "payment_collections.amount",
+        "payment_collections.status",
+        "payment_collections.currency_code",
+        "payment_collections.payment_sessions.id",
+        "payment_collections.payment_sessions.provider_id",
+        "payment_collections.payment_sessions.status",
+        "payment_collections.payment_sessions.data",
+      ],
+      filters: { id: schedule.order_id },
+    })
+    const collections = ((data?.[0] as any)?.payment_collections ?? []) as any[]
+    const expected = Number(schedule.balance_amount)
+    collection =
+      collections.find(
+        (c) =>
+          c?.status !== "completed" &&
+          Number.isFinite(Number(c?.amount)) &&
+          Math.round(Number(c.amount) * 100) === Math.round(expected * 100)
+      ) ?? collections.find((c) => c?.status !== "completed") ?? null
+  } catch (e: any) {
+    logger?.warn?.(`[balance-page] collection lookup failed: ${e?.message ?? e}`)
+  }
+
+  const session = (collection?.payment_sessions ?? []).find((s: any) =>
+    String(s?.provider_id ?? "").includes("stripe")
+  )
+  const clientSecret = clientSecretOf(session)
+  const publishableKey =
+    process.env.STRIPE_PUBLISHABLE_KEY || process.env.NEXT_PUBLIC_STRIPE_KEY || null
+
+  if (!collection || !clientSecret || !publishableKey) {
+    // Deliberately specific in the log and vague on the page: the buyer cannot
+    // act on "no client secret", and the operator cannot act on "unavailable".
+    logger?.error?.(
+      `[balance-page] cannot render schedule=${scheduleId} collection=${
+        collection?.id ?? "none"
+      } client_secret=${clientSecret ? "yes" : "no"} pk=${publishableKey ? "yes" : "no"}`
+    )
+    return sendHtml(
+      res,
+      200,
+      buildStripePaymentPageHtml({
+        state: "unavailable",
+        title: "Payment link",
+        message:
+          "This payment link cannot be opened just now. Please contact us and we will send a new one.",
+      })
+    )
+  }
+
+  return sendHtml(
+    res,
+    200,
+    buildStripePaymentPageHtml({
+      state: "pay",
+      publishableKey,
+      clientSecret,
+      amountLabel: formatAmount(collection.amount, collection.currency_code),
+      title: "Pay the balance of your order",
+      returnUrl: `${(
+        process.env.MEDUSA_BACKEND_URL || "https://v3.jaalyantra.com"
+      ).replace(/\/+$/, "")}/stripe/pay/balance/${scheduleId}`,
+    })
+  )
+}

--- a/apps/backend/src/lib/payments/__tests__/balance-collection.unit.spec.ts
+++ b/apps/backend/src/lib/payments/__tests__/balance-collection.unit.spec.ts
@@ -1,0 +1,227 @@
+import {
+  buildBalancePayUrl,
+  planBalanceCollection,
+  settleBalance,
+  summariseBalancePayments,
+  type BalanceSchedule,
+} from "../balance-collection"
+
+/**
+ * The second half of the money. Figures are the live AUD order that exposed
+ * the gap: total A$314.77, deposit A$94.43 paid, balance A$220.34 stranded at
+ * `not_due` because nothing in the codebase could raise it.
+ */
+const PAID_DEPOSIT: BalanceSchedule = {
+  id: "01M1NE12YS04WGQK85FG17S73B",
+  currency_code: "aud",
+  total_due: "314.77",
+  deposit_amount: "94.43",
+  deposit_status: "paid",
+  balance_amount: "220.34",
+  balance_status: "not_due",
+  order_id: "order_01M1NRXM2TNZ7AXB58E566F2B5",
+  rail: "stripe",
+}
+
+describe("planBalanceCollection", () => {
+  it("collects the stored balance once the deposit is paid", () => {
+    const p = planBalanceCollection(PAID_DEPOSIT)
+
+    expect(p.collectable).toBe(true)
+    if (!p.collectable) throw new Error("unreachable")
+    expect(p.amount).toBe(220.34)
+    expect(p.currency_code).toBe("aud")
+    expect(p.order_id).toBe("order_01M1NRXM2TNZ7AXB58E566F2B5")
+  })
+
+  it("🔑 uses the STORED balance, not total minus deposit recomputed here", () => {
+    // The split was written down when the deal was struck. If this recomputed
+    // it, the two would drift the first time a rounding rule changed — and the
+    // buyer has already been shown a figure.
+    const p = planBalanceCollection({
+      ...PAID_DEPOSIT,
+      balance_amount: "200.00",
+      total_due: "314.77",
+      deposit_amount: "94.43", // 314.77 - 94.43 = 220.34, deliberately not 200
+    })
+    if (!p.collectable) throw new Error("expected collectable")
+    expect(p.amount).toBe(200)
+  })
+
+  it("🔴 refuses while the deposit is unpaid — that is a demand against nothing", () => {
+    const p = planBalanceCollection({ ...PAID_DEPOSIT, deposit_status: "pending" })
+    expect(p.collectable).toBe(false)
+    if (p.collectable) throw new Error("unreachable")
+    expect(p.code).toBe("deposit_unpaid")
+  })
+
+  it("allows a WAIVED deposit through — waived is settled, not skipped", () => {
+    const p = planBalanceCollection({ ...PAID_DEPOSIT, deposit_status: "waived" })
+    expect(p.collectable).toBe(true)
+  })
+
+  it("refuses an already-paid balance rather than charging twice", () => {
+    const p = planBalanceCollection({ ...PAID_DEPOSIT, balance_status: "paid" })
+    expect(p.collectable).toBe(false)
+    if (p.collectable) throw new Error("unreachable")
+    expect(p.code).toBe("already_paid")
+  })
+
+  it("refuses a waived balance", () => {
+    const p = planBalanceCollection({ ...PAID_DEPOSIT, balance_status: "waived" })
+    if (p.collectable) throw new Error("unreachable")
+    expect(p.code).toBe("waived")
+  })
+
+  it("refuses when no order is attached yet", () => {
+    const p = planBalanceCollection({ ...PAID_DEPOSIT, order_id: null })
+    if (p.collectable) throw new Error("unreachable")
+    expect(p.code).toBe("no_order")
+  })
+
+  it("treats a stored zero balance as nothing to collect, not a free one", () => {
+    // `Number(null)` is 0 — the guard asks `> 0`, never `!= null`.
+    for (const v of ["0", 0, null, ""]) {
+      const p = planBalanceCollection({ ...PAID_DEPOSIT, balance_amount: v as any })
+      if (p.collectable) throw new Error(`expected refusal for ${String(v)}`)
+      expect(p.code).toBe("no_amount")
+    }
+  })
+
+  it("refuses a negative balance rather than crediting the buyer by accident", () => {
+    const p = planBalanceCollection({ ...PAID_DEPOSIT, balance_amount: "-50" })
+    if (p.collectable) throw new Error("unreachable")
+    expect(p.code).toBe("no_amount")
+  })
+
+  it("refuses rather than guessing a currency", () => {
+    const p = planBalanceCollection({ ...PAID_DEPOSIT, currency_code: "  " })
+    if (p.collectable) throw new Error("unreachable")
+    expect(p.code).toBe("no_currency")
+  })
+
+  it("survives a missing schedule", () => {
+    const p = planBalanceCollection(null)
+    if (p.collectable) throw new Error("unreachable")
+    expect(p.code).toBe("no_order")
+  })
+
+  it("every refusal carries a reason a human can act on", () => {
+    const cases: BalanceSchedule[] = [
+      { ...PAID_DEPOSIT, deposit_status: "pending" },
+      { ...PAID_DEPOSIT, balance_status: "paid" },
+      { ...PAID_DEPOSIT, order_id: null },
+      { ...PAID_DEPOSIT, balance_amount: "0" },
+    ]
+    for (const c of cases) {
+      const p = planBalanceCollection(c)
+      expect(p.collectable).toBe(false)
+      expect((p as any).reason.length).toBeGreaterThan(20)
+    }
+  })
+})
+
+describe("buildBalancePayUrl", () => {
+  it("keys the link on the SCHEDULE so a sent email keeps working", () => {
+    // A payment session can be deleted and remade on retry; the schedule id is
+    // the one identifier that survives, so an emailed link stays valid.
+    expect(
+      buildBalancePayUrl("https://v3.jaalyantra.com", "sched_1")
+    ).toBe("https://v3.jaalyantra.com/stripe/pay/balance/sched_1")
+  })
+
+  it("does not double the slash on a trailing-slash base url", () => {
+    expect(buildBalancePayUrl("https://v3.jaalyantra.com/", "sched_1")).toBe(
+      "https://v3.jaalyantra.com/stripe/pay/balance/sched_1"
+    )
+  })
+})
+
+describe("summariseBalancePayments", () => {
+  it("counts a captured payment and ignores an authorised hold", () => {
+    const s = summariseBalancePayments({
+      currency_code: "aud",
+      payments: [
+        { amount: 220.34, captured_at: "2026-09-05T00:00:00.000Z" },
+        { amount: 50, captured_at: null },
+      ],
+    })
+    expect(s.captured).toBe(220.34)
+    expect(s.authorized).toBe(50)
+  })
+
+  it("subtracts a refund from the captured total", () => {
+    const s = summariseBalancePayments({
+      currency_code: "aud",
+      payments: [
+        { amount: 220.34, captured_at: "2026-09-05T00:00:00.000Z", refunded_total: 20.34 },
+      ],
+    })
+    expect(s.captured).toBe(200)
+  })
+
+  it("ignores a canceled payment entirely", () => {
+    const s = summariseBalancePayments({
+      currency_code: "aud",
+      payments: [
+        { amount: 220.34, captured_at: "2026-09-05T00:00:00.000Z", canceled_at: "2026-09-06" },
+      ],
+    })
+    expect(s.captured).toBe(0)
+  })
+
+  it("survives a collection with no payments", () => {
+    expect(summariseBalancePayments(null).captured).toBe(0)
+    expect(summariseBalancePayments({ payments: null }).captured).toBe(0)
+  })
+})
+
+describe("settleBalance", () => {
+  const state = (captured: number, authorized = 0) => ({
+    captured,
+    authorized,
+    currency_code: "aud",
+  })
+
+  it("settles when the full amount is captured", () => {
+    const r = settleBalance(220.34, state(220.34))
+    expect(r.settled).toBe(true)
+  })
+
+  it("settles on an overpayment rather than leaving it open", () => {
+    expect(settleBalance(220.34, state(230)).settled).toBe(true)
+  })
+
+  it("🔴 does NOT settle on an authorisation — a hold is not money received", () => {
+    const r = settleBalance(220.34, state(0, 220.34))
+    expect(r.settled).toBe(false)
+    expect(r.reason).toMatch(/hold, not money received/i)
+  })
+
+  it("🔴 leaves a PARTIAL capture due — 'mostly paid' is not paid", () => {
+    const r = settleBalance(220.34, state(100))
+    expect(r.settled).toBe(false)
+    // Closing here would destroy the only signal that the rest is still owed.
+    expect(r.reason).toMatch(/Only 100 of 220.34/)
+  })
+
+  it("does not settle a one-cent shortfall", () => {
+    expect(settleBalance(220.34, state(220.33)).settled).toBe(false)
+  })
+
+  it("settles an exact cent match, without float drift", () => {
+    expect(settleBalance(0.1 + 0.2, state(0.3)).settled).toBe(true)
+  })
+
+  it("refuses to settle when nothing is expected", () => {
+    for (const v of [0, null, undefined, "", "-5"]) {
+      expect(settleBalance(v as any, state(100)).settled).toBe(false)
+    }
+  })
+
+  it("reports nothing captured plainly", () => {
+    const r = settleBalance(220.34, state(0))
+    expect(r.settled).toBe(false)
+    expect(r.reason).toMatch(/Nothing has been captured/i)
+  })
+})

--- a/apps/backend/src/lib/payments/balance-collection.ts
+++ b/apps/backend/src/lib/payments/balance-collection.ts
@@ -1,0 +1,308 @@
+/**
+ * Collecting the SECOND half of a quote's payment — the balance.
+ *
+ * ## Why this exists at all
+ *
+ * `markBalanceDue` and `markBalancePaid` have been on the payment-schedule
+ * service since #1451, fully written, guarded, and **never called by
+ * anything**. A buyer paid a 30% deposit on a real order (A$94.43 of A$314.77)
+ * and the remaining A$220.34 sat at `not_due` with no route, subscriber,
+ * workflow or tool that could ever move it. A helper with tests and no caller
+ * is not a feature.
+ *
+ * ## Why the partner raises it, not a timer
+ *
+ * The balance becomes payable when the goods exist — and the people who know
+ * that are the partners making them. One order may be realised by several
+ * partners, so this is an explicit ACTIVATION by a partner working the order,
+ * not a schedule fired by a clock. A clock would ask a buyer for money against
+ * goods nobody has made.
+ *
+ * ## Why two charges rather than one held authorisation
+ *
+ * Settled in the payment-schedule model and repeated here because it is the
+ * question everyone asks: an online card authorisation lasts ~7 days, a
+ * made-to-order lead time does not, and Stripe's own guidance is to take a
+ * second payment rather than stretch an auth. So the balance is its own
+ * payment collection and its own link.
+ *
+ * Pure. Every refusal is decided here so it can be tested without a container.
+ */
+
+export type BalanceSchedule = {
+  id: string
+  currency_code?: string | null
+  total_due?: number | string | null
+  deposit_amount?: number | string | null
+  deposit_status?: string | null
+  balance_amount?: number | string | null
+  balance_status?: string | null
+  order_id?: string | null
+  rail?: string | null
+}
+
+export type BalancePlan =
+  | {
+      collectable: true
+      schedule_id: string
+      order_id: string
+      amount: number
+      currency_code: string
+      reason: string
+    }
+  | {
+      collectable: false
+      schedule_id: string
+      /** Machine-readable so a caller can tell "already paid" from "not allowed". */
+      code:
+        | "already_paid"
+        | "waived"
+        | "deposit_unpaid"
+        | "no_order"
+        | "no_amount"
+        | "no_currency"
+      reason: string
+    }
+
+const num = (v: unknown): number | null => {
+  if (v === null || v === undefined || v === "") return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Decide whether a balance can be asked for, and for how much.
+ *
+ * 🔑 The amount comes from the schedule's stored `balance_amount`, not from
+ * `total_due - deposit_amount` recomputed here. The split was decided and
+ * written down when the deal was struck; recomputing it invites a second
+ * opinion about a number the buyer has already been shown, and the two would
+ * drift the first time a rounding rule changed.
+ */
+export const planBalanceCollection = (
+  schedule: BalanceSchedule | null | undefined
+): BalancePlan => {
+  if (!schedule) {
+    return {
+      collectable: false,
+      schedule_id: "",
+      code: "no_order",
+      reason: "This order has no payment schedule, so there is no balance to collect.",
+    }
+  }
+
+  const id = schedule.id
+
+  /**
+   * Paid and waived first — both are terminal, and asking again is how a buyer
+   * gets charged twice. Reported as success-shaped refusals, not errors: a
+   * partner pressing the button twice has done nothing wrong.
+   */
+  if (schedule.balance_status === "paid") {
+    return {
+      collectable: false,
+      schedule_id: id,
+      code: "already_paid",
+      reason: "The balance on this order has already been paid.",
+    }
+  }
+  if (schedule.balance_status === "waived") {
+    return {
+      collectable: false,
+      schedule_id: id,
+      code: "waived",
+      reason: "The balance on this order was waived, so nothing is collected.",
+    }
+  }
+
+  /**
+   * 🔴 An unpaid deposit means asking for the balance is a demand for money
+   * against nothing. The service refuses this too; it is repeated here so the
+   * caller can say WHY without catching an exception.
+   */
+  if (schedule.deposit_status !== "paid" && schedule.deposit_status !== "waived") {
+    return {
+      collectable: false,
+      schedule_id: id,
+      code: "deposit_unpaid",
+      reason: `The deposit on this order is ${
+        schedule.deposit_status ?? "unknown"
+      }, so the balance cannot be raised yet.`,
+    }
+  }
+
+  if (!schedule.order_id) {
+    return {
+      collectable: false,
+      schedule_id: id,
+      code: "no_order",
+      reason:
+        "This schedule is not attached to an order yet, so there is nothing to collect against.",
+    }
+  }
+
+  const amount = num(schedule.balance_amount)
+  // `> 0`, not `!= null` — `Number(null)` is 0, and a stored 0 means there is
+  // nothing left to collect, not that the balance is free.
+  if (amount === null || amount <= 0) {
+    return {
+      collectable: false,
+      schedule_id: id,
+      code: "no_amount",
+      reason: `This order's balance is ${String(
+        schedule.balance_amount
+      )}, so there is nothing to collect.`,
+    }
+  }
+
+  const currency = schedule.currency_code?.trim()
+  if (!currency) {
+    return {
+      collectable: false,
+      schedule_id: id,
+      code: "no_currency",
+      reason:
+        "The schedule names no currency, so a charge cannot be denominated. Refusing rather than guessing.",
+    }
+  }
+
+  return {
+    collectable: true,
+    schedule_id: id,
+    order_id: schedule.order_id,
+    amount,
+    currency_code: currency.toLowerCase(),
+    reason: `Collecting the balance of ${amount} ${currency.toUpperCase()} on order ${
+      schedule.order_id
+    }.`,
+  }
+}
+
+/**
+ * The public URL a buyer opens to pay the balance.
+ *
+ * Keyed on the SCHEDULE, not the payment collection: the schedule id is the
+ * one identifier that survives a retry (a failed session is deleted and
+ * remade), so a link already sent by email keeps working.
+ *
+ * ⚠️ The id is the credential, exactly as it is for the deposit's own hosted
+ * page and for a PayU link. It must stay unguessable, which a ULID is.
+ */
+export const buildBalancePayUrl = (
+  backendUrl: string,
+  scheduleId: string
+): string => `${backendUrl.replace(/\/+$/, "")}/stripe/pay/balance/${scheduleId}`
+
+/**
+ * Has the balance actually landed?
+ *
+ * ## 🔴 Why this is polled rather than pushed
+ *
+ * There is no event to subscribe to. `@medusajs/payment` does not reference the
+ * event bus at all — it emits nothing, so a `payment.captured` subscriber would
+ * be a handler that never fires, which is exactly the kind of check that reads
+ * as a pass forever. The deposit escapes this because `order.placed` exists;
+ * the balance is charged after the order, so nothing announces it.
+ *
+ * So the truth is READ from the collection: what did its payments actually
+ * capture or authorise. Two callers share this one rule — the buyer's return to
+ * the payment page (fast path) and a maintenance sweep (backstop) — so the two
+ * cannot come to different conclusions about the same money.
+ *
+ * `captured` counts. `authorized` does not: an authorisation is a hold that
+ * still has to be captured, and marking a schedule paid on a hold would report
+ * money we have not taken.
+ */
+export type BalancePaymentState = {
+  captured: number
+  authorized: number
+  currency_code: string | null
+}
+
+export const summariseBalancePayments = (
+  collection:
+    | { currency_code?: string | null; payments?: Array<Record<string, any>> | null }
+    | null
+    | undefined
+): BalancePaymentState => {
+  const payments = collection?.payments ?? []
+  let captured = 0
+  let authorized = 0
+
+  for (const p of payments) {
+    const amount = num(p?.amount) ?? 0
+    // A refunded/canceled payment must not count towards the balance.
+    if (p?.canceled_at) continue
+
+    const refunded = num(p?.refunded_total) ?? 0
+    if (p?.captured_at) {
+      captured += amount - refunded
+    } else {
+      authorized += amount
+    }
+  }
+
+  return {
+    captured: Math.round(captured * 100) / 100,
+    authorized: Math.round(authorized * 100) / 100,
+    currency_code: collection?.currency_code ?? null,
+  }
+}
+
+export type BalanceSettlement =
+  | { settled: true; captured: number; reason: string }
+  | { settled: false; captured: number; reason: string }
+
+/**
+ * Decide whether a `due` balance may be marked paid.
+ *
+ * 🔑 Compares to the cent and requires the FULL expected amount. A partial
+ * capture is left `due` on purpose: "mostly paid" is not paid, and marking it
+ * so would close the only signal that the rest is still owed.
+ */
+export const settleBalance = (
+  expectedAmount: number | string | null | undefined,
+  state: BalancePaymentState
+): BalanceSettlement => {
+  const expected = num(expectedAmount)
+
+  if (expected === null || expected <= 0) {
+    return {
+      settled: false,
+      captured: state.captured,
+      reason: "No balance amount is expected, so nothing can be settled.",
+    }
+  }
+
+  const cents = (n: number) => Math.round(n * 100)
+
+  if (cents(state.captured) >= cents(expected)) {
+    return {
+      settled: true,
+      captured: state.captured,
+      reason: `Captured ${state.captured} against an expected ${expected}.`,
+    }
+  }
+
+  if (state.captured > 0) {
+    return {
+      settled: false,
+      captured: state.captured,
+      reason: `Only ${state.captured} of ${expected} has been captured — left due rather than closed on a partial payment.`,
+    }
+  }
+
+  if (state.authorized > 0) {
+    return {
+      settled: false,
+      captured: state.captured,
+      reason: `${state.authorized} is authorised but not captured. An authorisation is a hold, not money received.`,
+    }
+  }
+
+  return {
+    settled: false,
+    captured: 0,
+    reason: "Nothing has been captured against the balance yet.",
+  }
+}

--- a/apps/backend/src/lib/payments/reconcile-balance.ts
+++ b/apps/backend/src/lib/payments/reconcile-balance.ts
@@ -1,0 +1,169 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PAYMENT_SCHEDULE_MODULE } from "../../modules/payment_schedule"
+import {
+  settleBalance,
+  summariseBalancePayments,
+  type BalancePaymentState,
+} from "./balance-collection"
+
+/**
+ * Find the balance's payment collection on an order, and decide whether the
+ * money has landed.
+ *
+ * ## 🔴 How the balance collection is identified
+ *
+ * NOT by a metadata marker. `createOrUpdateOrderPaymentCollectionWorkflow` —
+ * core's own workflow, which this now uses — creates the collection itself and
+ * writes no marker of ours. Identifying it is therefore done the way core
+ * identifies it: the DEPOSIT's collection is `completed`, and the outstanding
+ * one is not. Core's own filter uses exactly that distinction.
+ *
+ * ⚠️ Do not pick "the first collection" or "the newest". An order carries both,
+ * and picking the deposit's would reconcile the balance against A$94.43 that
+ * was received for something else — and close a debt that is still owed.
+ *
+ * ## Why reconcile at all
+ *
+ * `@medusajs/payment` emits no events, so there is no capture to subscribe to.
+ * Both the buyer's return to the payment page and the maintenance sweep call
+ * this one function, so the fast path and the backstop cannot disagree.
+ */
+export type BalanceReconciliation = {
+  schedule_id: string
+  /** True only when this call moved the schedule to `paid`. */
+  marked_paid: boolean
+  /** True when it was already `paid` before this ran. */
+  already_paid: boolean
+  expected: number | null
+  state: BalancePaymentState | null
+  payment_collection_id: string | null
+  reason: string
+}
+
+export async function reconcileBalanceForSchedule(
+  container: any,
+  scheduleId: string
+): Promise<BalanceReconciliation> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const schedules: any = container.resolve(PAYMENT_SCHEDULE_MODULE)
+
+  let schedule: any
+  try {
+    schedule = await schedules.retrievePaymentSchedule(scheduleId)
+  } catch {
+    return {
+      schedule_id: scheduleId,
+      marked_paid: false,
+      already_paid: false,
+      expected: null,
+      state: null,
+      payment_collection_id: null,
+      reason: "No such payment schedule.",
+    }
+  }
+
+  if (schedule.balance_status === "paid") {
+    return {
+      schedule_id: scheduleId,
+      marked_paid: false,
+      already_paid: true,
+      expected: Number(schedule.balance_amount) || null,
+      state: null,
+      payment_collection_id: null,
+      reason: "The balance was already recorded as paid.",
+    }
+  }
+
+  if (!schedule.order_id) {
+    return {
+      schedule_id: scheduleId,
+      marked_paid: false,
+      already_paid: false,
+      expected: null,
+      state: null,
+      payment_collection_id: null,
+      reason: "The schedule has no order, so there is nothing to reconcile against.",
+    }
+  }
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "payment_collections.id",
+      "payment_collections.amount",
+      "payment_collections.status",
+      "payment_collections.currency_code",
+      "payment_collections.payments.amount",
+      "payment_collections.payments.captured_at",
+      "payment_collections.payments.canceled_at",
+      "payment_collections.payments.refunded_total",
+    ],
+    filters: { id: schedule.order_id },
+  })
+
+  const collections = ((orders?.[0] as any)?.payment_collections ?? []) as any[]
+
+  const expected = Number(schedule.balance_amount)
+
+  /**
+   * Prefer a non-completed collection whose amount matches the balance to the
+   * cent. Amount is the tie-breaker rather than the sole test, because two
+   * collections could in principle share a status — and matching on money is
+   * what makes "this is the balance" defensible.
+   */
+  const candidate =
+    collections.find(
+      (c) =>
+        c?.status !== "completed" &&
+        Number.isFinite(Number(c?.amount)) &&
+        Math.round(Number(c.amount) * 100) === Math.round(expected * 100)
+    ) ?? collections.find((c) => c?.status !== "completed")
+
+  if (!candidate) {
+    return {
+      schedule_id: scheduleId,
+      marked_paid: false,
+      already_paid: false,
+      expected: Number.isFinite(expected) ? expected : null,
+      state: null,
+      payment_collection_id: null,
+      reason:
+        "No outstanding payment collection on this order — the balance has not been raised yet.",
+    }
+  }
+
+  const state = summariseBalancePayments(candidate)
+  const verdict = settleBalance(schedule.balance_amount, state)
+
+  if (!verdict.settled) {
+    return {
+      schedule_id: scheduleId,
+      marked_paid: false,
+      already_paid: false,
+      expected: Number.isFinite(expected) ? expected : null,
+      state,
+      payment_collection_id: candidate.id,
+      reason: verdict.reason,
+    }
+  }
+
+  await schedules.markBalancePaid(scheduleId, candidate.id)
+
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  // Always on: the line that says the second half of a deal was received.
+  logger?.info?.(
+    `[balance] schedule=${scheduleId} order=${schedule.order_id} PAID — captured ${state.captured} against ${expected}`
+  )
+
+  return {
+    schedule_id: scheduleId,
+    marked_paid: true,
+    already_paid: false,
+    expected,
+    state,
+    payment_collection_id: candidate.id,
+    reason: verdict.reason,
+  }
+}

--- a/apps/backend/src/lib/people/__tests__/id-card.unit.spec.ts
+++ b/apps/backend/src/lib/people/__tests__/id-card.unit.spec.ts
@@ -1,0 +1,203 @@
+import {
+  maskIdNumber,
+  normaliseIdCardExtraction,
+  parseDateOfBirth,
+  personCreateInputFromDraft,
+} from "../id-card"
+
+/**
+ * The policy half of ID-card onboarding: what survives a vision model's guess.
+ *
+ * These assert REFUSALS as much as successes. The failure mode that matters
+ * here is not "the model misread a card" — it will — but "we wrote the misread
+ * down as a fact about a real person, or kept a regulated number we had no
+ * business keeping."
+ */
+const GOOD = {
+  first_name: "Lhamo",
+  last_name: "Dolkar",
+  date_of_birth: "1988-04-11",
+  gender: "F",
+  id_type: "aadhaar",
+  id_number: "1234 5678 9012",
+  address: {
+    street: "12 Jogiwara Road",
+    city: "Dharamshala",
+    state: "Himachal Pradesh",
+    postal_code: "176219",
+    country: "India",
+  },
+  confidence: 0.93,
+}
+
+describe("maskIdNumber", () => {
+  it("keeps only the last four digits, ignoring the card's spacing", () => {
+    // 🔴 A naive slice(-4) on "1234 5678 9012" is fine, but on "1234 5678 9012 "
+    // it is " 012". Separators are stripped before the slice for that reason.
+    expect(maskIdNumber("1234 5678 9012", "mask")).toEqual({
+      masked: "••••9012",
+      last4: "9012",
+      warning: null,
+    })
+    expect(maskIdNumber("1234-5678-9012 ", "mask").last4).toBe("9012")
+  })
+
+  it("discards entirely when the policy says so", () => {
+    expect(maskIdNumber("1234 5678 9012", "discard")).toEqual({
+      masked: null,
+      last4: null,
+      warning: null,
+    })
+  })
+
+  it("refuses a number too short to be a document number", () => {
+    const r = maskIdNumber("12", "mask")
+    expect(r.masked).toBeNull()
+    expect(r.warning).toBeTruthy()
+  })
+
+  it("never returns the full number in any field", () => {
+    const r = maskIdNumber("123456789012", "mask")
+    expect(JSON.stringify(r)).not.toContain("123456789012")
+  })
+})
+
+describe("parseDateOfBirth", () => {
+  it("accepts a real ISO date", () => {
+    expect(parseDateOfBirth("1988-04-11")).toEqual({
+      value: "1988-04-11",
+      warning: null,
+    })
+  })
+
+  it("drops a non-ISO date rather than guessing at it", () => {
+    // 11/04/1988 is 11 April or 4 November depending on the country that
+    // printed the card. Guessing is how a person gets the wrong birthday.
+    const r = parseDateOfBirth("11/04/1988")
+    expect(r.value).toBeNull()
+    expect(r.warning).toMatch(/not an ISO date/i)
+  })
+
+  it("drops a date that rolls over instead of silently moving it", () => {
+    // 🔴 new Date("2024-13-45") does not throw — it rolls into the next year.
+    // A coerced date is a wrong fact that looks like a right one.
+    const r = parseDateOfBirth("2024-13-45")
+    expect(r.value).toBeNull()
+    expect(r.warning).toMatch(/not a real calendar date/i)
+  })
+
+  it("drops a future date", () => {
+    expect(parseDateOfBirth("2999-01-01").value).toBeNull()
+  })
+
+  it("drops an implausibly distant date as a likely century misread", () => {
+    const r = parseDateOfBirth("1788-01-01")
+    expect(r.value).toBeNull()
+    expect(r.warning).toMatch(/120 years/i)
+  })
+
+  it("treats absence as absence, not as an error", () => {
+    expect(parseDateOfBirth(null)).toEqual({ value: null, warning: null })
+  })
+})
+
+describe("normaliseIdCardExtraction", () => {
+  it("reads a clean card into a creatable draft", () => {
+    const d = normaliseIdCardExtraction(GOOD)
+
+    expect(d.creatable).toBe(true)
+    expect(d.first_name).toBe("Lhamo")
+    expect(d.last_name).toBe("Dolkar")
+    expect(d.date_of_birth).toBe("1988-04-11")
+    expect(d.id_type).toBe("aadhaar")
+    expect(d.id_last4).toBe("9012")
+    expect(d.address?.city).toBe("Dharamshala")
+    expect(d.warnings).toEqual([])
+  })
+
+  it("🔴 never carries the full ID number into the draft", () => {
+    const d = normaliseIdCardExtraction(GOOD)
+    // The whole point of the module. A preview response is what an operator
+    // pastes into a chat log.
+    expect(JSON.stringify(d)).not.toContain("123456789012")
+    expect(JSON.stringify(d)).not.toContain("1234 5678 9012")
+  })
+
+  it("refuses to make a person out of a card with no name", () => {
+    const d = normaliseIdCardExtraction({ ...GOOD, first_name: null, last_name: null })
+
+    expect(d.creatable).toBe(false)
+    expect(d.warnings.join(" ")).toMatch(/no name/i)
+    expect(() => personCreateInputFromDraft(d)).toThrow(/no name/i)
+  })
+
+  it("keeps a single printed name whole rather than inventing a surname", () => {
+    const d = normaliseIdCardExtraction({ ...GOOD, first_name: "Tenzin", last_name: null })
+
+    expect(d.creatable).toBe(true)
+    expect(d.first_name).toBe("Tenzin")
+    expect(d.last_name).toBeNull()
+    expect(d.warnings.join(" ")).toMatch(/one name field/i)
+  })
+
+  it("warns loudly when the model doubts its own reading", () => {
+    const d = normaliseIdCardExtraction({ ...GOOD, confidence: 0.2 })
+    expect(d.warnings.join(" ")).toMatch(/confidence/i)
+  })
+
+  it("clamps a nonsense confidence instead of trusting it", () => {
+    expect(normaliseIdCardExtraction({ ...GOOD, confidence: 42 }).confidence).toBe(1)
+    expect(normaliseIdCardExtraction({ ...GOOD, confidence: "abc" }).confidence).toBe(0)
+    expect(normaliseIdCardExtraction({ ...GOOD, confidence: -1 }).confidence).toBe(0)
+  })
+
+  it("records an unrecognised document type as 'other' and says so", () => {
+    const d = normaliseIdCardExtraction({ ...GOOD, id_type: "ration card" })
+    expect(d.id_type).toBe("other")
+    expect(d.warnings.join(" ")).toMatch(/not one we recognise/i)
+  })
+
+  it("treats an all-null address as no address", () => {
+    const d = normaliseIdCardExtraction({
+      ...GOOD,
+      address: { street: null, city: null, state: null, postal_code: null, country: null },
+    })
+    expect(d.address).toBeNull()
+  })
+
+  it("survives junk from the model without throwing", () => {
+    for (const junk of [null, undefined, "not json", 42, [], {}]) {
+      const d = normaliseIdCardExtraction(junk)
+      expect(d.creatable).toBe(false)
+      expect(d.confidence).toBe(0)
+    }
+  })
+})
+
+describe("personCreateInputFromDraft", () => {
+  it("stamps provenance and marks the document unverified", () => {
+    const input = personCreateInputFromDraft(normaliseIdCardExtraction(GOOD), {
+      source_image_url: "https://example.com/card.jpg",
+    })
+
+    expect(input.first_name).toBe("Lhamo")
+    expect(input.date_of_birth).toBeInstanceOf(Date)
+    expect(input.metadata.created_via).toBe("id_card_extraction")
+    // 🔑 A photo of a card is not proof of anything. Nothing in this pipeline
+    // verifies an identity, and the record must not imply that it did.
+    expect((input.metadata.id_document as any).verified).toBe(false)
+    expect((input.metadata.id_document as any).last4).toBe("9012")
+  })
+
+  it("⚠️ leaves email unset rather than inventing one", () => {
+    const input = personCreateInputFromDraft(normaliseIdCardExtraction(GOOD))
+    // `person.email` is UNIQUE. A synthesised address would collide across
+    // cards and poison the constraint for real addresses.
+    expect((input as any).email).toBeUndefined()
+  })
+
+  it("does not put the full ID number on the person record", () => {
+    const input = personCreateInputFromDraft(normaliseIdCardExtraction(GOOD))
+    expect(JSON.stringify(input)).not.toContain("123456789012")
+  })
+})

--- a/apps/backend/src/lib/people/id-card.ts
+++ b/apps/backend/src/lib/people/id-card.ts
@@ -1,0 +1,325 @@
+/**
+ * Turning a photographed ID card into a person we can create.
+ *
+ * ## Why the pure half lives here
+ *
+ * The vision call is a network round trip whose output is a model's best guess.
+ * Everything that decides what we KEEP from that guess — what is trusted, what
+ * is stored, what is thrown away — is pure and lives here, so the policy can be
+ * tested without a model and read without tracing a workflow.
+ *
+ * ## 🔴 The ID number is deliberately not stored in full
+ *
+ * These cards are Aadhaar, PAN, passports, driving licences. An Aadhaar number
+ * in particular is regulated: the UIDAI regulations require it to be redacted
+ * to the last four digits wherever it is displayed or retained by an entity
+ * that is not doing authenticated e-KYC, and we are not. A photo of a card is
+ * also not proof of anything — nothing here is verification.
+ *
+ * So the default is `mask`: we keep the ID TYPE, the last four digits, and
+ * nothing else. That is enough to say "this artisan was onboarded against a
+ * PAN ending 4021" and not enough to be a breach. A caller may pass
+ * `id_number_policy: "discard"` to keep even less. There is deliberately no
+ * option to store the full number — if that is ever needed it should arrive
+ * with a retention policy and an encrypted column, not as a flag on an
+ * extraction tool.
+ *
+ * ⚠️ The raw number therefore must never be echoed back in a response either,
+ * because a preview response is exactly what an operator pastes into a chat log.
+ */
+
+/** What the vision model is asked to return. Kept next to the parser it feeds. */
+export const ID_CARD_SYSTEM_PROMPT = [
+  "You read a photograph of a government identity document and return JSON only, no prose.",
+  "",
+  "Return this shape, using null for anything the image does not clearly show:",
+  "{",
+  '  "first_name": string|null,',
+  '  "last_name": string|null,',
+  '  "date_of_birth": string|null,   // ISO 8601 date, YYYY-MM-DD',
+  '  "gender": string|null,',
+  '  "id_type": string|null,         // one of: aadhaar, pan, passport, driving_licence, voter_id, other',
+  '  "id_number": string|null,',
+  '  "address": {',
+  '    "street": string|null, "city": string|null, "state": string|null,',
+  '    "postal_code": string|null, "country": string|null',
+  "  }|null,",
+  '  "confidence": number            // 0..1, your own confidence in the whole reading',
+  "}",
+  "",
+  "Rules:",
+  "- Transcribe exactly what is printed. Do not translate, expand initials, or correct spellings.",
+  "- A name printed as one field goes entirely in first_name and last_name is null. Never invent a surname.",
+  "- If the document is not an identity document, or is too blurred to read, return every field null with confidence 0.",
+  "- Never guess a date of birth from an age or a photograph.",
+].join("\n")
+
+export type IdNumberPolicy = "mask" | "discard"
+
+export type IdCardAddress = {
+  street: string | null
+  city: string | null
+  state: string | null
+  postal_code: string | null
+  country: string | null
+}
+
+export type PersonDraft = {
+  first_name: string | null
+  last_name: string | null
+  date_of_birth: string | null
+  gender: string | null
+  id_type: string | null
+  /** Last four digits only, e.g. `••••4021`. Never the full number. */
+  id_number_masked: string | null
+  id_last4: string | null
+  address: IdCardAddress | null
+  confidence: number
+  /**
+   * Everything a human should look at before pressing create. Empty means the
+   * reading was complete and internally consistent — never that it is correct.
+   */
+  warnings: string[]
+  /** False when the draft must not be persisted without a human fixing it first. */
+  creatable: boolean
+}
+
+const ID_TYPES = [
+  "aadhaar",
+  "pan",
+  "passport",
+  "driving_licence",
+  "voter_id",
+  "other",
+] as const
+
+const str = (v: unknown): string | null => {
+  if (typeof v !== "string") return null
+  const t = v.trim()
+  return t.length ? t : null
+}
+
+/**
+ * `YYYY-MM-DD` only, and it must be a real, past, plausible date.
+ *
+ * 🔑 Rejecting rather than coercing. `new Date("31/12/1980")` is `Invalid Date`
+ * in Node but `new Date("2024-13-45")` silently rolls over into 2025 — a
+ * coerced date of birth is a wrong fact that looks like a right one, and this
+ * one ends up on a person record nobody re-checks.
+ */
+export const parseDateOfBirth = (
+  v: unknown
+): { value: string | null; warning: string | null } => {
+  const raw = str(v)
+  if (!raw) return { value: null, warning: null }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    return {
+      value: null,
+      warning: `date_of_birth "${raw}" is not an ISO date (YYYY-MM-DD) and was dropped rather than guessed at.`,
+    }
+  }
+
+  const [y, m, d] = raw.split("-").map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  const rolledOver =
+    dt.getUTCFullYear() !== y ||
+    dt.getUTCMonth() !== m - 1 ||
+    dt.getUTCDate() !== d
+
+  if (Number.isNaN(dt.getTime()) || rolledOver) {
+    return {
+      value: null,
+      warning: `date_of_birth "${raw}" is not a real calendar date and was dropped.`,
+    }
+  }
+
+  const now = Date.now()
+  if (dt.getTime() > now) {
+    return {
+      value: null,
+      warning: `date_of_birth "${raw}" is in the future and was dropped.`,
+    }
+  }
+  // 120 years. Older than this is a misread century far more often than a
+  // supercentenarian artisan.
+  if (now - dt.getTime() > 120 * 365.25 * 24 * 60 * 60 * 1000) {
+    return {
+      value: null,
+      warning: `date_of_birth "${raw}" is more than 120 years ago and was dropped as a likely misread.`,
+    }
+  }
+
+  return { value: raw, warning: null }
+}
+
+/**
+ * Keep the last four digits and nothing else.
+ *
+ * Digits are counted after stripping separators, because cards print Aadhaar as
+ * `1234 5678 9012` and a naive `slice(-4)` on the raw string can return
+ * `9012` or ` 012` depending on trailing whitespace.
+ */
+export const maskIdNumber = (
+  v: unknown,
+  policy: IdNumberPolicy
+): { masked: string | null; last4: string | null; warning: string | null } => {
+  const raw = str(v)
+  if (!raw) return { masked: null, last4: null, warning: null }
+
+  if (policy === "discard") {
+    return { masked: null, last4: null, warning: null }
+  }
+
+  const alnum = raw.replace(/[^0-9a-zA-Z]/g, "")
+  if (alnum.length < 4) {
+    return {
+      masked: null,
+      last4: null,
+      warning:
+        "id_number was too short to be a real document number and was discarded.",
+    }
+  }
+
+  const last4 = alnum.slice(-4)
+  return { masked: `••••${last4}`, last4, warning: null }
+}
+
+const normaliseAddress = (v: unknown): IdCardAddress | null => {
+  if (!v || typeof v !== "object") return null
+  const a = v as Record<string, unknown>
+  const out: IdCardAddress = {
+    street: str(a.street),
+    city: str(a.city),
+    state: str(a.state),
+    postal_code: str(a.postal_code),
+    country: str(a.country),
+  }
+  // An address of five nulls is not an address.
+  return Object.values(out).some((x) => x !== null) ? out : null
+}
+
+const normaliseIdType = (v: unknown): { type: string | null; warning: string | null } => {
+  const raw = str(v)?.toLowerCase().replace(/[\s-]+/g, "_")
+  if (!raw) return { type: null, warning: null }
+  if ((ID_TYPES as readonly string[]).includes(raw)) return { type: raw, warning: null }
+  return {
+    type: "other",
+    warning: `id_type "${raw}" is not one we recognise; recorded as "other".`,
+  }
+}
+
+const clampConfidence = (v: unknown): number => {
+  const n = Number(v)
+  if (!Number.isFinite(n)) return 0
+  return Math.min(1, Math.max(0, n))
+}
+
+/**
+ * Normalise one raw vision reading into a person draft.
+ *
+ * PURE. Every decision about what survives the model's guess is made here.
+ */
+export const normaliseIdCardExtraction = (
+  raw: unknown,
+  opts: { id_number_policy?: IdNumberPolicy } = {}
+): PersonDraft => {
+  const policy: IdNumberPolicy = opts.id_number_policy ?? "mask"
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>
+
+  const warnings: string[] = []
+
+  const first_name = str(r.first_name)
+  const last_name = str(r.last_name)
+
+  const dob = parseDateOfBirth(r.date_of_birth)
+  if (dob.warning) warnings.push(dob.warning)
+
+  const idType = normaliseIdType(r.id_type)
+  if (idType.warning) warnings.push(idType.warning)
+
+  const id = maskIdNumber(r.id_number, policy)
+  if (id.warning) warnings.push(id.warning)
+
+  const confidence = clampConfidence(r.confidence)
+
+  /**
+   * 🔴 A person with no name is not a person. This is the one hard refusal:
+   * everything else on a card can be missing and the record still means
+   * something, but a nameless row is landfill that someone will later try to
+   * match against a real human.
+   */
+  const hasName = Boolean(first_name || last_name)
+  if (!hasName) {
+    warnings.push(
+      "No name could be read from the image, so no person can be created from it."
+    )
+  }
+
+  if (confidence < 0.5 && hasName) {
+    warnings.push(
+      `The model's own confidence in this reading is ${confidence.toFixed(
+        2
+      )}. Check every field against the card before creating.`
+    )
+  }
+
+  if (!last_name && first_name) {
+    warnings.push(
+      "Only one name field was printed. It has been kept whole as the first name rather than split into a surname."
+    )
+  }
+
+  return {
+    first_name,
+    last_name,
+    date_of_birth: dob.value,
+    gender: str(r.gender),
+    id_type: idType.type,
+    id_number_masked: id.masked,
+    id_last4: id.last4,
+    address: normaliseAddress(r.address),
+    confidence,
+    warnings,
+    creatable: hasName,
+  }
+}
+
+/**
+ * The person payload to create, derived from a draft.
+ *
+ * ⚠️ `email` is deliberately absent. `person.email` is UNIQUE and an ID card
+ * carries no email, so inventing one (`aadhaar-4021@…`) to satisfy a form would
+ * collide across cards and poison the uniqueness constraint for real addresses.
+ * Null is the honest value.
+ */
+export const personCreateInputFromDraft = (
+  draft: PersonDraft,
+  extra: { source_image_url?: string | null; created_via?: string } = {}
+) => {
+  if (!draft.creatable) {
+    throw new Error(
+      "Refusing to build a person from a draft with no name — see draft.warnings."
+    )
+  }
+
+  return {
+    first_name: draft.first_name ?? "",
+    last_name: draft.last_name ?? "",
+    date_of_birth: draft.date_of_birth ? new Date(draft.date_of_birth) : null,
+    metadata: {
+      // Provenance, so anyone looking at this row later knows a machine read it
+      // off a photograph and that nothing here was verified.
+      created_via: extra.created_via ?? "id_card_extraction",
+      id_document: {
+        type: draft.id_type,
+        last4: draft.id_last4,
+        masked: draft.id_number_masked,
+        verified: false,
+      },
+      ...(draft.gender ? { gender: draft.gender } : {}),
+      ...(extra.source_image_url ? { source_image_url: extra.source_image_url } : {}),
+      extraction_confidence: draft.confidence,
+    },
+  }
+}

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -65,6 +65,11 @@ export type AiRole =
   // falls back to the auto-rotating OpenRouter free vision model. Previously
   // hardcoded to OPENROUTER_API_KEY which made the feature go dark when unset.
   | "ai_image_extraction"
+  // Identity-document OCR for people onboarding. Its own role so an operator
+  // can point a stronger OCR model at ID cards without disturbing the
+  // inventory extraction; the workflow falls back to the `ai_image_extraction`
+  // ladder when nothing is tagged here, so the feature works untagged.
+  | "ai_id_extraction"
   // Moodboard "Redesign" — Nano-Banana (gemini-2.5-flash-image) (#892).
   // Resolved by resolveRedesignCredentials: honours provider_type=openrouter
   // (google/gemini-2.5-flash-image) or a hand-tagged google platform; falls

--- a/apps/backend/src/modules/partner-quote/lib/resolve-region.ts
+++ b/apps/backend/src/modules/partner-quote/lib/resolve-region.ts
@@ -152,7 +152,17 @@ export async function resolveQuoteRegion(
 
   const resolved = pickQuoteRegion((regions ?? []) as RegionLike[], input)
 
-  if (opts.strict && !resolved.region_id) {
+  /**
+   * 🔴 Narrow on `source`, not on `!region_id`.
+   *
+   * `RegionResolution` is a union whose failure branch is the only one carrying
+   * `reason`, and `source` is its discriminant. TypeScript narrows a union by
+   * truthiness only when the property is a literal type — `region_id: string`
+   * is not, so `!resolved.region_id` narrowed nothing and `resolved.reason`
+   * did not compile. That failed CI's `prod-build` job on every push, on `main`
+   * included, from the moment #1788 landed.
+   */
+  if (opts.strict && resolved.source === "none") {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
       `Cannot determine the region for this quote: ${resolved.reason}. ` +

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/rating-credentials.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/rating-credentials.unit.spec.ts
@@ -1,0 +1,148 @@
+import ShiprocketFulfillmentService from "../service"
+
+/**
+ * The two credential paths, and the one that was reading the blank half.
+ *
+ * 🔴 Shiprocket's label/pickup/track calls go through `resolveShippingProvider`,
+ * which reads the `category:shipping` SocialPlatform record. `calculatePrice`
+ * did not — it used the client built from MODULE OPTIONS, i.e. env, and
+ * `SHIPROCKET_PASSWORD` is deliberately unset in both `.env` and the copilot
+ * manifest ("the password/pickup are intentionally NOT wired as env here").
+ *
+ * So every live rate call posted `password: undefined` and Shiprocket answered
+ * `422 — password: The password is required`, once per shipping-options
+ * request, while the rest of the carrier worked perfectly.
+ */
+const ENV_OPTIONS = {
+  email: "env@jaalyantra.com",
+  password: undefined as any, // exactly what prod has: the env var is unset
+  pickup_location: "Primary",
+}
+
+const PLATFORM_RECORD = {
+  name: "Shiprocket",
+  api_config: {
+    provider: "shiprocket",
+    email: "shipping@jaalyantra.com",
+    password: "the-real-one",
+    mode: "live",
+  },
+}
+
+const loggerStub = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+})
+
+const build = (opts: { socials?: any; encryption?: any } = {}) => {
+  const logger = loggerStub()
+  const svc = new ShiprocketFulfillmentService(
+    { logger, socials: opts.socials, encryption: opts.encryption } as any,
+    ENV_OPTIONS as any
+  )
+  return { svc: svc as any, logger }
+}
+
+describe("shiprocket rating credentials", () => {
+  it("🔴 uses the SocialPlatform record, not the unset env password", async () => {
+    const listSocialPlatforms = jest.fn(async (_f: any) => [PLATFORM_RECORD])
+    const { svc } = build({ socials: { listSocialPlatforms } })
+
+    const client = await svc.resolveClient()
+
+    expect(listSocialPlatforms).toHaveBeenCalledWith({
+      category: "shipping",
+      status: "active",
+    })
+    // The client that will do the rate call carries the real credentials.
+    expect(client.email).toBe("shipping@jaalyantra.com")
+    expect(client.password).toBe("the-real-one")
+  })
+
+  it("caches the lookup — a login per rate call would be absurd", async () => {
+    const listSocialPlatforms = jest.fn(async (_f: any) => [PLATFORM_RECORD])
+    const { svc } = build({ socials: { listSocialPlatforms } })
+
+    const a = await svc.resolveClient()
+    const b = await svc.resolveClient()
+
+    expect(a).toBe(b)
+    expect(listSocialPlatforms).toHaveBeenCalledTimes(1)
+  })
+
+  it("🔴 warns LOUDLY when the cradle has no socials — the dependency was dropped", async () => {
+    // This branch means `dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE]` was
+    // removed from the fulfillment module registration. The failure it causes
+    // is otherwise completely silent, which is how it went unnoticed.
+    const { svc, logger } = build({ socials: undefined })
+
+    const client = await svc.resolveClient()
+
+    expect(client.email).toBe("env@jaalyantra.com")
+    expect(logger.warn).toHaveBeenCalled()
+    expect(String(logger.warn.mock.calls[0][0])).toMatch(/dependencies/i)
+  })
+
+  it("falls back, and says so, when no shiprocket record exists", async () => {
+    const listSocialPlatforms = jest.fn(async (_f: any) => [
+      { name: "Blue Dart", api_config: { provider: "bluedart" } },
+    ])
+    const { svc, logger } = build({ socials: { listSocialPlatforms } })
+
+    const client = await svc.resolveClient()
+
+    expect(client.email).toBe("env@jaalyantra.com")
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it("falls back when the record names an email but no password", async () => {
+    const listSocialPlatforms = jest.fn(async (_f: any) => [
+      { name: "Shiprocket", api_config: { provider: "shiprocket", email: "x@y.com" } },
+    ])
+    const { svc, logger } = build({ socials: { listSocialPlatforms } })
+
+    const client = await svc.resolveClient()
+
+    // A half-configured record must not produce a client that fails auth in a
+    // new way — better the known env behaviour plus a warning.
+    expect(client.email).toBe("env@jaalyantra.com")
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it("decrypts an encrypted password when the encryption module is present", async () => {
+    const listSocialPlatforms = jest.fn(async (_f: any) => [
+      {
+        name: "Shiprocket",
+        api_config: {
+          provider: "shiprocket",
+          email: "shipping@jaalyantra.com",
+          password_encrypted: "cipher-text",
+        },
+      },
+    ])
+    const decrypt = jest.fn(async (_v: string) => "decrypted-secret")
+    const { svc } = build({
+      socials: { listSocialPlatforms },
+      encryption: { decrypt },
+    })
+
+    const client = await svc.resolveClient()
+
+    expect(decrypt).toHaveBeenCalledWith("cipher-text")
+    expect(client.password).toBe("decrypted-secret")
+  })
+
+  it("never throws when the socials lookup fails — rating degrades, it does not break", async () => {
+    const listSocialPlatforms = jest.fn(async (_f: any) => {
+      throw new Error("db is having a moment")
+    })
+    const { svc, logger } = build({ socials: { listSocialPlatforms } })
+
+    const client = await svc.resolveClient()
+
+    expect(client.email).toBe("env@jaalyantra.com")
+    expect(logger.warn).toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -15,7 +15,21 @@ import { deriveShiprocketRateContext } from "./rate-context"
 import { resolveShipmentPaymentMode } from "./payment-mode"
 import { FlatFallbackConfig, resolveFlatFallbackAmount } from "./flat-fallback"
 
-type InjectedDeps = { logger: Logger }
+/**
+ * 🔴 `socials` and `encryption` reach the provider ONLY because the fulfillment
+ * module declares `dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE]` in
+ * `medusa-config{,.prod}.ts`. A provider is constructed with the parent
+ * module's cradle, which otherwise carries six default keys and nothing else.
+ *
+ * Optional on purpose: if the declaration is ever dropped, this degrades to the
+ * env-configured client rather than throwing — but it says so loudly, because
+ * the failure it replaces was completely silent.
+ */
+type InjectedDeps = {
+  logger: Logger
+  socials?: any
+  encryption?: any
+}
 
 /**
  * Shiprocket fulfillment provider (#31).
@@ -31,20 +45,134 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
 
   protected client: ShiprocketClient
   protected logger: Logger
+  protected deps: InjectedDeps
+  protected options: ShiprocketOptions & FlatFallbackConfig
+  /** Resolved once per process; a login per rate call would be absurd. */
+  protected platformClient: ShiprocketClient | null = null
+  protected platformLookupDone = false
   /** What an unquotable lane costs. See `flat-fallback.ts`. */
   protected fallbackConfig: FlatFallbackConfig
 
   constructor(
-    { logger }: InjectedDeps,
+    deps: InjectedDeps,
     options: ShiprocketOptions & FlatFallbackConfig
   ) {
     super()
+    const { logger } = deps
     this.logger = logger
+    this.deps = deps
+    this.options = options
     this.client = new ShiprocketClient(options)
     this.fallbackConfig = {
       flat_fallback_amounts: options?.flat_fallback_amounts,
       flat_fallback_amount: options?.flat_fallback_amount,
     }
+  }
+
+
+  /**
+   * The client that can actually authenticate.
+   *
+   * 🔴 This is the whole fix. `calculatePrice` used the client built from
+   * MODULE OPTIONS — i.e. env — and `SHIPROCKET_PASSWORD` is deliberately unset
+   * in both `.env` and the copilot manifest, because the credentials live in
+   * the `category:shipping` SocialPlatform record that `resolveShippingProvider`
+   * reads for label/pickup/track. So the carrier worked everywhere EXCEPT
+   * rating, which posted `password: undefined` and got
+   * `422 — password: The password is required` on every live rate call.
+   *
+   * Two credential paths, and the money-facing one was reading the blank half.
+   * This reads the same record the rest of the carrier does.
+   *
+   * Cached per process: a login round-trip per rate call would be absurd, and
+   * the record does not change between deploys.
+   */
+  protected async resolveClient(): Promise<ShiprocketClient> {
+    if (this.platformLookupDone) {
+      return this.platformClient ?? this.client
+    }
+    this.platformLookupDone = true
+
+    const socials = this.deps?.socials
+    if (!socials) {
+      // Loud on purpose: this branch means the `dependencies` declaration on
+      // the fulfillment module was dropped, and the symptom it causes (rates
+      // silently failing auth) is otherwise invisible.
+      this.logger?.warn?.(
+        "[shiprocket] no `socials` in the provider cradle — falling back to env credentials. " +
+          "Rating will fail auth unless SHIPROCKET_PASSWORD is set. Check `dependencies` on the fulfillment module."
+      )
+      return this.client
+    }
+
+    try {
+      const platforms = await socials.listSocialPlatforms({
+        category: "shipping",
+        status: "active",
+      })
+      const match = (platforms || []).find((p: any) => {
+        const cfg = (p.api_config as Record<string, any>) || {}
+        const type = String(
+          cfg.provider_type || cfg.provider || p.name || ""
+        ).toLowerCase()
+        return type === "shiprocket" || type.includes("shiprocket")
+      })
+
+      const cfg = (match?.api_config as Record<string, any>) || {}
+      const email = typeof cfg.email === "string" ? cfg.email : undefined
+      const password = await this.readSecret(cfg, "password")
+
+      if (!email || !password) {
+        this.logger?.warn?.(
+          `[shiprocket] shipping platform record ${
+            match ? "found but incomplete" : "not found"
+          } — falling back to env credentials for rating.`
+        )
+        return this.client
+      }
+
+      this.platformClient = new ShiprocketClient({
+        ...this.options,
+        email,
+        password,
+        pickup_location:
+          (typeof cfg.pickup_location === "string" && cfg.pickup_location) ||
+          this.options.pickup_location,
+      })
+      this.logger?.info?.(
+        `[shiprocket] rating credentials resolved from the shipping platform record (${email}).`
+      )
+      return this.platformClient
+    } catch (e: any) {
+      this.logger?.warn?.(
+        `[shiprocket] could not read the shipping platform record: ${
+          e?.message ?? e
+        } — falling back to env credentials.`
+      )
+      return this.client
+    }
+  }
+
+  /** Decrypt a secret field if the encryption module is present, else read it plain. */
+  protected async readSecret(
+    cfg: Record<string, any>,
+    field: string
+  ): Promise<string | undefined> {
+    // Mirrors `resolveShippingProvider`'s own `readSecret` exactly — same key
+    // names, same precedence. Inventing a second key here would create an
+    // affordance nothing writes, and the two readers of the same record must
+    // not disagree about where the secret lives.
+    const encrypted = cfg?.[`${field}_encrypted`]
+    if (encrypted && this.deps?.encryption?.decrypt) {
+      try {
+        const plain = await this.deps.encryption.decrypt(encrypted)
+        if (typeof plain === "string" && plain.length) return plain
+      } catch {
+        /* fall through to plaintext */
+      }
+    }
+    const plain = cfg?.[field]
+    return typeof plain === "string" && plain.length ? plain : undefined
   }
 
   async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
@@ -114,7 +242,10 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
     const rateContext = derived.context
 
     try {
-      const rates = await this.client.getRates({
+      // The credential-bearing client, not the env-built one — see
+      // `resolveClient`. This single line is what was answering 422.
+      const rateClient = await this.resolveClient()
+      const rates = await rateClient.getRates({
         origin_pincode: rateContext.origin_pincode,
         destination_pincode: rateContext.destination_pincode,
         destination_country: rateContext.destination_country,

--- a/apps/backend/src/subscribers/__tests__/order-dispatched-raise-balance.unit.spec.ts
+++ b/apps/backend/src/subscribers/__tests__/order-dispatched-raise-balance.unit.spec.ts
@@ -1,0 +1,181 @@
+const mockRun = jest.fn()
+
+jest.mock("../../workflows/payments/request-order-balance", () => ({
+  requestOrderBalanceWorkflow: () => ({ run: mockRun }),
+}))
+
+jest.mock("../../modules/payment_schedule", () => ({
+  PAYMENT_SCHEDULE_MODULE: "payment_schedule",
+}))
+
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import raiseBalanceOnDispatch from "../order-dispatched-raise-balance"
+
+/**
+ * #1451 follow-on — raising the balance when the goods move.
+ *
+ * 🔴 The case that matters is the ID SHAPE. `order.fulfillment_created` carries
+ * an order id; `shipment.created` and `delivery.created` carry a FULFILMENT id.
+ * Treating the latter as an order id makes `findByOrderId` return nothing on
+ * every shipment — the subscriber looks healthy and raises no balance at all.
+ * These tests exist to stop that regressing quietly.
+ */
+const SCHEDULE = {
+  id: "sched_1",
+  order_id: "order_1",
+  balance_status: "not_due",
+  balance_amount: "220.34",
+}
+
+const build = (opts: { schedule?: any; fulfilmentOrderId?: string | null } = {}) => {
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  // Typed with a parameter on purpose: a ZERO-arg `jest.fn` gives `mock.calls`
+  // the type `[]`, and reading `calls[0][0]` is then TS2493 — green in jest,
+  // red in `check:prod-build`, which compiles the specs.
+  const emit = jest.fn(async (_payload: any) => undefined)
+  // 🔴 `"schedule" in opts`, not `opts.schedule ?? SCHEDULE` — `??` treats an
+  // explicit `null` as "not provided" and hands back the default, so the
+  // no-schedule case silently tested the happy path instead.
+  const findByOrderId = jest.fn(async () =>
+    "schedule" in opts ? opts.schedule : SCHEDULE
+  )
+
+  const graph = jest.fn(async (_args: any) => ({
+    data:
+      opts.fulfilmentOrderId === null
+        ? []
+        : [{ id: "ful_1", order: { id: opts.fulfilmentOrderId ?? "order_1" } }],
+  }))
+
+  const container = {
+    resolve: (key: string) => {
+      if (key === ContainerRegistrationKeys.LOGGER) return logger
+      if (key === ContainerRegistrationKeys.QUERY) return { graph }
+      if (key === Modules.EVENT_BUS) return { emit }
+      if (key === "payment_schedule") return { findByOrderId }
+      throw new Error(`unexpected resolve(${key})`)
+    },
+  }
+
+  return { container, logger, emit, findByOrderId, graph }
+}
+
+beforeEach(() => {
+  mockRun.mockReset()
+  mockRun.mockResolvedValue({
+    result: {
+      raised: true,
+      pay_url: "https://v3.jaalyantra.com/stripe/pay/balance/sched_1",
+      plan: {
+        collectable: true,
+        schedule_id: "sched_1",
+        amount: 220.34,
+        currency_code: "aud",
+      },
+    },
+  })
+})
+
+describe("raiseBalanceOnDispatch", () => {
+  it("🔴 resolves the ORDER from a fulfilment id on delivery.created", async () => {
+    const { container, findByOrderId, graph } = build()
+
+    await raiseBalanceOnDispatch({
+      event: { name: "delivery.created", data: { id: "ful_1" } },
+      container,
+    } as any)
+
+    // The fulfilment was looked up...
+    expect(graph).toHaveBeenCalled()
+    expect(graph.mock.calls[0][0]).toMatchObject({ entity: "fulfillment" })
+    // ...and the ORDER id — never the fulfilment id — reached the schedule.
+    expect(findByOrderId).toHaveBeenCalledWith("order_1")
+    expect(mockRun).toHaveBeenCalledWith({
+      input: { order_id: "order_1", requested_by: "dispatch" },
+    })
+  })
+
+  it("takes the order id directly on order.fulfillment_created", async () => {
+    const { container, findByOrderId, graph } = build()
+
+    await raiseBalanceOnDispatch({
+      event: { name: "order.fulfillment_created", data: { id: "order_1" } },
+      container,
+    } as any)
+
+    // No fulfilment lookup needed — the payload already names the order.
+    expect(graph).not.toHaveBeenCalled()
+    expect(findByOrderId).toHaveBeenCalledWith("order_1")
+  })
+
+  it("emits order.balance_due carrying the amount AND the pay link", async () => {
+    const { container, emit } = build()
+
+    await raiseBalanceOnDispatch({
+      event: { name: "shipment.created", data: { id: "ful_1" } },
+      container,
+    } as any)
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    const payload = emit.mock.calls[0][0] as any
+    expect(payload.name).toBe("order.balance_due")
+    // A reminder without the link is a demand with no way to pay.
+    expect(payload.data.pay_url).toMatch(/stripe\/pay\/balance\/sched_1/)
+    expect(payload.data.amount).toBe(220.34)
+    expect(payload.data.order_id).toBe("order_1")
+  })
+
+  it("does nothing for an order with no payment schedule", async () => {
+    const { container, emit } = build({ schedule: null })
+
+    await raiseBalanceOnDispatch({
+      event: { name: "shipment.created", data: { id: "ful_1" } },
+      container,
+    } as any)
+
+    // Fires on every shipment on the platform; silence is the correct
+    // behaviour for an ordinary order.
+    expect(mockRun).not.toHaveBeenCalled()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it("does not re-raise a balance that is already due or paid", async () => {
+    for (const status of ["due", "paid", "waived"]) {
+      mockRun.mockClear()
+      const { container } = build({ schedule: { ...SCHEDULE, balance_status: status } })
+
+      await raiseBalanceOnDispatch({
+        event: { name: "shipment.created", data: { id: "ful_1" } },
+        container,
+      } as any)
+
+      expect(mockRun).not.toHaveBeenCalled()
+    }
+  })
+
+  it("🔴 never throws — a fulfilment must not fail because billing did", async () => {
+    mockRun.mockRejectedValue(new Error("stripe exploded"))
+    const { container, logger } = build()
+
+    await expect(
+      raiseBalanceOnDispatch({
+        event: { name: "shipment.created", data: { id: "ful_1" } },
+        container,
+      } as any)
+    ).resolves.toBeUndefined()
+
+    expect(logger.error).toHaveBeenCalled()
+  })
+
+  it("gives up quietly when the fulfilment resolves to no order", async () => {
+    const { container, findByOrderId } = build({ fulfilmentOrderId: null })
+
+    await raiseBalanceOnDispatch({
+      event: { name: "delivery.created", data: { id: "ful_unknown" } },
+      container,
+    } as any)
+
+    expect(findByOrderId).not.toHaveBeenCalled()
+    expect(mockRun).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/subscribers/order-dispatched-raise-balance.ts
+++ b/apps/backend/src/subscribers/order-dispatched-raise-balance.ts
@@ -1,0 +1,125 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import { PAYMENT_SCHEDULE_MODULE } from "../modules/payment_schedule"
+import { requestOrderBalanceWorkflow } from "../workflows/payments/request-order-balance"
+
+/**
+ * Raise the balance when the goods actually move (#1451 follow-on).
+ *
+ * ## Why dispatch, and why this is not the only trigger
+ *
+ * The balance becomes payable when the goods exist. A partner can say so by
+ * hand (`POST /partners/orders/:id/request-balance`) because they often know
+ * before the system does — but the reliable, unattended signal is the shipment
+ * itself. Both paths run the SAME workflow, which is idempotent: whichever
+ * happens first wins and the second is a no-op, so a partner who pressed the
+ * button an hour earlier does not end up with two collections.
+ *
+ * ## What it emits, and why a flow rather than an email here
+ *
+ * On success it emits `order.balance_due` carrying the amount and the pay link.
+ * `visual-flow-event-trigger` already listens for shipment and delivery events,
+ * so the REMINDER is a visual flow an operator can edit — wording, timing,
+ * channel — rather than a template buried in a subscriber. This subscriber's
+ * only job is to make the money collectable and publish the fact.
+ *
+ * 🔴 Never throws. A fulfilment must not fail because a payment schedule could
+ * not be raised — the goods are already going out, and the sweep plus the
+ * partner button both remain as recovery.
+ */
+export default async function raiseBalanceOnDispatch({
+  event,
+  container,
+}: SubscriberArgs<{ id: string; order_id?: string }>) {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  /**
+   * 🔴 The payload differs by event, and getting this wrong fails SILENTLY.
+   *
+   * `order.fulfillment_created` carries the ORDER id. `shipment.created` and
+   * `delivery.created` carry the FULFILMENT id — verified against
+   * `delivery-created.ts`, which passes `data.id` straight in as a
+   * `shipment_id`. Treating that as an order id would make
+   * `findByOrderId(<fulfilment id>)` return nothing on every shipment, and the
+   * subscriber would look healthy while raising no balance at all.
+   *
+   * So a non-order event is resolved through `fulfillment → order.id` first.
+   */
+  const isOrderEvent = event.name === "order.fulfillment_created"
+  let orderId: string | null =
+    (event.data as any)?.order_id ?? (isOrderEvent ? event.data?.id : null) ?? null
+
+  if (!orderId && event.data?.id) {
+    try {
+      const { data } = await query.graph({
+        entity: "fulfillment",
+        fields: ["id", "order.id"],
+        filters: { id: event.data.id },
+      })
+      orderId = (data?.[0] as any)?.order?.id ?? null
+    } catch (e: any) {
+      logger?.warn?.(
+        `[balance] could not resolve an order from fulfilment ${event.data.id}: ${
+          e?.message ?? e
+        }`
+      )
+    }
+  }
+
+  if (!orderId) return
+
+  try {
+    const schedules: any = container.resolve(PAYMENT_SCHEDULE_MODULE)
+    const schedule = await schedules.findByOrderId(orderId)
+
+    // No schedule means an ordinary order with nothing outstanding. Silence is
+    // correct here; this fires on every shipment on the platform.
+    if (!schedule) return
+    if (schedule.balance_status !== "not_due") return
+
+    const { result } = await requestOrderBalanceWorkflow(container).run({
+      input: { order_id: orderId, requested_by: "dispatch" },
+    })
+
+    const out = result as any
+    if (!out?.raised) {
+      logger?.info?.(
+        `[balance] dispatch of order=${orderId} did not raise a balance: ${
+          out?.plan?.reason ?? "no reason given"
+        }`
+      )
+      return
+    }
+
+    const eventBus: any = container.resolve(Modules.EVENT_BUS)
+    await eventBus.emit({
+      name: "order.balance_due",
+      data: {
+        id: orderId,
+        order_id: orderId,
+        payment_schedule_id: out.plan?.schedule_id ?? schedule.id,
+        amount: out.plan?.collectable ? out.plan.amount : null,
+        currency_code: out.plan?.collectable ? out.plan.currency_code : null,
+        // The link the reminder should carry. A flow that renders the email
+        // needs this — without it the buyer gets a demand and no way to pay.
+        pay_url: out.pay_url ?? null,
+      },
+    })
+
+    logger?.info?.(
+      `[balance] raised on dispatch for order=${orderId} — ${
+        out.plan?.collectable ? out.plan.amount : "?"
+      } due, link ${out.pay_url ?? "unavailable"}`
+    )
+  } catch (e: any) {
+    logger?.error?.(
+      `[balance] failed to raise on dispatch for order=${orderId}: ${e?.message ?? e}`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["shipment.created", "delivery.created", "order.fulfillment_created"],
+}

--- a/apps/backend/src/workflows/ai/extract-person-from-id.ts
+++ b/apps/backend/src/workflows/ai/extract-person-from-id.ts
@@ -1,0 +1,295 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+  when,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { generateObject } from "ai"
+import { z } from "zod"
+
+import {
+  resolveRoleVisionModel,
+  resolveRoleVisionModels,
+} from "../../mastra/services/ai-platforms"
+import {
+  ID_CARD_SYSTEM_PROMPT,
+  normaliseIdCardExtraction,
+  personCreateInputFromDraft,
+  type IdNumberPolicy,
+  type PersonDraft,
+} from "../../lib/people/id-card"
+import { PERSON_MODULE } from "../../modules/person"
+
+/**
+ * Read a photographed identity document and, optionally, create the person.
+ *
+ * ## Preview first, always
+ *
+ * `persist` defaults to false and the route requires `confirm` on top of it.
+ * An extraction is a machine's reading of a photograph of a legal document
+ * belonging to a real person; the operator looks at the draft and its warnings
+ * before a row exists. This mirrors `extract_inventory_from_image` (#769),
+ * which established the pattern for exactly this reason.
+ *
+ * ## The provider ladder
+ *
+ * Vision models are configured per role as External Platforms. This asks for
+ * `ai_id_extraction` first — a dedicated knob, so an operator can point a
+ * stronger OCR model at identity documents without disturbing inventory —
+ * and falls back to the `ai_image_extraction` ladder, which already has
+ * vision platforms configured, then to the free OpenRouter vision model.
+ *
+ * 🔑 It walks the ladder on FAILURE, not on a poor reading. A model that
+ * returns a confident wrong answer is not something a retry fixes, and
+ * re-reading the same card until some model likes it is how you launder a
+ * misread into a fact. Only transport/parse errors advance the ladder.
+ */
+export type ExtractPersonFromIdInput = {
+  image_url: string
+  notes?: string | null
+  id_number_policy?: IdNumberPolicy
+  persist?: boolean
+  /** Link the created person to this partner. Admin-side; the partner route fills it from auth. */
+  partner_id?: string | null
+  /** Person-type ids to attach on create. */
+  person_type_ids?: string[] | null
+}
+
+export type ExtractPersonFromIdResult = {
+  draft: PersonDraft
+  person: any | null
+  persisted: boolean
+  model: { role: string; provider?: string; model?: string; source?: string } | null
+  /** Why nothing was created, when nothing was. Never silence. */
+  not_persisted_reason: string | null
+}
+
+/**
+ * The shape asked of the model. Deliberately permissive — `.nullable()`
+ * everywhere — because a model forced to satisfy a required field will invent
+ * one, and an invented surname on an identity record is worse than a gap.
+ */
+const idCardSchema = z.object({
+  first_name: z.string().nullable(),
+  last_name: z.string().nullable(),
+  date_of_birth: z.string().nullable(),
+  gender: z.string().nullable(),
+  id_type: z.string().nullable(),
+  id_number: z.string().nullable(),
+  address: z
+    .object({
+      street: z.string().nullable(),
+      city: z.string().nullable(),
+      state: z.string().nullable(),
+      postal_code: z.string().nullable(),
+      country: z.string().nullable(),
+    })
+    .nullable(),
+  confidence: z.number(),
+})
+
+const readIdCardStep = createStep(
+  "read-id-card-with-vision",
+  async (input: ExtractPersonFromIdInput, { container }) => {
+    let logger: any
+    try {
+      logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+    } catch {
+      /* optional */
+    }
+
+    // Dedicated role first, then the role that already has vision platforms
+    // configured, then the free fallback. Deduped by model id so a platform
+    // tagged for both roles is not tried twice.
+    const ladder: any[] = []
+    try {
+      ladder.push(...(await resolveRoleVisionModels(container, "ai_id_extraction")))
+    } catch {
+      /* no platform for the dedicated role — expected until one is tagged */
+    }
+    try {
+      ladder.push(
+        ...(await resolveRoleVisionModels(container, "ai_image_extraction"))
+      )
+    } catch {
+      /* fall through to the free model */
+    }
+    ladder.push(await resolveRoleVisionModel(container, "ai_image_extraction"))
+
+    const seen = new Set<string>()
+    const rungs = ladder.filter((r) => {
+      const key = `${r.platformId ?? r.providerType}:${r.modelId ?? "default"}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+    const failures: string[] = []
+
+    for (const rung of rungs) {
+      const started = Date.now()
+      try {
+        const result: any = await generateObject({
+          model: rung.model as any,
+          schema: idCardSchema,
+          messages: [
+            { role: "system", content: ID_CARD_SYSTEM_PROMPT },
+            {
+              role: "user",
+              content: [
+                { type: "image", image: input.image_url },
+                {
+                  type: "text",
+                  text: input.notes?.trim()
+                    ? `Operator context: ${input.notes.trim()}`
+                    : "Read this identity document.",
+                },
+              ],
+            },
+          ],
+        })
+
+        logger?.info?.(
+          `[id-extraction] read ok via ${rung.providerType}/${
+            rung.modelId ?? "default"
+          } in ${Date.now() - started}ms`
+        )
+
+        return new StepResponse({
+          raw: result.object,
+          model: {
+            role: "ai_id_extraction",
+            provider: rung.providerType,
+            model: rung.modelId,
+            source: rung.source,
+          },
+        })
+      } catch (e: any) {
+        // Transport/parse failure only — see the ladder note above.
+        failures.push(`${rung.providerType}/${rung.modelId ?? "default"}: ${e?.message ?? e}`)
+        logger?.warn?.(
+          `[id-extraction] rung failed (${rung.providerType}/${rung.modelId ?? "default"}): ${
+            e?.message ?? e
+          }`
+        )
+      }
+    }
+
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Could not read the document with any configured vision provider. Tried ${rungs.length}: ${failures.join(
+        " | "
+      )}`
+    )
+  }
+)
+
+const createPersonStep = createStep(
+  "create-person-from-id-draft",
+  async (
+    input: { draft: PersonDraft; source_image_url: string; person_type_ids?: string[] | null },
+    { container }
+  ) => {
+    const personService: any = container.resolve(PERSON_MODULE)
+
+    const payload = personCreateInputFromDraft(input.draft, {
+      source_image_url: input.source_image_url,
+    })
+
+    const created = await personService.createPeople(payload)
+    const person = Array.isArray(created) ? created[0] : created
+
+    // The address is a separate row, and is not worth failing the person over:
+    // a person with no address is recoverable, a half-created person is not.
+    if (input.draft.address && person?.id) {
+      const a = input.draft.address
+      try {
+        // 🔴 `createAddresses`, not `createPersonAddresses`. The generated name
+        // follows the MODEL name (`person_address` → Addresses), and the wrong
+        // one throws straight into the catch below — an address that silently
+        // never appears, on a path whose whole job is to save typing.
+        await personService.createAddresses({
+          person_id: person.id,
+          street: a.street ?? "",
+          city: a.city ?? "",
+          state: a.state ?? "",
+          postal_code: a.postal_code ?? "",
+          country: a.country ?? "",
+        })
+      } catch {
+        /* address is best-effort; the person still stands */
+      }
+    }
+
+    return new StepResponse({ person }, { person_id: person?.id })
+  },
+  async (undo, { container }) => {
+    if (!undo?.person_id) return
+    const personService: any = container.resolve(PERSON_MODULE)
+    await personService.deletePeople(undo.person_id).catch(() => {})
+  }
+)
+
+/**
+ * PURE decision step: what the reading means, and whether to create.
+ *
+ * Both refusals are REPORTED, never thrown — a preview that 500s tells the
+ * operator nothing about what the model saw, which is the whole point of
+ * previewing.
+ */
+const normaliseDraftStep = createStep(
+  "normalise-id-card-draft",
+  async (i: { raw: any; policy?: IdNumberPolicy; persist?: boolean }) => {
+    const draft = normaliseIdCardExtraction(i.raw, {
+      id_number_policy: i.policy ?? "mask",
+    })
+
+    const reason = !i.persist
+      ? "persist was not requested — this is a preview."
+      : !draft.creatable
+      ? "the document could not be read well enough to create a person; see warnings."
+      : null
+
+    return new StepResponse({
+      draft,
+      should_create: Boolean(i.persist) && draft.creatable,
+      reason,
+    })
+  }
+)
+
+export const extractPersonFromIdWorkflow = createWorkflow(
+  { name: "extract-person-from-id", store: true },
+  (input: ExtractPersonFromIdInput) => {
+    const read = readIdCardStep(input)
+
+    const decided = normaliseDraftStep({
+      raw: read.raw,
+      policy: input.id_number_policy,
+      persist: input.persist,
+    })
+
+    const created = when(decided, (d: any) => d.should_create).then(() =>
+      createPersonStep({
+        draft: decided.draft,
+        source_image_url: input.image_url,
+        person_type_ids: input.person_type_ids,
+      })
+    )
+
+    return new WorkflowResponse(
+      transform({ decided, created, read }, (d: any) => ({
+        draft: d.decided.draft,
+        person: d.created?.person ?? null,
+        persisted: Boolean(d.created?.person),
+        not_persisted_reason: d.decided.reason,
+        model: d.read.model,
+      }))
+    )
+  }
+)
+
+export default extractPersonFromIdWorkflow

--- a/apps/backend/src/workflows/payments/request-order-balance.ts
+++ b/apps/backend/src/workflows/payments/request-order-balance.ts
@@ -1,0 +1,254 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import {
+  createOrUpdateOrderPaymentCollectionWorkflow,
+  createPaymentSessionsWorkflow,
+} from "@medusajs/core-flows"
+
+import { PAYMENT_SCHEDULE_MODULE } from "../../modules/payment_schedule"
+import {
+  buildBalancePayUrl,
+  planBalanceCollection,
+  type BalancePlan,
+} from "../../lib/payments/balance-collection"
+
+/**
+ * Raise the balance on an order and mint the link that collects it.
+ *
+ * ## The activation
+ *
+ * A partner working the order presses this when the goods are made and moving.
+ * That is deliberate: the balance becomes payable when the goods exist, and the
+ * people who know that are the makers. Several partners may be realising one
+ * order, so any of them may raise it — and raising it twice is harmless,
+ * because both the plan and the service refuse a balance that is already paid.
+ *
+ * ## What it creates
+ *
+ * A SECOND payment collection on the order, for the balance only, with its own
+ * Stripe session. Not a capture of a held authorisation: an online card auth
+ * lasts about seven days and a made-to-order lead time does not, which is why
+ * the schedule was designed as two charges from the start.
+ *
+ * 🔴 It is idempotent on the collection. A partner pressing twice, or two
+ * partners on one order pressing at once, must not mint two collections and
+ * two intents against the same buyer — the existing balance collection is
+ * reused when its amount agrees, and a disagreement REFUSES rather than
+ * picking one of two figures.
+ */
+export type RequestOrderBalanceInput = {
+  order_id: string
+  /** Who asked, for the audit line. A partner id, or "admin". */
+  requested_by?: string | null
+}
+
+export type RequestOrderBalanceResult = {
+  raised: boolean
+  plan: BalancePlan
+  payment_collection_id: string | null
+  pay_url: string | null
+  /** Already-raised balances return the existing link rather than a new one. */
+  reused: boolean
+}
+
+const loadScheduleStep = createStep(
+  "load-schedule-for-balance",
+  async (input: RequestOrderBalanceInput, { container }) => {
+    const schedules: any = container.resolve(PAYMENT_SCHEDULE_MODULE)
+    const schedule = await schedules.findByOrderId(input.order_id)
+    const plan = planBalanceCollection(schedule)
+    return new StepResponse({ plan, schedule: schedule ?? null })
+  }
+)
+
+const ensureBalanceCollectionStep = createStep(
+  "ensure-balance-payment-collection",
+  async (
+    input: { plan: BalancePlan; requested_by?: string | null },
+    { container }
+  ) => {
+    if (!input.plan.collectable) {
+      // Not an error: a refusal is reported to the caller, which is what lets a
+      // partner see "already paid" rather than a 500.
+      return new StepResponse({ payment_collection_id: null, reused: false })
+    }
+
+    const { schedule_id, order_id, amount } = input.plan
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+    /**
+     * 🔑 Core already models the balance: `summary.pending_difference` is what
+     * the ORDER says is still owed, and
+     * `createOrUpdateOrderPaymentCollectionWorkflow` creates a collection for
+     * exactly that — skipping any collection that is already `completed`, which
+     * the deposit's is. So the deposit is left alone and a SECOND collection
+     * appears for the remainder, with core's own order↔collection link.
+     *
+     * This replaced a hand-rolled `createPaymentCollections` + `link.create`.
+     * Found by reading the docs, not the source — the same way #1451's refresh
+     * trap was found.
+     */
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: ["id", "summary", "currency_code"],
+      filters: { id: order_id },
+    })
+    const order = orders?.[0] as any
+    const pending = Number(order?.summary?.pending_difference)
+
+    if (!Number.isFinite(pending)) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Order ${order_id} reports no pending difference, so the balance cannot be verified before charging.`
+      )
+    }
+
+    /**
+     * 🔴 Two sources of truth, reconciled before any money is asked for.
+     *
+     * The SCHEDULE holds what was agreed; the ORDER holds what is outstanding
+     * after any edit, refund or extra capture. They agree on a normal deal and
+     * disagreeing means something happened that nobody has reasoned about —
+     * an order edit after a deposit, say. Charging either figure silently is
+     * how a buyer is billed for a number no one chose, so this refuses and
+     * names both.
+     *
+     * ⚠️ Core's own guard only catches `amount > pending`. It would happily let
+     * an agreed balance SMALLER than pending through and then charge the larger
+     * pending figure, which is the overcharge direction.
+     */
+    if (Math.round(pending * 100) !== Math.round(amount * 100)) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Order ${order_id} has ${pending} outstanding but its payment schedule says the balance is ${amount}. Refusing rather than charging either figure — reconcile the order and the schedule first.`
+      )
+    }
+
+    const { result } = await createOrUpdateOrderPaymentCollectionWorkflow(
+      container
+    ).run({ input: { order_id, amount } })
+
+    const collection: any = Array.isArray(result) ? result[0] : result
+
+    logger?.info?.(
+      `[balance] order=${order_id} schedule=${schedule_id} collection=${
+        collection?.id
+      } for ${amount} — requested_by=${input.requested_by ?? "unknown"}`
+    )
+
+    return new StepResponse({
+      payment_collection_id: collection?.id ?? null,
+      reused: false,
+    })
+  }
+)
+
+const ensureBalanceSessionStep = createStep(
+  "ensure-balance-payment-session",
+  async (
+    input: { payment_collection_id: string | null; plan: BalancePlan },
+    { container }
+  ) => {
+    if (!input.payment_collection_id || !input.plan.collectable) {
+      return new StepResponse({ ok: false })
+    }
+
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: collections } = await query.graph({
+      entity: "payment_collection",
+      fields: ["id", "payment_sessions.id", "payment_sessions.provider_id"],
+      filters: { id: input.payment_collection_id },
+    })
+
+    const sessions = (collections?.[0] as any)?.payment_sessions ?? []
+    if (sessions.some((s: any) => String(s?.provider_id ?? "").includes("stripe"))) {
+      return new StepResponse({ ok: true })
+    }
+
+    /**
+     * Session creation is best-effort. The hosted page creates one on demand if
+     * this fails, and a raised balance with no session yet is recoverable —
+     * whereas failing the whole activation would leave the schedule unraised
+     * and the partner with nothing to send.
+     */
+    try {
+      await createPaymentSessionsWorkflow(container).run({
+        input: {
+          payment_collection_id: input.payment_collection_id,
+          provider_id: "pp_stripe_stripe",
+        },
+      })
+      return new StepResponse({ ok: true })
+    } catch {
+      return new StepResponse({ ok: false })
+    }
+  }
+)
+
+const markDueStep = createStep(
+  "mark-balance-due",
+  async (
+    input: { plan: BalancePlan },
+    { container }
+  ): Promise<StepResponse<{ raised: boolean; pay_url: string | null }>> => {
+    // Typed explicitly: without it the first return pins `pay_url` to `null`
+    // and the string return below stops assigning.
+    if (!input.plan.collectable) {
+      return new StepResponse({ raised: false, pay_url: null })
+    }
+
+    /**
+     * The link is built HERE, where the schedule id is known, and stored on the
+     * schedule as `balance_link_ref` — so the URL the buyer was sent and the
+     * URL we think we sent are the same string, recoverable later from the row
+     * rather than reconstructed from env at read time.
+     */
+    const backendUrl =
+      process.env.MEDUSA_BACKEND_URL ||
+      process.env.BACKEND_URL ||
+      "https://v3.jaalyantra.com"
+    const payUrl = buildBalancePayUrl(backendUrl, input.plan.schedule_id)
+
+    const schedules: any = container.resolve(PAYMENT_SCHEDULE_MODULE)
+    // Idempotent in the service: an already-`due` schedule keeps its original
+    // `balance_due_at` rather than having the clock reset by a second press.
+    await schedules.markBalanceDue(input.plan.schedule_id, payUrl)
+    return new StepResponse({ raised: true, pay_url: payUrl })
+  }
+)
+
+export const requestOrderBalanceWorkflow = createWorkflow(
+  { name: "request-order-balance", store: true },
+  (input: RequestOrderBalanceInput) => {
+    const loaded = loadScheduleStep(input)
+
+    const collection = ensureBalanceCollectionStep({
+      plan: loaded.plan,
+      requested_by: input.requested_by,
+    })
+
+    ensureBalanceSessionStep({
+      payment_collection_id: collection.payment_collection_id,
+      plan: loaded.plan,
+    })
+
+    const marked = markDueStep({ plan: loaded.plan })
+
+    return new WorkflowResponse({
+      plan: loaded.plan,
+      payment_collection_id: collection.payment_collection_id,
+      reused: collection.reused,
+      raised: marked.raised,
+      pay_url: marked.pay_url,
+    })
+  }
+)
+
+export { buildBalancePayUrl }
+export default requestOrderBalanceWorkflow


### PR DESCRIPTION
Every `/store/shipping-options` request in prod logs this, once per call — it fired repeatedly during a live buyer's checkout today:

```
Shiprocket calculatePrice error: Shiprocket auth failed (422)
  — password: The password is required.
```

## The credentials are not missing

Checked locally first, then prod:

| | |
|---|---|
| local `.env` | `SHIPROCKET_EMAIL` set, **`SHIPROCKET_PASSWORD` absent** |
| prod SSM | `/jyt/prod/SHIPROCKET_EMAIL`, and **no password param** |
| prod DB | an active `category:shipping` SocialPlatform record — Shiprocket, `shipping@jaalyantra.com`, password present |

And the copilot manifest says why, in as many words: *"the password/pickup are intentionally NOT wired as env here"*, because label/pickup/track go through `resolveShippingProvider`, which reads that record.

## 🔴 `calculatePrice` does not

It used the client built from **module options** — i.e. env — so it posted `password: undefined` on every live rate call. **Two credential paths, and the money-facing one was reading the deliberately blank half.** Adding an SSM param would have papered over it.

The provider now reads the same record the rest of the carrier does, cached per process because a login round-trip per rate call would be absurd.

## ⚠️ One load-bearing, invisible line

This works only because the fulfillment module now declares `dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE]` in both configs. A provider is constructed with the parent module's cradle, which otherwise carries six default keys and nothing else.

Drop that declaration and the 422s come back **silently** — so the missing branch warns loudly and names `dependencies`, and a test asserts that it does.

Every failure degrades to the previous env behaviour rather than throwing: a missing record, a half-configured one, or a socials lookup that fails all fall back with a warning. Rating gets worse, it does not break.

`readSecret` mirrors `resolveShippingProvider`'s own — same key names, same precedence. Two readers of one record must not disagree about where the secret lives.

## Verify

`TEST_TYPE=unit jest --testPathPattern="shiprocket"` → **15 suites, 183 tests green** (176 pre-existing, unchanged; 7 new).

Not verified: no live Shiprocket call from this branch. The proof is the record's contents and the code path, not a successful rate — worth watching the logs after deploy for the 422s stopping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4