### PR TITLE
fix(admin): Create Order crashed on a design the estimator cannot price (#1811)

### DIFF
--- a/apps/backend/src/admin/components/designs/__tests__/design-order-preview-lib.unit.spec.ts
+++ b/apps/backend/src/admin/components/designs/__tests__/design-order-preview-lib.unit.spec.ts
@@ -1,0 +1,161 @@
+import {
+  canCreateOrder,
+  hydrateEstimates,
+  money,
+  summariseEdits,
+} from "../design-order-preview-lib"
+
+const est = (over: any = {}) => ({
+  design_id: "des_1",
+  name: "Pashmina",
+  total_estimated: 850,
+  unit_price: 850,
+  confidence: "estimated",
+  material_cost: 500,
+  production_cost: 350,
+  ...over,
+})
+
+/**
+ * The crash this exists to stop:
+ *
+ *   null is not an object (evaluating 'est.unit_price.toFixed')
+ *
+ * `/design-order/preview` returns `unit_price: null` when the estimator had
+ * nothing to price from (#1564). The drawer typed it `number`, called
+ * `.toFixed(2)` during hydration, and died before rendering a row — taking down
+ * the only screen where the operator can supply the missing price.
+ */
+describe("hydrateEstimates", () => {
+  it("does not throw on an unpriceable design", () => {
+    expect(() =>
+      hydrateEstimates([est({ unit_price: null, total_estimated: null })] as any)
+    ).not.toThrow()
+  })
+
+  /** Empty, never "0.00" — a zero is a decision to give something away. */
+  it("leaves an unpriced line's field EMPTY rather than zero", () => {
+    const form = hydrateEstimates([
+      est({ unit_price: null, total_estimated: null }),
+    ] as any)
+
+    expect(form.des_1.unitPrice).toBe("")
+  })
+
+  it("fills a priced line normally", () => {
+    const form = hydrateEstimates([est()] as any)
+
+    expect(form.des_1).toEqual({
+      material: "500.00",
+      production: "350.00",
+      unitPrice: "850.00",
+    })
+  })
+
+  it("survives a missing cost component", () => {
+    const form = hydrateEstimates([
+      est({ material_cost: null, production_cost: undefined }),
+    ] as any)
+
+    expect(form.des_1.material).toBe("")
+    expect(form.des_1.production).toBe("")
+  })
+})
+
+describe("money", () => {
+  it("is empty for anything that is not a finite number", () => {
+    expect(money(null)).toBe("")
+    expect(money(undefined)).toBe("")
+    expect(money(NaN)).toBe("")
+  })
+
+  it("keeps a real zero visible", () => {
+    // A stored 0 IS a decision someone made; only ABSENCE is blank.
+    expect(money(0)).toBe("0.00")
+  })
+})
+
+describe("summariseEdits", () => {
+  it("names an untouched unpriceable line as unpriced", () => {
+    const estimates = [est({ unit_price: null, total_estimated: null })] as any
+    const summary = summariseEdits(estimates, hydrateEstimates(estimates))
+
+    expect(summary.unpriced).toEqual(["des_1"])
+    expect(summary.computedTotal).toBe(0)
+    expect(summary.priceOverrides).toEqual({})
+  })
+
+  /**
+   * 🔴 A blank is not a zero. Counting it as 0 produced a total that looked
+   * complete and a Create the workflow then refused, after the click.
+   */
+  it("never adds a blank line into the total", () => {
+    const estimates = [est(), est({ design_id: "des_2", unit_price: null })] as any
+    const summary = summariseEdits(estimates, {
+      des_1: { material: "500.00", production: "350.00", unitPrice: "850.00" },
+      des_2: { material: "", production: "", unitPrice: "" },
+    })
+
+    expect(summary.computedTotal).toBe(850)
+    expect(summary.unpriced).toEqual(["des_2"])
+  })
+
+  it("sends a typed price for an unpriceable line as an override", () => {
+    const estimates = [est({ unit_price: null, total_estimated: null })] as any
+    const summary = summariseEdits(estimates, {
+      des_1: { material: "", production: "", unitPrice: "1200" },
+    })
+
+    expect(summary.priceOverrides).toEqual({ des_1: 1200 })
+    expect(summary.unpriced).toEqual([])
+    expect(summary.hasChanges).toBe(true)
+  })
+
+  it("sends no override when the estimate is accepted as-is", () => {
+    const estimates = [est()] as any
+    const summary = summariseEdits(estimates, hydrateEstimates(estimates))
+
+    expect(summary.priceOverrides).toEqual({})
+    expect(summary.hasChanges).toBe(false)
+    expect(summary.computedTotal).toBe(850)
+  })
+
+  it("treats a zero or negative entry as missing, not as free", () => {
+    const estimates = [est(), est({ design_id: "des_2" })] as any
+    const summary = summariseEdits(estimates, {
+      des_1: { material: "", production: "", unitPrice: "0" },
+      des_2: { material: "", production: "", unitPrice: "-5" },
+    })
+
+    expect(summary.unpriced).toEqual(["des_1", "des_2"])
+    expect(summary.computedTotal).toBe(0)
+  })
+})
+
+describe("canCreateOrder", () => {
+  /**
+   * The old gate was `computedTotal === 0`, which let a batch through with one
+   * priced design and one blank — and the workflow threw on the blank.
+   */
+  it("refuses while ANY line is unpriced, even when the total is not zero", () => {
+    const estimates = [est(), est({ design_id: "des_2", unit_price: null })] as any
+    const summary = summariseEdits(estimates, {
+      des_1: { material: "", production: "", unitPrice: "850" },
+      des_2: { material: "", production: "", unitPrice: "" },
+    })
+
+    expect(summary.computedTotal).toBe(850)
+    expect(canCreateOrder(summary)).toBe(false)
+  })
+
+  it("allows a fully priced batch", () => {
+    const estimates = [est(), est({ design_id: "des_2", unit_price: null })] as any
+    const summary = summariseEdits(estimates, {
+      des_1: { material: "", production: "", unitPrice: "850" },
+      des_2: { material: "", production: "", unitPrice: "1200" },
+    })
+
+    expect(canCreateOrder(summary)).toBe(true)
+    expect(summary.computedTotal).toBe(2050)
+  })
+})

--- a/apps/backend/src/admin/components/designs/design-order-preview-drawer.tsx
+++ b/apps/backend/src/admin/components/designs/design-order-preview-drawer.tsx
@@ -10,6 +10,13 @@ import {
   Select,
 } from "@medusajs/ui"
 import type { DesignEstimatePreview } from "../../hooks/api/designs"
+import {
+  canCreateOrder,
+  hydrateEstimates,
+  money,
+  summariseEdits,
+  type EditableEstimate,
+} from "./design-order-preview-lib"
 
 const confidenceColor = (c: string): "green" | "orange" | "red" | "blue" => {
   switch (c) {
@@ -26,12 +33,6 @@ const formatCurrency = (amount: number, currency: string) => {
     currency: currency.toUpperCase(),
     minimumFractionDigits: 2,
   }).format(amount)
-}
-
-type EditableEstimate = {
-  material: string
-  production: string
-  unitPrice: string
 }
 
 const CURRENCY_OPTIONS = [
@@ -64,17 +65,15 @@ export const DesignOrderPreviewDrawer = ({
   const [edited, setEdited] = useState<Record<string, EditableEstimate>>({})
   const [overrideCurrency, setOverrideCurrency] = useState<string>("inr")
 
-  // Initialize from estimates — prices are stored as-is (not in cents)
+  /**
+   * 🔴 `null` is a real answer and must never reach `.toFixed()`. It used to,
+   * and the drawer died with `null is not an object` before rendering — see
+   * `design-order-preview-lib` for what that cost. The rules live there so they
+   * can be tested; this only wires them up.
+   */
   useEffect(() => {
-    const initial: Record<string, EditableEstimate> = {}
-    for (const est of estimates) {
-      initial[est.design_id] = {
-        material: est.material_cost.toFixed(2),
-        production: est.production_cost.toFixed(2),
-        unitPrice: est.unit_price.toFixed(2),
-      }
-    }
-    setEdited(initial)
+    setEdited(hydrateEstimates(estimates))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [estimates])
 
   const updateField = (
@@ -92,31 +91,17 @@ export const DesignOrderPreviewDrawer = ({
       if (field === "material" || field === "production") {
         const mat = parseFloat(field === "material" ? value : next.material) || 0
         const prod = parseFloat(field === "production" ? value : next.production) || 0
-        next.unitPrice = (mat + prod).toFixed(2)
+        next.unitPrice = money(mat + prod)
       }
 
       return { ...prev, [designId]: next }
     })
   }
 
-  const { priceOverrides, computedTotal, hasChanges } = useMemo(() => {
-    const overrides: Record<string, number> = {}
-    let newTotal = 0
-    let changed = false
-
-    for (const est of estimates) {
-      const entry = edited[est.design_id]
-      const editedPrice = parseFloat(entry?.unitPrice || "0")
-      newTotal += editedPrice
-
-      if (editedPrice !== est.unit_price) {
-        overrides[est.design_id] = editedPrice
-        changed = true
-      }
-    }
-
-    return { priceOverrides: overrides, computedTotal: newTotal, hasChanges: changed }
-  }, [edited, estimates])
+  const { priceOverrides, computedTotal, hasChanges, unpriced } = useMemo(
+    () => summariseEdits(estimates, edited),
+    [edited, estimates]
+  )
 
   const handleConfirm = () => {
     onConfirm(priceOverrides, hasChanges ? overrideCurrency : undefined)
@@ -159,8 +144,16 @@ export const DesignOrderPreviewDrawer = ({
               const entry = edited[est.design_id]
               if (!entry) return null
 
-              const editedPrice = parseFloat(entry.unitPrice || "0")
-              const isModified = editedPrice !== est.unit_price
+              /**
+               * A blank field is "not answered yet", not 0 — so an untouched
+               * unpriceable line does not claim to have been "manual"ly priced.
+               */
+              const typedPrice =
+                entry.unitPrice.trim() === "" ? null : parseFloat(entry.unitPrice)
+              const isModified =
+                typedPrice != null &&
+                Number.isFinite(typedPrice) &&
+                typedPrice !== est.unit_price
 
               return (
                 <div
@@ -210,6 +203,15 @@ export const DesignOrderPreviewDrawer = ({
                     </div>
                   </div>
 
+                  {/* Stops describing the estimate once the operator has answered it. */}
+                  {est.unit_price == null && !isModified && (
+                    <Text size="xsmall" className="text-ui-fg-error mt-2">
+                      Not priced — this design has no bill of materials and no
+                      cost history, so nothing could be estimated from. Enter a
+                      unit price.
+                    </Text>
+                  )}
+
                   {est.unit_price === 0 && !isModified && (
                     <Text size="xsmall" className="text-ui-fg-error mt-2">
                       Estimated cost is zero — please enter a price.
@@ -220,12 +222,33 @@ export const DesignOrderPreviewDrawer = ({
             })}
           </div>
 
+          {/*
+            Say what is still missing, in the footer's own words. The per-row
+            message is easy to scroll past on a batch, and the disabled Create
+            button says nothing about WHY on its own.
+          */}
+          {unpriced.length > 0 && (
+            <Text size="xsmall" className="text-ui-fg-error mt-4">
+              {unpriced.length === 1
+                ? "1 design still needs a unit price."
+                : `${unpriced.length} designs still need a unit price.`}{" "}
+              An order cannot be created until every line has one — a blank line
+              is not a free one.
+            </Text>
+          )}
+
           <div className="flex items-center justify-between mt-6 pt-4 border-t border-ui-border-base">
             <Heading level="h3">Order Total</Heading>
             <Heading level="h3">{formatCurrency(computedTotal, currencyCode)}</Heading>
           </div>
 
-          {hasChanges && (
+          {/*
+            🔑 Only when there WAS one. The server's total covers priced lines
+            only, so on a batch of unpriceable designs it is 0 — and
+            "Original estimate: ₹0.00" reads as "we estimated it at nothing"
+            rather than "nothing could be estimated".
+          */}
+          {hasChanges && total > 0 && (
             <Text size="xsmall" className="text-ui-fg-subtle mt-1">
               Original estimate: {formatCurrency(total, currencyCode)}
             </Text>
@@ -238,11 +261,19 @@ export const DesignOrderPreviewDrawer = ({
               Cancel
             </Button>
           </Drawer.Close>
+          {/*
+            🔑 Refused while ANY line is unpriced, not merely while the total is
+            zero. The old gate let a batch through with one priced design and
+            one blank — and the workflow then threw on the blank, after the
+            click, naming a design the operator could no longer see.
+          */}
           <Button
             size="small"
             onClick={handleConfirm}
             isLoading={isConfirming}
-            disabled={computedTotal === 0}
+            disabled={
+              !canCreateOrder({ priceOverrides, computedTotal, hasChanges, unpriced })
+            }
           >
             Create Draft Order
           </Button>

--- a/apps/backend/src/admin/components/designs/design-order-preview-lib.ts
+++ b/apps/backend/src/admin/components/designs/design-order-preview-lib.ts
@@ -1,0 +1,101 @@
+import type { DesignEstimatePreview } from "../../hooks/api/designs"
+
+/**
+ * The preview drawer's arithmetic, as pure functions.
+ *
+ * ## Why it is not inline in the component
+ *
+ * It threw. `est.unit_price.toFixed(2)` ran against a `null` and the drawer
+ * died with `null is not an object` before rendering a single row — and the
+ * drawer is the ONE screen where an operator can supply the price the backend
+ * is asking for, so an unpriceable design made the whole order impossible
+ * rather than merely unpriced.
+ *
+ * 🔑 `null` is a real answer from `/design-order/preview`: it means the
+ * estimator had nothing to price from — no bill of materials, no cost history
+ * (#1564). It is deliberately NOT zero, because zero is a decision to give
+ * something away, and `create-draft-order-from-designs` refuses a null outright
+ * rather than putting a 0 on an order line.
+ *
+ * The repo's admin tests are pure-logic (there is no React renderer here), so
+ * the rules that broke live where they can actually be tested.
+ */
+
+export type EditableEstimate = {
+  material: string
+  production: string
+  unitPrice: string
+}
+
+/**
+ * A number for a form field. A null/undefined/NaN becomes an EMPTY field —
+ * never `"0.00"`, which would read as a decision nobody made.
+ */
+export const money = (value: number | null | undefined): string =>
+  typeof value === "number" && Number.isFinite(value) ? value.toFixed(2) : ""
+
+/** The form's starting state for a batch of estimates. Never throws. */
+export const hydrateEstimates = (
+  estimates: DesignEstimatePreview[]
+): Record<string, EditableEstimate> => {
+  const initial: Record<string, EditableEstimate> = {}
+  for (const est of estimates ?? []) {
+    initial[est.design_id] = {
+      material: money(est.material_cost),
+      production: money(est.production_cost),
+      unitPrice: money(est.unit_price),
+    }
+  }
+  return initial
+}
+
+export type EditSummary = {
+  /** Only the lines whose price the operator actually decided. */
+  priceOverrides: Record<string, number>
+  /** The total of the lines that HAVE a price. */
+  computedTotal: number
+  hasChanges: boolean
+  /** design_ids with no usable price — the create would refuse these. */
+  unpriced: string[]
+}
+
+/**
+ * What the batch currently adds up to, and what is still missing.
+ *
+ * 🔴 A blank or non-positive field is counted as MISSING, not as zero. Adding
+ * it as 0 produced two failures at once: a total that looked complete while it
+ * was not, and a Create that the workflow then refused — after the click,
+ * naming a design the operator could no longer see.
+ */
+export const summariseEdits = (
+  estimates: DesignEstimatePreview[],
+  edited: Record<string, EditableEstimate>
+): EditSummary => {
+  const priceOverrides: Record<string, number> = {}
+  const unpriced: string[] = []
+  let computedTotal = 0
+  let hasChanges = false
+
+  for (const est of estimates ?? []) {
+    const raw = edited?.[est.design_id]?.unitPrice ?? ""
+    const typed = raw.trim() === "" ? NaN : parseFloat(raw)
+
+    if (!Number.isFinite(typed) || typed <= 0) {
+      unpriced.push(est.design_id)
+      continue
+    }
+
+    computedTotal += typed
+
+    if (typed !== est.unit_price) {
+      priceOverrides[est.design_id] = typed
+      hasChanges = true
+    }
+  }
+
+  return { priceOverrides, computedTotal, hasChanges, unpriced }
+}
+
+/** Nothing may be created while a line has no price. */
+export const canCreateOrder = (summary: EditSummary): boolean =>
+  summary.unpriced.length === 0 && summary.computedTotal > 0

--- a/apps/backend/src/admin/hooks/api/designs.ts
+++ b/apps/backend/src/admin/hooks/api/designs.ts
@@ -1315,8 +1315,18 @@ export interface CreateDesignOrderResponse {
 export interface DesignEstimatePreview {
   design_id: string
   name: string
-  total_estimated: number
-  unit_price: number
+  /**
+   * 🔴 `null` when the estimator had nothing to price from — no bill of
+   * materials, no cost history (#1564). It is NOT zero: zero is a deliberate
+   * freebie, and the two must not be spelled the same way.
+   *
+   * These were typed `number` here while the route had returned `number | null`
+   * since #1564, so the preview drawer called `.toFixed(2)` on a null and threw
+   * `null is not an object` before it could render — hiding the one screen
+   * where the operator supplies the missing price the backend asks for.
+   */
+  total_estimated: number | null
+  unit_price: number | null
   confidence: string
   material_cost: number
   production_cost: number
@@ -1325,7 +1335,12 @@ export interface DesignEstimatePreview {
 export interface PreviewDesignOrderResponse {
   estimates: DesignEstimatePreview[]
   currency_code: string
+  /** Covers only the lines that could be priced — see `total_is_complete`. */
   total: number
+  /** The designs the estimator could not price. Named, not absorbed into 0. */
+  unpriceable?: { design_id: string; name: string }[]
+  /** False when any line has no price, so the total above is partial. */
+  total_is_complete?: boolean
 }
 
 export const usePreviewDesignOrder = (


### PR DESCRIPTION
Closes #1811.

Selecting a design in the list and pressing **O** threw `null is not an object (evaluating 'est.unit_price.toFixed')`, and the preview drawer never rendered.

## `null` is the right answer — the client ignored it

`/admin/customers/:id/design-order/preview` returns `unit_price: null` when the estimator had nothing to price from: no bill of materials, no cost history. That is deliberate (#1564) — null means *"we could not price this"*, and it must not be spelled the same way as `0`, which is a decision to give something away. `create-draft-order-from-designs` agrees; it **refuses** a null rather than putting a zero on an order line, and names the remedy:

> Cannot price design "…": it has no bill of materials and no cost history. Supply a price for it in overrides.

The admin never followed. `DesignEstimatePreview` typed both fields `number`, and the drawer hydrated with `est.unit_price.toFixed(2)` — so it died inside its own `useEffect`, before rendering a row.

🔴 **The screen that crashed is the remedy.** It's the only place an operator can supply that override, so an unpriceable design didn't merely come through unpriced — it made the order impossible to create at all.

## Three more, in the same drawer

| | was | now |
|---|---|---|
| Create gate | `computedTotal === 0` — one priced + one blank passed, then the workflow threw *after* the click | refused while **any** line is unpriced |
| blank field | `parseFloat("" \|\| "0")`, summed → total looked complete | never counted; the line is named as missing |
| zero hint | keyed on a `0` the server stopped sending at #1564 | keyed on `null`, and it stops once the operator answers |

"Original estimate" is now hidden when there wasn't one, rather than claiming ₹0.00.

## Where the logic lives

The arithmetic moved into `design-order-preview-lib.ts`. The repo's admin tests are pure-logic — there's no React renderer here — and the rules that broke should live where they can actually be tested.

## Verification

- **13 unit tests.** Reverting the fix turns **8** red, including `does not throw on an unpriceable design`.
- `check:prod-build` — exit 0, both halves green.
- **The screen.** Reproduced first: of the designs carrying a customer link locally, *Claude Design 1781519205110* and *Minimal Brown Streetwear Shirt* both return `total_estimated: null, confidence: "none"`. The drawer now opens on the first of them, shows *"Not priced — this design has no bill of materials and no cost history"*, holds Create disabled at ₹0.00, and on typing `1200` flips the badge to **manual**, totals ₹1,200.00 and enables Create. `pageerror` listener: **none**.

## Also asked, and deliberately not changed

*"Some designs show no customer is linked — is that important?"* — that's the **O** command refusing because it builds a *customer* order and resolves the customer from the selected designs' link. A precondition, not corruption: locally only 28 of 269 designs have one, because a design only gets a customer when it was made for somebody. The refusal is correct; what's worth reconsidering is that the command is offered on every selection and only fails once pressed. Noted on #1811 rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
