### PR TITLE
feat(quotes): keep the buyer's card, and let a quote be a draft (#1446)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,7 @@ scripts/agent-daemon/delegate-logs/
 # Wave sentinels — process state, written so a chained batch can wait on a FILE
 # rather than on `pgrep`, which matches the waiter's own command line and hangs.
 .audit/batches/
+
+# Local audit workspace — session notes, never source (public repo)
+.audit/
+e2e/screenshots/

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -1,18 +1,16 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import {
   Button,
+  Container,
   Heading,
-  ProgressStatus,
-  ProgressTabs,
   Select,
   Text,
   toast,
 } from "@medusajs/ui"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { FieldPath, useForm } from "react-hook-form"
 
 import { Form } from "../../../components/common/form"
-import { RouteFocusModal } from "../../../components/modal/route-focus-modal"
 import { KeyboundForm } from "../../../components/utilitites/key-bound-form"
 import { usePartners } from "../../../hooks/api/partners"
 import {
@@ -25,12 +23,6 @@ import { ReadinessPanel } from "./readiness-panel"
 import {
   AdminQuoteCreateSchema,
   AdminQuoteCreateSchemaType,
-  QuoteBuyerFields,
-  QuoteBuyerSchema,
-  QuotePartnerFields,
-  QuotePartnerSchema,
-  QuoteProductFields,
-  QuoteProductsSchema,
 } from "./schema"
 import { BuyerStep } from "./steps/buyer-step"
 import { ProductsStep } from "./steps/products-step"
@@ -50,12 +42,28 @@ import { QuantitiesStep } from "./steps/quantities-step"
  * useless on the other, and the admin one could not be used against a real
  * catalogue at all.
  *
- * This is the partner's shape — `RouteFocusModal.Form` + `ProgressTabs`, one
- * step per question — with ONE extra leading step. An admin has no partner of
- * their own, and every quote is partner-scoped: the partner decides which
- * catalogue the variants come from and which location freight is quoted from,
- * so choosing products before a partner would build a basket that is then
- * rejected wholesale.
+ * ## Sections on a page, not steps in a modal
+ *
+ * This began as `RouteFocusModal.Form` + `ProgressTabs` — one step per
+ * question, mirroring the partner wizard. At 2,420 lines across its steps that
+ * had outgrown a modal: the operator could see exactly one answer at a time,
+ * could not glance back at the basket while typing a destination, and every
+ * mint navigated away from the list they started on.
+ *
+ * It is now the same four questions as SECTIONS down one page, in the layout of
+ * the quote detail route this very form produces — `TwoColumnPage` with the
+ * readiness verdict living in the sidebar rather than appearing, once, above a
+ * grid. Draft orders are the shape being borrowed.
+ *
+ * 🔑 What deliberately did NOT change: the quote is still minted by a SINGLE
+ * POST at the end. A draft order can persist section by section because its
+ * prices are just the variant's; a quote's are computed — freight, tax, duty,
+ * DDP, landed total — so a half-built quote row would be a quote with no price,
+ * which is the one thing a quote exists to carry.
+ *
+ * Order still matters even without gates. The partner decides which catalogue
+ * the variants come from and which location freight is quoted from, so it leads
+ * — pick products first and you build a basket that is then rejected wholesale.
  *
  * **Partner → Buyer → Products → Quantities.**
  *
@@ -68,27 +76,28 @@ import { QuantitiesStep } from "./steps/quantities-step"
  * a re-mint.
  */
 
-enum Tab {
-  PARTNER = "partner",
-  BUYER = "buyer",
-  PRODUCTS = "products",
-  QUANTITIES = "quantities",
-}
-
-const tabOrder = [Tab.PARTNER, Tab.BUYER, Tab.PRODUCTS, Tab.QUANTITIES] as const
-
-type TabState = Record<Tab, ProgressStatus>
-
-const initialTabState: TabState = {
-  [Tab.PARTNER]: "in-progress",
-  [Tab.BUYER]: "not-started",
-  [Tab.PRODUCTS]: "not-started",
-  [Tab.QUANTITIES]: "not-started",
-}
+/** The sections, in the order the page lays them out. */
+const SECTIONS = ["partner", "buyer", "products", "quantities"] as const
+type SectionId = (typeof SECTIONS)[number]
 
 export const MintQuoteForm = () => {
-  const [tab, setTab] = useState<Tab>(Tab.PARTNER)
-  const [tabState, setTabState] = useState<TabState>(initialTabState)
+  /**
+   * Scroll targets. With every section on the page, "you cannot mint yet"
+   * has somewhere to point — the refusal moves the page to the section that
+   * caused it instead of naming a step the operator must go and find.
+   */
+  const sectionRefs = useRef<Record<SectionId, HTMLDivElement | null>>({
+    partner: null,
+    buyer: null,
+    products: null,
+    quantities: null,
+  })
+
+  const goToSection = (id: SectionId) =>
+    sectionRefs.current[id]?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    })
   const [minted, setMinted] = useState<MintedQuoteResult | null>(
     null
   )
@@ -140,84 +149,6 @@ export const MintQuoteForm = () => {
   const { mutateAsync: checkReadiness, isPending: isChecking } =
     useAdminQuoteReadiness()
 
-  /**
-   * Validate only the fields belonging to the steps being skipped past.
-   * Same mechanism the partner wizard uses: a tab cannot be reached by
-   * clicking its header while an earlier one is incomplete, and the error is
-   * attached to the field rather than shouted in a toast.
-   */
-  const partialFormValidation = (
-    fields: readonly FieldPath<AdminQuoteCreateSchemaType>[],
-    schema: any
-  ) => {
-    form.clearErrors(fields as any)
-
-    const values = fields.reduce((acc, key) => {
-      acc[key] = form.getValues(key as any)
-      return acc
-    }, {} as Record<string, unknown>)
-
-    const validation = schema.safeParse(values)
-    if (validation.success) return true
-
-    for (const issue of validation.error.issues) {
-      form.setError(issue.path.join(".") as any, {
-        type: issue.code,
-        message: issue.message,
-      })
-    }
-    return false
-  }
-
-  const handleChangeTab = (update: Tab) => {
-    if (tab === update) return
-
-    // Going back is always allowed — an operator correcting an earlier answer
-    // must not be made to re-pass the steps after it.
-    if (tabOrder.indexOf(update) < tabOrder.indexOf(tab)) {
-      setTabState((prev) => ({ ...prev, [update]: "in-progress" }))
-      setTab(update)
-      return
-    }
-
-    for (const current of tabOrder.slice(0, tabOrder.indexOf(update))) {
-      if (current === Tab.PARTNER) {
-        if (!partialFormValidation(QuotePartnerFields, QuotePartnerSchema)) {
-          setTabState((prev) => ({ ...prev, [current]: "in-progress" }))
-          setTab(current)
-          return
-        }
-      } else if (current === Tab.BUYER) {
-        if (!partialFormValidation(QuoteBuyerFields, QuoteBuyerSchema)) {
-          setTabState((prev) => ({ ...prev, [current]: "in-progress" }))
-          setTab(current)
-          return
-        }
-      } else if (current === Tab.PRODUCTS) {
-        if (!partialFormValidation(QuoteProductFields, QuoteProductsSchema)) {
-          setTabState((prev) => ({ ...prev, [current]: "in-progress" }))
-          setTab(current)
-          return
-        }
-        if (!form.getValues("product_ids").length) {
-          toast.error("Pick at least one product.")
-          setTab(current)
-          return
-        }
-      }
-      setTabState((prev) => ({ ...prev, [current]: "completed" }))
-    }
-
-    setTabState((prev) => ({ ...prev, [update]: "in-progress" }))
-    setTab(update)
-  }
-
-  const handleNextTab = () => {
-    const i = tabOrder.indexOf(tab)
-    if (i === tabOrder.length - 1) return
-    handleChangeTab(tabOrder[i + 1])
-  }
-
   const handleSubmit = form.handleSubmit(async (data) => {
     /**
      * A blank or zero quantity means "not in this basket" — dropped, not sent
@@ -255,7 +186,7 @@ export const MintQuoteForm = () => {
       toast.error(
         "Set a quantity on at least one variant — a quote with no lines has nothing to price."
       )
-      setTab(Tab.QUANTITIES)
+      goToSection("quantities")
       return
     }
 
@@ -303,7 +234,7 @@ export const MintQuoteForm = () => {
 
     if (assessed && !assessed.ready) {
       toast.error("This quote cannot be minted yet — see the reasons above.")
-      setTab(Tab.QUANTITIES)
+      goToSection("quantities")
       return
     }
 
@@ -352,150 +283,132 @@ export const MintQuoteForm = () => {
     } as any)
   })
 
+  /**
+   * 🔴 A successful mint swaps the page for the panel and does NOT navigate.
+   *
+   * The raw token is returned by the API exactly once — only its sha256 is
+   * stored — so the panel holds the ONLY copy of the buyer's link. Every other
+   * create route calls `handleSuccess` here; doing that would discard the link
+   * and force a re-mint.
+   */
   if (minted) {
     return (
-      <RouteFocusModal.Body className="flex-1 overflow-y-auto">
+      <div className="flex w-full flex-col gap-y-3">
         <MintedPanel result={minted} />
-      </RouteFocusModal.Body>
+      </div>
     )
   }
 
-  return (
-    <RouteFocusModal.Form form={form}>
-      <ProgressTabs
-        value={tab}
-        onValueChange={(value) => handleChangeTab(value as Tab)}
-        className="flex h-full flex-col overflow-hidden"
+  /**
+   * A section is a container plus a scroll target — NOT a heading.
+   *
+   * 🔴 Wrapping each step in a titled header rendered "Buyer" twice and put
+   * "Items" directly above the step's own "Products": `BuyerStep`,
+   * `ProductsStep` and the rest were written for a modal that supplied no
+   * chrome, so they carry their own headings — and `BuyerStep` in fact carries
+   * THREE (Buyer, Freight source, Import duty). Only a render showed it; every
+   * test passed with the duplicate on screen.
+   *
+   * So the step owns its heading, and `title` is passed only where the body is
+   * inline JSX with no heading of its own.
+   */
+  const section = (
+    id: SectionId,
+    body: React.ReactNode,
+    header?: { title: string; description: string },
+    /**
+     * Whether the body needs the container's own inset.
+     *
+     * The steps were written as modal tabs: the form ones were given `p-16` by
+     * the tab that held them and so carry no padding of their own, while the
+     * table ones were deliberately full-bleed. Dropped into a `Container`
+     * unchanged, the form steps sat flush against the edge while the sections
+     * around them were inset — visible immediately on screen, invisible to
+     * every test.
+     */
+    padded = false
+  ) => (
+    <Container className={header ? "divide-y p-0" : "p-0"}>
+      <div
+        ref={(el) => {
+          sectionRefs.current[id] = el
+        }}
       >
-        <KeyboundForm onSubmit={handleSubmit} className="flex h-full flex-col">
-          <RouteFocusModal.Header>
-            <div className="-my-2 w-full max-w-[720px] border-l">
-              <ProgressTabs.List className="grid w-full grid-cols-4">
-                <ProgressTabs.Trigger
-                  status={tabState[Tab.PARTNER]}
-                  value={Tab.PARTNER}
-                >
-                  Partner
-                </ProgressTabs.Trigger>
-                <ProgressTabs.Trigger
-                  status={tabState[Tab.BUYER]}
-                  value={Tab.BUYER}
-                >
-                  Buyer
-                </ProgressTabs.Trigger>
-                <ProgressTabs.Trigger
-                  status={tabState[Tab.PRODUCTS]}
-                  value={Tab.PRODUCTS}
-                >
-                  Products
-                </ProgressTabs.Trigger>
-                <ProgressTabs.Trigger
-                  status={tabState[Tab.QUANTITIES]}
-                  value={Tab.QUANTITIES}
-                >
-                  Quantities
-                </ProgressTabs.Trigger>
-              </ProgressTabs.List>
-            </div>
-          </RouteFocusModal.Header>
+        {header && (
+          <div className="px-6 py-4">
+            <Heading level="h2">{header.title}</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              {header.description}
+            </Text>
+          </div>
+        )}
+      </div>
+      <div className={header || padded ? "px-6 py-4" : ""}>{body}</div>
+    </Container>
+  )
 
-          {/*
-            ⚠️ `overflow-hidden` here and `overflow-y-auto` on each tab's
-            content, not the other way round: a FocusModal.Body does not scroll
-            on its own, and the grid steps manage their own height.
-          */}
-          <RouteFocusModal.Body className="size-full overflow-hidden">
-            <ProgressTabs.Content
-              className="size-full overflow-y-auto p-16"
-              value={Tab.PARTNER}
-            >
-              <div className="flex flex-col gap-y-8">
-                <div className="flex flex-col gap-y-1">
-                  <Heading level="h2">Partner</Heading>
-                  <Text size="small" className="text-ui-fg-subtle">
-                    Prices come from this partner's catalogue and freight from
-                    their location. Variants outside their store are rejected —
-                    that check is why this step comes first.
-                  </Text>
-                </div>
-
-                <Form.Field
-                  control={form.control}
-                  name="partner_id"
-                  render={({ field }) => (
-                    <Form.Item>
-                      <Form.Label>Partner</Form.Label>
-                      <Form.Control>
-                        <Select
-                          value={field.value}
-                          onValueChange={field.onChange}
-                        >
-                          <Select.Trigger>
-                            <Select.Value placeholder="Select a partner" />
-                          </Select.Trigger>
-                          <Select.Content>
-                            {((partners ?? []) as any[]).map((p) => (
-                              <Select.Item key={p.id} value={p.id}>
-                                {p.name || p.id}
-                              </Select.Item>
-                            ))}
-                          </Select.Content>
-                        </Select>
-                      </Form.Control>
-                      <Form.ErrorMessage />
-                    </Form.Item>
-                  )}
-                />
-              </div>
-            </ProgressTabs.Content>
-
-            <ProgressTabs.Content
-              className="size-full overflow-y-auto p-16"
-              value={Tab.BUYER}
-            >
-              <BuyerStep form={form} />
-            </ProgressTabs.Content>
-
-            <ProgressTabs.Content
-              className="size-full overflow-y-auto"
-              value={Tab.PRODUCTS}
-            >
-              <ProductsStep form={form} />
-            </ProgressTabs.Content>
-
-            <ProgressTabs.Content
-              className="size-full overflow-hidden"
-              value={Tab.QUANTITIES}
-            >
-              <div className="flex h-full flex-col overflow-y-auto">
-                {readiness && (
-                  <div className="px-6 pt-4 md:px-16">
-                    <ReadinessPanel readiness={readiness} />
-                  </div>
+  return (
+    <Form {...form}>
+      <KeyboundForm onSubmit={handleSubmit} className="flex w-full flex-col">
+        <div className="flex flex-col gap-x-4 gap-y-3 xl:flex-row xl:items-start">
+          {/* ---- main column: the four questions, all visible ---- */}
+          <div className="flex w-full flex-col gap-y-3">
+            {section(
+              "partner",
+              <Form.Field
+                control={form.control}
+                name="partner_id"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Partner</Form.Label>
+                    <Form.Control>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select a partner" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {((partners ?? []) as any[]).map((p) => (
+                            <Select.Item key={p.id} value={p.id}>
+                              {p.name || p.id}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
                 )}
-                <div className="px-6 pt-4 md:px-16">
-                  <Text size="small" className="text-ui-fg-subtle">
-                    Leave the trade-price fields blank to quote at the catalog
-                    price. A unit price is read in the partner store's own
-                    currency and converted at mint; a discount is a percentage
-                    off the tier.
-                  </Text>
-                </div>
-                <QuantitiesStep form={form} />
-              </div>
-            </ProgressTabs.Content>
-          </RouteFocusModal.Body>
+              />,
+              {
+                title: "Partner",
+                description:
+                  "Prices come from this partner's catalogue and freight from their location. Variants outside their store are rejected — which is why this comes first.",
+              }
+            )}
 
-          <RouteFocusModal.Footer>
-            <div className="flex items-center justify-end gap-x-2">
-              <RouteFocusModal.Close asChild>
-                <Button variant="secondary" size="small">
-                  Cancel
-                </Button>
-              </RouteFocusModal.Close>
-              {tab === Tab.QUANTITIES ? (
+            {section("buyer", <BuyerStep form={form} />, undefined, true)}
+
+            {section("products", <ProductsStep form={form} />)}
+
+            {section("quantities", <QuantitiesStep form={form} />, {
+              title: "Quantities & pricing",
+              description:
+                "Leave the trade-price fields blank to quote at the catalog price. A unit price is read in the partner store's own currency and converted at mint; a discount is a percentage off the tier.",
+            })}
+          </div>
+
+          {/* ---- sidebar: the verdict, and the one button that mints ---- */}
+          <div className="flex w-full flex-col gap-y-3 xl:sticky xl:top-0 xl:max-w-[400px]">
+            <Container className="divide-y p-0">
+              <div className="px-6 py-4">
+                <Heading level="h2">Mint</Heading>
+                <Text size="small" className="text-ui-fg-subtle">
+                  Every line is priced and a carrier is asked for a rate before
+                  the quote is minted.
+                </Text>
+              </div>
+              <div className="flex items-center justify-end gap-x-2 px-6 py-4">
                 <Button
-                  key="submit"
                   type="submit"
                   variant="primary"
                   size="small"
@@ -503,21 +416,24 @@ export const MintQuoteForm = () => {
                 >
                   Mint quote
                 </Button>
-              ) : (
-                <Button
-                  key="next"
-                  type="button"
-                  variant="primary"
-                  size="small"
-                  onClick={handleNextTab}
-                >
-                  Continue
-                </Button>
-              )}
-            </div>
-          </RouteFocusModal.Footer>
-        </KeyboundForm>
-      </ProgressTabs>
-    </RouteFocusModal.Form>
+              </div>
+            </Container>
+
+            {/*
+              The readiness verdict lives here rather than above the grid, so a
+              refusal stays on screen while the operator fixes the line that
+              caused it.
+            */}
+            {readiness && (
+              <Container className="p-0">
+                <div className="px-6 py-4">
+                  <ReadinessPanel readiness={readiness} />
+                </div>
+              </Container>
+            )}
+          </div>
+        </div>
+      </KeyboundForm>
+    </Form>
   )
 }

--- a/apps/backend/src/admin/routes/quotes/create/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/page.tsx
@@ -1,22 +1,24 @@
-import { RouteFocusModal } from "../../../components/modal/route-focus-modal"
-
 import { MintQuoteForm } from "./mint-quote-form"
 
 /**
- * Minting lives in a focus modal, like every other create route on this admin.
+ * Minting is a PAGE, not a focus modal.
  *
- * It shipped as a plain `Container` on the page, which made it the one create
- * flow that navigated AWAY from wherever the operator was — and the quote list
- * is exactly the context you want back the moment a mint finishes.
+ * It shipped as a four-step wizard inside `RouteFocusModal` — the shape every
+ * other create route on this admin uses. That works for a form with a handful
+ * of fields; a quote is not that. The steps had grown to 2,420 lines, and a
+ * modal showed exactly one of the four questions at a time: the operator could
+ * not see the basket while typing a destination, nor re-read the buyer while
+ * setting quantities, and the readiness verdict appeared above a grid and
+ * scrolled away.
  *
- * 🔑 The hook lives in the CHILD. `useRouteModal` reads a context that
- * `RouteFocusModal` itself provides, so a component that renders the modal
- * cannot also call the hook — that is #1352, and it throws at render.
+ * As a page it is the same four questions as sections, laid out the way the
+ * quote DETAIL route is laid out — the create route now looks like the record
+ * it produces, which it never did before.
  */
 const MintQuotePage = () => (
-  <RouteFocusModal prev="/quotes">
+  <div className="flex w-full flex-col gap-y-3 p-3">
     <MintQuoteForm />
-  </RouteFocusModal>
+  </div>
 )
 
 export const handle = {

--- a/apps/backend/src/api/admin/quotes/drafts/[id]/mint/route.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/[id]/mint/route.ts
@@ -1,0 +1,124 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../../../modules/partner-quote"
+import { POST as mintQuote } from "../../../route"
+
+/**
+ * Freeze a draft into a real quote (#1446).
+ *
+ * ## It calls the mint route's own handler, deliberately
+ *
+ * `POST /admin/quotes` resolves design lines to variants, mints made-to-order
+ * products into the partner's catalogue, asserts every variant really is in
+ * that partner's store, runs `mintQuoteWorkflow` and delivers the buyer's
+ * email. Its own docblock says why a second implementation must not exist:
+ * that workflow's price-list assertion "is the only thing standing between a
+ * quote and a platform-wide price cut."
+ *
+ * So this does not restate any of it. It reads the draft's stored answers,
+ * shapes them into the body that route already validates, and hands them to the
+ * SAME function — which reads nothing from the request but `scope` and
+ * `validatedBody`. One mint, reached two ways.
+ *
+ * ## The draft is consumed, not converted
+ *
+ * A minted quote is a new row: the workflow creates it, complete with the token
+ * hash a draft has never had. The draft is deleted once that has succeeded —
+ * after, never before, so a mint that throws leaves the operator's work exactly
+ * where they left it rather than destroying it on the way to an error.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  const id = String(req.params.id || "")
+
+  const draft = id ? await service.retrievePartnerQuote(id).catch(() => null) : null
+  if (!draft) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Draft not found")
+  }
+  if (draft.status !== "draft") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Quote ${id} is ${draft.status}, not a draft — it has already been minted.`
+    )
+  }
+
+  const lines = await service.listPartnerQuoteLines({ quote_id: draft.id })
+  if (!lines?.length) {
+    /**
+     * Refused here rather than deep inside the pricer, where the same
+     * condition surfaces as an arithmetic error about an empty basket.
+     */
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "This draft has no items, so there is nothing to price."
+    )
+  }
+
+  const body = {
+    partner_id: draft.partner_id,
+    buyer_email: draft.email_sent_to,
+    recipient_name: draft.recipient_name,
+    recipient_company: draft.recipient_company,
+    buyer_tax_id: draft.buyer_tax_id,
+    buyer_tax_id_type: draft.buyer_tax_id_type,
+    partner_note: draft.partner_note,
+    currency_code: draft.currency_code,
+    region_id: draft.region_id,
+    destination_country_code: draft.destination_country_code,
+    destination_postal_code: draft.destination_postal_code,
+    destination_city: draft.destination_city,
+    // 🔑 `??`, never `||`: a stored 0% deposit is a real term.
+    deposit_pct: draft.deposit_pct ?? null,
+    duties_prepaid: draft.duties_prepaid ?? false,
+    ...(draft.duties_prepaid
+      ? {
+          duty_rate_percent: draft.duty_rate_percent ?? null,
+          import_tax_rate_percent: draft.import_tax_rate_percent ?? null,
+          ddp_fee_total: draft.ddp_fee_total ?? null,
+          duty_basis: draft.duty_basis || null,
+        }
+      : {}),
+    lines: [...lines]
+      .sort((a: any, b: any) => (a.position ?? 0) - (b.position ?? 0))
+      .map((l: any) => ({
+        variant_id: l.variant_id,
+        quantity: l.quantity,
+        position: l.position ?? 0,
+        ...(l.design_id ? { design_id: l.design_id } : {}),
+      })),
+  }
+
+  /**
+   * The response is written by the mint handler itself, so the body an operator
+   * receives here — the raw token included — is byte-for-byte the one the
+   * ordinary mint returns. A hand-rolled echo would be a second contract to
+   * keep in step.
+   */
+  const captured: { status?: number; body?: unknown } = {}
+  const proxyRes = {
+    status(code: number) {
+      captured.status = code
+      return this
+    },
+    json(payload: unknown) {
+      captured.body = payload
+      return this
+    },
+  } as unknown as MedusaResponse
+
+  await mintQuote(
+    { scope: req.scope, validatedBody: body } as unknown as MedusaRequest,
+    proxyRes
+  )
+
+  // Only now. A throw above leaves the draft intact.
+  // Lines first — see the DELETE handler: a parent delete with children still
+  // pointing at it fails with a message that names the parent as missing.
+  await service.deletePartnerQuoteLines(lines.map((l: any) => l.id))
+  await service.deletePartnerQuotes([draft.id])
+
+  res
+    .status(captured.status ?? 201)
+    .json({ ...(captured.body as object), draft_id: draft.id })
+}

--- a/apps/backend/src/api/admin/quotes/drafts/[id]/route.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/[id]/route.ts
@@ -1,0 +1,152 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
+
+/**
+ * One draft: read it, save a section's answers into it, or throw it away.
+ */
+
+/**
+ * 🔴 Every handler here re-reads the row and refuses anything that is not a
+ * draft.
+ *
+ * The id comes from the URL, and a URL naming a MINTED quote would otherwise
+ * let this route rewrite a frozen price — the one thing a quote exists to make
+ * unrewritable. Checking the status on the row we just read, rather than
+ * trusting the caller to only send draft ids, is the difference between a
+ * guard and a convention.
+ */
+const loadDraft = async (req: MedusaRequest) => {
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  const id = String(req.params.id || "")
+
+  if (!id) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Draft not found")
+  }
+
+  const quote = await service.retrievePartnerQuote(id).catch(() => null)
+  if (!quote) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Draft not found")
+  }
+
+  if (quote.status !== "draft") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Quote ${id} is ${quote.status}, not a draft. A minted quote's prices are frozen and cannot be edited here — use /admin/quotes/:id/adjust.`
+    )
+  }
+
+  return { service, quote }
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { service, quote } = await loadDraft(req)
+  const lines = await service.listPartnerQuoteLines({ quote_id: quote.id })
+  res.json({ draft: { ...quote, lines } })
+}
+
+/**
+ * A section saves its own answers.
+ *
+ * Only the keys a section actually sent are written. The buyer section must be
+ * able to save a company name without restating the destination, and spreading
+ * a partial body over the row would write `undefined` across every field it
+ * omitted.
+ */
+export const PATCH = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { service, quote } = await loadDraft(req)
+  const body = req.validatedBody as any
+
+  const FIELDS = [
+    "region_id",
+    "currency_code",
+    "destination_country_code",
+    "destination_postal_code",
+    "destination_city",
+    "recipient_name",
+    "recipient_company",
+    "buyer_tax_id",
+    "buyer_tax_id_type",
+    "partner_note",
+    "deposit_pct",
+    "duties_prepaid",
+    "duty_rate_percent",
+    "import_tax_rate_percent",
+    "ddp_fee_total",
+    "duty_basis",
+    "quoted_shipping_option_id",
+  ] as const
+
+  const patch: Record<string, unknown> = {}
+  for (const key of FIELDS) {
+    // `in`, not truthiness: `null` clears a field and `0` is a real deposit.
+    if (key in body) patch[key] = body[key]
+  }
+  if ("buyer_email" in body) patch.email_sent_to = body.buyer_email
+
+  if (Object.keys(patch).length) {
+    await service.updatePartnerQuotes({ id: quote.id, ...patch })
+  }
+
+  /**
+   * The basket is replaced wholesale when the items section sends one.
+   *
+   * 🔑 Absent `lines` means "this section did not speak", NOT "empty the
+   * basket" — which is why this is guarded on presence rather than on length.
+   * A buyer section saving a company name would otherwise silently delete
+   * every item.
+   */
+  if (Array.isArray(body.lines)) {
+    const existing = await service.listPartnerQuoteLines({ quote_id: quote.id })
+    if (existing?.length) {
+      await service.deletePartnerQuoteLines(existing.map((l: any) => l.id))
+    }
+    if (body.lines.length) {
+      await service.createPartnerQuoteLines(
+        body.lines.map((l: any, index: number) => ({
+          quote_id: quote.id,
+          variant_id: l.variant_id,
+          product_id: l.product_id ?? null,
+          design_id: l.design_id ?? null,
+          quantity: l.quantity,
+          position: l.position ?? index,
+        }))
+      )
+    }
+  }
+
+  const fresh = await service.retrievePartnerQuote(quote.id)
+  const lines = await service.listPartnerQuoteLines({ quote_id: quote.id })
+  res.json({ draft: { ...fresh, lines } })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { service, quote } = await loadDraft(req)
+
+  /**
+   * 🔴 The basket goes FIRST, or the parent delete fails.
+   *
+   * `PartnerQuoteLine` belongs to the quote, and deleting the parent while its
+   * lines still point at it answers
+   * "You tried to set relationship id: <the quote's id>, but such entity does
+   * not exist" — a 400 that names the row being deleted, so it reads as "this
+   * draft is missing" when it actually means "this draft still has children".
+   * A draft with an empty basket deleted fine, which is exactly why this only
+   * showed up once a real basket had been saved.
+   */
+  const lines = await service.listPartnerQuoteLines({ quote_id: quote.id })
+  if (lines?.length) {
+    await service.deletePartnerQuoteLines(lines.map((l: any) => l.id))
+  }
+  /**
+     * 🔴 An ARRAY, always. Given a bare string the generated delete reads it as
+     * a relationship selector and answers
+     * "You tried to set relationship id: …, but such entity does not exist" —
+     * a 400 that names the row it just refused to delete, so it reads like the
+     * row is missing rather than like the call is malformed. Same family as
+     * `updateStores({ id, ... })` being a selector rather than an update.
+     */
+    await service.deletePartnerQuotes([quote.id])
+  res.json({ id: quote.id, object: "quote_draft", deleted: true })
+}

--- a/apps/backend/src/api/admin/quotes/drafts/__tests__/draft-patch.unit.spec.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/__tests__/draft-patch.unit.spec.ts
@@ -1,0 +1,151 @@
+const retrievePartnerQuote = jest.fn()
+const updatePartnerQuotes = jest.fn().mockResolvedValue({})
+const listPartnerQuoteLines = jest.fn().mockResolvedValue([])
+const createPartnerQuoteLines = jest.fn().mockResolvedValue([])
+const deletePartnerQuoteLines = jest.fn().mockResolvedValue(undefined)
+const deletePartnerQuotes = jest.fn().mockResolvedValue(undefined)
+
+jest.mock("../../../../../modules/partner-quote", () => ({
+  PARTNER_QUOTE_MODULE: "partner_quote",
+}))
+
+import { DELETE, PATCH } from "../[id]/route"
+
+const makeReq = (body: any, id = "pq_1") =>
+  ({
+    params: { id },
+    validatedBody: body,
+    scope: {
+      resolve: () => ({
+        retrievePartnerQuote,
+        updatePartnerQuotes,
+        listPartnerQuoteLines,
+        createPartnerQuoteLines,
+        deletePartnerQuoteLines,
+        deletePartnerQuotes,
+      }),
+    },
+  }) as any
+
+const makeRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn() }) as any
+
+/**
+ * A section saves its OWN answers (#1446).
+ *
+ * The draft-order rail this mirrors saves each section independently against a
+ * persisted row. The failure mode that matters is a section clobbering another
+ * section's work on its way past.
+ */
+describe("PATCH /admin/quotes/drafts/:id", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    retrievePartnerQuote.mockResolvedValue({ id: "pq_1", status: "draft" })
+    listPartnerQuoteLines.mockResolvedValue([])
+  })
+
+  it("writes only the keys the section actually sent", async () => {
+    await PATCH(makeReq({ recipient_company: "Cici Label" }), makeRes())
+
+    const patch = updatePartnerQuotes.mock.calls[0][0]
+    expect(patch.recipient_company).toBe("Cici Label")
+    // Everything the section stayed silent about must be ABSENT, not undefined:
+    // spreading a partial body would blank each omitted column.
+    expect("destination_city" in patch).toBe(false)
+    expect("deposit_pct" in patch).toBe(false)
+  })
+
+  /**
+   * 🔑 `0` is a real deposit and `null` is a real clearing. Both must survive a
+   * membership test — a truthiness check would drop the first and a `||` would
+   * turn it into the 30% platform default.
+   */
+  it("carries a zero deposit and an explicit null through", async () => {
+    await PATCH(makeReq({ deposit_pct: 0, destination_city: null }), makeRes())
+
+    const patch = updatePartnerQuotes.mock.calls[0][0]
+    expect(patch.deposit_pct).toBe(0)
+    expect(patch.destination_city).toBeNull()
+  })
+
+  /**
+   * 🔴 The regression this exists to stop: the buyer section saving a company
+   * name and silently emptying the basket.
+   */
+  it("does NOT touch the basket when the section sent no lines", async () => {
+    listPartnerQuoteLines.mockResolvedValue([{ id: "l1" }])
+
+    await PATCH(makeReq({ recipient_company: "Cici Label" }), makeRes())
+
+    expect(deletePartnerQuoteLines).not.toHaveBeenCalled()
+    expect(createPartnerQuoteLines).not.toHaveBeenCalled()
+  })
+
+  it("replaces the whole basket when the items section sends one", async () => {
+    listPartnerQuoteLines.mockResolvedValue([{ id: "old" }])
+
+    await PATCH(
+      makeReq({ lines: [{ variant_id: "var_1", quantity: 500 }] }),
+      makeRes()
+    )
+
+    expect(deletePartnerQuoteLines).toHaveBeenCalledWith(["old"])
+    expect(createPartnerQuoteLines.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ variant_id: "var_1", quantity: 500, position: 0 }),
+    ])
+  })
+
+  /**
+   * An explicitly empty basket IS a clear — distinct from silence above.
+   */
+  it("empties the basket when the items section sends an empty array", async () => {
+    listPartnerQuoteLines.mockResolvedValue([{ id: "old" }])
+
+    await PATCH(makeReq({ lines: [] }), makeRes())
+
+    expect(deletePartnerQuoteLines).toHaveBeenCalledWith(["old"])
+    expect(createPartnerQuoteLines).not.toHaveBeenCalled()
+  })
+
+  /**
+   * 🔴 A URL naming a MINTED quote must not rewrite a frozen price. Checked on
+   * the row we just read, not assumed from the caller's choice of route.
+   */
+  it("refuses a quote that is not a draft", async () => {
+    retrievePartnerQuote.mockResolvedValue({ id: "pq_1", status: "active" })
+
+    await expect(
+      PATCH(makeReq({ recipient_company: "HIJACKED" }), makeRes())
+    ).rejects.toThrow(/not a draft/)
+
+    expect(updatePartnerQuotes).not.toHaveBeenCalled()
+  })
+
+  /**
+   * 🔴 The basket must be deleted BEFORE the draft that owns it.
+   *
+   * Deleting the parent while its lines still point at it answers
+   * "You tried to set relationship id: <the draft's id>, but such entity does
+   * not exist" — which names the row being deleted and so reads as "this draft
+   * is missing" rather than "this draft still has children".
+   *
+   * A draft with an EMPTY basket deletes cleanly, which is precisely why this
+   * survived the first probe and only appeared once a real basket was saved.
+   * Asserted on invocation order, not on the fact that both were called.
+   */
+  it("deletes the basket before the draft that owns it", async () => {
+    const order: string[] = []
+    deletePartnerQuoteLines.mockImplementation(async () => {
+      order.push("lines")
+    })
+    deletePartnerQuotes.mockImplementation(async () => {
+      order.push("quote")
+    })
+    listPartnerQuoteLines.mockResolvedValue([{ id: "l1" }])
+
+    await DELETE(makeReq({}), makeRes())
+
+    expect(order).toEqual(["lines", "quote"])
+    // And an array — a bare string is read as a relationship selector.
+    expect(deletePartnerQuotes).toHaveBeenCalledWith(["pq_1"])
+  })
+})

--- a/apps/backend/src/api/admin/quotes/drafts/route.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/route.ts
@@ -1,0 +1,77 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../modules/partner-quote"
+
+/**
+ * Draft quotes (#1446) — the draft-order rail, mirrored.
+ *
+ * A draft is a REAL ROW from the first save, exactly as a draft order is. The
+ * create modal asks only for what the table's NOT NULL columns demand —
+ * partner, where it ships, and the currency the region supplies — and the
+ * items, freight and duty terms are edited on the draft afterwards.
+ *
+ * 🔴 A draft has NO `token_hash`, and that is what keeps it away from buyers.
+ * `findByTokenHash` matches on that column and NULL equals nothing, so no token
+ * can ever resolve to a draft. It is unpriced by definition; showing one to a
+ * buyer would be showing a price that does not exist yet.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = req.validatedBody as any
+  const partnerId = String(body.partner_id || "").trim()
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "name", "stores.id"],
+    filters: { id: partnerId },
+  })
+
+  const partner = partners?.[0] as any
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+  }
+
+  /**
+   * The same refusal the mint makes, made HERE instead of three sections later.
+   *
+   * A quote is priced against a store's catalogue and shipped from its
+   * location. Letting a draft be created for a partner with no store would let
+   * an operator fill in a basket, a destination and duty terms before being
+   * told none of it can ever be priced.
+   */
+  if (!partner.stores?.[0]?.id) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Partner ${partner.name || partnerId} has no store, so a quote cannot be priced for them.`
+    )
+  }
+
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+
+  const quote = await service.createPartnerQuotes({
+    partner_id: partnerId,
+    store_id: partner.stores[0].id,
+    status: "draft",
+    // Never invented: the buyer's credential is minted once, at mint, and is
+    // unrecoverable afterwards. See the model's `token_hash`.
+    token_hash: null,
+    destination_country_code: body.destination_country_code,
+    currency_code: body.currency_code,
+    region_id: body.region_id ?? null,
+    destination_postal_code: body.destination_postal_code ?? null,
+    destination_city: body.destination_city ?? null,
+    email_sent_to: body.buyer_email ?? null,
+    recipient_name: body.recipient_name ?? null,
+    recipient_company: body.recipient_company ?? null,
+    buyer_tax_id: body.buyer_tax_id ?? null,
+    buyer_tax_id_type: body.buyer_tax_id_type ?? null,
+    partner_note: body.partner_note ?? null,
+    // 🔑 `??`, never `||` — a 0% deposit is a real term and `||` would store it
+    // as "unset", which resolves to the 30% platform default.
+    deposit_pct: body.deposit_pct ?? null,
+    created_by: (req as any).auth_context?.actor_id ?? null,
+  })
+
+  res.status(201).json({ draft: quote })
+}

--- a/apps/backend/src/api/admin/quotes/validators.ts
+++ b/apps/backend/src/api/admin/quotes/validators.ts
@@ -38,3 +38,87 @@ export const AdminQuoteReadinessReq = QuoteReadinessShape.extend({
 }).superRefine(dutyUndertakingRefinement)
 
 export type AdminQuoteReadinessReqType = z.infer<typeof AdminQuoteReadinessReq>
+
+
+/**
+ * Creating a DRAFT (#1446).
+ *
+ * ## Why this is not the mint schema with everything optional
+ *
+ * The draft-order rail this mirrors captures, in its create modal, exactly what
+ * is needed to MAKE THE ROW — region, sales channel, customer, address — and
+ * nothing else. Items arrive afterwards, on the draft.
+ *
+ * 🔑 The required set here is not a taste judgement: it is the table's NOT NULL
+ * columns. `partner_quote` requires `partner_id`, `destination_country_code`
+ * and `currency_code`, and everything else is nullable. So those three are
+ * required and the rest are not — which is also why the modal asks for a region
+ * first, since the region is what supplies the currency.
+ *
+ * ⚠️ NOT `.optional()` over a NOT NULL column. That combination is a 500 with an
+ * HTML body and no field name, diagnosable only from CloudWatch (#1737) — the
+ * schema has to agree with the constraint, not merely be permissive.
+ */
+export const AdminCreateQuoteDraftReq = z.object({
+  partner_id: z.string().min(1),
+  destination_country_code: z.string().min(1),
+  currency_code: z.string().min(1),
+  region_id: z.string().nullish(),
+  destination_postal_code: z.string().nullish(),
+  destination_city: z.string().nullish(),
+  buyer_email: z.string().email().nullish(),
+  recipient_name: z.string().nullish(),
+  recipient_company: z.string().nullish(),
+  buyer_tax_id: z.string().nullish(),
+  buyer_tax_id_type: z.string().nullish(),
+  partner_note: z.string().nullish(),
+  ttl_days: z.number().int().positive().nullish(),
+  /**
+   * 🔑 `nullish`, and read with `??` at the far end — never `||`. A 0% deposit
+   * is a real commercial term, and `||` would send it as "unset", which the
+   * backend resolves to the 30% platform default.
+   */
+  deposit_pct: z.number().min(0).max(100).nullish(),
+})
+
+export type AdminCreateQuoteDraftReqType = z.infer<
+  typeof AdminCreateQuoteDraftReq
+>
+
+/**
+ * A section saving its own answers (#1446).
+ *
+ * Every field is optional because a section only ever sends its own — the
+ * buyer section must not have to restate the destination in order to save a
+ * company name. `lines` is a WHOLE-BASKET replacement rather than a patch of
+ * individual rows: the items section owns the basket, and a partial line edit
+ * would need identities the browser does not have.
+ */
+export const AdminUpdateQuoteDraftReq = AdminCreateQuoteDraftReq.partial().extend(
+  {
+    lines: z
+      .array(
+        z.object({
+          variant_id: z.string().min(1),
+          quantity: z.number().int().positive(),
+          product_id: z.string().nullish(),
+          design_id: z.string().nullish(),
+          position: z.number().int().min(0).nullish(),
+          unit_weight_grams: z.number().positive().nullish(),
+          discount_percent: z.number().min(0).max(100).nullish(),
+          override_unit_amount: z.number().positive().nullish(),
+        })
+      )
+      .nullish(),
+    duties_prepaid: z.boolean().nullish(),
+    duty_rate_percent: z.number().min(0).nullish(),
+    import_tax_rate_percent: z.number().min(0).nullish(),
+    ddp_fee_total: z.number().min(0).nullish(),
+    duty_basis: z.string().nullish(),
+    quoted_shipping_option_id: z.string().nullish(),
+  }
+)
+
+export type AdminUpdateQuoteDraftReqType = z.infer<
+  typeof AdminUpdateQuoteDraftReq
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -324,7 +324,12 @@ import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProduct
 import { PartnerCreatePriceListReq, PartnerUpdatePriceListReq } from "./partners/price-lists/validators";
 import { AdjustQuoteReq, MintDesignVariantReq, PartnerMintQuoteReq, QuoteReadinessReq } from "./partners/quotes/validators";
 import { PartnerPostInquiryAnswersReq, PartnerPostInquirySubmitReq, PartnerListInquiriesQuery, PartnerPostCapabilitySampleReq, PartnerListCapabilitySamplesQuery } from "./partners/inquiries/validators";
-import { AdminMintQuoteReq, AdminQuoteReadinessReq } from "./admin/quotes/validators";
+import {
+  AdminCreateQuoteDraftReq,
+  AdminMintQuoteReq,
+  AdminQuoteReadinessReq,
+  AdminUpdateQuoteDraftReq,
+} from "./admin/quotes/validators";
 import { BATCH_VARIANT_FIELDS } from "../workflows/partner/batch-partner-variants";
 import { StoreMadeToSpecReq } from "./store/carts/[id]/made-to-spec/validators";
 import {
@@ -6143,6 +6148,24 @@ export default defineMiddlewares({
       matcher: "/admin/quotes",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminMintQuoteReq))],
+    },
+    /**
+     * Draft quotes (#1446).
+     *
+     * 🔴 Registered BEFORE `/admin/quotes/:id`, like `readiness` and `designs`
+     * above it. This file's ordering IS the contract: a static segment landing
+     * after the parameterised one is matched as an id called "drafts", and the
+     * body arrives unvalidated.
+     */
+    {
+      matcher: "/admin/quotes/drafts",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminCreateQuoteDraftReq))],
+    },
+    {
+      matcher: "/admin/quotes/drafts/:id",
+      method: "PATCH",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminUpdateQuoteDraftReq))],
     },
     {
       matcher: "/admin/quotes/readiness",

--- a/apps/backend/src/api/store/payment-collections/[id]/payment-sessions/__tests__/customer-from-cart.unit.spec.ts
+++ b/apps/backend/src/api/store/payment-collections/[id]/payment-sessions/__tests__/customer-from-cart.unit.spec.ts
@@ -1,0 +1,136 @@
+const runMock = jest.fn().mockResolvedValue({ result: {} })
+
+jest.mock("@medusajs/core-flows", () => ({
+  createPaymentSessionsWorkflow: jest.fn(() => ({ run: runMock })),
+}))
+jest.mock("@medusajs/framework/http", () => ({
+  refetchEntity: jest.fn().mockResolvedValue({ id: "pay_col_1" }),
+}))
+jest.mock(
+  "../../../../../../modules/payu-payment/lib/resolve-partner-creds",
+  () => ({
+    resolvePartnerPayuCredentials: jest.fn().mockResolvedValue(null),
+    resolveSalesChannelForCollection: jest.fn().mockResolvedValue(undefined),
+    payuContext: jest.fn(() => ({})),
+  })
+)
+jest.mock(
+  "../../../../../../modules/stripe-connect-payment/lib/resolve-connect",
+  () => ({
+    resolvePartnerConnect: jest.fn().mockResolvedValue(null),
+    connectContext: jest.fn(() => ({})),
+  })
+)
+
+const resolveCollectionPaymentContext = jest.fn()
+jest.mock("../../../../../../lib/payments/resolve-collection-customer", () => ({
+  resolveCollectionPaymentContext: (...a: any[]) =>
+    resolveCollectionPaymentContext(...a),
+}))
+
+import { POST } from "../route"
+
+const makeRes = () =>
+  ({ status: jest.fn().mockReturnThis(), json: jest.fn() }) as any
+
+/**
+ * The guest B2B buyer's card must still be attachable (#1792 tail).
+ *
+ * `auth_context.actor_id` is undefined for a guest, and a quote buyer is
+ * DELIBERATELY a guest — the token is the credential, no account required. So
+ * reading the customer from auth meant precisely the buyers whose card we want
+ * to keep were the ones who never got a Stripe Customer.
+ *
+ * 🔑 Asserted on `mock.calls` AFTER the call rather than inside the mock: an
+ * `expect()` thrown inside a mocked function can be swallowed by a `catch` in
+ * the code under test, and the spec then passes while the bug stands.
+ */
+describe("POST /store/payment-collections/:id/payment-sessions", () => {
+  beforeEach(() => {
+    runMock.mockClear()
+    resolveCollectionPaymentContext.mockReset()
+  })
+
+  it("takes the customer from the CART when the caller is a guest", async () => {
+    resolveCollectionPaymentContext.mockResolvedValue({
+      customer_id: "cus_from_cart",
+      plan: { basis: "deposit" },
+    })
+
+    await POST(
+      {
+        params: { id: "pay_col_1" },
+        body: { provider_id: "pp_stripe_stripe" },
+        scope: { resolve: jest.fn() },
+        // No auth_context at all — this IS the guest case.
+      } as any,
+      makeRes()
+    )
+
+    const input = runMock.mock.calls[0][0].input
+    expect(input.customer_id).toBe("cus_from_cart")
+  })
+
+  it("asks Stripe to keep the card when a balance follows", async () => {
+    resolveCollectionPaymentContext.mockResolvedValue({
+      customer_id: "cus_from_cart",
+      plan: { basis: "deposit" },
+    })
+
+    await POST(
+      {
+        params: { id: "pay_col_1" },
+        body: { provider_id: "pp_stripe_stripe" },
+        scope: { resolve: jest.fn() },
+      } as any,
+      makeRes()
+    )
+
+    expect(runMock.mock.calls[0][0].input.data).toEqual({
+      setup_future_usage: "off_session",
+    })
+  })
+
+  it("keeps no card when the whole total is being paid now", async () => {
+    resolveCollectionPaymentContext.mockResolvedValue({
+      customer_id: "cus_from_cart",
+      plan: { basis: "full" },
+    })
+
+    await POST(
+      {
+        params: { id: "pay_col_1" },
+        body: { provider_id: "pp_stripe_stripe" },
+        scope: { resolve: jest.fn() },
+      } as any,
+      makeRes()
+    )
+
+    const data = runMock.mock.calls[0][0].input.data
+    expect("setup_future_usage" in data).toBe(false)
+  })
+
+  /**
+   * A signed-in shopper on a cart with no customer bound must still work —
+   * the cart is preferred, but auth remains the fallback, not the other way
+   * round.
+   */
+  it("falls back to the authenticated caller when the cart names nobody", async () => {
+    resolveCollectionPaymentContext.mockResolvedValue({
+      customer_id: undefined,
+      plan: undefined,
+    })
+
+    await POST(
+      {
+        params: { id: "pay_col_1" },
+        body: { provider_id: "pp_stripe_stripe" },
+        scope: { resolve: jest.fn() },
+        auth_context: { actor_id: "cus_signed_in" },
+      } as any,
+      makeRes()
+    )
+
+    expect(runMock.mock.calls[0][0].input.customer_id).toBe("cus_signed_in")
+  })
+})

--- a/apps/backend/src/api/store/payment-collections/[id]/payment-sessions/route.ts
+++ b/apps/backend/src/api/store/payment-collections/[id]/payment-sessions/route.ts
@@ -13,6 +13,7 @@ import {
   resolvePartnerConnect,
   connectContext,
 } from "../../../../../modules/stripe-connect-payment/lib/resolve-connect"
+import { resolveCollectionCustomerId } from "../../../../../lib/payments/resolve-collection-customer"
 
 const DEFAULT_FIELDS = ["id", "currency_code", "amount", "*payment_sessions"]
 
@@ -82,11 +83,25 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
+  const cartCustomerId = await resolveCollectionCustomerId(
+    req.scope,
+    collectionId
+  ).catch(() => undefined)
+
   await createPaymentSessionsWorkflow(req.scope).run({
     input: {
       payment_collection_id: collectionId,
       provider_id,
-      customer_id: (req as any).auth_context?.actor_id,
+      /**
+       * 🔴 From the CART, falling back to the authenticated caller — not the
+       * other way round, and never auth alone.
+       *
+       * `auth_context.actor_id` is undefined for a guest, and a B2B quote
+       * buyer is deliberately a guest. That made the account holder — and so
+       * the saved card — impossible for exactly the buyers we want to keep a
+       * card for. See `resolveCollectionCustomerId`.
+       */
+      customer_id: cartCustomerId ?? (req as any).auth_context?.actor_id,
       data,
       ...(context ? { context } : {}),
     },

--- a/apps/backend/src/api/store/payment-collections/[id]/payment-sessions/route.ts
+++ b/apps/backend/src/api/store/payment-collections/[id]/payment-sessions/route.ts
@@ -13,7 +13,8 @@ import {
   resolvePartnerConnect,
   connectContext,
 } from "../../../../../modules/stripe-connect-payment/lib/resolve-connect"
-import { resolveCollectionCustomerId } from "../../../../../lib/payments/resolve-collection-customer"
+import { resolveCollectionPaymentContext } from "../../../../../lib/payments/resolve-collection-customer"
+import { saveCardSessionData } from "../../../../../lib/payments/save-card-intent"
 
 const DEFAULT_FIELDS = ["id", "currency_code", "amount", "*payment_sessions"]
 
@@ -83,10 +84,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
-  const cartCustomerId = await resolveCollectionCustomerId(
-    req.scope,
-    collectionId
-  ).catch(() => undefined)
+  const { customer_id: cartCustomerId, plan } =
+    await resolveCollectionPaymentContext(req.scope, collectionId).catch(
+      () => ({ customer_id: undefined, plan: undefined })
+    )
 
   await createPaymentSessionsWorkflow(req.scope).run({
     input: {
@@ -102,7 +103,15 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
        * card for. See `resolveCollectionCustomerId`.
        */
       customer_id: cartCustomerId ?? (req as any).auth_context?.actor_id,
-      data,
+      /**
+       * The save-card flag is decided HERE, not accepted from the caller.
+       *
+       * A storefront that forgot to ask would silently lose the card, and the
+       * loss would not surface until the balance was due weeks later. The
+       * server knows whether a balance follows — so the server says so, and a
+       * caller-supplied value cannot turn it off.
+       */
+      data: { ...(data ?? {}), ...(plan ? saveCardSessionData(plan) : {}) },
       ...(context ? { context } : {}),
     },
   })

--- a/apps/backend/src/api/store/stripe/lib/init-session.ts
+++ b/apps/backend/src/api/store/stripe/lib/init-session.ts
@@ -11,6 +11,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { createPaymentSessionsWorkflow } from "@medusajs/medusa/core-flows"
 
 import { ensureCartPaymentCollection } from "../../../../lib/payments/ensure-cart-collection"
+import { saveCardSessionData } from "../../../../lib/payments/save-card-intent"
 import {
   resolvePartnerConnect,
   connectContext,
@@ -62,6 +63,12 @@ export async function ensureStripeSession(
         "currency_code",
         "total",
         "sales_channel_id",
+        /**
+         * 🔴 Without this the guard below is dead — a field the query never
+         * fetched cannot be read, and the session would go on being created
+         * with no customer, silently, exactly as it did before.
+         */
+        "customer_id",
         "region.payment_providers.id",
         "region.payment_providers.is_enabled",
         "payment_collection.id",
@@ -107,7 +114,7 @@ export async function ensureStripeSession(
    * deposit the buyer had just been promised and charged the whole total.
    * `ensureCartPaymentCollection` makes that decision once, for both rails.
    */
-  const { id: pcId } = await ensureCartPaymentCollection(scope, cart)
+  const { id: pcId, plan } = await ensureCartPaymentCollection(scope, cart)
 
   // Ensure a Stripe session (initiatePayment → creates the PaymentIntent).
   let session = findStripeSession(cart.payment_collection?.payment_sessions)
@@ -124,6 +131,23 @@ export async function ensureStripeSession(
       input: {
         payment_collection_id: pcId!,
         provider_id: provider,
+        /**
+         * 🔴 This path passed NO `customer_id` at all, so core's
+         * `when("customer-id-exists")` never fired and no Stripe Customer was
+         * ever created here — for guests or signed-in buyers alike.
+         *
+         * Without a Stripe Customer the card cannot be attached, and an
+         * unattached card cannot be charged later. Nothing complains at the
+         * time: the intent still reports `setup_future_usage`, still confirms,
+         * still reaches `requires_capture`. The refusal arrives at the balance.
+         */
+        customer_id: cart.customer_id ?? undefined,
+        /**
+         * Keep the card only when a balance is still owed — see
+         * `save-card-intent.ts`. Spread, so a full-payment cart sends no key
+         * at all rather than an explicit `undefined` the provider forwards.
+         */
+        data: { ...saveCardSessionData(plan) },
         context: {
           sales_channel_id: cart.sales_channel_id,
           ...connectContext(connect),

--- a/apps/backend/src/lib/payments/__tests__/save-card-intent.unit.spec.ts
+++ b/apps/backend/src/lib/payments/__tests__/save-card-intent.unit.spec.ts
@@ -1,0 +1,49 @@
+import {
+  saveCardSessionData,
+  shouldSaveCardForLater,
+} from "../save-card-intent"
+
+/**
+ * The card is kept only when a balance follows (#1792 tail).
+ *
+ * These are cheap because the decision was deliberately made pure — the
+ * expensive half (does Stripe actually reuse the card?) was proven against
+ * Stripe test mode: with a customer the balance charged off-session and
+ * returned `succeeded`; without one it failed at
+ * "you must attach it to a Customer first".
+ */
+describe("shouldSaveCardForLater", () => {
+  it("keeps the card on a deposit — a balance is still owed", () => {
+    expect(shouldSaveCardForLater({ basis: "deposit" })).toBe(true)
+  })
+
+  it("does NOT keep the card on a full payment — nothing is left to charge", () => {
+    expect(shouldSaveCardForLater({ basis: "full" })).toBe(false)
+  })
+
+  it("does NOT keep the card when the plan refuses", () => {
+    expect(shouldSaveCardForLater({ basis: "refuse" })).toBe(false)
+  })
+})
+
+describe("saveCardSessionData", () => {
+  it("asks Stripe for off-session reuse on a deposit", () => {
+    expect(saveCardSessionData({ basis: "deposit" })).toEqual({
+      setup_future_usage: "off_session",
+    })
+  })
+
+  /**
+   * 🔴 The key must be ABSENT, not present-and-undefined.
+   *
+   * `stripe-base.js` forwards `extra?.setup_future_usage` straight into the
+   * PaymentIntent request, so an explicit `undefined` is still a key on the
+   * object. Asserting `toEqual({})` alone would pass for
+   * `{ setup_future_usage: undefined }`, so the key list is checked directly.
+   */
+  it("sends no key at all when the card should not be kept", () => {
+    const data = saveCardSessionData({ basis: "full" })
+    expect(Object.keys(data)).toEqual([])
+    expect("setup_future_usage" in data).toBe(false)
+  })
+})

--- a/apps/backend/src/lib/payments/resolve-collection-customer.ts
+++ b/apps/backend/src/lib/payments/resolve-collection-customer.ts
@@ -1,5 +1,8 @@
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
+import { PAYMENT_SCHEDULE_MODULE } from "../../modules/payment_schedule"
+import { planCartCollection, type CollectionPlan } from "./deposit-collection"
+
 /**
  * The customer a payment collection is being paid by, resolved from its cart.
  *
@@ -84,4 +87,70 @@ export const resolveCartCustomerId = async (
     .catch(() => ({ data: [] }))
 
   return carts?.[0]?.customer_id ?? undefined
+}
+
+
+/**
+ * Everything a payment session needs to know about the cart behind a
+ * collection: who is paying, and whether a balance follows.
+ *
+ * ## Why the plan, and not a second rule
+ *
+ * The store payment-sessions route has only a collection id in hand, so the
+ * tempting shortcut is to ask the schedule directly — "is `balance_amount`
+ * above zero?" — and decide from that. That would be a SECOND answer to a
+ * question `planCartCollection` already answers, and two answers to one
+ * question is how the deposit came to be charged three different ways.
+ *
+ * So the same pricer runs here as on the Stripe hosted-page rail, and the
+ * decision is read off `plan.basis` in both places.
+ *
+ * A cart that cannot be planned at all is not an error here — it simply means
+ * no card is kept. Refusing the session would break checkouts to protect a
+ * convenience.
+ */
+export const resolveCollectionPaymentContext = async (
+  scope: any,
+  collectionId: string
+): Promise<{ customer_id?: string; plan?: CollectionPlan }> => {
+  if (!collectionId) return {}
+
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: links } = await query
+    .graph({
+      entity: "cart_payment_collection",
+      filters: { payment_collection_id: collectionId },
+      fields: ["cart_id"],
+    })
+    .catch(() => ({ data: [] }))
+
+  const cartId = links?.[0]?.cart_id
+  if (!cartId) return {}
+
+  const { data: carts } = await query
+    .graph({
+      entity: "cart",
+      filters: { id: cartId },
+      fields: ["id", "customer_id", "currency_code", "total"],
+    })
+    .catch(() => ({ data: [] }))
+
+  const cart = carts?.[0]
+  if (!cart) return {}
+
+  let plan: CollectionPlan | undefined
+  try {
+    const schedules: any = scope.resolve(PAYMENT_SCHEDULE_MODULE)
+    const schedule = await schedules.findByCartId(cart.id)
+    plan = planCartCollection({
+      cartTotal: cart.total,
+      cartCurrency: cart.currency_code,
+      schedule,
+    })
+  } catch {
+    plan = undefined
+  }
+
+  return { customer_id: cart.customer_id ?? undefined, plan }
 }

--- a/apps/backend/src/lib/payments/resolve-collection-customer.ts
+++ b/apps/backend/src/lib/payments/resolve-collection-customer.ts
@@ -1,0 +1,87 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * The customer a payment collection is being paid by, resolved from its cart.
+ *
+ * ## Why this exists rather than reading the request
+ *
+ * `createPaymentSessionsWorkflow` only creates a Stripe account holder — i.e. a
+ * real Stripe Customer — `when("customer-id-exists")`, which is to say when a
+ * `customer_id` reaches its input. Both of our session call sites used to fail
+ * that test:
+ *
+ *   • the store payment-sessions route passed
+ *     `req.auth_context?.actor_id`, which is **undefined for a guest**, and
+ *   • `stripe/lib/init-session.ts` passed no `customer_id` at all.
+ *
+ * 🔴 A B2B quote buyer is DELIBERATELY a guest — the whole premise is that a
+ * procurement contact should not have to create an account before acting on a
+ * price. So the one population whose card we most want to keep was precisely
+ * the one that never got a Stripe Customer.
+ *
+ * The cart already knows. `acceptQuoteWorkflow` binds it to the quote's own
+ * customer server-side, so the answer is on the row rather than in the session.
+ *
+ * ## The failure this prevents is invisible until the money is due
+ *
+ * Stripe accepts `setup_future_usage` with no customer, reports it back on the
+ * PaymentIntent, and confirms the card happily — `requires_capture`, exactly as
+ * a healthy deposit looks. The card is simply never attached to anyone. The
+ * refusal arrives weeks later, at the balance charge:
+ *
+ *     The provided PaymentMethod cannot be attached. To reuse a PaymentMethod,
+ *     you must attach it to a Customer first.
+ *
+ * Nothing earlier in the flow says so. Verified end to end against Stripe test
+ * mode: with a customer the same rail charged the balance off-session and
+ * returned `succeeded`; without one it failed at exactly that sentence.
+ *
+ * 🔑 `has_account` is irrelevant — core creates the account holder for a guest
+ * customer record too. Only the presence of `customer_id` matters.
+ */
+export const resolveCollectionCustomerId = async (
+  scope: any,
+  collectionId: string
+): Promise<string | undefined> => {
+  /**
+   * A missing id would be `filters: { payment_collection_id: undefined }`,
+   * which is NOT "no rows" — it is *no filter*, and would hand back the first
+   * cart in the table. Refuse before asking.
+   */
+  if (!collectionId) return undefined
+
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: links } = await query
+    .graph({
+      entity: "cart_payment_collection",
+      filters: { payment_collection_id: collectionId },
+      fields: ["cart_id"],
+    })
+    .catch(() => ({ data: [] }))
+
+  const cartId = links?.[0]?.cart_id
+  if (!cartId) return undefined
+
+  return resolveCartCustomerId(scope, cartId)
+}
+
+/** The same answer when the cart is already in hand. */
+export const resolveCartCustomerId = async (
+  scope: any,
+  cartId: string
+): Promise<string | undefined> => {
+  if (!cartId) return undefined
+
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: carts } = await query
+    .graph({
+      entity: "cart",
+      filters: { id: cartId },
+      fields: ["customer_id"],
+    })
+    .catch(() => ({ data: [] }))
+
+  return carts?.[0]?.customer_id ?? undefined
+}

--- a/apps/backend/src/lib/payments/save-card-intent.ts
+++ b/apps/backend/src/lib/payments/save-card-intent.ts
@@ -1,0 +1,42 @@
+import type { CollectionPlan } from "./deposit-collection"
+
+/**
+ * Whether this payment session should ask Stripe to keep the buyer's card.
+ *
+ * ## Only when there is a second half to collect
+ *
+ * Storing someone's payment method is not free of consequence, so it is not
+ * default-on. The single condition is that the collection is a **deposit** —
+ * i.e. a balance is owed later and the alternative is emailing a procurement
+ * contact a link and hoping. A `full` collection has nothing left to charge, so
+ * keeping the card would buy nothing and store something anyway.
+ *
+ * 🔑 The decision reads `plan.basis`, the same figure that decided how much to
+ * charge now. Re-deriving "is this a deposit?" from the schedule a second time
+ * is how two answers to one question start to disagree — the plan is already
+ * the one place that decision lives.
+ *
+ * ## Cards only
+ *
+ * `off_session` reuse works for cards. Our Stripe provider runs with
+ * `automatic_payment_methods` enabled, so a session may also offer redirect
+ * methods that can never be charged unattended. That is not a reason to refuse
+ * the flag — the saved card is a *fast path*, and the balance pay link remains
+ * the fallback for every buyer whose method cannot be reused or whose
+ * off-session charge is declined.
+ */
+export const shouldSaveCardForLater = (plan: Pick<CollectionPlan, "basis">) =>
+  plan.basis === "deposit"
+
+/**
+ * The `data` a Stripe payment session needs in order to keep the card.
+ *
+ * Returned as a spreadable object so a caller adds nothing at all when the
+ * answer is no — an explicit `setup_future_usage: undefined` would still be a
+ * key on the intent request, and the provider forwards `extra?.setup_future_usage`
+ * straight through to Stripe.
+ */
+export const saveCardSessionData = (
+  plan: Pick<CollectionPlan, "basis">
+): { setup_future_usage?: "off_session" } =>
+  shouldSaveCardForLater(plan) ? { setup_future_usage: "off_session" } : {}

--- a/apps/backend/src/modules/partner-quote/__tests__/list-query.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/list-query.unit.spec.ts
@@ -78,7 +78,12 @@ describe("buildQuoteListQuery", () => {
       // relation the field is absent and every row reads "0 lines · 0 units".
       relations: ["lines"],
     })
-    expect(filters).toEqual({})
+    /**
+     * 🔑 Not `{}` any more. A default list means "the real quotes" — drafts are
+     * unpriced rows the operator is still building, and they belong in their
+     * own list rather than beside quotes a buyer is holding (#1446).
+     */
+    expect(filters).toEqual({ status: { $ne: "draft" } })
   })
 
   it("clamps limit to a ceiling — `?limit=100000` is a table scan on request", () => {

--- a/apps/backend/src/modules/partner-quote/lib/__tests__/draft-status.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/lib/__tests__/draft-status.unit.spec.ts
@@ -1,0 +1,37 @@
+import { buildQuoteListQuery } from "../list-query"
+
+/**
+ * Drafts are a separate list, not a badge on the ordinary one (#1446).
+ *
+ * A draft is an unpriced quote. Mixed into the operator's default list it sits
+ * beside quotes a buyer is holding, looking like one of them.
+ */
+describe("buildQuoteListQuery — drafts", () => {
+  const now = new Date("2026-09-04T00:00:00Z")
+
+  it("🔴 excludes drafts when no status is asked for", () => {
+    const { filters } = buildQuoteListQuery({}, {}, now)
+    expect(filters.status).toEqual({ $ne: "draft" })
+  })
+
+  it("shows drafts, and only drafts, when they are asked for", () => {
+    const { filters } = buildQuoteListQuery({ status: "draft" }, {}, now)
+    expect(filters.status).toBe("draft")
+  })
+
+  it("still narrows `active` by expiry, unchanged", () => {
+    const { filters } = buildQuoteListQuery({ status: "active" }, {}, now)
+    expect(filters.status).toBe("active")
+    expect(filters.$and).toBeDefined()
+  })
+
+  /**
+   * The pinned scope must survive the new default — a partner listing their
+   * own quotes must not be widened by it.
+   */
+  it("keeps a caller-pinned partner scope alongside the draft exclusion", () => {
+    const { filters } = buildQuoteListQuery({}, { partner_id: "par_1" }, now)
+    expect(filters.partner_id).toBe("par_1")
+    expect(filters.status).toEqual({ $ne: "draft" })
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/list-query.ts
+++ b/apps/backend/src/modules/partner-quote/lib/list-query.ts
@@ -183,7 +183,22 @@ export function buildQuoteListQuery(
   const filters: Record<string, unknown> = { ...scoped }
 
   const status = String(query.status ?? "").trim()
-  if (status) {
+  if (!status) {
+    /**
+     * 🔴 No status asked for means "the real quotes", NOT "everything".
+     *
+     * Nothing was applied here before, which was correct while every row was a
+     * real quote. With drafts in the same table it would put unpriced,
+     * half-built rows in the operator's ordinary list, mixed in with quotes a
+     * buyer is holding — and the count, the pager and the filter would all
+     * agree about a set nobody asked to see.
+     *
+     * Drafts are reachable, deliberately, at `?status=draft` — the way the
+     * admin keeps Orders and Drafts as separate lists rather than one list with
+     * a badge.
+     */
+    filters.status = { $ne: "draft" }
+  } else {
     const clause = buildQuoteStatusFilter(status, now)
     // `$and` may already be pinned by the caller; intersect rather than replace.
     const and = clause.$and as unknown[] | undefined

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260904120000.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260904120000.ts
@@ -1,0 +1,73 @@
+import { Migration } from "@mikro-orm/migrations"
+
+/**
+ * A quote can be a DRAFT (#1446 — the draft-order mirror).
+ *
+ * Minting was one shot: a form held every answer in the browser and a single
+ * POST created a fully priced quote. That is not how the draft-order rail this
+ * is modelled on works. There, a small modal captures only what is needed to
+ * make the row — region, sales channel, customer, address — saves it, and the
+ * items, shipping and promotions are edited section by section afterwards.
+ *
+ * So a quote gains the same shape, and the same first state.
+ *
+ * ## What a draft is allowed to be missing
+ *
+ * The table's NOT NULL columns are `partner_id`, `destination_country_code`,
+ * `currency_code`, `token_hash` and `status`. The first three are exactly what
+ * the create modal asks for — which is the check that the modal's field list is
+ * the right one, arrived at from the schema rather than from taste.
+ *
+ * 🔴 `token_hash` is the one a draft cannot have. It is the buyer's credential,
+ * minted once and never recoverable, so it cannot be invented at draft time and
+ * then thrown away. It becomes nullable: in Postgres a UNIQUE constraint admits
+ * many NULLs, so drafts do not collide with each other.
+ *
+ * 🔑 That nullability is also the SAFETY property. `findByTokenHash` matches on
+ * `token_hash`, and NULL is never equal to anything — so a draft is unreachable
+ * from the buyer-facing token route by construction, not by a guard somebody
+ * has to remember to write. A draft is an unpriced quote; showing one to a
+ * buyer would be showing them a price that does not exist yet.
+ *
+ * ## The enum is a CHECK constraint
+ *
+ * Adding a value means dropping and re-adding it — exactly as
+ * `Migration20260822061500` did for `superseded`. This has bitten before: the
+ * column's own docblock described a `"manual"` weight source the constraint had
+ * never learned, and every quote minted with a hand-typed weight died at the
+ * INSERT with a bare CheckConstraintViolationException.
+ */
+export class Migration20260904120000 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "partner_quote" drop constraint if exists "partner_quote_status_check";`
+    )
+    this.addSql(
+      `alter table if exists "partner_quote" add constraint "partner_quote_status_check" check ("status" in ('draft', 'active', 'revoked', 'superseded'));`
+    )
+    this.addSql(
+      `alter table if exists "partner_quote" alter column "token_hash" drop not null;`
+    )
+  }
+
+  async down(): Promise<void> {
+    /**
+     * 🔴 Drafts must go before the constraint can refuse them, or `down`
+     * fails on any database that has one. They are deleted rather than
+     * promoted: an unpriced quote has no business becoming `active`, which is
+     * the state the buyer-facing routes serve.
+     */
+    this.addSql(`delete from "partner_quote" where "status" = 'draft';`)
+    this.addSql(
+      `alter table if exists "partner_quote" drop constraint if exists "partner_quote_status_check";`
+    )
+    this.addSql(
+      `alter table if exists "partner_quote" add constraint "partner_quote_status_check" check ("status" in ('active', 'revoked', 'superseded'));`
+    )
+    /**
+     * Restoring NOT NULL would fail on any row left without a token, so the
+     * column stays nullable. A `down` that cannot run is worse than one that
+     * leaves a column wider than it found it.
+     */
+  }
+}

--- a/apps/backend/src/modules/partner-quote/models/partner-quote.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote.ts
@@ -280,7 +280,15 @@ const PartnerQuote = model.define("partner_quote", {
 
   // ===== Token + lifecycle ================================================
   // sha256(raw). The raw token is returned once, at mint.
-  token_hash: model.text().unique(),
+  /**
+   * The buyer's credential, sha256'd — null while the quote is a `draft`.
+   *
+   * Nullable is deliberate and load-bearing: `findByTokenHash` matches on this
+   * column, and NULL is never equal to anything, so a draft cannot be served to
+   * a buyer even if a token were guessed. Postgres admits many NULLs under a
+   * UNIQUE constraint, so drafts do not collide.
+   */
+  token_hash: model.text().unique().nullable(),
   /**
    * `superseded` means a NEWER quote to the same buyer replaced this one, and
    * this quote's price list has been expired so it can no longer price a cart.
@@ -288,7 +296,22 @@ const PartnerQuote = model.define("partner_quote", {
    * the buyer should be told a current one exists rather than that the partner
    * pulled the offer.
    */
-  status: model.enum(["active", "revoked", "superseded"]).default("active"),
+  /**
+   * 🔑 `draft` is the FIRST state, not a variant of `active`.
+   *
+   * A draft is an unpriced quote: the create modal has captured the partner,
+   * the region and where it ships, and nothing has been costed yet. It becomes
+   * `active` at mint, which is the moment prices are frozen and the buyer's
+   * token exists — see `token_hash`, which is null until then and is what makes
+   * a draft unreachable from the buyer's route.
+   *
+   * ⚠️ This is a CHECK constraint. A value added here without the matching
+   * migration does not fail at boot or in tsc — it fails at the INSERT, with a
+   * bare CheckConstraintViolationException and no field name.
+   */
+  status: model
+    .enum(["draft", "active", "revoked", "superseded"])
+    .default("active"),
   expires_at: model.dateTime().nullable(),
   /**
    * When this quote was last corrected in place, or null if never.

--- a/apps/backend/src/modules/partner-quote/service.ts
+++ b/apps/backend/src/modules/partner-quote/service.ts
@@ -15,6 +15,21 @@ class PartnerQuoteService extends MedusaService({
    * prober.
    */
   async findByTokenHash(tokenHash: string) {
+    /**
+     * 🔴 Refuse an empty hash rather than asking with it.
+     *
+     * `listPartnerQuotes({ token_hash: undefined })` is not "no rows" — it is
+     * NO FILTER, and it would hand back the first quote in the table. That was
+     * survivable while every row was a real quote belonging to somebody; with
+     * drafts in the same table it would serve a buyer an unpriced draft, and
+     * with any row it is somebody else's quote entirely.
+     *
+     * Drafts are additionally unreachable here by construction — their
+     * `token_hash` is NULL and NULL matches nothing — but that is the second
+     * line, not the first.
+     */
+    if (!tokenHash) return null
+
     const rows = await this.listPartnerQuotes({ token_hash: tokenHash })
     return rows?.[0] || null
   }

--- a/e2e/specs/admin-quote-mint-wizard.spec.ts
+++ b/e2e/specs/admin-quote-mint-wizard.spec.ts
@@ -5,12 +5,27 @@ import * as path from "path"
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 
 /**
- * The admin mint wizard, driven through a browser (#1439 S4 / #1446).
+ * The admin mint page, driven through a browser (#1439 S4 / #1446).
  *
  * 🔑 Why this file exists: the wizard shipped in #1463 and had never been
  * opened in a browser. tsc sees a component that compiles; only a render shows
  * a step that will not advance, a hook called outside its provider (#1352), or
  * a modal body that does not scroll.
+ *
+ * ## It is no longer a wizard
+ *
+ * Minting was four `ProgressTabs` steps inside a `RouteFocusModal`. At 2,420
+ * lines across its steps that had outgrown a modal — one answer visible at a
+ * time, no way to glance at the basket while typing a destination, and the
+ * readiness verdict scrolling away above a grid. It is now the same four
+ * questions as SECTIONS on a page, in the layout of the quote detail route it
+ * produces.
+ *
+ * So the assertions that made sense against a wizard — a dialog, `tab` roles,
+ * `aria-selected`, a `Continue` button that gates — are gone, because the
+ * things they described are gone. What replaced them is the property that
+ * actually matters now: **every question is on screen at once**, and the
+ * button that mints stays reachable while you work further down the page.
  *
  * ## What this deliberately does NOT do
  *
@@ -20,13 +35,8 @@ const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
  * `integration-tests/helpers/setup-quote-fixture.ts`, which already mints for
  * real against a container on every run. The arithmetic, the price-list rows
  * and the refusals are covered there.
- *
- * What is covered HERE is the half that suite cannot see: that it opens as a
- * modal at all, that the steps gate, and that picking a region INFERS the
- * currency instead of leaving two free-text boxes that can contradict each
- * other.
  */
-test.describe("Admin mint-quote wizard (#1446)", () => {
+test.describe("Admin mint-quote page (#1446)", () => {
   let seed: { email: string; password: string; parkedRunFreshPartnerName: string }
 
   test.beforeAll(() => {
@@ -52,64 +62,88 @@ test.describe("Admin mint-quote wizard (#1446)", () => {
     await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
   }
 
-  const openWizard = async (page: any) => {
+  const openMintPage = async (page: any) => {
     await page.goto("/app/quotes")
     await expect(page.getByRole("heading", { name: "Quotes" })).toBeVisible({
       timeout: 30000,
     })
     await page.getByRole("button", { name: "Mint quote" }).click()
-    // 🔑 A dialog, not a page. It shipped as a plain Container — the one
-    // create flow that navigated away from wherever the operator was.
-    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 30000 })
+    await page.waitForURL(/\/app\/quotes\/create/, { timeout: 30000 })
   }
 
-  test("opens as a focus modal with all four steps", async ({ page }) => {
-    await login(page)
-    await openWizard(page)
-
-    for (const step of ["Partner", "Buyer", "Products", "Quantities"]) {
-      await expect(page.getByRole("tab", { name: step })).toBeVisible()
-    }
-  })
-
-  test("will not leave the Partner step until a partner is chosen", async ({
+  test("🔑 every question is on the page at once, and it is not a dialog", async ({
     page,
   }) => {
     await login(page)
-    await openWizard(page)
+    await openMintPage(page)
 
-    // Every quote is partner-scoped: the partner decides which catalogue the
-    // variants come from and which location freight is quoted from, so
-    // choosing products first would build a basket rejected wholesale.
-    await page.getByRole("button", { name: "Continue" }).click()
-    await expect(page.getByRole("tab", { name: "Partner" })).toHaveAttribute(
-      "aria-selected",
-      "true"
-    )
+    /**
+     * All four at the same time — the property the wizard could not have. A
+     * `toBeVisible` per heading with no navigation between them IS the
+     * assertion; if any one of these still lived behind a step, the others
+     * would not be on screen with it.
+     */
+    for (const section of [
+      "Partner",
+      "Buyer",
+      "Products",
+      "Quantities & pricing",
+    ]) {
+      await expect(
+        page.getByRole("heading", { name: section, exact: true })
+      ).toBeVisible({ timeout: 30000 })
+    }
 
-    await page.getByText("Select a partner").click()
-    await page.getByRole("option", { name: seed.parkedRunFreshPartnerName }).click()
-    await page.getByRole("button", { name: "Continue" }).click()
+    // It used to open as a focus modal over the list.
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+  })
 
-    await expect(page.getByRole("tab", { name: "Buyer" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-      { timeout: 15000 }
-    )
+  test("🔴 the buyer section is not duplicated by its own container", async ({
+    page,
+  }) => {
+    await login(page)
+    await openMintPage(page)
+
+    /**
+     * The steps were written for a modal that supplied no chrome, so they
+     * carry their own headings — `BuyerStep` in fact carries three. Wrapping
+     * each one in a titled section rendered "Buyer" twice and put "Items"
+     * directly above the step's own "Products". Every test passed with the
+     * duplicate on screen; only a render caught it.
+     */
+    await expect(
+      page.getByRole("heading", { name: "Buyer", exact: true })
+    ).toHaveCount(1)
+    await expect(
+      page.getByRole("heading", { name: "Products", exact: true })
+    ).toHaveCount(1)
+  })
+
+  test("the mint button stays reachable from the bottom of the page", async ({
+    page,
+  }) => {
+    await login(page)
+    await openMintPage(page)
+
+    const products = page.getByRole("heading", { name: "Products", exact: true })
+    await products.scrollIntoViewIfNeeded()
+
+    /**
+     * The sidebar is sticky. In the modal the footer button was always there
+     * too — but the readiness verdict was NOT, and a refusal scrolled off
+     * above the grid the operator had to fix. Both now stay put together.
+     */
+    await expect(page.getByRole("button", { name: "Mint quote" })).toBeVisible()
   })
 
   test("🔑 picking a region infers the currency and narrows the destinations", async ({
     page,
   }) => {
     await login(page)
-    await openWizard(page)
+    await openMintPage(page)
 
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: seed.parkedRunFreshPartnerName }).click()
-    await page.getByRole("button", { name: "Continue" }).click()
-    await expect(page.getByText("Buyer", { exact: true }).first()).toBeVisible({
-      timeout: 15000,
-    })
 
     // Currency and destination used to be two free-text boxes, which let an
     // operator quote INR to a GB address — a combination no region supports.


### PR DESCRIPTION
Two halves of the same thread: the balance can now actually be **collected**, and a quote can be **built the way a draft order is**.

## 1. The buyer's card is kept when a balance follows

#1792 made the balance raisable. It could not be *charged* — because neither Stripe session call site ever created a Stripe Customer:

- `payment-collections/:id/payment-sessions` read `req.auth_context?.actor_id`, **undefined for a guest** — and a B2B quote buyer is deliberately a guest, the whole premise being that a procurement contact should not have to create an account.
- `stripe/lib/init-session.ts` passed **no `customer_id` at all**, and accepted no `data`.

🔴 **The failure is invisible until the money is due.** Stripe accepts `setup_future_usage` with no customer, reports it back on the intent, confirms the card, and reaches `requires_capture` exactly as a healthy deposit does. The card is simply never attached to anyone. The refusal arrives weeks later, at the balance:

> The provided PaymentMethod cannot be attached. To reuse a PaymentMethod, you must attach it to a Customer first.

Proven end to end against Stripe test mode. With a customer, the same rail charged **A$220.34 off-session, no buyer present, `succeeded`** — the exact outstanding balance on order #101. Without one, it failed at that sentence.

Supporting facts, verified rather than assumed:
- `stripe-base.js:42` forwards `setup_future_usage`, `off_session`, `confirm` and `payment_method`; it is also settable provider-wide via `paymentIntentOptions`.
- `capture_method` is **manual** for us (no `capture` option is set), so authorise-now / capture-later from the admin Payments button already works.
- `has_account` is irrelevant — core creates the account holder for a **guest** customer record too, so a tokenised buyer never needs to register.

The card is kept only when a balance follows, decided off `plan.basis` — the same figure that already decides how much to charge now, not a second reading of the schedule.

## 2. A quote can be a draft

The draft-order UI does **not** hold its answers in the browser. Its create modal captures only what makes the row — region, sales channel, customer, address — **saves**, and items/shipping/promotions are edited section by section afterwards. Minting was the opposite: one form, every answer, a single POST.

- `status` gains `draft` as its first state (CHECK constraint dropped and re-added, as #1510 did for `superseded`).
- `token_hash` becomes nullable. 🔑 That is the **safety property**, not a concession: `findByTokenHash` matches on it and NULL equals nothing, so a draft is unreachable from the buyer's route *by construction*. A draft is an unpriced quote.
- The default list previously applied **no** status filter — correct while every row was a real quote. It now excludes drafts; `?status=draft` reaches them.

The required fields were taken from the table's NOT NULL columns rather than from taste — `partner_id`, `destination_country_code`, `currency_code` — which is exactly what the draft-order modal asks for, and why region comes first (it supplies the currency).

`POST /admin/quotes/drafts/:id/mint` calls **`POST /admin/quotes`'s own handler**, not a copy. The draft is deleted only after that succeeds.

## Two bugs only the running routes revealed

🔴 `deletePartnerQuotes` with children attached answers *"You tried to set relationship id: &lt;the draft's id&gt;, but such entity does not exist"* — naming the row being deleted, so it reads as "this draft is missing" rather than "it still has lines". A draft with an **empty** basket deleted cleanly, which is why it survived the first probe.

🔴 I read that as "the DELETE route isn't matching", because `curl -o /dev/null` hid the body. The route had matched all along.

## Verified live

Zero deposit stores as `0`, not null · draft absent from the default list (99 real quotes) and present only under `?status=draft` · the buyer section saves without emptying the basket · the draft route refuses a minted quote by re-reading its status · a failed mint left the draft, its basket and its buyer email untouched.

## Tests

**1063 green** across the quote and payment suites. Every guard was checked by reverting it and watching the tests go red: 3 of 4 route tests fail without the `customer_id` fix, 3 of 6 without the PATCH guards.

`check:prod-build`: the only error is the **pre-existing `@jest/core`** one in `src/scripts/__tests__/generate-integration-test.e2e.spec.ts`, red on `main` all session and tolerated by CI. No errors in changed files; the frontend build (covering the admin UI) succeeded.

## Not in this PR

The **admin UI** — the create modal and the draft's section page. The mint form on this branch is a half-step: it is a full-page section layout, but still client-side with a single mint. It becomes the draft detail surface next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
