### PR TITLE
feat(inventory-orders): per-line extra cost, order tax, MCP create tool, and price pre-fill

### DIFF
--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -134,6 +134,69 @@ setupSharedTestSuite(() => {
       });
     });
 
+    // Per-line extra cost (colour job, …) + order-level tax entered at create.
+    describe("POST /admin/inventory-orders — per-line extra_cost + order tax", () => {
+      it("persists a per-unit extra_cost and records the order tax as a charge", async () => {
+        const orderPayload = {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 2, price: 100, extra_cost: 25 },
+          ],
+          quantity: 2,
+          total_price: 250, // (100 + 25) × 2
+          tax_amount: 30,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        };
+
+        const res = await api.post("/admin/inventory-orders", orderPayload, headers);
+        expect(res.status).toBe(201);
+        const orderId = res.data.inventoryOrder.id;
+
+        // The per-unit extra cost is persisted on the line (bigNumber → numeric).
+        const line = res.data.inventoryOrder.orderlines[0];
+        expect(Number(line.extra_cost)).toBe(25);
+
+        // The tax is recorded as an order charge of type "tax", raising the
+        // payable ceiling by exactly that amount (not folded into total_price).
+        const chargesRes = await api.get(`/admin/inventory-orders/${orderId}/charges`, headers);
+        expect(chargesRes.status).toBe(200);
+        expect(chargesRes.data.totals.raises).toBe(30);
+        expect(chargesRes.data.goods_total).toBe(250);
+        expect(chargesRes.data.payable_ceiling).toBe(280);
+      });
+
+      it("accepts lines without extra_cost and no tax (backwards-compatible)", async () => {
+        const orderPayload = {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 1, price: 100 },
+          ],
+          quantity: 1,
+          total_price: 100,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        };
+
+        const res = await api.post("/admin/inventory-orders", orderPayload, headers);
+        expect(res.status).toBe(201);
+        const orderId = res.data.inventoryOrder.id;
+
+        expect(Number(res.data.inventoryOrder.orderlines[0].extra_cost)).toBe(0);
+
+        // No tax charge was written, so the ceiling equals the goods total.
+        const chargesRes = await api.get(`/admin/inventory-orders/${orderId}/charges`, headers);
+        expect(chargesRes.data.charges).toHaveLength(0);
+        expect(chargesRes.data.payable_ceiling).toBe(100);
+      });
+    });
+
     type OrderLine = { inventory_item_id: string; quantity: number; price: number };
     describe("GET /admin/inventory-orders", () => {
       let createdOrders = [] as any[];

--- a/apps/backend/src/admin/components/creates/create-inventory-order-schema.ts
+++ b/apps/backend/src/admin/components/creates/create-inventory-order-schema.ts
@@ -22,9 +22,13 @@ export const inventoryOrderFormSchema = z
         inventory_item_id: z.string(),
         quantity: z.number(),
         price: z.number(),
+        // Per-unit extra charge on top of `price` (colour/dye job, finishing, …).
+        extra_cost: z.number().optional(),
         batch_number: z.number().int().positive().nullish(), // batch tag (separate-batch adds)
       })
     ),
+    // Order-level tax entered at create time (recorded as an order charge).
+    tax_amount: z.number().nonnegative("Tax must be zero or positive").optional(),
   })
   .superRefine((data, ctx) => {
     const lines = data.order_lines ?? [];

--- a/apps/backend/src/admin/components/creates/create-inventory-order.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order.tsx
@@ -1,7 +1,7 @@
 import { useForm, useFieldArray, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "@medusajs/framework/zod";
-import { Button, DatePicker, Heading, Text, ProgressTabs, ProgressStatus, Select, toast, Switch, Label } from "@medusajs/ui";
+import { Button, DatePicker, Heading, Text, ProgressTabs, ProgressStatus, Select, toast, Switch, Label, Input } from "@medusajs/ui";
 import { useRouteModal } from "../modal/use-route-modal";
 import { useCreateInventoryOrder } from "../../hooks/api/inventory-orders";
 import { RouteFocusModal } from "../modal/route-focus-modal";
@@ -28,6 +28,8 @@ interface OrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  // Per-unit extra charge on top of price (colour/dye job, finishing, …).
+  extra_cost?: number;
   batch_number?: number | null;
 }
 
@@ -47,7 +49,7 @@ export const CreateInventoryOrderComponent = () => {
       from_stock_location_id: undefined,
       is_sample: false,
       // Seed multiple empty rows so users can start filling without needing to add immediately
-      order_lines: Array.from({ length: 5 }, () => ({ inventory_item_id: "", quantity: 0, price: 0 })),
+      order_lines: Array.from({ length: 5 }, () => ({ inventory_item_id: "", quantity: 0, price: 0, extra_cost: 0 })),
     },
     resolver: zodResolver(inventoryOrderFormSchema),
   });
@@ -118,6 +120,11 @@ export const CreateInventoryOrderComponent = () => {
     .map((l) => l?.inventory_item_id)
     .filter(Boolean) as string[];
 
+  // Order-level tax, watched live for the footer grand total.
+  const watchedTax = useWatch({ control: form.control, name: "tax_amount" }) as
+    | number
+    | undefined;
+
   const { handleSuccess } = useRouteModal();
 
   const { mutateAsync, isPending } = useCreateInventoryOrder({
@@ -140,7 +147,14 @@ export const CreateInventoryOrderComponent = () => {
     const rows = source ?? (watchedForGroup ?? []);
     const validLines = rows.filter((line) => line?.inventory_item_id);
     const totalQuantity = validLines.reduce((sum: number, line) => sum + (Number(line.quantity) || 0), 0);
-    const totalPrice = validLines.reduce((sum: number, line) => sum + (Number(line.price) || 0) * (Number(line.quantity) || 0), 0);
+    // Per-unit price + per-unit extra cost (colour job), × quantity.
+    const totalPrice = validLines.reduce(
+      (sum: number, line) =>
+        sum +
+        ((Number(line.price) || 0) + (Number(line.extra_cost) || 0)) *
+          (Number(line.quantity) || 0),
+      0
+    );
     return { totalQuantity, totalPrice };
   };
 
@@ -162,12 +176,14 @@ export const CreateInventoryOrderComponent = () => {
       // untracked variant; `toOrderLineRef` sends the right field for each.
       order_lines: submittedLines
         .filter((l: OrderLine) => l.inventory_item_id)
-        .map(({ inventory_item_id, quantity, price, batch_number }: OrderLine) => ({
+        .map(({ inventory_item_id, quantity, price, extra_cost, batch_number }: OrderLine) => ({
           ...toOrderLineRef(inventory_item_id),
           quantity: Number(quantity) || 0,
           price: Number(price) || 0,
+          extra_cost: Number(extra_cost) || 0,
           batch_number: batch_number ?? null,
         })),
+      tax_amount: data.tax_amount != null ? Number(data.tax_amount) : undefined,
     };
     if (data.from_stock_location_id) {
       payload.from_stock_location_id = data.from_stock_location_id;
@@ -315,6 +331,35 @@ export const CreateInventoryOrderComponent = () => {
                     )}
                   />
                 </div>
+                {/* Order-level tax, recorded as an order charge (not folded into the goods total). */}
+                <div className="mt-4">
+                  <Form.Field
+                    control={form.control}
+                    name="tax_amount"
+                    render={({ field }) => (
+                      <Form.Item>
+                        <Form.Label>Tax (optional)</Form.Label>
+                        <Form.Control>
+                          <Input
+                            type="number"
+                            min={0}
+                            step="any"
+                            placeholder="0"
+                            value={field.value == null ? "" : field.value}
+                            onChange={(e) =>
+                              field.onChange(
+                                e.target.value === "" ? undefined : Number(e.target.value)
+                              )
+                            }
+                            onBlur={field.onBlur}
+                            ref={field.ref}
+                          />
+                        </Form.Control>
+                        <Form.ErrorMessage />
+                      </Form.Item>
+                    )}
+                  />
+                </div>
                 <div className="mt-4">
                   <Form.Field
                     control={form.control}
@@ -383,6 +428,16 @@ export const CreateInventoryOrderComponent = () => {
                   <div className="flex justify-between items-center">
                     <Text weight="plus">Total Order Price:</Text>
                     <Text weight="plus">₹{calculateTotals().totalPrice.toFixed(2)}</Text>
+                  </div>
+                  <div className="flex justify-between items-center mt-2">
+                    <Text weight="plus">Tax:</Text>
+                    <Text weight="plus">₹{(Number(watchedTax) || 0).toFixed(2)}</Text>
+                  </div>
+                  <div className="flex justify-between items-center mt-2 border-t pt-2">
+                    <Text weight="plus">Grand Total:</Text>
+                    <Text weight="plus">
+                      ₹{(calculateTotals().totalPrice + (Number(watchedTax) || 0)).toFixed(2)}
+                    </Text>
                   </div>
                 </div>
               </div>

--- a/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
+++ b/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
@@ -21,6 +21,9 @@ type PickedInventoryItem = InventoryItem & {
     id: string
     title?: string | null
     sku?: string | null
+    // #1744 — the variant's existing price (money amounts per currency), so
+    // picking a finished good pre-fills `price`.
+    prices?: Array<{ amount?: number | string | null; currency_code?: string | null }>
     product?: { id: string; title?: string | null; thumbnail?: string | null } | null
   }>
   kind?:
@@ -47,12 +50,15 @@ const ItemComboboxCell = ({
   options,
   loading,
   onSearch,
+  onItemPick,
 }: {
   form: UseFormReturn<any>;
   index: number;
   options: PickerOption[];
   loading?: boolean;
   onSearch?: (query: string) => void;
+  /** Called with the picked item id so the grid can pre-fill `price` (#1744). */
+  onItemPick?: (itemId: string) => void;
 }) => {
   const [query, setQuery] = useState("");
 
@@ -100,7 +106,11 @@ const ItemComboboxCell = ({
         >
           <Combobox
             value={(field.value as string) || ""}
-            onChange={(v) => field.onChange((v as string) ?? "")}
+            onChange={(v) => {
+              const id = (v as string) ?? "";
+              field.onChange(id);
+              if (id && onItemPick) onItemPick(id);
+            }}
             onBlur={field.onBlur}
             searchValue={query}
             onSearchValueChange={setQuery}
@@ -129,6 +139,8 @@ interface InventoryOrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  // Per-unit extra charge on top of price (colour/dye job, finishing, …).
+  extra_cost?: number;
   batch_number?: number | null;
 }
 
@@ -318,6 +330,33 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
     return map
   }, [mergedItems])
 
+  /**
+   * #1744 — the existing per-unit price to pre-fill when an item is picked.
+   *
+   * A raw-material-backed item prices from its material's `unit_cost`; a
+   * finished-good/variant item prices from the variant's money amounts,
+   * INR-matched (never "the first price" — a variant carries a row per
+   * currency, so prices[0] mixes INR with USD). Null when the item has no
+   * readable price, so the buyer's 0 stands rather than being overwritten.
+   */
+  const existingPriceFor = (itemId: string): number | null => {
+    const item = inventoryItemMap.get(itemId)
+    if (!item) return null
+    const unitCost = item.raw_materials?.unit_cost
+    if (unitCost != null && Number.isFinite(Number(unitCost))) {
+      return Number(unitCost)
+    }
+    const variant = (item.variants ?? [])[0]
+    const prices = variant?.prices ?? []
+    const inr = prices.find(
+      (p) => String(p?.currency_code ?? "").toLowerCase() === "inr"
+    )
+    const match = inr ?? prices[0]
+    return match?.amount != null && Number.isFinite(Number(match.amount))
+      ? Number(match.amount)
+      : null
+  }
+
   const columns: ColumnDef<InventoryOrderLine>[] = [
     columnHelper.column({
       id: "image",
@@ -367,6 +406,12 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
             options={rowOptions}
             loading={loading}
             onSearch={onSearchItems}
+            onItemPick={(itemId) => {
+              const price = existingPriceFor(itemId)
+              if (price != null) {
+                form.setValue(`order_lines.${rowIndex}.price`, price)
+              }
+            }}
           />
         );
       },
@@ -540,6 +585,23 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
       disableHiding: true,
     }),
     columnHelper.column({
+      id: "extra_cost",
+      name: "Extra Cost",
+      header: "Extra Cost",
+      // Per-unit charge a partner adds on top of price (colour job, finishing, …).
+      field: (context: any) => `order_lines.${context.row.index}.extra_cost`,
+      type: "number",
+      cell: (context: any) => {
+        return (
+          <DataGridCurrencyCell
+            context={context}
+            code={defaultCurrencyCode}
+          />
+        );
+      },
+      disableHiding: true,
+    }),
+    columnHelper.column({
       id: "actions",
       name: "Actions",
       header: "",
@@ -616,6 +678,9 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
       }
       if (col.id === "price") {
         return { ...col, size: 220, maxSize: 320 }
+      }
+      if (col.id === "extra_cost") {
+        return { ...col, size: 200, maxSize: 300 }
       }
       if (col.id === "actions") {
         return { ...col, size: 120, maxSize: 140 }

--- a/apps/backend/src/admin/components/inventory-orders/__tests__/order-lines-payload.unit.spec.ts
+++ b/apps/backend/src/admin/components/inventory-orders/__tests__/order-lines-payload.unit.spec.ts
@@ -27,6 +27,14 @@ describe("computeOrderLineTotals", () => {
     expect(totals.totalQuantity).toBe(18);
     expect(totals.totalPrice).toBe(10 * 100 + 5 * 200 + 3 * 50); // 2150
   });
+
+  it("adds a per-unit extra_cost on top of price", () => {
+    // (100 + 25) × 2 = 250.
+    const totals = computeOrderLineTotals([
+      { inventory_item_id: "iitem_X", quantity: 2, price: 100, extra_cost: 25 },
+    ]);
+    expect(totals.totalPrice).toBe(250);
+  });
 });
 
 describe("buildOrderLinesUpdatePayload", () => {
@@ -59,6 +67,13 @@ describe("buildOrderLinesUpdatePayload", () => {
     const created = payload.order_lines.filter((l) => !l.remove && !l.id);
     expect(created).toHaveLength(1);
     expect(created[0].inventory_item_id).toBe("iitem_D");
+  });
+
+  it("persists a per-unit extra_cost on the keep entry", () => {
+    const edited = [{ ...THREE[0], extra_cost: 30 }, THREE[1], THREE[2]];
+    const payload = buildOrderLinesUpdatePayload(THREE, edited);
+    const first = payload.order_lines.find((l) => l.id === "ordli_A");
+    expect(first).toMatchObject({ id: "ordli_A", extra_cost: 30 });
   });
 
   it("remove ONE line: exactly one removal marker for the dropped DB id", () => {

--- a/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
@@ -25,6 +25,8 @@ const editOrderLinesSchema = z.object({
         inventory_item_id: z.string().min(1, "Item is required"),
         quantity: z.number().min(1, "Quantity must be at least 1"),
         price: z.number().min(0, "Price must be non-negative"),
+        // Per-unit extra charge on top of price (colour/dye job, finishing, …).
+        extra_cost: z.number().min(0, "Extra cost must be non-negative").optional(),
         batch_number: z.number().int().positive().nullish(), // batch tag (separate-batch adds)
         isExisting: z.boolean().optional(), // Flag to mark existing lines
       })
@@ -39,6 +41,8 @@ interface OrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  // Per-unit extra charge on top of price (colour/dye job, finishing, …).
+  extra_cost?: number;
   batch_number?: number | null;
   isExisting?: boolean;
 }
@@ -60,6 +64,7 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
     inventory_item_id: line.inventory_items?.[0]?.id || line.inventory_item_id || "",
     quantity: line.quantity,
     price: line.price,
+    extra_cost: line.extra_cost ?? 0,
     batch_number: line.batch_number ?? null,
     isExisting: true, // Mark as existing
   }));
@@ -120,6 +125,7 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
         inventory_item_id: formLine.inventory_item_id,
         quantity: Number(formLine.quantity) || 0,
         price: Number(formLine.price) || 0,
+        extra_cost: Number(formLine.extra_cost) || 0,
         batch_number: (formLine as any).batch_number ?? line.batch_number ?? null,
       };
     });
@@ -158,14 +164,14 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
                     <AddMaterialGroupControl
                       existingItemIds={existingItemIds}
                       onAdd={(lines) =>
-                        lines.forEach((l) => append({ ...l, isExisting: false }))
+                        lines.forEach((l) => append({ ...l, extra_cost: 0, isExisting: false }))
                       }
                     />
                     <Button
                       size="small"
                       variant="secondary"
                       type="button"
-                      onClick={() => append({ inventory_item_id: "", quantity: 0, price: 0, isExisting: false })}
+                      onClick={() => append({ inventory_item_id: "", quantity: 0, price: 0, extra_cost: 0, isExisting: false })}
                     >
                       Add New Line
                     </Button>
@@ -185,7 +191,7 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
                   inventoryItems={inventory_items}
                   defaultCurrencyCode="INR"
                   loading={isLoading}
-                  onAddNewRow={() => append({ inventory_item_id: "", quantity: 0, price: 0, isExisting: false })}
+                  onAddNewRow={() => append({ inventory_item_id: "", quantity: 0, price: 0, extra_cost: 0, isExisting: false })}
                   onRemoveRow={remove}
                 />
               </div>

--- a/apps/backend/src/admin/components/inventory-orders/order-lines-payload.ts
+++ b/apps/backend/src/admin/components/inventory-orders/order-lines-payload.ts
@@ -23,6 +23,8 @@ export interface EditableOrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  // Per-unit extra charge on top of price (colour/dye job, finishing, …).
+  extra_cost?: number;
   batch_number?: number | null;
   /** True for rows that already exist in the database. */
   isExisting?: boolean;
@@ -35,6 +37,8 @@ export interface OrderLineUpdateEntry {
   variant_id?: string;
   quantity?: number;
   price?: number;
+  // Per-unit extra charge on top of price (colour/dye job, finishing, …).
+  extra_cost?: number;
   batch_number?: number | null;
   remove?: boolean;
 }
@@ -51,8 +55,12 @@ export function computeOrderLineTotals(lines: EditableOrderLine[]): {
 } {
   const valid = lines.filter((l) => l && l.inventory_item_id);
   const totalQuantity = valid.reduce((sum, l) => sum + (Number(l.quantity) || 0), 0);
+  // Per-unit price + per-unit extra cost (colour job), × quantity.
   const totalPrice = valid.reduce(
-    (sum, l) => sum + (Number(l.price) || 0) * (Number(l.quantity) || 0),
+    (sum, l) =>
+      sum +
+      ((Number(l.price) || 0) + (Number(l.extra_cost) || 0)) *
+        (Number(l.quantity) || 0),
     0
   );
   return { totalQuantity, totalPrice };
@@ -81,6 +89,7 @@ export function buildOrderLinesUpdatePayload(
     ...toOrderLineRef(line.inventory_item_id),
     quantity: Number(line.quantity) || 0,
     price: Number(line.price) || 0,
+    extra_cost: Number(line.extra_cost) || 0,
     batch_number: line.batch_number ?? null,
   }));
 

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -16,6 +16,8 @@ export interface OrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  // Per-unit extra charge on top of price (colour/dye job, finishing, …).
+  extra_cost?: number | null;
   // Batch tag for separate-batch quick-add lines (null ⇒ not batched).
   batch_number?: number | null;
   // #817 S2 — denormalized color identity persisted on the line.

--- a/apps/backend/src/admin/hooks/api/raw-materials.ts
+++ b/apps/backend/src/admin/hooks/api/raw-materials.ts
@@ -528,6 +528,9 @@ export type InventoryCatalogItem = InventoryItem & {
     id: string
     title?: string | null
     sku?: string | null
+    // #1744 — the variant's existing price (money amounts, one per currency),
+    // so the order-lines form can pre-fill `price` on pick.
+    prices?: Array<{ amount?: number | string | null; currency_code?: string | null }>
     product?: { id: string; title?: string | null; thumbnail?: string | null } | null
   }>
   kind?: InventoryCatalogKind

--- a/apps/backend/src/api/admin/inventory-items/catalog/helpers.ts
+++ b/apps/backend/src/api/admin/inventory-items/catalog/helpers.ts
@@ -148,6 +148,11 @@ export const getInventoryCatalog = async (
         "variants.id",
         "variants.title",
         "variants.sku",
+        // #1744 — the variant's existing price, so the order-lines form can
+        // pre-fill `price` when a finished-goods variant is picked. Money
+        // amounts, one row per currency; the UI matches on INR (or first).
+        "variants.prices.amount",
+        "variants.prices.currency_code",
         "variants.product.id",
         "variants.product.title",
         "variants.product.thumbnail",
@@ -167,6 +172,10 @@ export const getInventoryCatalog = async (
         "variants.title",
         "variants.sku",
         "variants.manage_inventory",
+        // #1744 — same reason as the inventory_item sweep above: carry the
+        // untracked variant's price so the form can pre-fill it on pick.
+        "variants.prices.amount",
+        "variants.prices.currency_code",
         "variants.inventory_items.inventory_item_id",
         "variants.inventory_items.inventory.id",
       ],
@@ -236,6 +245,7 @@ export const getInventoryCatalog = async (
             id: variant.id,
             title: variant.title,
             sku: variant.sku,
+            prices: variant.prices ?? [],
             product: productId
               ? {
                   id: productId,

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -17,6 +17,8 @@ export const inventoryOrderLineInputSchema = z.object({
   // Allow decimal quantities >= 0 (0 allowed for empty seeded rows)
   quantity: z.number().nonnegative("Quantity must be zero or positive"),
   price: z.number().nonnegative("Price must be zero or positive"),
+  // Per-unit extra charge on top of `price` (colour/dye job, finishing, …).
+  extra_cost: z.number().nonnegative("Extra cost must be zero or positive").optional(),
   // Optional batch tag for the "keep batches as separate lines" quick-add mode.
   batch_number: z.number().int().positive().nullish(),
   metadata: z.record(z.string(), z.unknown()).optional(),
@@ -48,6 +50,9 @@ const inventoryOrdersBaseSchema = z.object({
   // Allow decimal order quantity (sum of line quantities)
   quantity: z.number().nonnegative("Order quantity must be zero or positive"),
   total_price: z.number().nonnegative("Total price must be zero or positive"),
+  // Order-level tax entered at create time. Written as an order charge of type
+  // "tax" (NOT folded into total_price) so the payable ceiling picks it up.
+  tax_amount: z.number().nonnegative("Tax must be zero or positive").optional(),
   // #778 H9 — ISO currency code; defaults to inr at the DB layer when omitted.
   currency_code: z.string().min(3).max(3).optional(),
   // System-only statuses (e.g. "Partial") are intentionally excluded — see
@@ -188,6 +193,8 @@ export const updateOrderLineSchema = z
     variant_id: z.string().optional(),
     quantity: z.number().optional(),
     price: z.number().optional(),
+    // Per-unit extra charge on top of `price` (see inventoryOrderLineInputSchema).
+    extra_cost: z.number().nonnegative().optional(),
     // Optional batch tag (see inventoryOrderLineInputSchema).
     batch_number: z.number().int().positive().nullish(),
     // Explicit removal marker for an existing line: the update workflow

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -494,6 +494,106 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       status: STR("Optional status filter."),
     }),
   },
+  {
+    name: "create_inventory_order",
+    description:
+      "Create an inventory order (a raw-material purchase / stock movement) with its order lines. Each line carries a per-unit `price` and an optional per-unit `extra_cost` (a colour/dye job or other finishing a partner charges on top); `tax_amount` is an ORDER-LEVEL tax recorded as a charge and must NOT be folded into `total_price`. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/inventory-orders",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "order_lines",
+      "quantity",
+      "total_price",
+      "currency_code",
+      "status",
+      "expected_delivery_date",
+      "order_date",
+      "shipping_address",
+      "stock_location_id",
+      "from_stock_location_id",
+      "to_stock_location_id",
+      "is_sample",
+      "tax_amount",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        order_lines: {
+          type: "array",
+          description:
+            "The order lines. Each names an existing inventory item (inventory_item_id) OR an untracked product variant (variant_id), with quantity, per-unit price, and optional per-unit extra_cost (colour job).",
+          items: {
+            type: "object",
+            properties: {
+              inventory_item_id: STR(
+                "Existing inventory item id. Exactly one of inventory_item_id or variant_id."
+              ),
+              variant_id: STR(
+                "Untracked product variant id (the order write establishes its inventory item). Exactly one of inventory_item_id or variant_id."
+              ),
+              quantity: { type: "number", description: "Quantity to order." },
+              price: { type: "number", description: "Per-unit price." },
+              extra_cost: {
+                type: "number",
+                description:
+                  "Per-unit extra charge on top of price (colour/dye job, finishing). Defaults to 0.",
+              },
+              batch_number: {
+                type: "integer",
+                description: "Optional batch tag for separate-batch lines.",
+              },
+            },
+            required: ["quantity", "price"],
+            additionalProperties: false,
+          },
+        },
+        quantity: {
+          type: "number",
+          description: "Total quantity — the sum of line quantities.",
+        },
+        total_price: {
+          type: "number",
+          description:
+            "Total goods price: Σ (price + extra_cost) × quantity. Do NOT include tax here.",
+        },
+        currency_code: STR("ISO currency code, e.g. 'inr'. Defaults to inr."),
+        status: STR(
+          "Order status: Pending, Processing, Ready for Delivery, Shipped, Delivered, Cancelled. Typically 'Pending'."
+        ),
+        expected_delivery_date: STR("ISO date the order is expected to arrive."),
+        order_date: STR("ISO date of the order."),
+        shipping_address: {
+          type: "object",
+          description: "Shipping address object. Usually {} when unknown.",
+        },
+        stock_location_id: STR("Destination ('to') stock location id (required)."),
+        from_stock_location_id: STR("Optional source ('from') stock location id."),
+        to_stock_location_id: STR(
+          "Alias for the destination ('to') stock location — omit if stock_location_id is given."
+        ),
+        is_sample: BOOL("Whether this is a sample order (defaults false)."),
+        metadata: { type: "object", description: "Free-form metadata." },
+        tax_amount: {
+          type: "number",
+          description:
+            "Order-level tax, recorded as a charge of type 'tax'. Raises the payable ceiling; never folded into total_price.",
+        },
+      },
+      [
+        "order_lines",
+        "quantity",
+        "total_price",
+        "status",
+        "expected_delivery_date",
+        "order_date",
+        "shipping_address",
+        "stock_location_id",
+      ]
+    ),
+    nextSteps: ["list_inventory_orders"],
+  },
 
   // ===== Money =============================================================
   {

--- a/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
@@ -34,6 +34,17 @@ describe("sumLineTotals (#778 H9 — price is per-unit)", () => {
   it("is 0 for no lines", () => {
     expect(sumLineTotals([])).toBe(0)
   })
+
+  it("adds a per-unit extra_cost on top of price", () => {
+    // (100 + 20) × 3 = 360.
+    expect(
+      sumLineTotals([{ price: 100, extra_cost: 20, quantity: 3 }])
+    ).toBe(360)
+  })
+
+  it("treats a missing extra_cost as 0", () => {
+    expect(sumLineTotals([{ price: 100, quantity: 2 }])).toBe(200)
+  })
 })
 
 describe("buildOrderLinePayloads (#778 C3)", () => {
@@ -46,8 +57,8 @@ describe("buildOrderLinePayloads (#778 C3)", () => {
       "invord_1"
     )
     expect(payloads).toEqual([
-      { quantity: 10, price: 50, metadata: { sku: "A" }, inventory_orders: "invord_1", batch_number: null, color: null, material_name: null, raw_material_id: null },
-      { quantity: 4, price: 100, metadata: null, inventory_orders: "invord_1", batch_number: null, color: null, material_name: null, raw_material_id: null },
+      { quantity: 10, price: 50, metadata: { sku: "A" }, inventory_orders: "invord_1", batch_number: null, color: null, material_name: null, raw_material_id: null, extra_cost: null },
+      { quantity: 4, price: 100, metadata: null, inventory_orders: "invord_1", batch_number: null, color: null, material_name: null, raw_material_id: null, extra_cost: null },
     ])
   })
 
@@ -68,6 +79,18 @@ describe("buildOrderLinePayloads (#778 C3)", () => {
       "invord_1"
     )
     expect(payload).toMatchObject({ color: "Blue", material_name: "Cotton Poplin", raw_material_id: "rm_1" })
+  })
+
+  it("passes through a per-unit extra_cost, defaulting to null", () => {
+    const [withCost, withoutCost] = buildOrderLinePayloads(
+      [
+        { inventory_id: "iitem_1", quantity: 1, price: 100, extra_cost: 20 },
+        { inventory_id: "iitem_2", quantity: 1, price: 50 },
+      ],
+      "invord_1"
+    )
+    expect(withCost.extra_cost).toBe(20)
+    expect(withoutCost.extra_cost).toBeNull()
   })
 })
 

--- a/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
@@ -19,6 +19,8 @@ export type CreateOrderLineInput = {
   color?: string | null
   material_name?: string | null
   raw_material_id?: string | null
+  // Per-unit extra charge on top of `price` (colour job, finishing, …).
+  extra_cost?: number | null
 }
 
 export type OrderLinePayload = {
@@ -32,6 +34,8 @@ export type OrderLinePayload = {
   color: string | null
   material_name: string | null
   raw_material_id: string | null
+  // Per-unit extra charge on top of `price` (null ⇒ none).
+  extra_cost: number | null
 }
 
 /** The line ↔ inventory-item pairing used to create the module links. */
@@ -44,14 +48,19 @@ export type LineItemPair = {
  * Sum the per-unit line prices into an order total (#778 H9).
  *
  * `price` is the PER-UNIT price (matches the admin UI, validators, and registry
- * cost reads), so each line contributes `price × quantity`. Used as the fallback
- * order total when a caller (e.g. a visual flow) omits `total_price`.
+ * cost reads), so each line contributes `price × quantity`. `extra_cost` is a
+ * per-unit add-on billed on top of the price (colour job, …), so a line with one
+ * contributes `(price + extra_cost) × quantity`. Used as the fallback order total
+ * when a caller (e.g. a visual flow) omits `total_price`.
  */
 export const sumLineTotals = (
-  order_lines: Pick<CreateOrderLineInput, "price" | "quantity">[]
+  order_lines: Pick<CreateOrderLineInput, "price" | "quantity" | "extra_cost">[]
 ): number =>
   order_lines.reduce(
-    (sum, l) => sum + (Number(l.price) || 0) * (Number(l.quantity) || 0),
+    (sum, l) =>
+      sum +
+      ((Number(l.price) || 0) + (Number(l.extra_cost) || 0)) *
+        (Number(l.quantity) || 0),
     0
   )
 
@@ -71,6 +80,8 @@ export const buildOrderLinePayloads = (
     color: line.color ?? null,
     material_name: line.material_name ?? null,
     raw_material_id: line.raw_material_id ?? null,
+    // Per-unit extra charge on top of price (defaults to null when absent).
+    extra_cost: line.extra_cost ?? null,
   }))
 
 /** Denormalized color identity for one inventory_item's linked raw_material. */

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260904130000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260904130000.ts
@@ -1,0 +1,26 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Adds nullable `extra_cost` to `inventory_order_line` — a per-unit extra
+ * charge a partner bills on top of `price` (colour/dye job, finishing, …).
+ *
+ * Hand-written idempotent ALTER: the table exists on live DBs, and a generated
+ * migration here would re-emit columns owned by earlier hand-written ones.
+ */
+export class Migration20260904130000 extends Migration {
+
+  override async up(): Promise<void> {
+    // `extra_cost` is a bigNumber, which Medusa DML models as TWO columns: the
+    // numeric value and a `raw_<field>` jsonb carrying the raw BigNumber (value
+    // + precision). Adding only the numeric column leaves the ORM writing to a
+    // `raw_extra_cost` that does not exist.
+    this.addSql(`alter table if exists "inventory_order_line" add column if not exists "extra_cost" numeric null;`);
+    this.addSql(`alter table if exists "inventory_order_line" add column if not exists "raw_extra_cost" jsonb null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_order_line" drop column if exists "extra_cost";`);
+    this.addSql(`alter table if exists "inventory_order_line" drop column if exists "raw_extra_cost";`);
+  }
+
+}

--- a/apps/backend/src/modules/inventory_orders/models/orderline.ts
+++ b/apps/backend/src/modules/inventory_orders/models/orderline.ts
@@ -6,6 +6,17 @@ const OrderLine = model.define("inventory_order_line", {
   // We are linking module links to order line with inventory and product
   quantity: model.float(),
   price: model.bigNumber(),
+  /**
+   * Per-unit extra charge a partner applies on top of `price` — a colour/dye
+   * job, a finishing step, any value-add they bill per piece. Null means "none".
+   *
+   * Per-UNIT, not a line total: like `price`, a line contributes
+   * `(price + extra_cost) × quantity` to the order total, so the colour job is
+   * part of the goods' agreed value rather than a separate obligation. Folded
+   * into `total_price` at write time, so the payable ceiling (goods + charges)
+   * picks it up without a second arithmetic path.
+   */
+  extra_cost: model.bigNumber().nullable(),
   // #817 S2 — color identity denormalized off the linked inventory_item's
   // raw_material at creation time, so an order line is self-describing (display
   // + filtering) without re-traversing line → inventory_item → raw_material.

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -28,6 +28,12 @@ interface CreateInventoryOrder {
   metadata?: Record<string, unknown>;
   shipping_address: Record<string, unknown>;
   is_sample: boolean;
+  /**
+   * Order-level tax entered at create time. Written as an `inventory_order_charge`
+   * of type `tax` in the same transaction, so it raises the payable ceiling via
+   * the existing `order-charges` fold (never folded into `total_price`).
+   */
+  tax_amount?: number;
 }
 
 interface CreateOrderLine {
@@ -39,6 +45,8 @@ interface CreateOrderLine {
   color?: string | null;
   material_name?: string | null;
   raw_material_id?: string | null;
+  // Per-unit extra charge on top of `price` (colour job, finishing, …).
+  extra_cost?: number | null;
 }
 
 class InventoryOrderService extends MedusaService({
@@ -109,11 +117,16 @@ class InventoryOrderService extends MedusaService({
     let order: InferTypeOf<typeof InventoryOrder>;
     let orderLines: OrderLinesResponse;
     try {
+      // `tax_amount` is not an inventory_order column — it is a charge that rides
+      // beside the order. Strip it before the order write so `createInventoryOrders`
+      // never sees an unknown field, then write it as a charge below in the SAME
+      // transaction (a failure there rolls the order back too).
+      const { tax_amount, ...orderFields } = inventory_order;
       // Both writes share `sharedContext` → same transaction. A failure on the
       // lines rolls the order back too (rethrow below keeps us inside the
       // transaction's failure path).
       order = (await this.createInventoryOrders(
-        { ...inventory_order },
+        { ...orderFields },
         sharedContext
       )) as InferTypeOf<typeof InventoryOrder>;
 
@@ -121,6 +134,20 @@ class InventoryOrderService extends MedusaService({
         buildOrderLinePayloads(order_lines, order.id),
         sharedContext
       )) as OrderLinesResponse;
+
+      // Order-level tax, recorded as a charge (NOT goods). `type: "tax"` is what
+      // makes `foldOrderCharges` count it as a raise to the payable ceiling.
+      if (tax_amount != null && Number(tax_amount) > 0) {
+        await this.createOrderCharges(
+          {
+            type: "tax",
+            amount: Number(tax_amount),
+            note: null,
+            inventory_orders_id: order.id,
+          },
+          sharedContext
+        );
+      }
     } catch (err: any) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -40,6 +40,8 @@ export interface InventoryOrderLineInput {
   variant_id?: string;
   quantity: number;
   price: number;
+  // Per-unit extra charge on top of `price` (colour/dye job, finishing, …).
+  extra_cost?: number;
   batch_number?: number | null;
   metadata?: Record<string, unknown>;
 }
@@ -57,6 +59,8 @@ export interface CreateInventoryOrderInput {
   metadata?: Record<string, unknown>;
   order_lines: InventoryOrderLineInput[];
   is_sample: boolean;
+  // Order-level tax, recorded as an order charge of type "tax" at create.
+  tax_amount?: number;
 }
 
 // --- Inventory Orders Steps ---
@@ -87,6 +91,7 @@ export const createInventoryOrderWithLinesStep = createStep(
       inventory_id: line.inventory_item_id,
       quantity: line.quantity,
       price: line.price,
+      extra_cost: line.extra_cost ?? null,
       batch_number: line.batch_number ?? null,
       metadata: line.metadata
     };

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -304,10 +304,13 @@ export const dualWriteUnifiedOrderStep = createStep(
       // UI, validators, and registry cost reads). Core also wants unit price, so
       // pass it straight through — do NOT divide by quantity (that was the money
       // bug: it under-priced every multi-unit line on the unified order).
+      // `extra_cost` (colour job, …) is a per-unit add-on folded into the legacy
+      // order's total, so it folds into the mirrored unit price too — otherwise
+      // the unified order understates the legacy order's value by the job cost.
       const items = orderLines.map((line: any, idx: number) => {
         const legacyLine = input.order_lines[idx]
         const quantity = Number(line.quantity)
-        const unitPrice = Number(line.price)
+        const unitPrice = Number(line.price) + Number(line.extra_cost || 0)
         return {
           title: titleByItemId.get(legacyLine?.inventory_item_id) ?? "Raw material",
           quantity,

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -53,6 +53,8 @@ export type UpdateInventoryOrderLineInput = {
   variant_id?: string;
   quantity?: number;
   price?: number;
+  // Per-unit extra charge on top of `price` (colour/dye job, finishing, …).
+  extra_cost?: number;
   batch_number?: number | null; // Batch tag for separate-batch quick-add lines
   remove?: boolean; // If true, remove this orderline
 };
@@ -266,7 +268,7 @@ export const updateOrderLinesStep = createStep(
     }
 
     const created: Array<{ id: string; inventory_item_id?: string }> = [];
-    const updated: Array<{ id: string; prevQuantity: number; prevPrice: any }> = [];
+    const updated: Array<{ id: string; prevQuantity: number; prevPrice: any; prevExtraCost: any }> = [];
     const removed: Array<{ id: string; inventory_item_id?: string; quantity: number; price: any }> = [];
 
     // Remove orderlines marked for removal
@@ -297,13 +299,14 @@ export const updateOrderLinesStep = createStep(
       if (line.id) {
         const prev = byId.get(line.id);
         // Capture prior values before overwriting so compensation restores them in place.
-        updated.push({ id: line.id, prevQuantity: prev?.quantity, prevPrice: prev?.price });
+        updated.push({ id: line.id, prevQuantity: prev?.quantity, prevPrice: prev?.price, prevExtraCost: prev?.extra_cost });
         // Update orderline fields
         await inventoryOrderService.updateOrderLines({
           selector: { id: line.id },
           data: {
             quantity: line.quantity,
             price: line.price,
+            ...(line.extra_cost !== undefined ? { extra_cost: line.extra_cost } : {}),
             ...(line.batch_number !== undefined ? { batch_number: line.batch_number } : {}),
           }
         });
@@ -315,6 +318,7 @@ export const updateOrderLinesStep = createStep(
           inventory_orders_id: input.order_id,
           quantity: line.quantity,
           price: line.price,
+          extra_cost: line.extra_cost ?? null,
           batch_number: line.batch_number ?? null,
           color: info?.color ?? null,
           material_name: info?.material_name ?? null,
@@ -349,7 +353,7 @@ export const updateOrderLinesStep = createStep(
   async (
     compensationData: {
       created: Array<{ id: string; inventory_item_id?: string }>;
-      updated: Array<{ id: string; prevQuantity: number; prevPrice: any }>;
+      updated: Array<{ id: string; prevQuantity: number; prevPrice: any; prevExtraCost: any }>;
       removed: Array<{ id: string; inventory_item_id?: string; quantity: number; price: any }>;
       order_id: string;
     },
@@ -372,7 +376,7 @@ export const updateOrderLinesStep = createStep(
     for (const u of compensationData.updated || []) {
       await inventoryOrderService.updateOrderLines({
         selector: { id: u.id },
-        data: { quantity: u.prevQuantity, price: u.prevPrice },
+        data: { quantity: u.prevQuantity, price: u.prevPrice, extra_cost: u.prevExtraCost },
       });
     }
     // Restore removed lines (same ids) + recreate their links


### PR DESCRIPTION
## Summary

Inventory orders can now bill a **per-unit extra cost** on each line (a colour/dye job or other finishing a partner charges on top of the goods price) and an **order-level tax** entered manually at create time. The create and edit UIs expose both, the admin MCP surface gains a `create_inventory_order` tool carrying them, and picking an item pre-fills its price.

## Changes

- **Data** — `inventory_order_line.extra_cost` (per-unit, bigNumber) + migration; folded into `total_price` at write time so the existing payable-ceiling path picks it up automatically.
- **Tax** — `tax_amount` on create is written as an `inventory_order_charge` (type `tax`) in the same transaction, raising the payable ceiling (never folded into `total_price`).
- **Create UI** — new **Extra Cost** grid column + **Tax** field, footer totals include both.
- **Edit UI** — `extra_cost` is editable on the order-lines screen (preserved on update, not dropped).
- **MCP** — new `create_inventory_order` tool (tier `sensitive`) with `extra_cost` per line + `tax_amount`.
- **Price pre-fill** — the catalog now carries variant prices; picking an item auto-fills `price` from the raw material's `unit_cost` or the variant's INR price.

## Testing

- Unit: catalog helpers, order-lines-payload, create-helpers, MCP tier/slice/dispatch/coverage — all pass.
- Integration: `inventory-orders-api` — 26/26 (includes new extra_cost + tax cases).

## Migration

`Migration20260904130000` adds `extra_cost` (numeric) + `raw_extra_cost` (jsonb) to `inventory_order_line`.