### PR TITLE
fix(admin): the Summary card kept saying 'No items yet' after a save

### DIFF
--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -10,6 +10,21 @@ import {
 import { sdk } from "../../lib/config"
 import { queryKeysFactory } from "../../lib/query-key-factory"
 
+/**
+ * 🔴 In every mutation below, `...options` is spread BEFORE `onSuccess`.
+ *
+ * The other order — which 165 mutation hooks across this admin still use — means
+ * a caller that passes its own `onSuccess` **replaces** the hook's, and the
+ * cache invalidation inside it never runs. The symptom is not an error: the
+ * mutation succeeds, the toast fires, the page navigates, and the screen keeps
+ * showing the old row until a hard refresh.
+ *
+ * That is exactly what happened here — saving items on a draft left the Summary
+ * card saying "No items yet" while the row had 500 units on it.
+ *
+ * Spreading first lets the hook's own `onSuccess` win and call the caller's
+ * from inside it, so both run.
+ */
 const QUOTES_QUERY_KEY = "quotes" as const
 export const quoteQueryKeys = queryKeysFactory(QUOTES_QUERY_KEY)
 
@@ -232,11 +247,11 @@ export const useMintQuote = (
         method: "POST",
         body: payload,
       }),
+    ...options,
     onSuccess: (data, variables, _mutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: quoteQueryKeys.lists() })
       options?.onSuccess?.(data, variables, _mutateResult, context)
     },
-    ...options,
   })
 }
 
@@ -255,6 +270,7 @@ export const useRevokeQuote = (
         `/admin/quotes/${id}/revoke`,
         { method: "POST" }
       ),
+    ...options,
     onSuccess: (data, variables, _mutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: quoteQueryKeys.lists() })
       // The detail carries the status badge AND the activity timeline the
@@ -264,7 +280,6 @@ export const useRevokeQuote = (
       })
       options?.onSuccess?.(data, variables, _mutateResult, context)
     },
-    ...options,
   })
 }
 
@@ -410,6 +425,7 @@ export const useMintDesignVariant = (
         `/admin/quotes/designs/${payload.design_id}/variant`,
         { method: "POST", body: { currency_code: payload.currency_code } }
       ),
+    ...options,
     onSuccess: (data, variables, _mutateResult, context) => {
       // The design now resolves to a variant, so the picker's rows are stale.
       queryClient.invalidateQueries({
@@ -417,7 +433,6 @@ export const useMintDesignVariant = (
       })
       options?.onSuccess?.(data, variables, _mutateResult, context)
     },
-    ...options,
   })
 }
 
@@ -486,11 +501,11 @@ export const useCreateQuoteDraft = (
         method: "POST",
         body: payload,
       }),
+    ...options,
     onSuccess: (data, vars, _mutateResult, ctx) => {
       queryClient.invalidateQueries({ queryKey: quoteQueryKeys.lists() })
       options?.onSuccess?.(data, vars, _mutateResult, ctx)
     },
-    ...options,
   })
 }
 
@@ -513,13 +528,13 @@ export const useUpdateQuoteDraft = (
         `/admin/quotes/drafts/${id}`,
         { method: "PATCH", body: payload }
       ),
+    ...options,
     onSuccess: (data, vars, _mutateResult, ctx) => {
       queryClient.invalidateQueries({
         queryKey: quoteQueryKeys.detail(`draft-${id}`),
       })
       options?.onSuccess?.(data, vars, _mutateResult, ctx)
     },
-    ...options,
   })
 }
 
@@ -534,11 +549,11 @@ export const useMintQuoteDraft = (
         `/admin/quotes/drafts/${id}/mint`,
         { method: "POST" }
       ),
+    ...options,
     onSuccess: (data, vars, _mutateResult, ctx) => {
       queryClient.invalidateQueries({ queryKey: quoteQueryKeys.lists() })
       options?.onSuccess?.(data, vars, _mutateResult, ctx)
     },
-    ...options,
   })
 }
 
@@ -554,10 +569,10 @@ export const useDeleteQuoteDraft = (
         `/admin/quotes/drafts/${id}`,
         { method: "DELETE" }
       ),
+    ...options,
     onSuccess: (data, vars, _mutateResult, ctx) => {
       queryClient.invalidateQueries({ queryKey: quoteQueryKeys.lists() })
       options?.onSuccess?.(data, vars, _mutateResult, ctx)
     },
-    ...options,
   })
 }


### PR DESCRIPTION
Saving items on a draft left the Summary card showing an empty basket while the row had 500 units on it. A hard refresh fixed it — which is the tell.

## The cause

`...options` was spread **after** `onSuccess`:

```ts
return useMutation({
  mutationFn: …,
  onSuccess: (data, vars, _r, ctx) => {
    queryClient.invalidateQueries({ queryKey: … })   // ← never runs
    options?.onSuccess?.(data, vars, _r, ctx)
  },
  ...options,        // 🔴 the caller's onSuccess REPLACES the one above
})
```

The items modal passes its own `onSuccess` to toast and navigate, so it **replaced** the hook's — and the `invalidateQueries` inside it never ran.

It is not an error. The mutation succeeds, the toast fires, the modal closes, the page navigates, and the screen keeps showing the stale row. It reads as "the save didn't work", so the instinct is to look at the route rather than at the hook.

Spreading first lets the hook's own `onSuccess` win and call the caller's from inside it, so both run. All 7 quote mutations reordered.

## Verified in a browser

| | before | after |
|---|---|---|
| Summary after save, no reload | still "No items yet" | **shows 500** |
| Summary after hard reload | shows 500 | shows 500 |

The Buyer card picks up a contact name the same way, and the Shipping card shares the hook.

## ⚠️ This is repo-wide

I audited every `useMutation` block under `src/admin/hooks/api/`: **165 hooks across 37 files** use the broken order — `designs.ts` (22), `production-runs.ts` (17), `payment-submissions.ts` (11), `persons.ts` (9), `inventory-orders.ts` (8) and on down. **26 already use the correct order**, so the pattern is inconsistent rather than uniformly wrong; those must not be "fixed".

Filed as **#1800** rather than swept here. The change is mechanical, but it turns invalidation back on across the entire admin, so it wants reviewable batches per file — not one commit touching 37 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
