### PR TITLE
fix(admin): Save did nothing on the draft's items modal (#1446)

### DIFF
--- a/apps/backend/src/admin/routes/quotes/create/bulk-discount-panel.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/bulk-discount-panel.tsx
@@ -1,0 +1,109 @@
+import { Button, Input, Label, Text } from "@medusajs/ui"
+import { useState } from "react"
+import { UseFormReturn } from "react-hook-form"
+
+import { AdminQuoteCreateSchemaType } from "./schema"
+
+type Props = {
+  form: UseFormReturn<AdminQuoteCreateSchemaType>
+  /** The selected products, whose variants are the lines to fill. */
+  products: any[]
+}
+
+/**
+ * One percentage across the whole basket (#1446).
+ *
+ * ## Why it is not a quote-level discount
+ *
+ * 🔑 It writes into the PER-LINE fields rather than becoming a discount of its
+ * own. The backend stores the override per line with the rate and input it was
+ * reached by, because that is what makes a quoted number reproducible later — a
+ * basket-level percentage would have to be re-derived against catalogue prices
+ * that have since moved. So this is a typing shortcut with no server-side
+ * counterpart, which is exactly what it should be.
+ *
+ * ## Why it has its own step now
+ *
+ * It used to sit in a strip above the quantities DataGrid, competing with it
+ * for the same width and reading as a filter over the table rather than an
+ * action on it. A discount is a commercial decision, not a grid control: it
+ * deserves the room to say what it does to every line and what it clears.
+ *
+ * The per-line `Discount %` COLUMN stays in the grid. That is per-line data and
+ * belongs beside the line it prices; this is only the shortcut that fills it.
+ */
+export const BulkDiscountPanel = ({ form, products }: Props) => {
+  const [bulkDiscount, setBulkDiscount] = useState<string>("")
+
+  /**
+   * Fills every variant of every selected product, INCLUDING ones with no
+   * quantity yet: a line added afterwards would otherwise silently miss the
+   * discount the operator believes they applied to "everything".
+   */
+  const applyToAll = () => {
+    const percent = Number(bulkDiscount)
+    if (!Number.isFinite(percent) || percent <= 0 || percent > 100) return
+
+    const next: Record<string, number> = {}
+    for (const product of products) {
+      for (const variant of (product?.variants ?? []) as any[]) {
+        next[variant.id] = percent
+      }
+    }
+
+    form.setValue("discounts", next, { shouldDirty: true })
+    /**
+     * A flat unit price and a percentage are mutually exclusive per line, and
+     * the backend refuses both together. Applying a blanket percentage clears
+     * the prices it would otherwise collide with, rather than minting a basket
+     * that 400s on submit.
+     */
+    form.setValue("overrides", {}, { shouldDirty: true })
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex flex-wrap items-end gap-x-3 gap-y-2">
+        <div className="flex flex-col gap-y-1">
+          <Label size="small">Discount % on every line</Label>
+          <Input
+            type="number"
+            min={0}
+            max={100}
+            className="w-32"
+            placeholder="e.g. 15"
+            value={bulkDiscount}
+            onChange={(e) => setBulkDiscount(e.target.value)}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          size="small"
+          onClick={applyToAll}
+          disabled={!bulkDiscount}
+        >
+          Apply to all
+        </Button>
+      </div>
+
+      <Text size="small" className="text-ui-fg-subtle">
+        A shortcut for the column — every line is still quoted, stored and
+        audited individually, and any line can be overridden afterwards on the
+        Quantities step.
+      </Text>
+      <Text size="small" className="text-ui-fg-subtle">
+        It fills every variant of every product you picked, including ones with
+        no quantity yet, so a line added later does not silently miss the
+        discount. Applying it also <strong>clears any flat unit prices</strong>:
+        a percentage and a fixed price are mutually exclusive on a line, and the
+        backend refuses both together.
+      </Text>
+      {!products.length && (
+        <Text size="small" className="text-ui-fg-muted">
+          Nothing picked yet — there are no lines to discount.
+        </Text>
+      )}
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
@@ -11,7 +11,25 @@ import {
 } from "../../../../hooks/api/quote-buyer-sources"
 import { AdminQuoteCreateSchemaType } from "../schema"
 
-type Props = { form: UseFormReturn<AdminQuoteCreateSchemaType> }
+type Props = {
+  form: UseFormReturn<AdminQuoteCreateSchemaType>
+  /**
+   * Which blocks to render (#1446).
+   *
+   * This step holds three unrelated questions in one scroll: who the buyer is,
+   * which carrier is asked for a rate, and who pays the duty. On the draft page
+   * those are separate cards, because a draft ORDER keeps Customer and Shipping
+   * apart — you settle the buyer, add items, and only then add shipping.
+   *
+   * 🔑 A flag rather than three files. All three blocks share the same hooks —
+   * `region`, the carrier list, and `isDomesticLane`, which decides whether the
+   * duty block exists at all and is derived from the destination the BUYER
+   * block sets. Splitting the file would have duplicated that wiring.
+   *
+   * Default `"all"` leaves every existing caller rendering exactly what it did.
+   */
+  only?: "buyer" | "shipping" | "all"
+}
 
 /**
  * Step 2 — who the quote is for, and where it lands.
@@ -51,7 +69,9 @@ const DEFAULT_CARRIER = "__default__"
 /** The "type it yourself" branch, for a carrier registered after this build. */
 const OTHER_CARRIER = "__other__"
 
-export const BuyerStep = ({ form }: Props) => {
+export const BuyerStep = ({ form, only = "all" }: Props) => {
+  const showBuyer = only === "all" || only === "buyer"
+  const showShipping = only === "all" || only === "shipping"
   const [search, setSearch] = useState("")
   const { regions } = useQuoteRegions()
   const { options: buyers } = useQuoteBuyerOptions(search)
@@ -164,6 +184,8 @@ export const BuyerStep = ({ form }: Props) => {
 
   return (
     <div className="flex flex-col gap-y-8">
+      {showBuyer && (
+      <>
       <div className="flex flex-col gap-y-1">
         <Heading level="h2">Buyer</Heading>
         <Text size="small" className="text-ui-fg-subtle">
@@ -468,6 +490,11 @@ export const BuyerStep = ({ form }: Props) => {
         )}
       />
 
+      </>
+      )}
+
+      {showShipping && (
+      <>
       <div className="flex flex-col gap-y-1">
         <Heading level="h2">Freight source</Heading>
         <Text size="small" className="text-ui-fg-subtle">
@@ -822,6 +849,8 @@ export const BuyerStep = ({ form }: Props) => {
           </div>
         </div>
       ) : null}
+      </>
+      )}
     </div>
   )
 }

--- a/apps/backend/src/admin/routes/quotes/create/steps/quantities-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/quantities-step.tsx
@@ -9,6 +9,7 @@ import { DataGridNumberCell } from "../../../../components/data-grid/components/
 import { DataGridReadonlyCell } from "../../../../components/data-grid/components/data-grid-readonly-cell"
 import { createDataGridHelper } from "../../../../components/data-grid/helpers/create-data-grid-column-helper"
 import { useProducts } from "../../../../hooks/api/products"
+import { BulkDiscountPanel } from "../bulk-discount-panel"
 import { AdminLineDesignsPanel } from "../line-designs-panel"
 import { AdminQuoteCreateSchemaType } from "../schema"
 
@@ -24,6 +25,15 @@ type Props = {
    * to reach it. Stacked, it opens over the grid it annotates.
    */
   showDesignPanel?: boolean
+  /**
+   * Render the basket-wide discount strip above the grid.
+   *
+   * Default `true` keeps every existing caller unchanged. The draft's items
+   * modal passes `false` and gives it a step of its own: above the grid it
+   * competed for the same width and read as a FILTER over the table rather
+   * than an action on it.
+   */
+  showBulkDiscount?: boolean
 }
 
 type Row = any
@@ -59,7 +69,11 @@ const columnHelper = createDataGridHelper<Row, AdminQuoteCreateSchemaType>()
  * and the header says so. A number typed against a USD quote is otherwise read
  * as dollars; the conversion happens once at mint, at a rate the quote records.
  */
-export const QuantitiesStep = ({ form, showDesignPanel = true }: Props) => {
+export const QuantitiesStep = ({
+  form,
+  showDesignPanel = true,
+  showBulkDiscount = true,
+}: Props) => {
   const ids = useWatch({ control: form.control, name: "product_ids" })
   const { products } = useProducts({ limit: 100 } as any)
 
@@ -205,71 +219,13 @@ export const QuantitiesStep = ({ form, showDesignPanel = true }: Props) => {
     []
   )
 
-  /**
-   * One percentage across the whole basket (#1446).
-   *
-   * 🔑 It writes into the per-line fields rather than becoming a quote-level
-   * discount of its own. The backend stores the override PER LINE with the
-   * rate and input it was reached by, because that is what makes a quoted
-   * number reproducible later — a basket-level percentage would have to be
-   * re-derived against catalogue prices that have since moved. So this is a
-   * typing shortcut with no server-side counterpart, which is exactly what it
-   * should be.
-   *
-   * It fills every variant of every selected product, including ones with no
-   * quantity yet: a line added afterwards would otherwise silently miss the
-   * discount the operator believes they applied to "everything".
-   */
-  const [bulkDiscount, setBulkDiscount] = useState<string>("")
-
-  const applyToAll = () => {
-    const percent = Number(bulkDiscount)
-    if (!Number.isFinite(percent) || percent <= 0 || percent > 100) return
-
-    const next: Record<string, number> = {}
-    for (const product of selected) {
-      for (const variant of (product.variants ?? []) as Row[]) {
-        next[variant.id] = percent
-      }
-    }
-
-    form.setValue("discounts", next, { shouldDirty: true })
-    // A flat unit price and a percentage are mutually exclusive per line, and
-    // the backend refuses both together. Applying a blanket percentage clears
-    // the prices it would otherwise collide with, rather than minting a basket
-    // that 400s on submit.
-    form.setValue("overrides", {}, { shouldDirty: true })
-  }
-
   return (
     <div className="flex h-full flex-col">
-      <div className="flex flex-wrap items-end gap-x-3 gap-y-2 px-6 pb-4 md:px-16">
-        <div className="flex flex-col gap-y-1">
-          <Label size="small">Discount % on every line</Label>
-          <Input
-            type="number"
-            min={0}
-            max={100}
-            className="w-32"
-            placeholder="e.g. 15"
-            value={bulkDiscount}
-            onChange={(e) => setBulkDiscount(e.target.value)}
-          />
+      {showBulkDiscount && (
+        <div className="px-6 pb-4 md:px-16">
+          <BulkDiscountPanel form={form} products={selected} />
         </div>
-        <Button
-          type="button"
-          variant="secondary"
-          size="small"
-          onClick={applyToAll}
-          disabled={!bulkDiscount}
-        >
-          Apply to all
-        </Button>
-        <Text size="small" className="text-ui-fg-subtle">
-          A shortcut for the column — every line is still quoted, stored and
-          audited individually, and any line can be overridden afterwards.
-        </Text>
-      </div>
+      )}
 
       <DataGrid
         columns={columns}

--- a/apps/backend/src/admin/routes/quotes/drafts/[id]/draft-sections.tsx
+++ b/apps/backend/src/admin/routes/quotes/drafts/[id]/draft-sections.tsx
@@ -92,7 +92,7 @@ export const DraftSections = ({ draft }: { draft: AdminQuoteDraft }) => {
   const navigate = useNavigate()
   const [minted, setMinted] = useState<MintedQuoteResult | null>(null)
   const [readiness, setReadiness] = useState<QuoteReadiness | null>(null)
-  const [drawer, setDrawer] = useState<null | "buyer">(null)
+  const [drawer, setDrawer] = useState<null | "buyer" | "shipping">(null)
 
   const form = useForm<AdminQuoteCreateSchemaType>({
     defaultValues: {
@@ -405,6 +405,57 @@ export const DraftSections = ({ draft }: { draft: AdminQuoteDraft }) => {
             </div>
           </Container>
 
+          {/*
+            Shipping, as its own card (#1446).
+            
+            A draft order has one, and its position is the point: you settle the
+            customer, add items, and only THEN add shipping — because the lane
+            is quoted against the basket's weight, so it cannot be answered
+            before the basket exists. It used to be buried in the middle of the
+            buyer form, asked before there was anything to ship.
+          */}
+          <Container className="divide-y p-0">
+            <div className="flex items-center justify-between px-6 py-4">
+              <Heading level="h2">Shipping</Heading>
+              <ActionMenu
+                groups={[
+                  {
+                    actions: [
+                      {
+                        icon: <PencilSquare />,
+                        label: "Edit shipping & duty",
+                        onClick: () => setDrawer("shipping"),
+                      },
+                    ],
+                  },
+                ]}
+              />
+            </div>
+            <Row
+              label="Rate source"
+              value={
+                (draft as any).quoted_freight_source ||
+                "Platform default — a carrier is asked at mint"
+              }
+            />
+            <Row
+              label="Duty"
+              value={
+                (draft as any).duties_prepaid
+                  ? "We pay the import duty (DDP)"
+                  : "Buyer is importer of record"
+              }
+            />
+            {!lines.length && (
+              <div className="px-6 py-4">
+                <Text size="small" className="text-ui-fg-subtle">
+                  The lane is quoted against the basket's weight, so add items
+                  first — a rate asked now would be a rate for nothing.
+                </Text>
+              </div>
+            )}
+          </Container>
+
           {readiness && (
             <Container className="p-0">
               <div className="px-6 py-4">
@@ -460,13 +511,42 @@ export const DraftSections = ({ draft }: { draft: AdminQuoteDraft }) => {
       </TwoColumnPage>
 
       {/* ---- editing happens here, not on the page ---- */}
+      <Drawer
+        open={drawer === "shipping"}
+        onOpenChange={(o) => !o && setDrawer(null)}
+      >
+        <Drawer.Content>
+          <Drawer.Header>
+            <Drawer.Title>Shipping & duty</Drawer.Title>
+          </Drawer.Header>
+          <Drawer.Body className="overflow-y-auto">
+            <BuyerStep form={form} only="shipping" />
+          </Drawer.Body>
+          <Drawer.Footer>
+            <Drawer.Close asChild>
+              <Button variant="secondary" size="small">
+                Cancel
+              </Button>
+            </Drawer.Close>
+            {/*
+              The same field list as the buyer drawer: both write columns the
+              draft owns, and `saveBuyer` sends no `lines` key — which is what
+              stops either of them emptying the basket.
+            */}
+            <Button size="small" isLoading={isSaving} onClick={saveBuyer}>
+              Save
+            </Button>
+          </Drawer.Footer>
+        </Drawer.Content>
+      </Drawer>
+
       <Drawer open={drawer === "buyer"} onOpenChange={(o) => !o && setDrawer(null)}>
         <Drawer.Content>
           <Drawer.Header>
             <Drawer.Title>Buyer & terms</Drawer.Title>
           </Drawer.Header>
           <Drawer.Body className="overflow-y-auto">
-            <BuyerStep form={form} />
+            <BuyerStep form={form} only="buyer" />
           </Drawer.Body>
           <Drawer.Footer>
             <Drawer.Close asChild>

--- a/apps/backend/src/admin/routes/quotes/drafts/[id]/items/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/drafts/[id]/items/page.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Button, Heading, Text, toast } from "@medusajs/ui"
-import { useEffect, useMemo } from "react"
+import { Button, Heading, ProgressTabs, Text, toast } from "@medusajs/ui"
+import { useEffect, useMemo, useState } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import { useParams } from "react-router-dom"
 
@@ -15,6 +15,7 @@ import {
   useQuoteDraft,
   useUpdateQuoteDraft,
 } from "../../../../../hooks/api/quotes"
+import { BulkDiscountPanel } from "../../../create/bulk-discount-panel"
 import { AdminLineDesignsPanel } from "../../../create/line-designs-panel"
 import {
   AdminQuoteCreateSchema,
@@ -24,6 +25,24 @@ import { ProductsStep } from "../../../create/steps/products-step"
 import { QuantitiesStep } from "../../../create/steps/quantities-step"
 
 const DESIGNS_MODAL_ID = "quote-draft-line-designs"
+
+/**
+ * Picking WHAT, then saying HOW MANY — two steps, not one scroll.
+ *
+ * Both are full-width tables. Stacked vertically the operator picked products
+ * at the top, scrolled past the whole catalogue page, and met a quantities grid
+ * for rows they could no longer see. Worse, the grid renders a row per variant
+ * of every SELECTED product, so before anything is ticked it is simply empty —
+ * a second table showing nothing, under a first table showing everything.
+ *
+ * As steps each one owns the modal while it is being answered, and the second
+ * cannot be reached before the first has an answer to give it.
+ */
+enum ItemsTab {
+  PRODUCTS = "products",
+  QUANTITIES = "quantities",
+  DISCOUNT = "discount",
+}
 
 /**
  * Editing a draft's items (#1446).
@@ -112,6 +131,8 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draft?.id])
 
+  const [tab, setTab] = useState<ItemsTab>(ItemsTab.PRODUCTS)
+
   const { mutate: save, isPending } = useUpdateQuoteDraft(draftId, {
     onSuccess: () => {
       toast.success("Items saved.")
@@ -127,13 +148,30 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
    * which lines exist.
    */
   const pickedIds = useWatch({ control: form.control, name: "product_ids" })
+  /** What the first step has answered, watched so the second step reacts to it. */
+  const picked = (pickedIds ?? []) as any[]
   const { products } = useProducts({ limit: 100 } as any)
   const selectedProducts = useMemo(() => {
     const wanted = new Set(((pickedIds ?? []) as any[]).map((p) => p.id))
     return ((products ?? []) as any[]).filter((p) => wanted.has(p.id))
   }, [products, pickedIds])
 
-  const handleSubmit = form.handleSubmit(() => {
+  /**
+   * 🔴 NOT `form.handleSubmit`.
+   *
+   * The form is resolved against `AdminQuoteCreateSchema` — the WHOLE quote —
+   * because the steps it hosts are written against that shape. This modal
+   * hydrates only the partner, the lane and the basket, so `buyer_email`,
+   * `region_id` and the rest are absent and the schema fails. `handleSubmit`
+   * then never calls its callback: Save did nothing, silently, and the errors
+   * attached to fields this modal does not render — an error count with
+   * nothing on screen to point at.
+   *
+   * The basket is saved by reading the values directly, exactly as the draft
+   * page's drawers already do. The resolver stays for the DataGrid's own
+   * per-cell validation; it simply no longer gates a save it cannot judge.
+   */
+  const handleSave = () => {
     const values = form.getValues()
     const lines = Object.entries(values.quantities ?? {})
       .filter(([, qty]) => typeof qty === "number" && qty > 0)
@@ -152,7 +190,7 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
      * never empty it from another section.
      */
     save({ lines })
-  })
+  }
 
   /**
    * A skeleton, not a spinner and not nothing.
@@ -163,20 +201,67 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
    */
   if (isLoading || !draft) {
     return (
-      <RouteFocusModal.Body className="flex-1 overflow-y-auto p-6">
-        <TwoColumnPageSkeleton mainSections={2} sidebarSections={0} />
-      </RouteFocusModal.Body>
+      <>
+        {/*
+          🔴 The loading branch needs a `Title` too.
+          
+          The dialog is already mounted while the draft is being fetched, and a
+          branch that returns only a Body leaves Radix with an untitled dialog
+          for that whole window — which is exactly what a screen-reader user
+          meets first. The warning only appears on this route because only this
+          route has a loading branch.
+        */}
+        <RouteFocusModal.Header>
+          <RouteFocusModal.Title asChild>
+            <span className="sr-only">Edit items</span>
+          </RouteFocusModal.Title>
+        </RouteFocusModal.Header>
+        <RouteFocusModal.Body className="flex-1 overflow-y-auto p-6">
+          <TwoColumnPageSkeleton mainSections={2} sidebarSections={0} />
+        </RouteFocusModal.Body>
+      </>
     )
   }
 
   return (
     <RouteFocusModal.Form form={form}>
-      <KeyboundForm onSubmit={handleSubmit} className="flex h-full flex-col">
+      <ProgressTabs
+        value={tab}
+        onValueChange={(v) => setTab(v as ItemsTab)}
+        className="flex h-full flex-col overflow-hidden"
+      >
+        {/* Enter must not submit a schema this modal cannot satisfy. */}
+        <KeyboundForm
+          onSubmit={(e: any) => e.preventDefault()}
+          className="flex h-full flex-col"
+        >
         <RouteFocusModal.Header>
           <RouteFocusModal.Title asChild>
             <span className="sr-only">Edit items</span>
           </RouteFocusModal.Title>
-          <div className="flex w-full items-center justify-end gap-x-2">
+          <div className="flex w-full items-center justify-between gap-x-2">
+            <div className="-my-2 w-full max-w-[560px] border-l">
+              <ProgressTabs.List className="grid w-full grid-cols-3">
+                <ProgressTabs.Trigger
+                  status={picked.length ? "completed" : "in-progress"}
+                  value={ItemsTab.PRODUCTS}
+                >
+                  Products &amp; designs
+                </ProgressTabs.Trigger>
+                <ProgressTabs.Trigger
+                  status={tab === ItemsTab.QUANTITIES ? "in-progress" : "not-started"}
+                  value={ItemsTab.QUANTITIES}
+                >
+                  Quantities
+                </ProgressTabs.Trigger>
+                <ProgressTabs.Trigger
+                  status={tab === ItemsTab.DISCOUNT ? "in-progress" : "not-started"}
+                  value={ItemsTab.DISCOUNT}
+                >
+                  Discount
+                </ProgressTabs.Trigger>
+              </ProgressTabs.List>
+            </div>
             {/*
               🔴 `Trigger` and `Content` must share ONE `StackedFocusModal`
               root. With the trigger outside it, the click never reached the
@@ -228,12 +313,49 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
           </div>
         </RouteFocusModal.Header>
 
-        <RouteFocusModal.Body className="flex-1 overflow-y-auto">
-          <div className="flex flex-col gap-y-6">
+        <RouteFocusModal.Body className="flex-1 overflow-hidden">
+          <ProgressTabs.Content
+            className="size-full overflow-y-auto"
+            value={ItemsTab.PRODUCTS}
+          >
             <ProductsStep form={form} />
-            {/* The panel is lifted out of the step and stacked — see the header. */}
-            <QuantitiesStep form={form} showDesignPanel={false} />
-          </div>
+          </ProgressTabs.Content>
+
+          <ProgressTabs.Content
+            className="size-full overflow-y-auto"
+            value={ItemsTab.QUANTITIES}
+          >
+            {picked.length ? (
+              /* The design panel is lifted out and stacked — see the header. */
+              <QuantitiesStep
+                form={form}
+                showDesignPanel={false}
+                showBulkDiscount={false}
+              />
+            ) : (
+              <div className="px-6 py-8">
+                <Text size="small" className="text-ui-fg-subtle">
+                  Nothing picked yet. The grid shows a row per variant of the
+                  products you choose, so it has nothing to show until the first
+                  step has an answer.
+                </Text>
+              </div>
+            )}
+          </ProgressTabs.Content>
+
+          <ProgressTabs.Content
+            className="size-full overflow-y-auto"
+            value={ItemsTab.DISCOUNT}
+          >
+            <div className="px-6 py-6 md:px-16">
+              <Heading level="h2">Discount</Heading>
+              <Text size="small" className="text-ui-fg-subtle mb-6">
+                One percentage across the basket. A commercial decision, so it
+                gets its own step rather than a strip above the grid.
+              </Text>
+              <BulkDiscountPanel form={form} products={selectedProducts} />
+            </div>
+          </ProgressTabs.Content>
         </RouteFocusModal.Body>
 
         <RouteFocusModal.Footer>
@@ -243,13 +365,47 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
                 Cancel
               </Button>
             </RouteFocusModal.Close>
-            <Button type="submit" variant="primary" size="small" isLoading={isPending}>
+            {/*
+              🔴 Save is ALWAYS available, Continue is the extra.
+              
+              Gating Save behind the last step would make an operator who only
+              wanted to fix a quantity walk through Discount to persist it —
+              and steps exist here to stop two tables fighting for one screen,
+              not to impose an order on a basket that is already saved as a
+              whole.
+            */}
+            {tab !== ItemsTab.DISCOUNT && (
+              <Button
+                key="continue"
+                type="button"
+                variant="secondary"
+                size="small"
+                onClick={() =>
+                  setTab(
+                    tab === ItemsTab.PRODUCTS
+                      ? ItemsTab.QUANTITIES
+                      : ItemsTab.DISCOUNT
+                  )
+                }
+              >
+                Continue
+              </Button>
+            )}
+            <Button
+              key="submit"
+              type="button"
+              variant="primary"
+              size="small"
+              isLoading={isPending}
+              onClick={handleSave}
+            >
               Save
             </Button>
           </div>
         </RouteFocusModal.Footer>
 
-      </KeyboundForm>
+        </KeyboundForm>
+      </ProgressTabs>
     </RouteFocusModal.Form>
   )
 }

--- a/e2e/specs/admin-quote-drafts.spec.ts
+++ b/e2e/specs/admin-quote-drafts.spec.ts
@@ -136,6 +136,12 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.waitForURL(/\/app\/quotes\/drafts\//, { timeout: 30000 })
 
     await expect(page.getByRole("heading", { name: "Summary" })).toBeVisible()
+    /**
+     * Shipping is its OWN card, as a draft order has — and its position is the
+     * point. The lane is quoted against the basket's weight, so it is asked
+     * after the items rather than buried mid-way through the buyer form.
+     */
+    await expect(page.getByRole("heading", { name: "Shipping" })).toBeVisible()
     await expect(page.getByRole("heading", { name: "Buyer" })).toBeVisible()
     await expect(page.getByRole("button", { name: "Mint quote" })).toBeVisible()
 
@@ -170,6 +176,36 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.waitForURL(/\/items$/, { timeout: 30000 })
 
     await expect(page.getByRole("dialog")).toHaveCount(1)
+
+    /**
+     * Two steps, not one scroll. Both halves are full-width tables, and the
+     * quantities grid renders a row per variant of the SELECTED products — so
+     * before anything is ticked it is empty. Stacked vertically that was a
+     * second table showing nothing beneath a first table showing everything.
+     */
+    await expect(page.getByRole("tab", { name: /Products/ })).toBeVisible()
+    await expect(page.getByRole("tab", { name: "Quantities" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "Continue" })).toBeVisible()
+
+    await expect(page.getByRole("tab", { name: "Discount" })).toBeVisible()
+
+    /**
+     * 🔴 Save is available on EVERY step. It was briefly gated behind the last
+     * one, which made an operator who only wanted to fix a quantity walk
+     * through Discount to persist it.
+     */
+    await expect(page.getByRole("button", { name: "Save" })).toBeVisible()
+
+    await page.getByRole("checkbox").nth(1).click()
+    await page.getByRole("button", { name: "Continue" }).click()
+
+    /**
+     * The basket-wide discount is NOT a strip above the grid any more — there
+     * it competed for the same width and read as a filter over the table
+     * rather than an action on it.
+     */
+    await expect(page.getByPlaceholder("e.g. 15")).toHaveCount(0)
+
     await page.getByRole("button", { name: "Designs per line" }).click()
 
     // Stacked ON TOP — the editor underneath must still be there.
@@ -177,6 +213,40 @@ test.describe("Admin quote drafts (#1446)", () => {
       page.getByRole("heading", { name: "Designs per line" })
     ).toBeVisible({ timeout: 15000 })
     await expect(page.getByRole("dialog")).not.toHaveCount(0)
+  })
+
+  /**
+   * 🔴 The regression the founder hit: Save did nothing and showed an error
+   * count with nothing on screen.
+   *
+   * The form is resolved against the WHOLE quote schema, because the steps it
+   * hosts are written against that shape — but this modal hydrates only the
+   * partner, the lane and the basket. `form.handleSubmit` therefore never
+   * called its callback, and the errors attached to fields this modal does not
+   * render. The basket is saved by reading values directly instead.
+   */
+  test("🔑 saving the basket actually persists it", async ({ page }) => {
+    await login(page)
+    await openStartModal(page)
+    await page.getByText("Select a partner").click()
+    await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
+    await page.getByText("Select a region").click()
+    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("button", { name: "Save" }).click()
+    await page.waitForURL(/\/app\/quotes\/drafts\//, { timeout: 30000 })
+
+    await page.locator('[aria-label="Open actions menu"]').nth(1).click()
+    await page.getByRole("menuitem", { name: /Edit items/ }).click()
+    await page.waitForURL(/\/items$/, { timeout: 30000 })
+
+    await page.getByRole("checkbox").nth(1).click()
+    await page.getByRole("button", { name: "Continue" }).click()
+    await page.locator('input[name^="quantities."]').first().fill("500")
+    await page.getByRole("button", { name: "Save" }).click()
+
+    // Back on the draft, and the units are on the record — not zero.
+    await page.waitForURL(/\/app\/quotes\/drafts\/[^/]+$/, { timeout: 30000 })
+    await expect(page.getByText("500")).toBeVisible({ timeout: 15000 })
   })
 
   test("the buyer drawer saves without emptying the basket", async ({ page }) => {


### PR DESCRIPTION
## 🔴 The bug you hit

Picking products, typing a quantity and pressing **Save persisted nothing**, showed an error count, and put no error on screen.

The form is resolved against `AdminQuoteCreateSchema` — the **whole quote** — because the steps it hosts are written against that shape. The items modal hydrates only the partner, the lane and the basket, so `buyer_email`, `region_id` and the rest were absent and the schema failed. `form.handleSubmit` therefore **never called its callback**, and the errors attached to fields this modal does not render. An invisible refusal.

The basket is now saved by reading the values directly, exactly as the draft page's drawers already do. The resolver stays for the DataGrid's own per-cell validation; it simply no longer gates a save it cannot judge.

Reproduced **before** the fix — `LINES PERSISTED: 0`, `form errors visible: 0`, URL unchanged — and **after** — `LINES PERSISTED: 1`, navigated back. There is now an e2e case that fails if it regresses.

## Items is stepped

**Products & designs → Quantities → Discount.**

Both halves are full-width tables, and the quantities grid renders a row per variant of the *selected* products — so stacked vertically it was a second table showing nothing beneath a first table showing everything.

Save stays available on **every** step. I briefly gated it behind the last one, which would have made an operator who only wanted to fix a quantity walk through Discount to persist it.

## The discount gets its own step

Above the grid it competed for the same width and read as a *filter over* the table rather than an *action on* it.

It still writes into the **per-line** fields rather than becoming a quote-level discount — the backend stores the override per line with the rate it was reached by, which is what makes a quoted number reproducible later; a basket-level percentage would have to be re-derived against catalogue prices that have since moved. The per-line `Discount %` **column stays in the grid**, beside the line it prices.

Verified live: applying 15% on the Discount step writes `15` into the per-line column on the Quantities step.

## Shipping is its own card

As a draft order has — and its position is the point: **the lane is quoted against the basket's weight**, so it is asked *after* the items rather than buried mid-way through the buyer form. The card says so when the basket is still empty.

`BuyerStep` gained an `only` flag rather than being split into three files, because all three blocks share `region`, the carrier list and `isDomesticLane` — which decides whether the duty block exists at all and is derived from the destination the buyer block sets. Default `"all"` leaves every existing caller rendering exactly what it did.

## One more accessibility gap

The items modal's **loading branch had no dialog `Title`**, so Radix warned that screen-reader users meet an untitled dialog for the whole fetch window. Console is clean on both routes now.

## Tests

**1063 unit tests green.** `check:prod-build`: only the pre-existing `@jest/core` error, red on `main` all session and tolerated by CI; frontend build (which covers all of this) succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
