### PR TITLE
feat(production-runs): bulk approve/reject what completed runs produced (#1805)

### DIFF
--- a/apps/backend/integration-tests/http/admin-run-output-review.spec.ts
+++ b/apps/backend/integration-tests/http/admin-run-output-review.spec.ts
@@ -1,0 +1,406 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(240000)
+
+/**
+ * Reviewing what completed runs produced, in bulk (#1805).
+ *
+ * ## The assertion that matters is a COUNT, not a 200
+ *
+ * `create-product-from-design` appends another `"Custom - <name>"` variant when
+ * the design already has a product. One approval at a time that is a rare
+ * misclick; over a selection of runs it is the default, because a design
+ * routinely has several completed runs and "select all completed" selects all
+ * of them. A bulk tool that returns 200 twice while quietly listing the same
+ * design twice is exactly the failure this exists to prevent — so the tests
+ * below count products and variants after the fact, as the issue asked.
+ */
+setupSharedTestSuite(() => {
+  describe("POST /admin/production-runs/approvals", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    const loud = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+      try {
+        return await fn()
+      } catch (e: any) {
+        console.log(`[${label}] ${e.response?.status}`, JSON.stringify(e.response?.data))
+        throw e
+      }
+    }
+
+    async function setup() {
+      const container = getContainer()
+      const unique = Date.now()
+      await createAdminUser(container)
+      const adminHeaders = await getAuthHeaders(api)
+      return { adminHeaders, unique }
+    }
+
+    async function createPartner(unique: number, tag: string) {
+      const email = `review-${tag}-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      let login = await api.post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${login.data.token}` }
+
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Review Partner ${tag} ${unique}`,
+          handle: `review-partner-${tag}-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      login = await api.post("/auth/partner/emailpass", { email, password })
+      return {
+        partnerId: res.data.partner.id,
+        partnerHeaders: { Authorization: `Bearer ${login.data.token}` },
+      }
+    }
+
+    async function createTemplate(adminHeaders: any, unique: number) {
+      const name = `review-cutting-${unique}`
+      await api.post(
+        "/admin/task-templates",
+        {
+          name,
+          description: "Cutting",
+          priority: "medium",
+          estimated_duration: 60,
+          required_fields: {},
+          eventable: false,
+          notifiable: false,
+          message_template: "",
+          metadata: { workflow_type: "production_run" },
+          category: `Review Test ${unique}`,
+        },
+        adminHeaders
+      )
+      return name
+    }
+
+    /** A design costed in INR — the currency the product must be listed in. */
+    async function createDesign(adminHeaders: any, unique: number, tag = "a") {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name: `Review Design ${tag} ${unique}`,
+          description: "Design for output review",
+          design_type: "Original",
+          status: "In_Development",
+          priority: "Medium",
+          estimated_cost: 850,
+          cost_currency: "inr",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id
+    }
+
+    async function completeRun(runId: string, partnerHeaders: any, produced = 10) {
+      await api.post(`/partners/production-runs/${runId}/accept`, {}, { headers: partnerHeaders })
+      await api.post(`/partners/production-runs/${runId}/start`, {}, { headers: partnerHeaders })
+      await api.post(`/partners/production-runs/${runId}/finish`, {}, { headers: partnerHeaders })
+      const res = await api.post(
+        `/partners/production-runs/${runId}/complete`,
+        { produced_quantity: produced },
+        { headers: partnerHeaders }
+      )
+      expect(res.data.production_run.status).toBe("completed")
+    }
+
+    /**
+     * TWO completed runs of ONE design — the shape that breaks a naive bulk
+     * loop. Partner assignments fan a design's run out into children, and both
+     * children are "completed runs" in the operator's list.
+     */
+    async function twoCompletedRunsOfOneDesign(adminHeaders: any, unique: number) {
+      const template = await createTemplate(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique)
+      const a = await createPartner(unique, "a")
+      const b = await createPartner(unique, "b")
+
+      const createRes = await loud("create-runs", () =>
+        api.post(
+          `/admin/designs/${designId}/production-runs`,
+          {
+            quantity: 20,
+            assignments: [
+              { partner_id: a.partnerId, quantity: 10, template_names: [template] },
+              { partner_id: b.partnerId, quantity: 10, template_names: [template] },
+            ],
+          },
+          adminHeaders
+        )
+      )
+      const children = createRes.data.children
+      expect(children).toHaveLength(2)
+
+      await completeRun(children[0].id, a.partnerHeaders)
+      await completeRun(children[1].id, b.partnerHeaders)
+
+      return { designId, runIds: [children[0].id, children[1].id] as string[] }
+    }
+
+    const readRun = async (adminHeaders: any, runId: string) =>
+      (await api.get(`/admin/production-runs/${runId}`, adminHeaders)).data
+        .production_run
+
+    /** 🔑 The count, straight off the product. */
+    const readProduct = async (adminHeaders: any, productId: string) =>
+      (
+        await api.get(
+          `/admin/products/${productId}?fields=*variants,*variants.prices`,
+          adminHeaders
+        )
+      ).data.product
+
+    it("previews the batch and creates nothing", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runIds } = await twoCompletedRunsOfOneDesign(adminHeaders, unique)
+
+      const res = await loud("dry-run", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: runIds, decision: "approve", dry_run: true },
+          adminHeaders
+        )
+      )
+
+      const report = res.data.run_approvals
+      expect(report.dry_run).toBe(true)
+      expect(report.approved).toHaveLength(2)
+      // Two runs, ONE design — the number the list cannot show.
+      expect(report.design_ids).toHaveLength(1)
+      expect(report.created_product_ids).toEqual([])
+
+      // Nothing was decided.
+      for (const runId of runIds) {
+        expect((await readRun(adminHeaders, runId)).approval_decision).toBeNull()
+      }
+    })
+
+    /**
+     * 🔴 THE test. Two runs, one design, one product — and approving again
+     * must still leave one product with one variant.
+     */
+    it("creates ONE product for two runs of a design, and is idempotent", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runIds } = await twoCompletedRunsOfOneDesign(adminHeaders, unique)
+
+      const first = await loud("approve", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: runIds, decision: "approve" },
+          adminHeaders
+        )
+      )
+
+      const report = first.data.run_approvals
+      expect(report.approved).toHaveLength(2)
+      expect(report.created_product_ids).toHaveLength(1)
+
+      const productId = report.created_product_ids[0]
+      const product = await readProduct(adminHeaders, productId)
+      expect(product.variants).toHaveLength(1)
+
+      // Both runs name the SAME product.
+      for (const runId of runIds) {
+        const run = await readRun(adminHeaders, runId)
+        expect(run.approval_decision).toBe("approved")
+        expect(run.approved_product_id).toBe(productId)
+        // The work still reads as completed — that is what the partner is paid on.
+        expect(run.status).toBe("completed")
+      }
+
+      // ---- and again -------------------------------------------------------
+      const second = await loud("approve-again", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: runIds, decision: "approve" },
+          adminHeaders
+        )
+      )
+      expect(second.data.run_approvals.created_product_ids).toEqual([])
+      expect(second.data.run_approvals.skipped).toHaveLength(2)
+
+      const after = await readProduct(adminHeaders, productId)
+      // 🔑 STILL ONE. A second "Custom - <name>" variant here is the defect.
+      expect(after.variants).toHaveLength(1)
+    })
+
+    /**
+     * 🔴 The case the per-design grouping alone does NOT cover, and the one the
+     * founder named: a LATER run of a design that was already approved.
+     *
+     * Inside one batch the design is grouped and the product is created once —
+     * so a test that approves two runs together passes whether or not the
+     * "already has a product" branch exists. It is the SECOND batch, weeks
+     * later, on a recreated or re-run job, that meets
+     * `create-product-from-design`'s append-a-variant branch. That is where the
+     * design gets listed twice, and this is the test that watches for it.
+     */
+    it("does not add a second variant when a later run of the same design is approved", async () => {
+      const { adminHeaders, unique } = await setup()
+      const template = await createTemplate(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique, "later")
+      const a = await createPartner(unique, "later-a")
+      const b = await createPartner(unique, "later-b")
+
+      const firstRun = await loud("first-run", () =>
+        api.post(
+          `/admin/designs/${designId}/production-runs`,
+          {
+            quantity: 10,
+            assignments: [
+              { partner_id: a.partnerId, quantity: 10, template_names: [template] },
+            ],
+          },
+          adminHeaders
+        )
+      )
+      const runOne = firstRun.data.children[0].id
+      await completeRun(runOne, a.partnerHeaders)
+
+      const approvedFirst = await loud("approve-first", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: [runOne], decision: "approve" },
+          adminHeaders
+        )
+      )
+      const productId = approvedFirst.data.run_approvals.created_product_ids[0]
+      expect(productId).toBeTruthy()
+      expect((await readProduct(adminHeaders, productId)).variants).toHaveLength(1)
+
+      // ---- a second job for the same design, finished later ----------------
+      const secondRun = await loud("second-run", () =>
+        api.post(
+          `/admin/designs/${designId}/production-runs`,
+          {
+            quantity: 5,
+            assignments: [
+              { partner_id: b.partnerId, quantity: 5, template_names: [template] },
+            ],
+          },
+          adminHeaders
+        )
+      )
+      const runTwo = secondRun.data.children[0].id
+      await completeRun(runTwo, b.partnerHeaders, 5)
+
+      const approvedSecond = await loud("approve-second", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: [runTwo], decision: "approve" },
+          adminHeaders
+        )
+      )
+
+      /**
+       * 🔑 The catalogue FIRST, before any assertion about the report. A
+       * second "Custom - <name>" variant here is the defect the issue opened
+       * on, and it is a fact about the database — the report is only this
+       * code's account of itself, and an account is not evidence.
+       */
+      const after = await readProduct(adminHeaders, productId)
+      expect(after.variants).toHaveLength(1)
+
+      const report = approvedSecond.data.run_approvals
+      expect(report.approved).toEqual([runTwo])
+      // Nothing new was created — the design was already listed.
+      expect(report.created_product_ids).toEqual([])
+      expect(report.runs[0].product_existed).toBe(true)
+      expect(report.runs[0].product_id).toBe(productId)
+
+      // And the later run names the same product it was folded into.
+      expect((await readRun(adminHeaders, runTwo)).approved_product_id).toBe(productId)
+    })
+
+    /** The design was costed in INR; listing it in USD is the bug (#1805). */
+    it("lists the product in the design's currency, not usd", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runIds } = await twoCompletedRunsOfOneDesign(adminHeaders, unique)
+
+      const res = await loud("approve-currency", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: runIds, decision: "approve" },
+          adminHeaders
+        )
+      )
+
+      const productId = res.data.run_approvals.created_product_ids[0]
+      const product = await readProduct(adminHeaders, productId)
+      const currencies = (product.variants?.[0]?.prices ?? []).map(
+        (p: any) => p.currency_code
+      )
+      expect(currencies).toContain("inr")
+      expect(currencies).not.toContain("usd")
+    })
+
+    it("rejects without creating anything, and keeps the run completed", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runIds } = await twoCompletedRunsOfOneDesign(adminHeaders, unique)
+
+      const res = await loud("reject", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          {
+            run_ids: [runIds[0]],
+            decision: "reject",
+            reason: "Dye lot off-shade",
+          },
+          adminHeaders
+        )
+      )
+
+      expect(res.data.run_approvals.rejected).toEqual([runIds[0]])
+      expect(res.data.run_approvals.created_product_ids).toEqual([])
+
+      const run = await readRun(adminHeaders, runIds[0])
+      expect(run.approval_decision).toBe("rejected")
+      expect(run.approval_reason).toBe("Dye lot off-shade")
+      expect(run.approved_product_id).toBeNull()
+      // 🔴 Still completed. The goods were made and are still billable.
+      expect(run.status).toBe("completed")
+    })
+
+    it("refuses a rejection with no reason", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runIds } = await twoCompletedRunsOfOneDesign(adminHeaders, unique)
+
+      await expect(
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: runIds, decision: "reject" },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    /** The queue: completed runs nobody has decided about. */
+    it("lists only the runs awaiting review", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runIds } = await twoCompletedRunsOfOneDesign(adminHeaders, unique)
+
+      await api.post(
+        "/admin/production-runs/approvals",
+        { run_ids: [runIds[0]], decision: "reject", reason: "Off-shade" },
+        adminHeaders
+      )
+
+      const res = await api.get(
+        "/admin/production-runs?status=completed&approval_decision=none&limit=100",
+        adminHeaders
+      )
+      const ids = res.data.production_runs.map((r: any) => r.id)
+      expect(ids).toContain(runIds[1])
+      // The decided one has LEFT the queue — the whole point of the column.
+      expect(ids).not.toContain(runIds[0])
+    })
+  })
+})

--- a/apps/backend/src/admin/components/production-runs/run-output-review-panel.tsx
+++ b/apps/backend/src/admin/components/production-runs/run-output-review-panel.tsx
@@ -1,0 +1,344 @@
+import {
+  Badge,
+  Button,
+  Drawer,
+  Heading,
+  Table,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { useEffect, useMemo, useState } from "react"
+
+import {
+  useRunApprovals,
+  type RunApprovalReport,
+} from "../../hooks/api/production-runs"
+
+type Decision = "approve" | "reject"
+
+type Props = {
+  decision: Decision | null
+  runIds: string[]
+  onClose: () => void
+  /** Called after a decision has actually been applied. */
+  onApplied: () => void
+}
+
+const outcomeColor = (outcome: RunApprovalReport["outcome"]) =>
+  outcome === "approved"
+    ? "green"
+    : outcome === "rejected"
+      ? "orange"
+      : outcome === "failed"
+        ? "red"
+        : "grey"
+
+const shortId = (id: string) => (id?.length > 12 ? `${id.slice(0, 10)}…` : id)
+
+/**
+ * Reviewing what completed runs produced, in bulk (#1805).
+ *
+ * ## The preview is the point, not a courtesy
+ *
+ * An operator selecting "all completed runs" is selecting several runs of the
+ * SAME design — parent/child partner assignments, recreations — and approval
+ * creates a product per design, not per run. So the count they selected and the
+ * count of things that will be created are different numbers, and the
+ * difference is invisible from the list. This panel asks the server what would
+ * happen (`dry_run`) and shows it before anything is created: which runs map to
+ * which design, which designs already have a product and will NOT be listed
+ * again, and what each will be listed at.
+ *
+ * 🔑 The same call, run for real, returns the same per-run shape — so the
+ * "before" and the "after" are the same table, and an operator can see that
+ * three runs were skipped rather than reading a toast that says "Done".
+ */
+export const RunOutputReviewPanel = ({
+  decision,
+  runIds,
+  onClose,
+  onApplied,
+}: Props) => {
+  const [reason, setReason] = useState("")
+  const [plan, setPlan] = useState<RunApprovalReport[] | null>(null)
+  const [applied, setApplied] = useState<RunApprovalReport[] | null>(null)
+  /**
+   * How many runs the batch WAS, frozen at submit.
+   *
+   * The parent clears its selection the moment a decision lands, so reading
+   * `runIds.length` afterwards reported "1 of 0 runs" — a live count describing
+   * a finished batch.
+   */
+  const [batchSize, setBatchSize] = useState(0)
+
+  const { mutateAsync: review, isPending } = useRunApprovals()
+
+  const open = Boolean(decision)
+
+  /**
+   * Ask the server what this batch means, whenever the batch changes.
+   *
+   * 🔴 Keyed on a STRING signature, not on the array. `runIds` is rebuilt by
+   * the parent on every render, so an effect depending on the array itself
+   * re-fires forever — and each re-fire would wipe a reason the operator was
+   * halfway through typing (#1803).
+   */
+  const signature = `${decision ?? ""}:${runIds.join(",")}`
+
+  useEffect(() => {
+    if (!decision || !runIds.length) {
+      setPlan(null)
+      return
+    }
+    setApplied(null)
+    setReason("")
+    setBatchSize(runIds.length)
+
+    let cancelled = false
+    review({
+      run_ids: runIds,
+      decision,
+      dry_run: true,
+    })
+      .then((res) => {
+        if (!cancelled) setPlan(res.run_approvals.runs)
+      })
+      .catch((e: any) => {
+        if (!cancelled) {
+          toast.error(e?.message ?? "Could not work out what this would do.")
+          setPlan([])
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signature])
+
+  const rows = applied ?? plan ?? []
+
+  const actionable = useMemo(
+    () =>
+      rows.filter((r) => r.outcome === "approved" || r.outcome === "rejected"),
+    [rows]
+  )
+  const skipped = useMemo(
+    () => rows.filter((r) => r.outcome === "skipped"),
+    [rows]
+  )
+  const failed = useMemo(() => rows.filter((r) => r.outcome === "failed"), [rows])
+
+  /** Designs that will be listed for the first time by THIS batch. */
+  const toCreate = useMemo(
+    () =>
+      new Set(
+        rows
+          .filter((r) => r.outcome === "approved" && !r.product_existed)
+          .map((r) => r.design_id)
+      ).size,
+    [rows]
+  )
+  const alreadyListed = useMemo(
+    () =>
+      new Set(
+        rows
+          .filter((r) => r.outcome === "approved" && r.product_existed)
+          .map((r) => r.design_id)
+      ).size,
+    [rows]
+  )
+
+  const needsReason = decision === "reject" && !reason.trim()
+
+  const confirm = async () => {
+    if (!decision) return
+    try {
+      const res = await review({
+        run_ids: runIds,
+        decision,
+        ...(decision === "reject" ? { reason: reason.trim() } : {}),
+      })
+      const result = res.run_approvals
+      setApplied(result.runs)
+      onApplied()
+
+      const done =
+        decision === "approve" ? result.approved.length : result.rejected.length
+
+      /**
+       * 🔑 The counts, out loud. A partial batch is a real outcome (#1263) and
+       * a toast that says "Done" over three failures is how it goes unnoticed.
+       */
+      const parts = [`${done} run${done === 1 ? "" : "s"} ${decision}d`]
+      if (decision === "approve") {
+        parts.push(
+          `${result.created_product_ids.length} product${
+            result.created_product_ids.length === 1 ? "" : "s"
+          } created`
+        )
+      }
+      if (result.skipped.length) parts.push(`${result.skipped.length} skipped`)
+      if (result.failed.length) parts.push(`${result.failed.length} failed`)
+
+      if (result.failed.length) {
+        toast.warning(parts.join(", "))
+      } else {
+        toast.success(parts.join(", "))
+      }
+    } catch (e: any) {
+      toast.error(e?.message ?? "Could not apply the decision.")
+    }
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={(next) => !next && onClose()}>
+      <Drawer.Content className="flex flex-col">
+        <Drawer.Header>
+          <Drawer.Title asChild>
+            <Heading level="h2">
+              {decision === "reject" ? "Reject output" : "Approve output"}
+            </Heading>
+          </Drawer.Title>
+        </Drawer.Header>
+
+        <Drawer.Body className="flex-1 overflow-y-auto">
+          <Text size="small" className="text-ui-fg-subtle mb-4">
+            {decision === "reject"
+              ? "Nothing is created. The runs stay completed — the work was done and is still billable — and they leave this queue with the reason recorded."
+              : "A product is created once per DESIGN, however many of its runs you selected. A design that already has a product is not listed again."}
+          </Text>
+
+          {isPending && !rows.length ? (
+            <Text size="small" className="text-ui-fg-subtle">
+              Working out what this would do…
+            </Text>
+          ) : null}
+
+          {rows.length ? (
+            <>
+              {!applied && (
+                <Text size="small" weight="plus" className="mb-1">
+                  Preview — nothing has been created yet.
+                </Text>
+              )}
+              <div className="mb-4 flex flex-wrap gap-x-4 gap-y-1">
+                <Text size="small" weight="plus">
+                  {actionable.length} of {batchSize} runs
+                </Text>
+                {decision === "approve" && (
+                  <>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {toCreate} product{toCreate === 1 ? "" : "s"} to create
+                    </Text>
+                    {alreadyListed > 0 && (
+                      <Text size="small" className="text-ui-fg-subtle">
+                        {alreadyListed} design
+                        {alreadyListed === 1 ? "" : "s"} already listed
+                      </Text>
+                    )}
+                  </>
+                )}
+                {skipped.length > 0 && (
+                  <Text size="small" className="text-ui-fg-subtle">
+                    {skipped.length} skipped
+                  </Text>
+                )}
+                {failed.length > 0 && (
+                  <Text size="small" className="text-ui-fg-error">
+                    {failed.length} failed
+                  </Text>
+                )}
+              </div>
+
+              <div className="overflow-x-auto">
+                <Table>
+                  <Table.Header>
+                    <Table.Row>
+                      <Table.HeaderCell>Run</Table.HeaderCell>
+                      <Table.HeaderCell>Design</Table.HeaderCell>
+                      <Table.HeaderCell>Outcome</Table.HeaderCell>
+                      <Table.HeaderCell>Notes</Table.HeaderCell>
+                    </Table.Row>
+                  </Table.Header>
+                  <Table.Body>
+                    {rows.map((r) => (
+                      <Table.Row key={r.run_id}>
+                        <Table.Cell className="font-mono text-ui-fg-subtle">
+                          {shortId(r.run_id)}
+                        </Table.Cell>
+                        <Table.Cell>{r.design_name ?? "—"}</Table.Cell>
+                        <Table.Cell>
+                          {/*
+                            The outcome word alone. "would be approved" wrapped
+                            to two lines inside the column and read as a
+                            different, longer status — the preview/applied
+                            distinction is said once, above the table, where it
+                            has room to be said properly.
+                          */}
+                          <Badge size="2xsmall" color={outcomeColor(r.outcome) as any}>
+                            {r.outcome}
+                          </Badge>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Text size="small" className="text-ui-fg-subtle">
+                            {r.reason
+                              ? r.reason
+                              : r.product_existed
+                                ? "Already listed — nothing new created"
+                                : r.outcome === "approved"
+                                  ? `Lists at ${r.listed_price ?? 0} ${(
+                                      r.currency_code ?? ""
+                                    ).toUpperCase()}`
+                                  : "—"}
+                          </Text>
+                        </Table.Cell>
+                      </Table.Row>
+                    ))}
+                  </Table.Body>
+                </Table>
+              </div>
+            </>
+          ) : null}
+
+          {decision === "reject" && !applied && (
+            <div className="mt-4">
+              <Text size="small" weight="plus" className="mb-1">
+                Why is this output being refused?
+              </Text>
+              <Text size="small" className="text-ui-fg-subtle mb-2">
+                Required. It is the only record of why, and the partner who made
+                the goods has to be able to be told.
+              </Text>
+              <Textarea
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="e.g. Dye lot off-shade against the approved swatch"
+              />
+            </div>
+          )}
+        </Drawer.Body>
+
+        <Drawer.Footer>
+          <Button variant="secondary" size="small" onClick={onClose}>
+            {applied ? "Close" : "Cancel"}
+          </Button>
+          {!applied && (
+            <Button
+              size="small"
+              variant={decision === "reject" ? "danger" : "primary"}
+              isLoading={isPending}
+              disabled={!actionable.length || needsReason}
+              onClick={confirm}
+            >
+              {decision === "reject"
+                ? `Reject ${actionable.length}`
+                : `Approve ${actionable.length}`}
+            </Button>
+          )}
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -57,6 +57,53 @@ export type AdminProductionRun = Record<string, any> & {
   short_closed_by?: string | null
   short_close_reason?: string | null
   short_closed_quantity?: number | null
+  /**
+   * #1805 — the OUTPUT review. Null means nobody has looked yet, which is what
+   * the review queue filters on. A rejected run stays `completed`: the work was
+   * done and the partner is still owed for it.
+   */
+  approval_decision?: "approved" | "rejected" | null
+  approval_decided_at?: string | null
+  approval_decided_by?: string | null
+  approval_reason?: string | null
+  approved_product_id?: string | null
+  approved_variant_id?: string | null
+}
+
+/** One run's fate in a bulk output review (#1805). */
+export type RunApprovalReport = {
+  run_id: string
+  design_id: string | null
+  design_name: string | null
+  status: string | null
+  outcome: "approved" | "rejected" | "skipped" | "failed"
+  reason?: string
+  product_id?: string | null
+  variant_id?: string | null
+  product_existed?: boolean
+  currency_code?: string
+  listed_price?: number
+}
+
+export type RunApprovalsResponse = {
+  run_approvals: {
+    decision: "approve" | "reject"
+    dry_run?: boolean
+    runs: RunApprovalReport[]
+    design_ids: string[]
+    created_product_ids: string[]
+    approved: string[]
+    rejected: string[]
+    skipped: string[]
+    failed: string[]
+  }
+}
+
+export type RunApprovalsPayload = {
+  run_ids: string[]
+  decision: "approve" | "reject"
+  reason?: string | null
+  dry_run?: boolean
 }
 
 export type AdminCreateDesignProductionRunResponse =
@@ -937,6 +984,44 @@ export const useReopenProductionRun = (
       queryClient.invalidateQueries({
         queryKey: [...productionRunQueryKeys.detail(runId), "activities"],
       })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+  })
+}
+
+/**
+ * Review what completed runs produced, in bulk (#1805).
+ *
+ * 🔴 `...options` BEFORE `onSuccess`, never after. Spread afterwards, a
+ * caller's own `onSuccess` REPLACES this one and the list silently keeps
+ * showing decided runs until a hard refresh — the defect #1800 found in 165
+ * hooks.
+ *
+ * 🔑 A `dry_run` call must invalidate NOTHING: it changed nothing, and
+ * refetching the list underneath a review the operator is reading is how a
+ * preview turns into a moving target.
+ */
+export const useRunApprovals = (
+  options?: UseMutationOptions<
+    RunApprovalsResponse,
+    FetchError,
+    RunApprovalsPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: RunApprovalsPayload) =>
+      sdk.client.fetch<RunApprovalsResponse>(
+        "/admin/production-runs/approvals",
+        { method: "POST", body: payload }
+      ),
+    ...options,
+    onSuccess: (data, variables, _mutateResult, context) => {
+      if (!variables.dry_run) {
+        queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.lists() })
+        queryClient.invalidateQueries({ queryKey: designQueryKeys.lists() })
+      }
       options?.onSuccess?.(data, variables, _mutateResult, context)
     },
   })

--- a/apps/backend/src/admin/routes/production-runs/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/page.tsx
@@ -1,15 +1,18 @@
 import {
+  Badge,
+  CommandBar,
   Container,
   DataTable,
   DataTableFilteringState,
   DataTablePaginationState,
+  DataTableRowSelectionState,
   Heading,
   StatusBadge,
   Text,
+  createDataTableColumnHelper,
   createDataTableFilterHelper,
   useDataTable,
 } from "@medusajs/ui"
-import { createColumnHelper } from "@tanstack/react-table"
 import { useCallback, useMemo, useState } from "react"
 import debounce from "lodash/debounce"
 import { Link, useNavigate } from "react-router-dom"
@@ -17,10 +20,19 @@ import { Link, useNavigate } from "react-router-dom"
 import { useProductionRuns, type AdminProductionRun } from "../../hooks/api/production-runs"
 import { usePartners } from "../../hooks/api/partners"
 import { productionRunStatusColor } from "../../lib/status-colors"
+import { RunOutputReviewPanel } from "../../components/production-runs/run-output-review-panel"
 
 const PAGE_SIZE = 20
 
-const columnHelper = createColumnHelper<AdminProductionRun>()
+/**
+ * 🔴 Medusa's OWN helper, not `@tanstack/react-table`'s.
+ *
+ * Only this one has `.select()`, and without that column the table renders no
+ * checkboxes at all — `rowSelection` state is wired, nothing can set it, and
+ * the bulk command bar can never open. Configuring the state is not the same as
+ * offering the control; the screen is the only place that difference shows.
+ */
+const columnHelper = createDataTableColumnHelper<AdminProductionRun>()
 
 const STATUS_OPTIONS = [
   "draft",
@@ -51,6 +63,9 @@ const ProductionRunsListPage = () => {
   })
   const [filtering, setFiltering] = useState<DataTableFilteringState>({})
   const [search, setSearch] = useState("")
+  const [rowSelection, setRowSelection] = useState<DataTableRowSelectionState>({})
+  /** Which review is open, if any (#1805). */
+  const [decision, setDecision] = useState<"approve" | "reject" | null>(null)
 
   const handleFilterChange = useCallback(
     debounce((nf: DataTableFilteringState) => {
@@ -76,6 +91,12 @@ const ProductionRunsListPage = () => {
       : (filtering.status as string)
     : undefined
 
+  const reviewFilter = filtering.approval_decision
+    ? Array.isArray(filtering.approval_decision)
+      ? (filtering.approval_decision[0] as string)
+      : (filtering.approval_decision as string)
+    : undefined
+
   const runTypeFilter = filtering.run_type
     ? Array.isArray(filtering.run_type)
       ? (filtering.run_type[0] as string)
@@ -95,6 +116,7 @@ const ProductionRunsListPage = () => {
     status: statusFilter,
     run_type: runTypeFilter,
     partner_id: partnerFilter,
+    approval_decision: reviewFilter,
     exclude_children: true,
   })
 
@@ -107,8 +129,14 @@ const ProductionRunsListPage = () => {
     [partners],
   )
 
+  const selectedRunIds = useMemo(
+    () => Object.keys(rowSelection).filter((k) => rowSelection[k]),
+    [rowSelection]
+  )
+
   const columns = useMemo(
     () => [
+      columnHelper.select(),
       columnHelper.accessor("id", {
         header: "Run",
         cell: ({ getValue }) => (
@@ -195,6 +223,34 @@ const ProductionRunsListPage = () => {
           )
         },
       }),
+      /**
+       * #1805 — the output review, as its own column.
+       *
+       * It is deliberately NOT folded into Status: a rejected run is still
+       * `completed`, because the work was done and the partner is still owed
+       * for it. Two facts, two columns — and "—" on a completed run is the
+       * queue's whole content: nobody has looked at it yet.
+       */
+      columnHelper.accessor("approval_decision", {
+        header: "Review",
+        cell: ({ row, getValue }) => {
+          const decided = getValue() as string | null | undefined
+          if (!decided) {
+            return row.original?.status === "completed" ? (
+              <Text size="small" className="text-ui-fg-subtle">
+                Awaiting review
+              </Text>
+            ) : (
+              <Text size="small" className="text-ui-fg-subtle">—</Text>
+            )
+          }
+          return (
+            <Badge size="2xsmall" color={decided === "approved" ? "green" : "orange"}>
+              {labelFor(decided)}
+            </Badge>
+          )
+        },
+      }),
       columnHelper.accessor("created_at", {
         header: "Created",
         cell: ({ getValue }) => {
@@ -236,6 +292,20 @@ const ProductionRunsListPage = () => {
         label: "Partner",
         options: partnerOptions,
       }),
+      /*
+        #1805 — "Awaiting review" + Status: Completed IS the review queue.
+        `none` rather than an empty value: absent means "any", and the queue
+        needs to ask for the runs nobody has decided about.
+      */
+      filterHelper.accessor("approval_decision", {
+        type: "select",
+        label: "Review",
+        options: [
+          { label: "Awaiting review", value: "none" },
+          { label: "Approved", value: "approved" },
+          { label: "Rejected", value: "rejected" },
+        ],
+      }),
     ],
     [partnerOptions],
   )
@@ -247,6 +317,10 @@ const ProductionRunsListPage = () => {
     filters,
     getRowId: (row) => row.id,
     onRowClick: (_, row) => navigate(`/production-runs/${row.id}`),
+    rowSelection: {
+      state: rowSelection,
+      onRowSelectionChange: setRowSelection,
+    },
     isLoading,
     pagination: {
       state: pagination,
@@ -288,6 +362,42 @@ const ProductionRunsListPage = () => {
         <DataTable.Table />
         <DataTable.Pagination />
       </DataTable>
+
+      {/*
+        #1805 — the output review, in bulk. Approve creates the catalogue
+        product (once per DESIGN, however many of its runs are selected);
+        reject creates nothing and records why.
+      */}
+      <CommandBar open={selectedRunIds.length > 0}>
+        <CommandBar.Bar>
+          <CommandBar.Value>{selectedRunIds.length} selected</CommandBar.Value>
+          <CommandBar.Seperator />
+          <CommandBar.Command
+            label="Approve"
+            shortcut="a"
+            action={() => setDecision("approve")}
+          />
+          <CommandBar.Seperator />
+          <CommandBar.Command
+            label="Reject"
+            shortcut="r"
+            action={() => setDecision("reject")}
+          />
+        </CommandBar.Bar>
+      </CommandBar>
+
+      <RunOutputReviewPanel
+        decision={decision}
+        runIds={selectedRunIds}
+        onClose={() => setDecision(null)}
+        /*
+         * Clear the selection once a decision has landed. Leaving it would
+         * offer the same runs for a second decision they can no longer take,
+         * and the second attempt would come back as a list of "Already
+         * approved" skips — technically correct, and unreadable as feedback.
+         */
+        onApplied={() => setRowSelection({})}
+      />
     </Container>
   )
 }

--- a/apps/backend/src/api/admin/designs/[id]/approve/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/approve/route.ts
@@ -7,6 +7,10 @@ import type { IEventBusModuleService } from "@medusajs/types";
 import updateDesignWorkflow from "../../../../../workflows/designs/update-design";
 import { createProductFromDesignWorkflow } from "../../../../../workflows/designs/create-product-from-design";
 import designCustomerLink from "../../../../../links/design-customer-link";
+import {
+  readStoreCurrency,
+  resolveApprovalCurrency,
+} from "../../../../../workflows/production-runs/approve-run-output";
 
 /**
  * POST /admin/designs/:id/approve
@@ -34,7 +38,7 @@ export async function POST(
     const { data: designs } = await query.graph({
       entity: "design",
       filters: { id: designId },
-      fields: ["id", "name", "estimated_cost"],
+      fields: ["id", "name", "estimated_cost", "cost_currency"],
     });
 
     if (!designs || designs.length === 0) {
@@ -78,7 +82,17 @@ export async function POST(
           design_id: designId,
           estimated_cost: design.estimated_cost || 0,
           customer_id: customerId,
-          currency_code: "usd",
+          /**
+           * 🔴 Was hardcoded `"usd"` on a platform that trades in AUD and INR,
+           * so every approved design was listed in a currency nobody sells in
+           * (#1805). Resolved from the design's own `cost_currency` — what the
+           * work was costed in — with the store default behind it. The rule is
+           * shared with the bulk review so the two paths cannot disagree.
+           */
+          currency_code: resolveApprovalCurrency({
+            designCurrency: (design as any).cost_currency,
+            storeCurrency: await readStoreCurrency(req.scope),
+          }),
         },
       });
 

--- a/apps/backend/src/api/admin/production-runs/approvals/route.ts
+++ b/apps/backend/src/api/admin/production-runs/approvals/route.ts
@@ -1,0 +1,41 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+
+import { applyRunApprovals } from "../../../../workflows/production-runs/approve-run-output"
+
+/**
+ * POST /admin/production-runs/approvals — review what completed runs produced
+ * (#1805).
+ *
+ * `{ run_ids[], decision: "approve" | "reject", reason?, dry_run? }`
+ *
+ * Approve creates the catalogue product (once per DESIGN, however many of its
+ * runs are in the selection); reject records the refusal and creates nothing.
+ * Everything that makes this more than a loop — the per-design idempotency, the
+ * resolved currency, the per-run report — lives in `applyRunApprovals`, whose
+ * docblock has the argument.
+ *
+ * 🔑 It answers 200 with a REPORT, not a bare success. A batch where 3 of 12
+ * runs were skipped because their design already had a product is a normal
+ * outcome and the operator has to be able to see it (#1263).
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> => {
+  const body = req.validatedBody as any
+
+  const result = await applyRunApprovals(req.scope, {
+    runIds: body.run_ids,
+    decision: body.decision,
+    reason: body.reason ?? null,
+    // Who decided. `auth_context` is the admin acting; "system" only when a
+    // job ever calls this.
+    actorId: req.auth_context?.actor_id ?? null,
+    dryRun: Boolean(body.dry_run),
+  })
+
+  res.status(200).json({ run_approvals: result })
+}

--- a/apps/backend/src/api/admin/production-runs/route.ts
+++ b/apps/backend/src/api/admin/production-runs/route.ts
@@ -265,6 +265,18 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   if (q.run_type) {
     filters.run_type = q.run_type
   }
+  /**
+   * #1805 — the output-review queue.
+   *
+   * `"none"` is a real answer and the one the queue is built on: a completed
+   * run nobody has decided about yet. It cannot be spelled by omitting the
+   * param (that means "any"), and `null` cannot travel in a query string —
+   * hence the word.
+   */
+  if (q.approval_decision) {
+    filters.approval_decision =
+      q.approval_decision === "none" ? null : q.approval_decision
+  }
 
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -169,6 +169,47 @@ export const AdminFinishProductionRunReq = z.object({
   notes: z.string().max(1000).nullish(),
 })
 
+/**
+ * Reviewing what completed runs produced, in bulk (#1805).
+ *
+ * 🔴 A rejection MUST carry a reason. "Rejected" with nothing beside it is the
+ * same dead end as no state at all, one step later: the next person meets a run
+ * that was refused and cannot learn why, and the partner who made the goods
+ * cannot be told. An approval needs no reason — the product it created is the
+ * record.
+ *
+ * `run_ids` is bounded. A selection is something a person made on a screen; an
+ * unbounded list is how a mis-built client asks to decide the entire platform's
+ * production history in one call.
+ */
+export const AdminRunApprovalsReq = z
+  .object({
+    run_ids: z.array(z.string().trim().min(1)).min(1).max(200),
+    decision: z.enum(["approve", "reject"]),
+    reason: z.string().trim().max(1000).nullish(),
+    /**
+     * Resolve which runs map to which designs, which designs already have a
+     * product, and what each decision WOULD create — and create nothing. Same
+     * reason the collate wizard has one (#1803): the operator sees the shape of
+     * the batch before it happens.
+     */
+    dry_run: z.boolean().optional(),
+  })
+  .refine(
+    // A PREVIEW is not a decision, so it does not need the reason a decision
+    // does — an operator asks what a rejection would cover before writing the
+    // sentence that explains it.
+    (b) =>
+      b.dry_run === true ||
+      b.decision !== "reject" ||
+      Boolean(b.reason && b.reason.trim()),
+    {
+      message:
+        "A rejection needs a reason — it is the only record of why the output was refused, and the partner who made the goods has to be able to be told.",
+      path: ["reason"],
+    }
+  )
+
 export type AdminCreateProductionRunReq = z.infer<typeof AdminCreateProductionRunReq>
 export type AdminApproveProductionRunReq = z.infer<typeof AdminApproveProductionRunReq>
 export type AdminSendProductionRunToProductionReq = z.infer<typeof AdminSendProductionRunToProductionReq>
@@ -177,3 +218,4 @@ export type AdminResumeDispatchProductionRunReq = z.infer<typeof AdminResumeDisp
 export type AdminAssignProductionRunPartnerReq = z.infer<typeof AdminAssignProductionRunPartnerReq>
 export type AdminRedispatchParkedRunsReq = z.infer<typeof AdminRedispatchParkedRunsReq>
 export type AdminFinishProductionRunReq = z.infer<typeof AdminFinishProductionRunReq>
+export type AdminRunApprovalsReq = z.infer<typeof AdminRunApprovalsReq>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -161,6 +161,7 @@ import {
   AdminApproveProductionRunReq,
   AdminAssignProductionRunPartnerReq,
   AdminRedispatchParkedRunsReq,
+  AdminRunApprovalsReq,
   AdminCreateProductionRunReq,
   AdminCancelProductionRunReq,
   AdminResumeDispatchProductionRunReq,
@@ -5089,6 +5090,18 @@ export default defineMiddlewares({
       matcher: "/admin/production-runs/redispatch-parked",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminRedispatchParkedRunsReq))],
+    },
+    {
+      /**
+       * #1805 — review what completed runs produced, in bulk.
+       *
+       * A static segment beside `redispatch-parked`. Nothing shadows it: every
+       * parameterised production-run matcher carries a second segment, so none
+       * of them can read "approvals" as an id.
+       */
+      matcher: "/admin/production-runs/approvals",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminRunApprovalsReq))],
     },
 
     {

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260905093000.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260905093000.ts
@@ -1,0 +1,81 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * #1805 — the output review on a completed run.
+ *
+ * A completed run's goods are reviewed before anything is listed for sale:
+ * approve creates the catalogue product, reject creates nothing. Until now
+ * there was no record of either, so "rejected" was indistinguishable from
+ * "nobody has looked yet" and a rejected run came back in the queue forever.
+ *
+ * 🔴 A separate AXIS from `status`. A rejected run stays `completed` — it WAS
+ * completed, the partner is still owed for `produced_quantity`, and billing
+ * keys on that status. See the model for the full argument.
+ *
+ * All nullable with no default, so every existing run reads as UNREVIEWED,
+ * which is what they are.
+ *
+ * ⚠️ The check constraint is written the way MikroORM writes one for a DML
+ * enum (`<table>_<column>_check`). Leaving it out would let the column drift
+ * from the model, and a value the model has never heard of is how an enum
+ * column fails an INSERT with a bare 500 (#1439's `quoted_weight_source`).
+ */
+export class Migration20260905093000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      alter table if exists "production_runs"
+        add column if not exists "approval_decision" text null,
+        add column if not exists "approval_decided_at" timestamptz null,
+        add column if not exists "approval_decided_by" text null,
+        add column if not exists "approval_reason" text null,
+        add column if not exists "approved_product_id" text null,
+        add column if not exists "approved_variant_id" text null;
+    `);
+
+    this.addSql(`
+      alter table if exists "production_runs"
+        drop constraint if exists "production_runs_approval_decision_check";
+    `);
+    this.addSql(`
+      alter table if exists "production_runs"
+        add constraint "production_runs_approval_decision_check"
+        check("approval_decision" in ('approved', 'rejected'));
+    `);
+
+    /**
+     * The review queue is "completed runs nobody has decided on yet", and it is
+     * the only query these columns exist to serve. Partial on the undecided
+     * rows, which is the half that stays small as decided runs accumulate.
+     */
+    this.addSql(`
+      create index if not exists "IDX_production_runs_awaiting_output_review"
+        on "production_runs" ("status")
+        where "approval_decision" is null and "deleted_at" is null;
+    `);
+  }
+
+  /**
+   * Reversible: without these columns every run reads as unreviewed again,
+   * which is the pre-migration behaviour. It DOES discard the decisions
+   * themselves — acceptable because nothing downstream depends on them yet;
+   * the products an approval created are ordinary catalogue rows and survive.
+   */
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_production_runs_awaiting_output_review";`);
+    this.addSql(`
+      alter table if exists "production_runs"
+        drop constraint if exists "production_runs_approval_decision_check";
+    `);
+    this.addSql(`
+      alter table if exists "production_runs"
+        drop column if exists "approval_decision",
+        drop column if exists "approval_decided_at",
+        drop column if exists "approval_decided_by",
+        drop column if exists "approval_reason",
+        drop column if exists "approved_product_id",
+        drop column if exists "approved_variant_id";
+    `);
+  }
+
+}

--- a/apps/backend/src/modules/production_runs/models/production-run.ts
+++ b/apps/backend/src/modules/production_runs/models/production-run.ts
@@ -96,6 +96,44 @@ const ProductionRun = model.define("production_runs", {
   short_close_reason: model.text().nullable(),
   short_closed_quantity: model.float().nullable(),
 
+  /**
+   * ===== The OUTPUT review (#1805) ====================================
+   *
+   * A completed run's goods are looked at before anything is listed for sale:
+   * approve creates the catalogue product, reject creates nothing.
+   *
+   * 🔴 A separate AXIS from `status`, deliberately. A rejected run stays
+   * `completed`, because it WAS completed — the partner made the goods and is
+   * still owed for `produced_quantity`, and billing (`payable-runs`, the
+   * short-close ceiling) keys on that status. Moving the run to a terminal
+   * `rejected` would quietly change what a partner may claim, and would erase
+   * the fact that the work happened at all.
+   *
+   * Null means nobody has looked yet — which is exactly what the review queue
+   * filters on. Before these columns existed, "rejected" was indistinguishable
+   * from "unreviewed", so a rejected run came back in the list forever.
+   *
+   * Typed columns, not metadata: this decides whether something goes on sale
+   * (#1557).
+   */
+  approval_decision: model.enum(["approved", "rejected"]).nullable(),
+  approval_decided_at: model.dateTime().nullable(),
+  /** Admin actor id, or "system". */
+  approval_decided_by: model.text().nullable(),
+  /**
+   * Why. REQUIRED by the route for a rejection — a rejection with no reason is
+   * the same dead end as no state at all, one step later.
+   */
+  approval_reason: model.text().nullable(),
+  /**
+   * What the approval PRODUCED. Names the catalogue product this run's output
+   * was listed as, so an approved run can say what became of it — and so a
+   * second run of the same design can be seen to share one product rather than
+   * having quietly minted a second variant.
+   */
+  approved_product_id: model.text().nullable(),
+  approved_variant_id: model.text().nullable(),
+
   // Cost
   partner_cost_estimate: model.float().nullable(),
   cost_type: model.enum(["per_unit", "total"]).default("total").nullable(),

--- a/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
@@ -1,0 +1,401 @@
+const runWorkflow = jest.fn()
+const createProductFromDesignWorkflow = jest.fn(() => ({ run: createProductRun }))
+const createProductRun = jest.fn()
+const updateDesignRun = jest.fn().mockResolvedValue({ result: {} })
+
+jest.mock("../../designs/create-product-from-design", () => ({
+  createProductFromDesignWorkflow: (...a: any[]) =>
+    (createProductFromDesignWorkflow as any)(...a),
+}))
+jest.mock("../../designs/update-design", () => ({
+  __esModule: true,
+  default: () => ({ run: updateDesignRun }),
+}))
+jest.mock("../../../modules/production_runs", () => ({
+  PRODUCTION_RUNS_MODULE: "production_runs",
+}))
+
+import {
+  applyRunApprovals,
+  resolveApprovalCurrency,
+} from "../approve-run-output"
+
+const listProductionRuns = jest.fn()
+const updateProductionRuns = jest.fn().mockResolvedValue({})
+const graph = jest.fn()
+const emit = jest.fn().mockResolvedValue(undefined)
+
+const container = {
+  resolve: (key: string) => {
+    if (key === "production_runs") {
+      return { listProductionRuns, updateProductionRuns }
+    }
+    if (key === "query") return { graph }
+    if (key === "logger") return { error: jest.fn(), info: jest.fn() }
+    if (key === "event_bus") return { emit }
+    return {}
+  },
+}
+
+const completedRun = (id: string, design_id: string | null, extra: any = {}) => ({
+  id,
+  design_id,
+  status: "completed",
+  snapshot: { design: { name: `Design ${design_id}` } },
+  approval_decision: null,
+  ...extra,
+})
+
+/** A design the graph answers with. `products: []` = never approved. */
+const design = (id: string, extra: any = {}) => ({
+  id,
+  name: `Design ${id}`,
+  estimated_cost: 850,
+  cost_currency: "inr",
+  products: [],
+  ...extra,
+})
+
+const stubGraph = (designsById: Record<string, any>, storeCurrency = "aud") => {
+  graph.mockImplementation(async ({ entity, filters }: any) => {
+    if (entity === "store") {
+      return {
+        data: [
+          {
+            id: "store_1",
+            supported_currencies: [
+              { currency_code: "usd", is_default: false },
+              { currency_code: storeCurrency, is_default: true },
+            ],
+          },
+        ],
+      }
+    }
+    if (entity === "design") {
+      const d = designsById[filters?.id]
+      return { data: d ? [d] : [] }
+    }
+    return { data: [] }
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  createProductFromDesignWorkflow.mockReturnValue({ run: createProductRun } as any)
+  createProductRun.mockResolvedValue({
+    result: { product_id: "prod_new", variant_id: "var_new" },
+  })
+  updateDesignRun.mockResolvedValue({ result: {} })
+})
+
+describe("resolveApprovalCurrency", () => {
+  /**
+   * 🔴 The approve route listed every design in USD on a platform trading in
+   * AUD and INR.
+   */
+  it("prefers what the design was costed in", () => {
+    expect(
+      resolveApprovalCurrency({ designCurrency: "INR", storeCurrency: "aud" })
+    ).toBe("inr")
+  })
+
+  it("falls back to the store, then to usd", () => {
+    expect(resolveApprovalCurrency({ storeCurrency: "AUD" })).toBe("aud")
+    expect(resolveApprovalCurrency({})).toBe("usd")
+  })
+})
+
+describe("applyRunApprovals — approving", () => {
+  /**
+   * 🔴 THE rule. `create-product-from-design` appends another
+   * "Custom - <name>" variant when a design already has a product, so two
+   * completed runs of one design — parent/child assignments, recreations —
+   * would list the same design twice, silently, across a whole selection.
+   */
+  it("creates ONE product for two runs of the same design", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1"),
+      completedRun("run_2", "des_1"),
+    ])
+    stubGraph({ des_1: design("des_1") })
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1", "run_2"],
+      decision: "approve",
+    })
+
+    expect(createProductRun).toHaveBeenCalledTimes(1)
+    expect(result.approved).toEqual(["run_1", "run_2"])
+    expect(result.created_product_ids).toEqual(["prod_new"])
+    // Both runs record the SAME product.
+    expect(result.runs.map((r) => r.product_id)).toEqual(["prod_new", "prod_new"])
+  })
+
+  /** Running it again must create nothing — the second half of idempotency. */
+  it("creates nothing when the design already has a product", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({
+      des_1: design("des_1", {
+        products: [{ id: "prod_existing", variants: [{ id: "var_existing" }] }],
+      }),
+    })
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1"],
+      decision: "approve",
+    })
+
+    expect(createProductRun).not.toHaveBeenCalled()
+    expect(result.created_product_ids).toEqual([])
+    expect(result.runs[0]).toMatchObject({
+      outcome: "approved",
+      product_id: "prod_existing",
+      variant_id: "var_existing",
+      product_existed: true,
+    })
+  })
+
+  it("lists the product in the design's currency, not usd", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { cost_currency: "inr" }) })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(createProductRun.mock.calls[0][0].input).toMatchObject({
+      design_id: "des_1",
+      currency_code: "inr",
+      estimated_cost: 850,
+    })
+  })
+
+  it("falls back to the store's default currency", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { cost_currency: null }) }, "aud")
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(createProductRun.mock.calls[0][0].input.currency_code).toBe("aud")
+  })
+
+  /**
+   * 🔑 Partners are notified off `design.approved`. A 40-run batch over 5
+   * designs must send 5 notifications, not 40 — and none for a design whose
+   * product was already there, because nothing new was approved.
+   */
+  it("emits design.approved once per newly approved design", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1"),
+      completedRun("run_2", "des_1"),
+      completedRun("run_3", "des_2"),
+    ])
+    stubGraph({
+      des_1: design("des_1"),
+      des_2: design("des_2", {
+        products: [{ id: "prod_existing", variants: [] }],
+      }),
+    })
+
+    await applyRunApprovals(container, {
+      runIds: ["run_1", "run_2", "run_3"],
+      decision: "approve",
+    })
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit.mock.calls[0][0].data.design_id).toBe("des_1")
+  })
+
+  it("records the decision on every run of the design", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1"),
+      completedRun("run_2", "des_1"),
+    ])
+    stubGraph({ des_1: design("des_1") })
+
+    await applyRunApprovals(container, {
+      runIds: ["run_1", "run_2"],
+      decision: "approve",
+      actorId: "user_1",
+    })
+
+    const written = updateProductionRuns.mock.calls.map((c) => c[0])
+    expect(written.map((w) => w.id)).toEqual(["run_1", "run_2"])
+    for (const w of written) {
+      expect(w.approval_decision).toBe("approved")
+      expect(w.approved_product_id).toBe("prod_new")
+      expect(w.approval_decided_by).toBe("user_1")
+    }
+  })
+})
+
+describe("applyRunApprovals — refusing what it must not decide", () => {
+  it("skips a run that is not completed, and says why", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1", { status: "in_progress" }),
+    ])
+    stubGraph({ des_1: design("des_1") })
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1"],
+      decision: "approve",
+    })
+
+    expect(result.skipped).toEqual(["run_1"])
+    expect(result.runs[0].reason).toMatch(/in_progress/)
+    expect(createProductRun).not.toHaveBeenCalled()
+  })
+
+  it("skips a run that was already decided", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1", {
+        approval_decision: "rejected",
+        approved_product_id: null,
+      }),
+    ])
+    stubGraph({ des_1: design("des_1") })
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1"],
+      decision: "approve",
+    })
+
+    expect(result.skipped).toEqual(["run_1"])
+    expect(result.runs[0].reason).toMatch(/Already rejected/)
+    expect(updateProductionRuns).not.toHaveBeenCalled()
+  })
+
+  it("reports an unknown run as failed rather than throwing the batch away", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1") })
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_missing", "run_1"],
+      decision: "approve",
+    })
+
+    expect(result.failed).toEqual(["run_missing"])
+    expect(result.approved).toEqual(["run_1"])
+  })
+
+  /**
+   * 🔴 An empty list must never reach the service: an absent id filter means
+   * ALL rows, and a decision applied to every run on the platform is the one
+   * mistake this must be incapable of.
+   */
+  it("never queries with an empty id list", async () => {
+    const result = await applyRunApprovals(container, {
+      runIds: [],
+      decision: "approve",
+    })
+
+    expect(listProductionRuns).not.toHaveBeenCalled()
+    expect(result.runs).toEqual([])
+  })
+
+  it("isolates a design whose product creation throws", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1"),
+      completedRun("run_2", "des_2"),
+    ])
+    stubGraph({ des_1: design("des_1"), des_2: design("des_2") })
+    createProductRun
+      .mockRejectedValueOnce(new Error("price set write failed"))
+      .mockResolvedValueOnce({
+        result: { product_id: "prod_2", variant_id: "var_2" },
+      })
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1", "run_2"],
+      decision: "approve",
+    })
+
+    expect(result.failed).toEqual(["run_1"])
+    expect(result.approved).toEqual(["run_2"])
+    expect(result.runs[0].reason).toMatch(/price set write failed/)
+  })
+})
+
+describe("applyRunApprovals — rejecting", () => {
+  it("creates no product and records the reason", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1") })
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1"],
+      decision: "reject",
+      reason: "Dye lot off-shade",
+      actorId: "user_1",
+    })
+
+    expect(createProductRun).not.toHaveBeenCalled()
+    expect(result.rejected).toEqual(["run_1"])
+
+    const [written] = updateProductionRuns.mock.calls[0]
+    expect(written.approval_decision).toBe("rejected")
+    expect(written.approval_reason).toBe("Dye lot off-shade")
+    // 🔴 The run stays COMPLETED. The partner made the goods and is still owed
+    // for produced_quantity; billing keys on that status.
+    expect("status" in written).toBe(false)
+  })
+
+  /** A run with no design can still be refused — there is just nothing to make. */
+  it("can reject a run that has no design behind it", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", null)])
+    stubGraph({})
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1"],
+      decision: "reject",
+      reason: "Wrong goods",
+    })
+
+    expect(result.rejected).toEqual(["run_1"])
+  })
+
+  it("skips approving a run that has no design", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", null)])
+    stubGraph({})
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1"],
+      decision: "approve",
+    })
+
+    expect(result.skipped).toEqual(["run_1"])
+    expect(result.runs[0].reason).toMatch(/no design/)
+  })
+})
+
+describe("applyRunApprovals — dry run", () => {
+  /** Shows the shape of the batch and writes nothing (#1803's lesson). */
+  it("reports what would happen and creates nothing", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1"),
+      completedRun("run_2", "des_1"),
+      completedRun("run_3", "des_2"),
+    ])
+    stubGraph({
+      des_1: design("des_1"),
+      des_2: design("des_2", {
+        products: [{ id: "prod_existing", variants: [{ id: "var_e" }] }],
+      }),
+    })
+
+    const result = await applyRunApprovals(container, {
+      runIds: ["run_1", "run_2", "run_3"],
+      decision: "approve",
+      dryRun: true,
+    })
+
+    expect(createProductRun).not.toHaveBeenCalled()
+    expect(updateProductionRuns).not.toHaveBeenCalled()
+    expect(updateDesignRun).not.toHaveBeenCalled()
+    expect(emit).not.toHaveBeenCalled()
+
+    expect(result.dry_run).toBe(true)
+    expect(result.approved).toEqual(["run_1", "run_2", "run_3"])
+    // The one thing an operator most needs to see BEFORE deciding: which of
+    // these designs already has a product.
+    expect(result.runs.map((r) => r.product_existed)).toEqual([false, false, true])
+    expect(result.design_ids).toEqual(["des_1", "des_2"])
+  })
+})

--- a/apps/backend/src/workflows/production-runs/approve-run-output.ts
+++ b/apps/backend/src/workflows/production-runs/approve-run-output.ts
@@ -1,0 +1,443 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IEventBusModuleService } from "@medusajs/types"
+
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import { createProductFromDesignWorkflow } from "../designs/create-product-from-design"
+import updateDesignWorkflow from "../designs/update-design"
+
+/**
+ * Reviewing what a completed run PRODUCED (#1805).
+ *
+ * The founder's ask: *"select all complete runs and mass approve/reject.
+ * Reject means no product created, approve means a product was created."*
+ *
+ * ## Why this is not a loop around `POST /admin/designs/:id/approve`
+ *
+ * Three things break at scale, and each is silent:
+ *
+ * 🔴 **Approving twice does not no-op — it adds a variant.**
+ * `create-product-from-design` branches on whether the design already has a
+ * linked product, and when it does it appends another `"Custom - <name>"`
+ * variant. One at a time that is a rare misclick. Over a selection of runs it
+ * is the DEFAULT outcome, because a design routinely has several completed
+ * runs — parent/child partner assignments, recreated runs — and the operator
+ * selecting "all completed" selects all of them. So the unit of the decision
+ * is the RUN, but the unit of product creation is the DESIGN, and a design
+ * that already has a product is left alone.
+ *
+ * 🔴 **`currency_code: "usd"` was hardcoded** in the approve route while the
+ * platform trades in AUD and INR. At scale that mis-prices a whole batch. The
+ * design's own `cost_currency` is the answer; the store default is the
+ * fallback (see `resolveApprovalCurrency`).
+ *
+ * 🔴 **A partial batch is a real outcome and must be said out loud** (#1263).
+ * Every run comes back with what happened to it — approved, rejected, skipped
+ * or failed, and why — rather than one 200 that flattens 40 runs into "done".
+ *
+ * ## Rejection changes nothing about the WORK
+ *
+ * A rejected run stays `completed`. The partner made the goods and is still
+ * owed for `produced_quantity`; billing keys on that status. Rejection is
+ * recorded on its own axis (`approval_decision`), which is also what lets the
+ * queue tell "rejected" from "nobody has looked yet".
+ */
+
+export type RunApprovalDecision = "approve" | "reject"
+
+export type RunApprovalOutcome =
+  | "approved"
+  | "rejected"
+  /** Ineligible, and deliberately not an error — the batch carries on. */
+  | "skipped"
+  /** Eligible, attempted, and it threw. Isolated to this run. */
+  | "failed"
+
+export type RunApprovalReport = {
+  run_id: string
+  design_id: string | null
+  design_name: string | null
+  status: string | null
+  outcome: RunApprovalOutcome
+  /** Why, whenever the outcome is not the obvious one. */
+  reason?: string
+  product_id?: string | null
+  variant_id?: string | null
+  /**
+   * The product was already there and was NOT re-created. The difference
+   * between this and a fresh approval is the whole idempotency story, so it is
+   * reported rather than hidden behind an identical-looking success.
+   */
+  product_existed?: boolean
+  currency_code?: string
+  listed_price?: number
+}
+
+export type RunApprovalResult = {
+  decision: RunApprovalDecision
+  dry_run?: boolean
+  /** One row per requested run, in the order given. */
+  runs: RunApprovalReport[]
+  /** Distinct designs the decision actually applied to. */
+  design_ids: string[]
+  /** Products created by THIS call. Empty on a re-run — that is the point. */
+  created_product_ids: string[]
+  approved: string[]
+  rejected: string[]
+  skipped: string[]
+  failed: string[]
+}
+
+/**
+ * PURE. The currency a design's product is listed in. Exported for tests.
+ *
+ * 🔴 The approve route hardcoded `"usd"` on a platform trading in AUD and INR,
+ * so every approved design was listed in a currency nobody sells in. The
+ * design's own `cost_currency` is what the work was costed in and is the only
+ * figure with a claim to authority here; the store default is a fallback for
+ * designs costed before that column was filled in, and `"usd"` survives only as
+ * the last resort it always was.
+ */
+export function resolveApprovalCurrency(input: {
+  designCurrency?: string | null
+  storeCurrency?: string | null
+}): string {
+  const pick = input.designCurrency || input.storeCurrency || "usd"
+  return String(pick).trim().toLowerCase()
+}
+
+/** The store's default currency, for designs that never recorded their own. */
+export async function readStoreCurrency(container: any): Promise<string | null> {
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const { data: stores = [] } = await query.graph({
+      entity: "store",
+      fields: ["id", "supported_currencies.currency_code", "supported_currencies.is_default"],
+    })
+    const supported = stores?.[0]?.supported_currencies ?? []
+    const fallback = supported.find((c: any) => c?.is_default) ?? supported[0]
+    return fallback?.currency_code ?? null
+  } catch {
+    // A store we cannot read is not a reason to refuse the batch; the design's
+    // own currency answers for most rows, and `resolveApprovalCurrency` still
+    // has its last resort.
+    return null
+  }
+}
+
+const isDecided = (run: any) => Boolean(run?.approval_decision)
+
+export async function applyRunApprovals(
+  container: any,
+  input: {
+    runIds: string[]
+    decision: RunApprovalDecision
+    reason?: string | null
+    actorId?: string | null
+    dryRun?: boolean
+  }
+): Promise<RunApprovalResult> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  const requested = [...new Set(input.runIds.filter(Boolean))]
+  const reports: RunApprovalReport[] = []
+
+  /**
+   * 🔴 Never call the service with an empty id list. `filters: { id: [] }` is
+   * NOT "no rows" in every Medusa reader — an absent filter means ALL rows, and
+   * a bulk decision applied to every run on the platform is the one mistake
+   * this function must be incapable of.
+   */
+  if (!requested.length) {
+    return {
+      decision: input.decision,
+      dry_run: input.dryRun || undefined,
+      runs: [],
+      design_ids: [],
+      created_product_ids: [],
+      approved: [],
+      rejected: [],
+      skipped: [],
+      failed: [],
+    }
+  }
+
+  const runs: any[] = await runService.listProductionRuns({ id: requested })
+  const byId = new Map<string, any>(runs.map((r: any) => [r.id, r]))
+
+  // ---- 1. Which runs may be decided at all -------------------------------
+  const eligible: any[] = []
+
+  for (const runId of requested) {
+    const run = byId.get(runId)
+
+    if (!run) {
+      reports.push({
+        run_id: runId,
+        design_id: null,
+        design_name: null,
+        status: null,
+        outcome: "failed",
+        reason: "No such production run.",
+      })
+      continue
+    }
+
+    const base = {
+      run_id: run.id,
+      design_id: run.design_id ?? null,
+      design_name: run.snapshot?.design?.name ?? null,
+      status: run.status ?? null,
+    }
+
+    if (run.status !== "completed") {
+      reports.push({
+        ...base,
+        outcome: "skipped",
+        reason: `This run is ${run.status}, not completed — there is no output to review yet.`,
+      })
+      continue
+    }
+
+    if (isDecided(run)) {
+      reports.push({
+        ...base,
+        outcome: "skipped",
+        reason: `Already ${run.approval_decision}.`,
+        product_id: run.approved_product_id ?? null,
+        variant_id: run.approved_variant_id ?? null,
+      })
+      continue
+    }
+
+    /**
+     * A run with no design behind it (#1112 — the retail-fulfilment provenance
+     * run) has nothing to make a product FROM. Rejecting it is still
+     * meaningful, so only the approve path refuses it.
+     */
+    if (input.decision === "approve" && !run.design_id) {
+      reports.push({
+        ...base,
+        outcome: "skipped",
+        reason:
+          "This run has no design behind it, so approval has nothing to create a product from.",
+      })
+      continue
+    }
+
+    eligible.push(run)
+  }
+
+  // ---- 2. Reject: record the decision, create nothing ---------------------
+  if (input.decision === "reject") {
+    for (const run of eligible) {
+      const base = {
+        run_id: run.id,
+        design_id: run.design_id ?? null,
+        design_name: run.snapshot?.design?.name ?? null,
+        status: run.status ?? null,
+      }
+
+      if (!input.dryRun) {
+        try {
+          await runService.updateProductionRuns({
+            id: run.id,
+            approval_decision: "rejected",
+            approval_decided_at: new Date(),
+            approval_decided_by: input.actorId ?? "system",
+            approval_reason: input.reason ?? null,
+          })
+        } catch (e: any) {
+          reports.push({
+            ...base,
+            outcome: "failed",
+            reason: e?.message ?? "Could not record the rejection.",
+          })
+          continue
+        }
+      }
+
+      reports.push({ ...base, outcome: "rejected", reason: input.reason ?? undefined })
+    }
+
+    return summarise(input, reports, [])
+  }
+
+  // ---- 3. Approve: one product per DESIGN, however many runs --------------
+  const storeCurrency = await readStoreCurrency(container)
+
+  /** design_id → the runs of that design in this batch, in the order given. */
+  const byDesign = new Map<string, any[]>()
+  for (const run of eligible) {
+    const list = byDesign.get(run.design_id) ?? []
+    list.push(run)
+    byDesign.set(run.design_id, list)
+  }
+
+  const createdProductIds: string[] = []
+
+  for (const [designId, designRuns] of byDesign) {
+    let product_id: string | null = null
+    let variant_id: string | null = null
+    let productExisted = false
+    let currency = resolveApprovalCurrency({ storeCurrency })
+    let price = 0
+
+    try {
+      const { data: designs = [] } = await query.graph({
+        entity: "design",
+        filters: { id: designId },
+        fields: [
+          "id",
+          "name",
+          "estimated_cost",
+          "cost_currency",
+          "products.id",
+          "products.variants.id",
+        ],
+      })
+
+      const design = designs?.[0]
+      if (!design) {
+        throw new Error(`Design not found: ${designId}`)
+      }
+
+      currency = resolveApprovalCurrency({
+        designCurrency: design.cost_currency,
+        storeCurrency,
+      })
+      price = Number(design.estimated_cost ?? 0) || 0
+
+      const linked = design.products?.[0]
+      productExisted = Boolean(linked?.id)
+
+      if (productExisted) {
+        /**
+         * 🔴 THE idempotency rule. `create-product-from-design` would append
+         * another `"Custom - <name>"` variant here, so a design with two
+         * completed runs in one selection would be listed twice, silently.
+         * The existing product IS the approval's output; it is recorded on
+         * every run of the design and nothing is created.
+         */
+        product_id = linked.id
+        variant_id = linked.variants?.[0]?.id ?? null
+      } else if (!input.dryRun) {
+        const { result } = await createProductFromDesignWorkflow(container).run({
+          input: {
+            design_id: designId,
+            estimated_cost: price,
+            currency_code: currency,
+          },
+        })
+        product_id = result?.product_id ?? null
+        variant_id = result?.variant_id ?? null
+        if (product_id) createdProductIds.push(product_id)
+      }
+
+      if (!input.dryRun) {
+        await updateDesignWorkflow(container).run({
+          input: { id: designId, status: "Approved" },
+        })
+
+        for (const run of designRuns) {
+          await runService.updateProductionRuns({
+            id: run.id,
+            approval_decision: "approved",
+            approval_decided_at: new Date(),
+            approval_decided_by: input.actorId ?? "system",
+            approval_reason: input.reason ?? null,
+            approved_product_id: product_id,
+            approved_variant_id: variant_id,
+          })
+        }
+
+        /**
+         * 🔑 ONCE per design that newly gained a product — not once per run.
+         * Partners are notified off `design.approved`, and a 40-run batch over
+         * 5 designs must send 5 notifications, not 40. A design whose product
+         * already existed is not newly approved and says nothing.
+         */
+        if (!productExisted && product_id) {
+          try {
+            const eventBus = container.resolve(
+              Modules.EVENT_BUS
+            ) as IEventBusModuleService
+            await eventBus.emit({
+              name: "design.approved",
+              data: { design_id: designId, product_id, variant_id },
+            })
+          } catch {
+            // Best-effort, exactly as the single-design route treats it.
+          }
+        }
+      }
+
+      for (const run of designRuns) {
+        reports.push({
+          run_id: run.id,
+          design_id: designId,
+          design_name: design.name ?? run.snapshot?.design?.name ?? null,
+          status: run.status ?? null,
+          outcome: "approved",
+          product_id,
+          variant_id,
+          product_existed: productExisted,
+          currency_code: currency,
+          listed_price: price,
+        })
+      }
+    } catch (e: any) {
+      logger?.error?.(
+        `[#1805] Approving design ${designId} failed: ${e?.message ?? e}`
+      )
+      /**
+       * Isolated to this design's runs. One design whose product write fails
+       * must not discard the decisions already made for the others — that is
+       * the difference between a batch and a transaction, and a batch is what
+       * an operator working a queue needs.
+       */
+      for (const run of designRuns) {
+        reports.push({
+          run_id: run.id,
+          design_id: designId,
+          design_name: run.snapshot?.design?.name ?? null,
+          status: run.status ?? null,
+          outcome: "failed",
+          reason: e?.message ?? "Could not create the product for this design.",
+        })
+      }
+    }
+  }
+
+  return summarise(input, reports, createdProductIds)
+}
+
+/** The counts an operator reads first, derived from the per-run rows. */
+function summarise(
+  input: { decision: RunApprovalDecision; dryRun?: boolean },
+  reports: RunApprovalReport[],
+  createdProductIds: string[]
+): RunApprovalResult {
+  const ids = (outcome: RunApprovalOutcome) =>
+    reports.filter((r) => r.outcome === outcome).map((r) => r.run_id)
+
+  return {
+    decision: input.decision,
+    dry_run: input.dryRun || undefined,
+    runs: reports,
+    design_ids: [
+      ...new Set(
+        reports
+          .filter((r) => r.outcome === "approved" || r.outcome === "rejected")
+          .map((r) => r.design_id)
+          .filter((d): d is string => Boolean(d))
+      ),
+    ],
+    created_product_ids: createdProductIds,
+    approved: ids("approved"),
+    rejected: ids("rejected"),
+    skipped: ids("skipped"),
+    failed: ids("failed"),
+  }
+}


### PR DESCRIPTION
Closes #1805.

> *"after each production run, could we have this bulk tool we can open from production runs for approval where it would create a product — select all complete runs and mass approve/reject. Reject means no product created, approve means a product was created."*

## The gap this had to close first

The unit of the decision is the **run**; the unit of product creation is the **design**. A loop around `POST /admin/designs/:id/approve` breaks on that, three ways, all silent:

| | what happens | why it matters at batch scale |
|---|---|---|
| **Double-listing** | `create-product-from-design` *appends* another `"Custom - <name>"` variant when the design already has a product | a design routinely has several completed runs (parent/child assignments, recreations) — "select all completed" selects all of them, so this becomes the **default** outcome |
| **Currency** | `currency_code: "usd"` hardcoded, on a platform trading in AUD and INR | mis-prices a whole batch at once |
| **Partial batches** | one 200 for 40 runs | 3 skips and 2 failures in a batch of 40 are invisible |

## What's here

**`POST /admin/production-runs/approvals`** — `{ run_ids[], decision, reason?, dry_run? }`. Resolves runs → designs, applies the decision **once per design**, and returns a per-run report (`approved` / `rejected` / `skipped` / `failed`, each with a reason). A design whose product write throws is isolated to its own runs; the rest of the batch stands (#1263).

**The output review as its own axis on the run** — `approval_decision`, `approval_decided_at`/`_by`, `approval_reason`, `approved_product_id`, `approved_variant_id`.

🔴 A rejected run **stays `completed`**. The work *was* done and the partner is still owed for `produced_quantity` — `payable-runs` and the short-close ceiling key on that status, so a terminal `rejected` would quietly change what a partner can claim, and would erase the fact that the goods were made. Null means nobody has looked yet, which is exactly what the queue filters on: before this, "rejected" and "unreviewed" were the same thing and a refused run came back forever.

**Currency resolved** from the design's `cost_currency`, then the store default — shared with the single-design approve route, so the two paths cannot disagree. (Per your call: the design estimate stays the listed price; the run's *actual* cost is a separate decision and is untouched here.)

**A reason is required to reject** — but not to preview. A rejection nobody can explain is the same dead end one step later, and the partner who made the goods has to be able to be told.

**The queue, in the admin** — a select column, a command bar (`A` approve / `R` reject), a **Review** column, an `approval_decision` filter, and a drawer that asks the server what the batch would do *before* doing it: which runs map to which design, which designs are already listed, what each will be listed at.

**One `design.approved` per newly approved design**, not per run — a 40-run batch over 5 designs notifies 5 partners, not 40.

## Verification

- **17 unit tests** on the batch logic. Reverting the "already has a product" guard turns the idempotency test red.
- **7 HTTP integration tests against a database** — counting products and variants, as the issue asked. Two runs of one design → **one** product, one variant. A *later* run of an already-listed design → nothing created, **still one variant**. Reverting the guard turns that test red (I checked: my first version of it passed either way, because inside a single batch the per-design grouping already covers it — the case that actually bites is the second batch, weeks later).
- **The screen.** Selected a completed run in the admin, approved it, and re-read the row: `approval_decision: approved`, `approved_product_id: prod_01M1QBJEB5H9V4NRDH5EV6N0A9`, `approval_decided_by` = the admin's actor id, `status` still `completed`, and the product has exactly one variant. Rejected another: reason recorded, no product, run still completed. That render is also what caught the bulk tool being **unusable** — `rowSelection` was wired but `@tanstack/react-table`'s column helper has no `.select()`, so the table rendered no checkboxes and the command bar could never open. Every test passed throughout.

`check:prod-build`: frontend green; backend fails only on the pre-existing `@jest/core` spec, identical to `main`.

## Migration

One additive migration (`Migration20260905093000`) — six nullable columns, a check constraint matching the DML enum, and a partial index on the review queue. Every existing run reads as unreviewed, which is what they are.

## Still open from the issue

The founder's second open question — whether approving a run should mean "list this design" (what this does, and what the request describes) or "accept this batch of finished goods" — matters for short-closed and partially-produced runs (#1596). Worth revisiting once the queue has been worked a few times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
