### PR TITLE
fix(admin): draft quotes discarded the per-line trade price (#1806)

### DIFF
--- a/apps/backend/integration-tests/http/admin-quote-draft-trade-price.spec.ts
+++ b/apps/backend/integration-tests/http/admin-quote-draft-trade-price.spec.ts
@@ -1,0 +1,207 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { PARTNER_QUOTE_MODULE } from "../../src/modules/partner-quote"
+import {
+  setupQuoteFixture,
+  type QuoteFixture,
+  VARIANT_A_TIER_PRICE,
+} from "../helpers/setup-quote-fixture"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * A negotiated price typed into a DRAFT reaches the minted quote (#1806).
+ *
+ * ## Why this could not be caught by the unit suites
+ *
+ * Every layer was individually fine. The grid bound a "Unit price" cell, the
+ * draft validator accepted `override_unit_amount`, and `mintQuoteWorkflow` had
+ * frozen per-line overrides correctly since #1439 S7 — with its own container
+ * suite proving it. What nobody owned was the JOURNEY: the save built a line
+ * without the number, the PATCH wrote five columns, and the mint body named
+ * five fields. Three silent drops in a row, each in a file whose own tests
+ * passed.
+ *
+ * So the assertions here are deliberately end-to-end and about a NUMBER, never
+ * about a 200: type a trade price, save it, read the row back, mint, and check
+ * what the buyer was actually quoted. "Items saved." is not evidence.
+ */
+
+const loud = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+  try {
+    return await fn()
+  } catch (e: any) {
+    console.log(`[${label}] ${e.response?.status}`, JSON.stringify(e.response?.data))
+    throw e
+  }
+}
+
+setupSharedTestSuite(() => {
+  describe("the draft rail carries a per-line trade price (#1806)", () => {
+    let seed: QuoteFixture
+    let adminHeaders: any
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+      seed = await setupQuoteFixture(api, getContainer)
+    })
+
+    const readLines = async (quoteId: string) => {
+      const container = getSharedTestEnv().getContainer()
+      const service: any = container.resolve(PARTNER_QUOTE_MODULE)
+      return await service.listPartnerQuoteLines({ quote_id: quoteId })
+    }
+
+    const startDraft = async (label: string) => {
+      const { api } = getSharedTestEnv()
+      const res = await loud(label, () =>
+        api.post(
+          "/admin/quotes/drafts",
+          {
+            partner_id: seed.partnerId,
+            destination_country_code: "in",
+            destination_postal_code: "400001",
+            destination_city: "Mumbai",
+            currency_code: seed.currencyCode,
+            region_id: seed.regionId,
+            buyer_email: `buyer-${label}-${seed.unique}@jaalyantra.test`,
+          },
+          adminHeaders
+        )
+      )
+      return res.data.draft.id as string
+    }
+
+    /**
+     * 🔑 The assertion the issue asked for: re-read the row, do not trust the
+     * toast. A save that persists nothing and a save that persists everything
+     * return the same 200.
+     */
+    it("persists a flat unit price on the draft line", async () => {
+      const { api } = getSharedTestEnv()
+      const draftId = await startDraft("flat")
+
+      await loud("patch-flat", () =>
+        api.patch(
+          `/admin/quotes/drafts/${draftId}`,
+          {
+            lines: [
+              {
+                variant_id: seed.variantA.id,
+                quantity: 25,
+                override_unit_amount: 19000,
+              },
+            ],
+          },
+          adminHeaders
+        )
+      )
+
+      const [line] = await readLines(draftId)
+      expect(line.override_kind).toBe("override_unit_amount")
+      expect(Number(line.override_input_amount)).toBe(19000)
+      /**
+       * 🔑 And the product the variant belongs to, which the browser does not
+       * send. The items modal rebuilds its product selection from this column,
+       * and the grid renders a row per variant of the SELECTED products — saved
+       * null, a reopened draft shows an empty grid over a full basket, with no
+       * row to type a price onto.
+       */
+      expect(line.product_id).toBe(seed.productId)
+    })
+
+    it("persists a discount and an operator-typed weight", async () => {
+      const { api } = getSharedTestEnv()
+      const draftId = await startDraft("pct")
+
+      await loud("patch-pct", () =>
+        api.patch(
+          `/admin/quotes/drafts/${draftId}`,
+          {
+            lines: [
+              {
+                variant_id: seed.variantA.id,
+                quantity: 25,
+                discount_percent: 20,
+                unit_weight_grams: 415,
+              },
+            ],
+          },
+          adminHeaders
+        )
+      )
+
+      const [line] = await readLines(draftId)
+      expect(line.override_kind).toBe("discount_percent")
+      expect(Number(line.override_input_amount)).toBe(20)
+      expect(Number(line.quoted_unit_weight_grams)).toBe(415)
+      // The provenance travels with the number, at the moment it is typed.
+      expect(line.quoted_weight_source).toBe("manual")
+    })
+
+    /**
+     * 🔴 The whole point. Before this, the draft minted at catalogue no matter
+     * what had been typed — so the assertion is on the FROZEN unit amount of
+     * the quote the buyer receives, not on anything the draft says.
+     */
+    it("mints at the negotiated price, not at catalogue", async () => {
+      const { api } = getSharedTestEnv()
+      const draftId = await startDraft("mint")
+
+      await loud("patch-mint", () =>
+        api.patch(
+          `/admin/quotes/drafts/${draftId}`,
+          {
+            lines: [
+              { variant_id: seed.variantA.id, quantity: 25, discount_percent: 20 },
+            ],
+          },
+          adminHeaders
+        )
+      )
+
+      const res = await loud("mint", () =>
+        api.post(`/admin/quotes/drafts/${draftId}/mint`, {}, adminHeaders)
+      )
+
+      const quoteId = res.data.quote.id
+      const lines = await readLines(quoteId)
+
+      const expected = Math.round(VARIANT_A_TIER_PRICE * 0.8 * 100) / 100
+      expect(Number(lines[0].quoted_unit_amount)).toBe(expected)
+      expect(lines[0].override_kind).toBe("discount_percent")
+      expect(Number(lines[0].override_input_amount)).toBe(20)
+      // And the catalogue price is NOT what was quoted — the assertion that
+      // fails on the old code.
+      expect(Number(lines[0].quoted_unit_amount)).not.toBe(VARIANT_A_TIER_PRICE)
+    })
+
+    /**
+     * "Which one wins" must not have an answer, and the refusal belongs where
+     * the number is stored rather than minutes later at the mint.
+     */
+    it("refuses a line carrying both a discount and a flat price", async () => {
+      const { api } = getSharedTestEnv()
+      const draftId = await startDraft("both")
+
+      await expect(
+        api.patch(
+          `/admin/quotes/drafts/${draftId}`,
+          {
+            lines: [
+              {
+                variant_id: seed.variantA.id,
+                quantity: 25,
+                discount_percent: 20,
+                override_unit_amount: 19000,
+              },
+            ],
+          },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+})

--- a/apps/backend/src/admin/routes/quotes/create/__tests__/draft-lines.unit.spec.ts
+++ b/apps/backend/src/admin/routes/quotes/create/__tests__/draft-lines.unit.spec.ts
@@ -1,0 +1,227 @@
+import {
+  basketFromDraftLines,
+  conflictingOverrides,
+  draftLinesFromForm,
+} from "../draft-lines"
+
+/**
+ * The basket mapping, both directions (#1806).
+ *
+ * The defect this exists to stop is not exotic: the grid collected a negotiated
+ * unit price, the save built a line without it, and the operator was told
+ * "Items saved." The assertions below are therefore about what is SENT and what
+ * is READ BACK, never about whether a call succeeded.
+ */
+describe("draftLinesFromForm", () => {
+  it("carries the negotiated unit price onto the line", () => {
+    const lines = draftLinesFromForm({
+      quantities: { var_1: 500 },
+      overrides: { var_1: 1200 },
+    })
+
+    expect(lines).toEqual([
+      { variant_id: "var_1", quantity: 500, position: 0, override_unit_amount: 1200 },
+    ])
+  })
+
+  it("carries a discount percentage", () => {
+    const lines = draftLinesFromForm({
+      quantities: { var_1: 500 },
+      discounts: { var_1: 12.5 },
+    })
+
+    expect(lines[0].discount_percent).toBe(12.5)
+    expect("override_unit_amount" in lines[0]).toBe(false)
+  })
+
+  it("carries the operator-typed weight", () => {
+    const lines = draftLinesFromForm({
+      quantities: { var_1: 20 },
+      weights: { var_1: 115 },
+    })
+
+    expect(lines[0].unit_weight_grams).toBe(115)
+  })
+
+  /**
+   * 🔴 A blank DataGrid cell arrives as 0, and a 0 here is not "no answer": a
+   * zero unit price asks the backend to mint an ACTIVE price of zero, and a
+   * zero weight is a consignment every carrier rates at its floor (#1430).
+   */
+  it("drops a zero price, a zero weight and a zero discount as blanks", () => {
+    const lines = draftLinesFromForm({
+      quantities: { var_1: 500 },
+      overrides: { var_1: 0 },
+      discounts: { var_1: 0 },
+      weights: { var_1: 0 },
+    })
+
+    expect(lines[0]).toEqual({ variant_id: "var_1", quantity: 500, position: 0 })
+  })
+
+  it("leaves an untouched line exactly as it was", () => {
+    const lines = draftLinesFromForm({
+      quantities: { var_1: 500 },
+      overrides: {},
+      discounts: {},
+      design_by_variant: { var_1: "des_1" },
+    })
+
+    expect(lines[0]).toEqual({
+      variant_id: "var_1",
+      quantity: 500,
+      position: 0,
+      design_id: "des_1",
+    })
+  })
+
+  it("drops variants with no quantity, and only those", () => {
+    const lines = draftLinesFromForm({
+      quantities: { var_1: 0, var_2: 3 },
+      overrides: { var_1: 900, var_2: 800 },
+    })
+
+    expect(lines.map((l) => l.variant_id)).toEqual(["var_2"])
+    expect(lines[0].override_unit_amount).toBe(800)
+  })
+
+  /** A flat price and a percentage never travel together. */
+  it("sends the flat price alone when both cells are filled", () => {
+    const lines = draftLinesFromForm({
+      quantities: { var_1: 10 },
+      discounts: { var_1: 10 },
+      overrides: { var_1: 900 },
+    })
+
+    expect(lines[0].override_unit_amount).toBe(900)
+    expect("discount_percent" in lines[0]).toBe(false)
+  })
+})
+
+describe("conflictingOverrides", () => {
+  it("names the lines carrying both forms", () => {
+    expect(
+      conflictingOverrides({
+        quantities: { var_1: 10, var_2: 10 },
+        discounts: { var_1: 10, var_2: 10 },
+        overrides: { var_1: 900 },
+      })
+    ).toEqual(["var_1"])
+  })
+
+  it("is silent when each line answers one way", () => {
+    expect(
+      conflictingOverrides({
+        quantities: { var_1: 10, var_2: 10 },
+        discounts: { var_2: 10 },
+        overrides: { var_1: 900, var_2: 0 },
+      })
+    ).toEqual([])
+  })
+})
+
+describe("basketFromDraftLines", () => {
+  it("reads the stored trade price back into the grid's cells", () => {
+    const basket = basketFromDraftLines([
+      {
+        variant_id: "var_1",
+        quantity: 500,
+        override_kind: "override_unit_amount",
+        override_input_amount: 1200,
+        quoted_unit_weight_grams: 115,
+      },
+      {
+        variant_id: "var_2",
+        quantity: 10,
+        override_kind: "discount_percent",
+        override_input_amount: 12.5,
+      },
+    ])
+
+    expect(basket.overrides).toEqual({ var_1: 1200 })
+    expect(basket.discounts).toEqual({ var_2: 12.5 })
+    expect(basket.weights).toEqual({ var_1: 115 })
+  })
+
+  /**
+   * 🔴 `Number(null)` is `0`. Coercing before the guard would read a typed zero
+   * back onto every ordinary line — and the next save would send it.
+   */
+  it("leaves an ordinary line's cells empty rather than zero", () => {
+    const basket = basketFromDraftLines([
+      { variant_id: "var_1", quantity: 500, override_input_amount: null },
+    ])
+
+    expect(basket.discounts).toEqual({})
+    expect(basket.overrides).toEqual({})
+    expect(basket.weights).toEqual({})
+  })
+
+  /**
+   * 🔴 Both steps read `product_ids` as `ids.map((p) => p.id)`. Hydrated as
+   * bare strings that yields `undefined`, the selected set matches nothing, and
+   * a saved draft reopens with an EMPTY quantities grid over a full basket —
+   * no row to type a trade price onto.
+   */
+  it("hydrates product_ids as the { id } objects the steps read", () => {
+    const basket = basketFromDraftLines([
+      { variant_id: "var_1", product_id: "prod_1", quantity: 1 },
+      { variant_id: "var_2", product_id: "prod_1", quantity: 1 },
+      { variant_id: "var_3", product_id: "prod_2", quantity: 1 },
+    ])
+
+    expect(basket.product_ids).toEqual([{ id: "prod_1" }, { id: "prod_2" }])
+    expect(basket.product_ids.map((p) => p.id)).toEqual(["prod_1", "prod_2"])
+  })
+
+  /** A bigNumber column can arrive as a string. */
+  it("reads a stringified amount", () => {
+    const basket = basketFromDraftLines([
+      {
+        variant_id: "var_1",
+        quantity: 1,
+        override_kind: "override_unit_amount",
+        override_input_amount: "1200",
+      },
+    ])
+
+    expect(basket.overrides).toEqual({ var_1: 1200 })
+  })
+
+  /**
+   * 🔑 The round trip is the real assertion. Whatever the save sends, reopening
+   * the modal must produce the same cells — a trip that loses a field is the
+   * same silent discard wearing a different coat.
+   */
+  it("survives a round trip through the stored columns", () => {
+    const values = {
+      quantities: { var_1: 500, var_2: 10 },
+      overrides: { var_1: 1200 },
+      discounts: { var_2: 12.5 },
+      weights: { var_1: 115 },
+      design_by_variant: { var_2: "des_9" },
+    }
+
+    const stored = draftLinesFromForm(values).map((l) => ({
+      variant_id: l.variant_id,
+      quantity: l.quantity,
+      design_id: l.design_id ?? null,
+      override_kind:
+        l.override_unit_amount !== undefined
+          ? ("override_unit_amount" as const)
+          : l.discount_percent !== undefined
+            ? ("discount_percent" as const)
+            : null,
+      override_input_amount: l.override_unit_amount ?? l.discount_percent ?? null,
+      quoted_unit_weight_grams: l.unit_weight_grams ?? null,
+    }))
+
+    const basket = basketFromDraftLines(stored)
+
+    expect(basket.quantities).toEqual(values.quantities)
+    expect(basket.overrides).toEqual(values.overrides)
+    expect(basket.discounts).toEqual(values.discounts)
+    expect(basket.weights).toEqual(values.weights)
+    expect(basket.design_by_variant).toEqual(values.design_by_variant)
+  })
+})

--- a/apps/backend/src/admin/routes/quotes/create/draft-lines.ts
+++ b/apps/backend/src/admin/routes/quotes/create/draft-lines.ts
@@ -1,0 +1,183 @@
+/**
+ * The basket, both ways: form → draft lines, and draft lines → form (#1806).
+ *
+ * ## Why this is a module and not two inline `.map`s
+ *
+ * The grid renders a **Discount %** and a **Unit price** column, and for three
+ * months every layer between them and the mint dropped the number. The operator
+ * typed a negotiated price, saw *"Items saved."*, and the quote minted at
+ * retail — the single worst way for a save to fail, because the screen agreed
+ * with them.
+ *
+ * The reason it could happen twice over is that the basket is built in TWO
+ * places: the items modal's Save, and the draft page's Mint (which re-saves the
+ * basket from its own form first, so a mapping that forgets a field there wipes
+ * one the modal had just persisted). Two homes for one mapping is how this
+ * regresses. There is one home now, and it is tested.
+ *
+ * 🔑 The pair is deliberately symmetrical: whatever `draftLinesFromForm` sends,
+ * `basketFromDraftLines` must be able to read back. A round trip that loses a
+ * field is the same silent discard wearing a different coat.
+ */
+
+/** The per-variant maps the grid writes into. */
+export type BasketFormValues = {
+  quantities?: Record<string, number | null | undefined> | null
+  discounts?: Record<string, number | null | undefined> | null
+  overrides?: Record<string, number | null | undefined> | null
+  weights?: Record<string, number | null | undefined> | null
+  design_by_variant?: Record<string, string> | null
+}
+
+/** A line as the draft PATCH / mint bodies accept it. */
+export type DraftLinePayload = {
+  variant_id: string
+  quantity: number
+  position: number
+  design_id?: string
+  discount_percent?: number
+  override_unit_amount?: number
+  unit_weight_grams?: number
+}
+
+/**
+ * A number the operator actually gave.
+ *
+ * 🔴 `> 0`, not `!= null`. A blank cell in the DataGrid arrives as `0` or `""`
+ * on its way through, and a zero is not "no answer" here — a 0 unit price asks
+ * the backend to mint an ACTIVE price of zero, and a 0 weight is a weightless
+ * consignment every carrier rates at its floor (#1430). Both are refused
+ * downstream, but they must never be SENT as though they were typed.
+ *
+ * A 0% discount is likewise indistinguishable from an empty cell, and means
+ * exactly the same thing — retail — so dropping it costs nothing.
+ */
+const typed = (value: unknown): number | undefined => {
+  const n = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+/**
+ * Build the basket the draft rail persists.
+ *
+ * Lines are keyed by variant because that is how every per-line map in the form
+ * is keyed — one basket, not four that have to be kept in step.
+ */
+export const draftLinesFromForm = (
+  values: BasketFormValues
+): DraftLinePayload[] =>
+  Object.entries(values.quantities ?? {})
+    .filter(([, qty]) => typeof qty === "number" && qty > 0)
+    .map(([variant_id, quantity], index) => {
+      const discount = typed(values.discounts?.[variant_id])
+      const override = typed(values.overrides?.[variant_id])
+      const weight = typed(values.weights?.[variant_id])
+      const design = values.design_by_variant?.[variant_id]
+
+      return {
+        variant_id,
+        quantity: quantity as number,
+        position: index,
+        ...(design ? { design_id: design } : {}),
+        /**
+         * 🔑 The override WINS when both are somehow set. The schemas refuse
+         * the pair on both rails, so this is unreachable through the API — but
+         * an operator can type into both cells, and sending both would meet
+         * them as a 400 naming a field rather than as the flat price they just
+         * asked for. `conflictingOverrides` reports it so the modal can say so
+         * before saving.
+         */
+        ...(override !== undefined
+          ? { override_unit_amount: override }
+          : discount !== undefined
+            ? { discount_percent: discount }
+            : {}),
+        ...(weight !== undefined ? { unit_weight_grams: weight } : {}),
+      }
+    })
+
+/**
+ * Variant ids where the operator has typed BOTH a discount and a flat price.
+ *
+ * "Which one wins" is not a question that should have an answer — the mint
+ * validator refuses the pair outright. Named here so the modal can refuse it
+ * with the line in hand instead of forwarding a 400.
+ */
+export const conflictingOverrides = (values: BasketFormValues): string[] =>
+  Object.entries(values.quantities ?? {})
+    .filter(([, qty]) => typeof qty === "number" && qty > 0)
+    .filter(
+      ([variant_id]) =>
+        typed(values.discounts?.[variant_id]) !== undefined &&
+        typed(values.overrides?.[variant_id]) !== undefined
+    )
+    .map(([variant_id]) => variant_id)
+
+/** A stored draft line, as the GET returns it. */
+export type StoredDraftLine = {
+  variant_id: string
+  product_id?: string | null
+  design_id?: string | null
+  quantity: number
+  override_kind?: "discount_percent" | "override_unit_amount" | null
+  override_input_amount?: number | string | null
+  quoted_unit_weight_grams?: number | string | null
+}
+
+/**
+ * The reverse: rebuild the form's per-variant maps from what was stored.
+ *
+ * Without this the modal reopens with the price cells blank over a line that
+ * HAS a negotiated price — and the next Save, built from those blanks, erases
+ * it. A hydration gap and a save gap produce the same lost number.
+ *
+ * 🔑 `Number(...)` only after a `!= null` guard: `override_input_amount` is a
+ * bigNumber column, and `Number(null)` is `0` — which would read back as a
+ * typed zero on every ordinary line.
+ */
+export const basketFromDraftLines = (lines: StoredDraftLine[] | null | undefined) => {
+  const quantities: Record<string, number> = {}
+  const discounts: Record<string, number> = {}
+  const overrides: Record<string, number> = {}
+  const weights: Record<string, number> = {}
+  const design_by_variant: Record<string, string> = {}
+  /**
+   * 🔴 `{ id }` OBJECTS, not bare ids.
+   *
+   * `product_ids` is `z.array(z.object({ id }))`, and both steps read it as
+   * `ids.map((p) => p.id)`. Hydrated as plain strings that map yields
+   * `undefined` for every entry, so the selected-product set matches nothing:
+   * reopening a saved draft showed an EMPTY quantities grid over a basket that
+   * was fully populated in the database. The trade price cannot be typed onto a
+   * row that is not rendered, which is how #1806 survived being looked at.
+   */
+  const product_ids: { id: string }[] = []
+  const seenProducts = new Set<string>()
+
+  for (const line of lines ?? []) {
+    quantities[line.variant_id] = line.quantity
+    if (line.design_id) design_by_variant[line.variant_id] = line.design_id
+    if (line.product_id && !seenProducts.has(line.product_id)) {
+      seenProducts.add(line.product_id)
+      product_ids.push({ id: line.product_id })
+    }
+
+    if (line.override_input_amount != null) {
+      const amount = Number(line.override_input_amount)
+      if (Number.isFinite(amount)) {
+        if (line.override_kind === "discount_percent") {
+          discounts[line.variant_id] = amount
+        } else if (line.override_kind === "override_unit_amount") {
+          overrides[line.variant_id] = amount
+        }
+      }
+    }
+
+    if (line.quoted_unit_weight_grams != null) {
+      const grams = Number(line.quoted_unit_weight_grams)
+      if (Number.isFinite(grams)) weights[line.variant_id] = grams
+    }
+  }
+
+  return { quantities, discounts, overrides, weights, design_by_variant, product_ids }
+}

--- a/apps/backend/src/admin/routes/quotes/drafts/[id]/draft-sections.tsx
+++ b/apps/backend/src/admin/routes/quotes/drafts/[id]/draft-sections.tsx
@@ -24,6 +24,10 @@ import {
   useMintQuoteDraft,
   useUpdateQuoteDraft,
 } from "../../../../hooks/api/quotes"
+import {
+  basketFromDraftLines,
+  draftLinesFromForm,
+} from "../../create/draft-lines"
 import { MintedPanel, type MintedQuoteResult } from "../../create/minted-panel"
 import { ReadinessPanel } from "../../create/readiness-panel"
 import {
@@ -33,6 +37,31 @@ import {
 import { BuyerStep } from "../../create/steps/buyer-step"
 import { ProductsStep } from "../../create/steps/products-step"
 import { QuantitiesStep } from "../../create/steps/quantities-step"
+
+/**
+ * How this line is being priced, in one phrase — or nothing at all.
+ *
+ * Reads the stored columns rather than the form, so it says what WAS SAVED.
+ * `override_input_amount` is a bigNumber: guard on `!= null` before coercing,
+ * because `Number(null)` is `0` and would print "0 off" on every ordinary line.
+ */
+const tradePrice = (line: any): string | null => {
+  const amount = line?.override_input_amount
+  if (amount == null) return null
+  const value = Number(amount)
+  if (!Number.isFinite(value)) return null
+  if (line.override_kind === "discount_percent") return `${value}% off catalogue`
+  if (line.override_kind === "override_unit_amount") {
+    /**
+     * 🔑 "store currency", never the quote's. An override is typed in the
+     * PARTNER STORE's default currency — the one the operator thinks in — and
+     * is converted once, at mint. Printing it beside the quote's INR badge with
+     * no qualifier would read as a number in a currency it is not in.
+     */
+    return `${value} per unit (agreed, store currency)`
+  }
+  return null
+}
 
 /**
  * A draft quote's page (#1446) — the draft ORDER detail page, mirrored.
@@ -134,17 +163,23 @@ export const DraftSections = ({ draft }: { draft: AdminQuoteDraft }) => {
    */
   useEffect(() => {
     if (!draft) return
-    const quantities: Record<string, number> = {}
-    const designByVariant: Record<string, string> = {}
-    const productIds: string[] = []
-
-    for (const line of draft.lines ?? []) {
-      quantities[line.variant_id] = line.quantity
-      if (line.design_id) designByVariant[line.variant_id] = line.design_id
-      if (line.product_id && !productIds.includes(line.product_id)) {
-        productIds.push(line.product_id)
-      }
-    }
+    /**
+     * 🔴 The trade price and the typed weight are hydrated here TOO (#1806).
+     *
+     * `handleMint` re-saves the basket from THIS form before pricing it, and
+     * the PATCH replaces the basket wholesale. So a hydration that stopped at
+     * quantities did not merely fail to show the negotiated price — pressing
+     * Mint overwrote the line the items modal had just saved it on, and the
+     * quote froze at retail. Hydrate what you are going to send back.
+     */
+    const {
+      quantities,
+      discounts,
+      overrides,
+      weights,
+      design_by_variant: designByVariant,
+      product_ids: productIds,
+    } = basketFromDraftLines(draft.lines as any)
 
     form.reset({
       ...form.getValues(),
@@ -165,6 +200,9 @@ export const DraftSections = ({ draft }: { draft: AdminQuoteDraft }) => {
       duties_prepaid: (draft as any).duties_prepaid ?? false,
       product_ids: productIds,
       quantities,
+      discounts,
+      overrides,
+      weights,
       design_by_variant: designByVariant,
     } as any)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -197,20 +235,14 @@ export const DraftSections = ({ draft }: { draft: AdminQuoteDraft }) => {
   const { mutateAsync: checkReadiness, isPending: isChecking } =
     useAdminQuoteReadiness()
 
-  /** The basket as the grid currently holds it. */
-  const currentLines = () => {
-    const data = form.getValues()
-    return Object.entries(data.quantities ?? {})
-      .filter(([, qty]) => typeof qty === "number" && qty > 0)
-      .map(([variant_id, quantity], index) => ({
-        variant_id,
-        quantity: quantity as number,
-        position: index,
-        ...(data.design_by_variant?.[variant_id]
-          ? { design_id: data.design_by_variant[variant_id] }
-          : {}),
-      }))
-  }
+  /**
+   * The basket as the grid currently holds it — negotiated prices included.
+   *
+   * 🔑 The SAME mapping the items modal saves with. This is re-saved on the way
+   * to the mint, so anything it omits is not just missing from this call: it is
+   * deleted from the row the modal wrote it to.
+   */
+  const currentLines = () => draftLinesFromForm(form.getValues() as any)
 
   const saveBuyer = () => {
     const data = form.getValues() as any
@@ -255,10 +287,25 @@ export const DraftSections = ({ draft }: { draft: AdminQuoteDraft }) => {
       const data = form.getValues()
       const result = await checkReadiness({
         partner_id: data.partner_id,
+        /**
+         * 🔑 The readiness preflight prices the SAME basket the mint will, so
+         * it is given the same lines. Dropping `unit_weight_grams` here made it
+         * refuse exactly the design-led baskets an operator-typed weight exists
+         * to unblock — a preflight that fails what the mint would accept.
+         */
         lines: lines.map((l) => ({
           variant_id: l.variant_id,
           quantity: l.quantity,
           ...(l.design_id ? { design_id: l.design_id } : {}),
+          ...(l.discount_percent !== undefined
+            ? { discount_percent: l.discount_percent }
+            : {}),
+          ...(l.override_unit_amount !== undefined
+            ? { override_unit_amount: l.override_unit_amount }
+            : {}),
+          ...(l.unit_weight_grams !== undefined
+            ? { unit_weight_grams: l.unit_weight_grams }
+            : {}),
         })),
         destination_country_code: data.destination_country_code,
         destination_postal_code: data.destination_postal_code || null,
@@ -365,7 +412,21 @@ export const DraftSections = ({ draft }: { draft: AdminQuoteDraft }) => {
                   key={l.id}
                   className="grid grid-cols-[1fr_auto] items-center gap-x-4 px-6 py-3"
                 >
-                  <Text size="small">{l.variant_id}</Text>
+                  <div className="flex flex-col">
+                    <Text size="small">{l.variant_id}</Text>
+                    {/*
+                      🔑 The negotiated price, shown on the row it is stored on.
+                      A number the operator typed and cannot see afterwards is
+                      indistinguishable from one that was discarded — which is
+                      exactly what #1806 was: three layers dropped it and the
+                      toast still said "Items saved."
+                    */}
+                    {tradePrice(l) && (
+                      <Text size="xsmall" className="text-ui-fg-subtle">
+                        {tradePrice(l)}
+                      </Text>
+                    )}
+                  </div>
                   <Text size="small" className="text-ui-fg-subtle">
                     {l.quantity}×
                   </Text>

--- a/apps/backend/src/admin/routes/quotes/drafts/[id]/items/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/drafts/[id]/items/page.tsx
@@ -16,6 +16,11 @@ import {
   useUpdateQuoteDraft,
 } from "../../../../../hooks/api/quotes"
 import { BulkDiscountPanel } from "../../../create/bulk-discount-panel"
+import {
+  basketFromDraftLines,
+  conflictingOverrides,
+  draftLinesFromForm,
+} from "../../../create/draft-lines"
 import { AdminLineDesignsPanel } from "../../../create/line-designs-panel"
 import {
   AdminQuoteCreateSchema,
@@ -106,16 +111,22 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
 
   useEffect(() => {
     if (!draft) return
-    const quantities: Record<string, number> = {}
-    const designByVariant: Record<string, string> = {}
-    const productIds: string[] = []
-    for (const line of draft.lines ?? []) {
-      quantities[line.variant_id] = line.quantity
-      if (line.design_id) designByVariant[line.variant_id] = line.design_id
-      if (line.product_id && !productIds.includes(line.product_id)) {
-        productIds.push(line.product_id)
-      }
-    }
+    /**
+     * 🔑 The trade price and the typed weight are hydrated too (#1806).
+     *
+     * They used not to be, and the modal reopened with blank price cells over
+     * lines that HAD a negotiated price — so the next Save, built from those
+     * blanks, erased it. The mapping is shared with the save that mirrors it;
+     * a round trip that loses a field is the same silent discard.
+     */
+    const {
+      quantities,
+      discounts,
+      overrides,
+      weights,
+      design_by_variant: designByVariant,
+      product_ids: productIds,
+    } = basketFromDraftLines(draft.lines as any)
     form.reset({
       ...form.getValues(),
       // 🔴 `?? ""` throughout: a null column handed to a controlled input makes
@@ -126,6 +137,9 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
       destination_country_code: (draft as any).destination_country_code ?? "",
       product_ids: productIds,
       quantities,
+      discounts,
+      overrides,
+      weights,
       design_by_variant: designByVariant,
     } as any)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -173,16 +187,32 @@ const DraftItemsForm = ({ draftId }: { draftId: string }) => {
    */
   const handleSave = () => {
     const values = form.getValues()
-    const lines = Object.entries(values.quantities ?? {})
-      .filter(([, qty]) => typeof qty === "number" && qty > 0)
-      .map(([variant_id, quantity], index) => ({
-        variant_id,
-        quantity: quantity as number,
-        position: index,
-        ...(values.design_by_variant?.[variant_id]
-          ? { design_id: values.design_by_variant[variant_id] }
-          : {}),
-      }))
+
+    /**
+     * 🔴 Refused HERE, with the line in hand.
+     *
+     * Both rails' schemas refuse a line carrying a discount AND a flat price —
+     * "which one wins" is a question that should not have an answer. Forwarding
+     * the pair would meet the operator as a 400 naming a zod path instead of a
+     * sentence naming the row they need to clear.
+     */
+    const conflicts = conflictingOverrides(values as any)
+    if (conflicts.length) {
+      toast.error(
+        `Clear either the discount or the unit price on ${conflicts.length} line${
+          conflicts.length > 1 ? "s" : ""
+        } — a line takes one or the other, never both.`
+      )
+      return
+    }
+
+    /**
+     * The negotiated price travels with the line (#1806). Built by the shared
+     * mapping rather than inline: the draft page's Mint re-saves this same
+     * basket from its own form, and a second copy that forgot a column is how
+     * a price saved here was silently dropped on the way to the mint.
+     */
+    const lines = draftLinesFromForm(values as any)
 
     /**
      * An empty basket IS savable here — this modal OWNS the basket, so

--- a/apps/backend/src/api/admin/quotes/drafts/[id]/mint/route.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/[id]/mint/route.ts
@@ -86,6 +86,35 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         quantity: l.quantity,
         position: l.position ?? 0,
         ...(l.design_id ? { design_id: l.design_id } : {}),
+        /**
+         * The negotiated price the draft was saved with (#1806).
+         *
+         * 🔴 This is the layer the number died at last. The grid collected it,
+         * the validator accepted it, the mint has always known how to freeze it
+         * — and the body built here named five fields, so every draft minted at
+         * catalogue price no matter what the operator had typed.
+         *
+         * 🔑 `!= null` BEFORE `Number(...)`: `override_input_amount` is a
+         * bigNumber column and `Number(null)` is `0` — which would send a 0%
+         * discount, or worse a `0` flat price, on every ordinary line.
+         */
+        ...(l.override_input_amount != null &&
+        l.override_kind === "discount_percent"
+          ? { discount_percent: Number(l.override_input_amount) }
+          : {}),
+        ...(l.override_input_amount != null &&
+        l.override_kind === "override_unit_amount"
+          ? { override_unit_amount: Number(l.override_input_amount) }
+          : {}),
+        /**
+         * The operator-typed weight, for the lines the catalogue cannot weigh.
+         * Without it `buildShippingEstimate` refuses the WHOLE basket on the
+         * first weightless line — so a design-led draft that priced fine in the
+         * grid could not be minted at all.
+         */
+        ...(l.quoted_unit_weight_grams != null
+          ? { unit_weight_grams: Number(l.quoted_unit_weight_grams) }
+          : {}),
       })),
   }
 

--- a/apps/backend/src/api/admin/quotes/drafts/[id]/route.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/[id]/route.ts
@@ -1,5 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
 
@@ -39,6 +39,110 @@ const loadDraft = async (req: MedusaRequest) => {
 
   return { service, quote }
 }
+
+/**
+ * A draft line, from the body a section sent (#1806).
+ *
+ * ## The negotiated price is stored, not dropped
+ *
+ * The grid has rendered a **Discount %** and a **Unit price** column since
+ * #1439 S7, this validator has accepted both since #1446, and this function's
+ * predecessor wrote five columns and threw the rest away. An operator typed a
+ * trade price, got *"Items saved."*, and the quote minted at retail — the
+ * failure that most defeats the purpose of a manual quote, made invisible by a
+ * toast that agreed with them.
+ *
+ * ## Why the existing columns and not new ones
+ *
+ * `override_kind` / `override_input_amount` are documented on the model as
+ * "what the partner actually TYPED, before any conversion" — which is exactly
+ * what a draft holds. Nothing on a draft is frozen: `quoted_unit_amount` and
+ * every other frozen column stays null until a mint, and a draft row is
+ * DELETED by the mint rather than promoted, so no row ever carries both
+ * meanings at once. A parallel set of `draft_*` columns would be the same
+ * three numbers under a second name, and two names for one fact is how they
+ * drift apart.
+ *
+ * 🔑 `quoted_weight_source: "manual"` is written beside a typed weight so the
+ * number can never be mistaken for one the catalogue answered — the same
+ * distinction the mint freezes, made at the moment the operator types it.
+ *
+ * ⚠️ The two price forms are mutually exclusive and the validator refuses the
+ * pair. The branch below still ranks them rather than trusting that, because
+ * "which one wins" must not depend on which schema the caller came through.
+ */
+/**
+ * The product each variant belongs to, for the lines that did not say.
+ *
+ * 🔴 `product_id` is not decoration on a draft line: the items modal rebuilds
+ * its PRODUCT selection from it, and the quantities grid renders a row per
+ * variant of the SELECTED products. Saved as null, a reopened draft showed an
+ * empty grid over a full basket — the operator could see no line, so the trade
+ * price could not be typed on one either.
+ *
+ * The browser cannot supply it reliably (the form holds a variant-keyed basket
+ * and a separate product list), and the server can always derive it. One graph
+ * call for the whole basket, and only when something is missing.
+ */
+const resolveProductIds = async (
+  req: MedusaRequest,
+  lines: any[]
+): Promise<Map<string, string>> => {
+  const wanted = [
+    ...new Set(
+      lines
+        .filter((l) => !l.product_id && l.variant_id)
+        .map((l) => String(l.variant_id))
+    ),
+  ]
+  if (!wanted.length) return new Map()
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  const { data: variants = [] } = await query.graph({
+    entity: "variant",
+    fields: ["id", "product.id"],
+    filters: { id: wanted },
+  })
+
+  return new Map(
+    (variants ?? [])
+      .filter((v: any) => v?.product?.id)
+      .map((v: any) => [v.id as string, v.product.id as string])
+  )
+}
+
+const toLineRow =
+  (quoteId: string, products: Map<string, string> = new Map()) =>
+  (l: any, index: number) => {
+    const given = (v: unknown) => v !== null && v !== undefined
+    const hasOverride = given(l.override_unit_amount)
+    const hasDiscount = given(l.discount_percent)
+
+    return {
+      quote_id: quoteId,
+      variant_id: l.variant_id,
+      product_id: l.product_id ?? products.get(l.variant_id) ?? null,
+      design_id: l.design_id ?? null,
+      quantity: l.quantity,
+      position: l.position ?? index,
+
+      override_kind: hasOverride
+        ? "override_unit_amount"
+        : hasDiscount
+          ? "discount_percent"
+          : null,
+      override_input_amount: hasOverride
+        ? l.override_unit_amount
+        : hasDiscount
+          ? l.discount_percent
+          : null,
+
+      quoted_unit_weight_grams: given(l.unit_weight_grams)
+        ? l.unit_weight_grams
+        : null,
+      quoted_weight_source: given(l.unit_weight_grams) ? "manual" : null,
+    }
+  }
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { service, quote } = await loadDraft(req)
@@ -103,15 +207,9 @@ export const PATCH = async (req: MedusaRequest, res: MedusaResponse) => {
       await service.deletePartnerQuoteLines(existing.map((l: any) => l.id))
     }
     if (body.lines.length) {
+      const products = await resolveProductIds(req, body.lines)
       await service.createPartnerQuoteLines(
-        body.lines.map((l: any, index: number) => ({
-          quote_id: quote.id,
-          variant_id: l.variant_id,
-          product_id: l.product_id ?? null,
-          design_id: l.design_id ?? null,
-          quantity: l.quantity,
-          position: l.position ?? index,
-        }))
+        body.lines.map(toLineRow(quote.id, products))
       )
     }
   }

--- a/apps/backend/src/api/admin/quotes/drafts/__tests__/draft-patch.unit.spec.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/__tests__/draft-patch.unit.spec.ts
@@ -16,14 +16,19 @@ const makeReq = (body: any, id = "pq_1") =>
     params: { id },
     validatedBody: body,
     scope: {
-      resolve: () => ({
-        retrievePartnerQuote,
-        updatePartnerQuotes,
-        listPartnerQuoteLines,
-        createPartnerQuoteLines,
-        deletePartnerQuoteLines,
-        deletePartnerQuotes,
-      }),
+      // The route resolves the graph too, to fill in the product a variant
+      // belongs to when the caller did not name one (#1806).
+      resolve: (key: string) =>
+        key === "query"
+          ? { graph: jest.fn().mockResolvedValue({ data: [] }) }
+          : ({
+              retrievePartnerQuote,
+              updatePartnerQuotes,
+              listPartnerQuoteLines,
+              createPartnerQuoteLines,
+              deletePartnerQuoteLines,
+              deletePartnerQuotes,
+            } as any),
     },
   }) as any
 

--- a/apps/backend/src/api/admin/quotes/drafts/__tests__/draft-trade-price.unit.spec.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/__tests__/draft-trade-price.unit.spec.ts
@@ -1,0 +1,238 @@
+const retrievePartnerQuote = jest.fn()
+const updatePartnerQuotes = jest.fn().mockResolvedValue({})
+const listPartnerQuoteLines = jest.fn().mockResolvedValue([])
+const createPartnerQuoteLines = jest.fn().mockResolvedValue([])
+const deletePartnerQuoteLines = jest.fn().mockResolvedValue(undefined)
+const deletePartnerQuotes = jest.fn().mockResolvedValue(undefined)
+
+jest.mock("../../../../../modules/partner-quote", () => ({
+  PARTNER_QUOTE_MODULE: "partner_quote",
+}))
+
+/**
+ * The mint handler is stubbed: this suite is about the BODY it is handed, which
+ * is the layer the negotiated price died at. What the workflow then does with a
+ * `discount_percent` is `line-override`'s own suite.
+ */
+const mintQuote = jest.fn(async (_req: any, res: any) => res.status(201).json({ quote: {} }))
+jest.mock("../../route", () => ({ POST: (...args: any[]) => (mintQuote as any)(...args) }))
+
+import { PATCH } from "../[id]/route"
+import { POST as mintDraft } from "../[id]/mint/route"
+import { AdminUpdateQuoteDraftReq } from "../../validators"
+
+const graph = jest.fn().mockResolvedValue({ data: [] })
+
+const scope = {
+  resolve: (key: string) =>
+    key === "query"
+      ? { graph }
+      : ({
+    retrievePartnerQuote,
+    updatePartnerQuotes,
+    listPartnerQuoteLines,
+    createPartnerQuoteLines,
+    deletePartnerQuoteLines,
+    deletePartnerQuotes,
+      } as any),
+}
+
+const makeReq = (body: any, id = "pq_1") =>
+  ({ params: { id }, validatedBody: body, scope }) as any
+
+const makeRes = () =>
+  ({ status: jest.fn().mockReturnThis(), json: jest.fn() }) as any
+
+/**
+ * A negotiated price the operator typed must reach the mint (#1806).
+ *
+ * It reached nothing: the grid bound the cell, the validator accepted the
+ * field, and the two layers in between named five columns each. The quote
+ * minted at retail and the toast said "Items saved."
+ */
+describe("the draft rail carries a per-line trade price", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    retrievePartnerQuote.mockResolvedValue({
+      id: "pq_1",
+      status: "draft",
+      partner_id: "pa_1",
+      currency_code: "aud",
+      destination_country_code: "au",
+    })
+    listPartnerQuoteLines.mockResolvedValue([])
+  })
+
+  it("PATCH stores a flat unit price as a typed override, not as metadata", async () => {
+    await PATCH(
+      makeReq({
+        lines: [{ variant_id: "var_1", quantity: 500, override_unit_amount: 1200 }],
+      }),
+      makeRes()
+    )
+
+    const [row] = createPartnerQuoteLines.mock.calls[0][0]
+    expect(row.override_kind).toBe("override_unit_amount")
+    expect(row.override_input_amount).toBe(1200)
+  })
+
+  it("PATCH stores a discount percentage", async () => {
+    await PATCH(
+      makeReq({
+        lines: [{ variant_id: "var_1", quantity: 500, discount_percent: 12.5 }],
+      }),
+      makeRes()
+    )
+
+    const [row] = createPartnerQuoteLines.mock.calls[0][0]
+    expect(row.override_kind).toBe("discount_percent")
+    expect(row.override_input_amount).toBe(12.5)
+  })
+
+  /**
+   * 🔑 A typed weight is marked `manual` where it is stored, so it can never be
+   * mistaken for a figure the catalogue answered.
+   */
+  it("PATCH stores an operator-typed weight with its provenance", async () => {
+    await PATCH(
+      makeReq({
+        lines: [{ variant_id: "var_1", quantity: 20, unit_weight_grams: 115 }],
+      }),
+      makeRes()
+    )
+
+    const [row] = createPartnerQuoteLines.mock.calls[0][0]
+    expect(row.quoted_unit_weight_grams).toBe(115)
+    expect(row.quoted_weight_source).toBe("manual")
+  })
+
+  /**
+   * 🔴 The items modal rebuilds its PRODUCT selection from `product_id`, and
+   * the grid renders a row per variant of the selected products. Saved null, a
+   * reopened draft shows an empty grid over a full basket — and a price cannot
+   * be typed onto a row that does not render.
+   */
+  it("PATCH fills in the product a variant belongs to", async () => {
+    graph.mockResolvedValueOnce({
+      data: [{ id: "var_1", product: { id: "prod_1" } }],
+    })
+
+    await PATCH(
+      makeReq({ lines: [{ variant_id: "var_1", quantity: 5 }] }),
+      makeRes()
+    )
+
+    const [row] = createPartnerQuoteLines.mock.calls[0][0]
+    expect(row.product_id).toBe("prod_1")
+  })
+
+  it("PATCH leaves an ordinary line's price columns null", async () => {
+    await PATCH(
+      makeReq({ lines: [{ variant_id: "var_1", quantity: 500 }] }),
+      makeRes()
+    )
+
+    const [row] = createPartnerQuoteLines.mock.calls[0][0]
+    expect(row.override_kind).toBeNull()
+    expect(row.override_input_amount).toBeNull()
+    expect(row.quoted_unit_weight_grams).toBeNull()
+    expect(row.quoted_weight_source).toBeNull()
+  })
+
+  it("mints with the stored flat price, not at catalogue", async () => {
+    listPartnerQuoteLines.mockResolvedValue([
+      {
+        id: "l1",
+        variant_id: "var_1",
+        quantity: 500,
+        position: 0,
+        override_kind: "override_unit_amount",
+        override_input_amount: 1200,
+        quoted_unit_weight_grams: 115,
+      },
+    ])
+
+    await mintDraft(makeReq({}), makeRes())
+
+    const body = mintQuote.mock.calls[0][0].validatedBody
+    expect(body.lines[0].override_unit_amount).toBe(1200)
+    expect(body.lines[0].unit_weight_grams).toBe(115)
+    expect("discount_percent" in body.lines[0]).toBe(false)
+  })
+
+  it("mints with the stored discount", async () => {
+    listPartnerQuoteLines.mockResolvedValue([
+      {
+        id: "l1",
+        variant_id: "var_1",
+        quantity: 500,
+        position: 0,
+        override_kind: "discount_percent",
+        override_input_amount: "12.5",
+      },
+    ])
+
+    await mintDraft(makeReq({}), makeRes())
+
+    const body = mintQuote.mock.calls[0][0].validatedBody
+    expect(body.lines[0].discount_percent).toBe(12.5)
+    expect("override_unit_amount" in body.lines[0]).toBe(false)
+  })
+
+  /**
+   * 🔴 `Number(null)` is `0`, and a `0` here is a flat price of zero — an
+   * ACTIVE price the cart would cheerfully charge. An ordinary line must send
+   * no price field at all.
+   */
+  it("sends no price field for a line that never had one", async () => {
+    listPartnerQuoteLines.mockResolvedValue([
+      {
+        id: "l1",
+        variant_id: "var_1",
+        quantity: 500,
+        position: 0,
+        override_kind: null,
+        override_input_amount: null,
+        quoted_unit_weight_grams: null,
+      },
+    ])
+
+    await mintDraft(makeReq({}), makeRes())
+
+    const line = mintQuote.mock.calls[0][0].validatedBody.lines[0]
+    expect("override_unit_amount" in line).toBe(false)
+    expect("discount_percent" in line).toBe(false)
+    expect("unit_weight_grams" in line).toBe(false)
+  })
+})
+
+/**
+ * "Which one wins" must not have an answer — and it must be refused where the
+ * number is FIRST stored, not minutes later at the mint.
+ */
+describe("AdminUpdateQuoteDraftReq", () => {
+  it("refuses a line carrying both a discount and a flat price", () => {
+    const result = AdminUpdateQuoteDraftReq.safeParse({
+      lines: [
+        {
+          variant_id: "var_1",
+          quantity: 1,
+          discount_percent: 10,
+          override_unit_amount: 900,
+        },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts either one alone", () => {
+    for (const line of [
+      { variant_id: "var_1", quantity: 1, discount_percent: 10 },
+      { variant_id: "var_1", quantity: 1, override_unit_amount: 900 },
+      { variant_id: "var_1", quantity: 1, unit_weight_grams: 115 },
+    ]) {
+      expect(AdminUpdateQuoteDraftReq.safeParse({ lines: [line] }).success).toBe(true)
+    }
+  })
+})

--- a/apps/backend/src/api/admin/quotes/validators.ts
+++ b/apps/backend/src/api/admin/quotes/validators.ts
@@ -98,16 +98,41 @@ export const AdminUpdateQuoteDraftReq = AdminCreateQuoteDraftReq.partial().exten
   {
     lines: z
       .array(
-        z.object({
-          variant_id: z.string().min(1),
-          quantity: z.number().int().positive(),
-          product_id: z.string().nullish(),
-          design_id: z.string().nullish(),
-          position: z.number().int().min(0).nullish(),
-          unit_weight_grams: z.number().positive().nullish(),
-          discount_percent: z.number().min(0).max(100).nullish(),
-          override_unit_amount: z.number().positive().nullish(),
-        })
+        z
+          .object({
+            variant_id: z.string().min(1),
+            quantity: z.number().int().positive(),
+            product_id: z.string().nullish(),
+            design_id: z.string().nullish(),
+            position: z.number().int().min(0).nullish(),
+            unit_weight_grams: z.number().positive().nullish(),
+            discount_percent: z.number().min(0).max(100).nullish(),
+            override_unit_amount: z.number().positive().nullish(),
+          })
+          /**
+           * The same rule the MINT refuses on, applied where the number is
+           * first stored (#1806).
+           *
+           * "Which one wins" is not a question that should have an answer. The
+           * draft rail persists these and hands them to the mint later, so a
+           * pair accepted here would be refused minutes afterwards, at the
+           * mint, against a draft that looked saved — the error arriving one
+           * step away from the cell that caused it.
+           */
+          .refine(
+            (l) =>
+              !(
+                l.discount_percent !== null &&
+                l.discount_percent !== undefined &&
+                l.override_unit_amount !== null &&
+                l.override_unit_amount !== undefined
+              ),
+            {
+              message:
+                "A line takes either a discount_percent or an override_unit_amount, never both.",
+              path: ["override_unit_amount"],
+            }
+          )
       )
       .nullish(),
     duties_prepaid: z.boolean().nullish(),


### PR DESCRIPTION
Closes #1806.

An operator opens a draft quote's items modal, types a negotiated price into **Unit price**, hits Save, and reads *"Items saved."* The number was discarded and the quote minted at retail.

## Why it survived so long

Every layer was individually fine, and every layer's own tests passed:

| layer | state |
|---|---|
| the grid | bound `discounts.*` / `overrides.*` since #1439 S7 ✅ |
| `handleSave` | read `quantities` and `design_by_variant`, nothing else ❌ |
| the draft `PATCH` | wrote five columns ❌ |
| the draft's mint body | named five fields ❌ |
| the mint validator + workflow | accepted and froze overrides correctly all along ✅ |

Three silent drops in a row, in files whose suites were green. What nobody owned was the journey.

## What changed

- **`create/draft-lines.ts` — one mapping, both directions.** The basket was built in *two* places: the modal's Save, and the draft page's Mint, which re-saves the basket from its own form first. So a field forgotten there did not merely go missing — pressing Mint **deleted** the price the modal had just stored. The hydration half is the mirror image: cells that reopen blank get erased by the next save. Round-tripped in the unit suite.
- **The `PATCH` stores the trade price** in `override_kind` / `override_input_amount` — the model's own *"what the partner actually TYPED, before any conversion"* columns — and a typed weight in `quoted_unit_weight_grams` with `quoted_weight_source: "manual"`. **No migration.** Nothing on a draft is frozen (`quoted_unit_amount` stays null until a mint) and the mint *deletes* the draft rather than promoting it, so no row ever carries both meanings. A parallel set of `draft_*` columns would be the same three numbers under a second name.
- **The mint body carries them through**, guarding `!= null` **before** `Number(…)` — `Number(null)` is `0`, and a `0` here is a flat price of zero, which the cart would cheerfully charge.
- **The draft validator refuses a line holding both forms**, where the number is first stored rather than minutes later at the mint. The modal refuses it earlier still, naming the line instead of forwarding a zod path.
- **`product_id` is resolved server-side from the variant.** Saved null (the browser never sent it), a reopened draft rendered an **empty grid over a full basket** — no row to type a price onto, which is how #1806 survived being looked at. `product_ids` is hydrated as the `{ id }` objects both steps read, for the same reason.
- The summary row now shows the agreed price, qualified **"store currency"** — an override is typed in the partner store's currency, not the quote's.

## Verification

Not by the toast.

- **31 unit tests.** Reverting the three backend files turns **7 of 9** in the new suite RED; the 2 that stay green are the null-guard cases, which must pass either way.
- **4 HTTP integration tests against a database** (`admin-quote-draft-trade-price.spec.ts`) — persistence, the typed weight and its provenance, the both-forms 400, and the one that matters: **a draft with a 20% discount mints at tier×0.8, not at the catalogue price.** All 4 go RED on the old code.
- **The screen.** Typed `17500` into the grid in a real browser, pressed Save, and re-read the row through the API:

```
LINES PERSISTED: [{"variant_id":"variant_01KPTE…","product_id":"prod_01KPTE…",
  "quantity":5,"override_kind":"override_unit_amount","override_input_amount":17500}]
```

The summary row then reads *"17500 per unit (agreed, store currency)"*. That render is also what caught the empty-grid defect above — tsc, the unit suites and a live API probe all passed over it.

`check:prod-build`: frontend green, backend fails only on the pre-existing `@jest/core` spec (identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
