### PR TITLE
feat(admin): show partner name with item-line tooltip on the inventory orders list

### DIFF
--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -269,6 +269,99 @@ setupSharedTestSuite(() => {
       });
     });
 
+    // #1737 follow-up — the list table's "Order ID" column was replaced with the
+    // partner name (line details in a tooltip), so GET /admin/inventory-orders
+    // must resolve + attach `partner` and `order_lines` per row without breaking
+    // the existing list contract.
+    describe("GET /admin/inventory-orders — partner + order lines for the list table", () => {
+      let listPartnerId: string;
+      let listPartnerName: string;
+      let listItemId: string;
+      let assignedOrderId: string;
+      let unassignedOrderId: string;
+
+      beforeEach(async () => {
+        const unique = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`;
+        listPartnerName = `List Partner ${unique}`;
+
+        const partnerRes = await api.post(
+          "/admin/partners",
+          {
+            partner: { name: listPartnerName, handle: `list-partner-${unique}` },
+            admin: { email: `list-partner-${unique}@jyt.test`, first_name: "L", last_name: "P" },
+          },
+          headers
+        );
+        expect(partnerRes.status).toBe(201);
+        listPartnerId = partnerRes.data.partner.id;
+
+        const itemRes = await api.post("/admin/inventory-items", { title: `List Fabric ${unique}` }, headers);
+        expect(itemRes.status).toBe(200);
+        listItemId = itemRes.data.inventory_item.id;
+
+        const base = {
+          order_lines: [{ inventory_item_id: listItemId, quantity: 2, price: 100 }],
+          quantity: 2,
+          total_price: 200,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        };
+
+        const assignedRes = await api.post("/admin/inventory-orders", base, headers);
+        expect(assignedRes.status).toBe(201);
+        assignedOrderId = assignedRes.data.inventoryOrder.id;
+
+        const assignRes = await api.post(
+          `/admin/inventory-orders/${assignedOrderId}/assign-partner`,
+          { partner_id: listPartnerId },
+          headers
+        );
+        expect(assignRes.status).toBe(200);
+
+        const unassignedRes = await api.post("/admin/inventory-orders", base, headers);
+        expect(unassignedRes.status).toBe(201);
+        unassignedOrderId = unassignedRes.data.inventoryOrder.id;
+      });
+
+      it("attaches the partner name and item lines to an assigned order", async () => {
+        const res = await api.get(`/admin/inventory-orders?q=${assignedOrderId}&limit=100`, headers);
+        expect(res.status).toBe(200);
+
+        const order = res.data.inventory_orders.find((o: any) => o.id === assignedOrderId);
+        expect(order).toBeDefined();
+
+        // Partner name reaches the list (the "Partner" column).
+        expect(order.partner).toBeDefined();
+        expect(order.partner.name).toBe(listPartnerName);
+
+        // Item lines reach the list (the tooltip).
+        expect(Array.isArray(order.order_lines)).toBe(true);
+        expect(order.order_lines.length).toBe(1);
+        expect(Number(order.order_lines[0].quantity)).toBe(2);
+        expect(Number(order.order_lines[0].price)).toBe(100);
+        expect(order.order_lines[0].inventory_items[0].id).toBe(listItemId);
+
+        // The list contract is unchanged for the same row.
+        expect(order.status).toBe("Pending");
+        expect(Number(order.quantity)).toBe(2);
+      });
+
+      it("still lists an unassigned order without a partner (no breakage)", async () => {
+        const res = await api.get(`/admin/inventory-orders?q=${unassignedOrderId}&limit=100`, headers);
+        expect(res.status).toBe(200);
+
+        const order = res.data.inventory_orders.find((o: any) => o.id === unassignedOrderId);
+        expect(order).toBeDefined();
+        expect(order.partner).toBeUndefined();
+        expect(Array.isArray(order.order_lines)).toBe(true);
+        expect(order.order_lines.length).toBe(1);
+      });
+    });
+
     describe("GET /admin/inventory-orders/:id", () => {
       let createdOrder: any;
       let createdOrderId: string;

--- a/apps/backend/src/admin/routes/orders/inventory/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/page.tsx
@@ -11,11 +11,13 @@ import {
   Button,
   Badge,
   StatusBadge,
+  Tooltip,
+  TooltipProvider,
 } from "@medusajs/ui";
 import { Outlet, useNavigate, useSearchParams } from "react-router-dom";
 import { keepPreviousData } from "@tanstack/react-query";
 import { defineRouteConfig } from "@medusajs/admin-sdk";
-import { ToolsSolid, PencilSquare } from "@medusajs/icons";
+import { ToolsSolid, PencilSquare, InformationCircleSolid } from "@medusajs/icons";
 import CreateButton from "../../../components/creates/create-button";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { EntityActions } from "../../../components/persons/personsActions";
@@ -36,7 +38,47 @@ import {
 const columnHelper = createColumnHelper<AdminInventoryOrder>();
 export const useColumns = () => {
   const columns = useMemo(() => [
-    columnHelper.accessor("id", { header: "Order ID", enableSorting: true }),
+    columnHelper.display({
+      id: "partner",
+      header: "Partner",
+      // Derived via the partner-inventory-order link (not an order column) →
+      // not server-sortable. Replaces the "Order ID" column; line details ride
+      // in the tooltip.
+      cell: ({ row }) => {
+        const partner = row.original.partner;
+        const orderLines = (row.original as any).order_lines || [];
+        const name = partner?.name;
+        return (
+          <div className="flex items-center gap-1.5">
+            <span className="text-ui-fg-base">{name || "—"}</span>
+            {orderLines.length > 0 && (
+              <TooltipProvider>
+                <Tooltip
+                  content={
+                    <div className="flex flex-col gap-y-1">
+                      {orderLines.map((line: any, i: number) => {
+                        const label =
+                          line.material_name ||
+                          line.inventory_items?.[0]?.title ||
+                          line.inventory_items?.[0]?.sku ||
+                          "Item";
+                        return (
+                          <span key={line.id ?? i} className="text-ui-fg-base">
+                            {label} — Qty {line.quantity} × ₹{line.price}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  }
+                >
+                  <InformationCircleSolid className="text-ui-fg-muted" />
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+        );
+      },
+    }),
     columnHelper.accessor("status", { header: "Status", enableSorting: true }),
     columnHelper.display({
       id: "work_status",
@@ -56,14 +98,6 @@ export const useColumns = () => {
     columnHelper.accessor("total_price", { header: "Total Price", enableSorting: true }),
     columnHelper.accessor("order_date", {
       header: "Order Date",
-      enableSorting: true,
-      cell: info => {
-        const val = info.getValue<string>();
-        return val ? new Date(val).toLocaleDateString() : "-";
-      },
-    }),
-    columnHelper.accessor("expected_delivery_date", {
-      header: "Expected Delivery",
       enableSorting: true,
       cell: info => {
         const val = info.getValue<string>();

--- a/apps/backend/src/api/admin/inventory-orders/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/route.ts
@@ -173,20 +173,38 @@ export const GET = async (
       const graph: any = req.scope.resolve(ContainerRegistrationKeys.QUERY);
       const { data } = await graph.graph({
         entity: "inventory_orders",
-        fields: ["id", "order.unified_order_status.partner_status"],
+        fields: [
+          "id",
+          "order.unified_order_status.partner_status",
+          // Partner name + order lines for the list table (#1737 follow-up): the
+          // "Order ID" column was replaced with the partner name, whose line
+          // details ride in a tooltip. Both reach through links (partner via
+          // partner-inventory-order, lines via orderlines.*), so resolve them
+          // here and attach, mirroring unified_order_status below.
+          "partner.id",
+          "partner.name",
+          "orderlines.*",
+          "orderlines.inventory_items.*",
+        ],
         filters: { id: ids },
       });
-      const statusById = new Map<string, any>(
-        (data ?? []).map((io: any) => [io.id, io.order?.unified_order_status])
-      );
+      const byId = new Map<string, any>((data ?? []).map((io: any) => [io.id, io]));
       for (const row of rows) {
-        if (statusById.get(row.id)) {
-          row.unified_order_status = statusById.get(row.id);
+        const io = byId.get(row.id);
+        if (!io) continue;
+        if (io.order?.unified_order_status) {
+          row.unified_order_status = io.order.unified_order_status;
+        }
+        if (io.partner) {
+          row.partner = io.partner;
+        }
+        if (io.orderlines) {
+          row.order_lines = io.orderlines;
         }
       }
     }
   } catch {
-    // leave rows as-is; the column falls back to "—"
+    // leave rows as-is; the columns fall back to "—"
   }
 
   res.status(200).json({


### PR DESCRIPTION
## Summary

The Inventory Orders table listed the raw `Order ID` and an `Expected Delivery` column. This replaces the `Order ID` column with the **partner name** (with a tooltip listing each item line's label, quantity, and price), and removes the `Expected Delivery` column.

## Changes

- **Backend** (`src/api/admin/inventory-orders/route.ts`): the list endpoint now resolves and attaches `partner` (name) and `order_lines` per row via the existing `query.graph` pass, mirroring how `unified_order_status` is already attached.
- **Admin UI** (`src/admin/routes/orders/inventory/page.tsx`): `Order ID` column → `Partner` display column with item-line tooltip; removed `Expected Delivery`.
- **Test** (`integration-tests/http/inventory-orders-api.spec.ts`): covers that an assigned order returns `partner.name` + `order_lines` and that an unassigned order still lists without a partner.

## Testing

- `TEST_TYPE=integration:http NODE_OPTIONS="--experimental-vm-modules" jest --testPathPattern="inventory-orders-api"` → 26 passed.