### PR TITLE
feat(checkout): adopt the modern single-page checkout layout

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -1,9 +1,11 @@
 import { retrieveCart, retrieveQuoteTerms } from "@lib/data/cart"
 import { retrieveCustomer } from "@lib/data/customer"
 import PaymentWrapper from "@modules/checkout/components/payment-wrapper"
+import { CartUpdateProvider } from "@modules/checkout/context/cart-update-context"
 import CheckoutForm from "@modules/checkout/templates/checkout-form"
 import CheckoutSummary from "@modules/checkout/templates/checkout-summary"
 import { Metadata } from "next"
+
 import { notFound } from "next/navigation"
 
 export const metadata: Metadata = {
@@ -11,7 +13,10 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 }
 
-export default async function Checkout() {
+export default async function Checkout(props: {
+  params: Promise<{ countryCode: string }>
+}) {
+  const { countryCode } = await props.params
   const cart = await retrieveCart()
 
   if (!cart) {
@@ -25,11 +30,19 @@ export default async function Checkout() {
   ])
 
   return (
-    <div className="grid grid-cols-1 small:grid-cols-[1fr_416px] content-container gap-x-40 py-12">
-      <PaymentWrapper cart={cart}>
-        <CheckoutForm cart={cart} customer={customer} />
-      </PaymentWrapper>
-      <CheckoutSummary cart={cart} quoteTerms={quoteTerms} />
-    </div>
+    <PaymentWrapper cart={cart}>
+      <CartUpdateProvider>
+        <div className="overflow-x-hidden">
+          <div className="lg:content-container flex flex-col lg:grid lg:grid-cols-[7fr_5fr] min-h-screen">
+            <CheckoutForm
+              cart={cart}
+              customer={customer}
+              countryCode={countryCode}
+            />
+            <CheckoutSummary cart={cart} quoteTerms={quoteTerms} />
+          </div>
+        </div>
+      </CartUpdateProvider>
+    </PaymentWrapper>
   )
 }

--- a/apps/storefront/src/app/[countryCode]/(checkout)/layout.tsx
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/layout.tsx
@@ -1,43 +1,86 @@
+import { retrieveCustomer } from "@lib/data/customer"
+import { ArrowLeft, UserMini } from "@medusajs/icons"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
-import ChevronDown from "@modules/common/icons/chevron-down"
 import MedusaCTA from "@modules/layout/components/medusa-cta"
+import type { Metadata } from "next"
 
-export default function CheckoutLayout({
+const STORE_NAME = "Cici Label Store"
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+export default async function CheckoutLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const customer = await retrieveCustomer()
+
   return (
-    <div className="w-full bg-white relative small:min-h-screen">
-      <div className="h-16 bg-white border-b ">
-        <nav className="flex h-full items-center content-container justify-between">
-          <LocalizedClientLink
-            href="/cart"
-            className="text-small-semi text-ui-fg-base flex items-center gap-x-2 uppercase flex-1 basis-0"
-            data-testid="back-to-cart-link"
-          >
-            <ChevronDown className="rotate-90" size={16} />
-            <span className="mt-px hidden small:block txt-compact-plus text-ui-fg-subtle hover:text-ui-fg-base ">
-              Back to shopping cart
-            </span>
-            <span className="mt-px block small:hidden txt-compact-plus text-ui-fg-subtle hover:text-ui-fg-base">
-              Back
-            </span>
-          </LocalizedClientLink>
+    <div className="min-h-screen bg-ui-bg-base flex flex-col">
+      <header className="border-b border-ui-border-base bg-ui-bg-base sticky top-0 z-40">
+        <div className="flex items-center content-container py-3 h-16">
+          <div className="flex flex-1 items-center">
+            <LocalizedClientLink
+              href="/cart"
+              className="flex items-center gap-x-2 txt-compact-medium-plus text-ui-fg-subtle hover:text-ui-fg-base transition-colors"
+              data-testid="back-to-cart-link"
+            >
+              <ArrowLeft />
+              <span className="hidden sm:inline">Back to shopping cart</span>
+              <span className="sm:hidden font-semibold uppercase whitespace-nowrap">
+                {STORE_NAME}
+              </span>
+            </LocalizedClientLink>
+          </div>
+
           <LocalizedClientLink
             href="/"
-            className="txt-compact-xlarge-plus text-ui-fg-subtle hover:text-ui-fg-base uppercase"
+            className="hidden sm:block shrink-0 txt-compact-medium font-semibold text-ui-fg-subtle uppercase hover:text-ui-fg-base transition-colors"
             data-testid="store-link"
           >
-            Cici Label Store
+            {STORE_NAME}
           </LocalizedClientLink>
-          <div className="flex-1 basis-0" />
-        </nav>
-      </div>
-      <div className="relative" data-testid="checkout-container">{children}</div>
-      <div className="py-4 w-full flex items-center justify-center">
-        <MedusaCTA />
-      </div>
+
+          <div className="flex flex-1 items-center justify-end">
+            {customer ? (
+              <div className="flex items-center gap-x-1 txt-compact-medium text-ui-fg-subtle">
+                <UserMini />
+                <span className="text-xs truncate hidden md:block">
+                  {customer.email}
+                </span>
+              </div>
+            ) : (
+              <LocalizedClientLink
+                href="/account"
+                className="txt-compact-medium text-ui-fg-base hover:text-ui-fg-subtle transition-colors"
+              >
+                Sign in
+              </LocalizedClientLink>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1" data-testid="checkout-container">
+        {children}
+      </main>
+
+      <footer className="border-t border-ui-border-base bg-ui-bg-base">
+        <div className="flex flex-col items-center gap-2 content-container py-4 text-center lg:hidden">
+          <span className="text-base font-light text-ui-fg-subtle">
+            © {new Date().getFullYear()} {STORE_NAME}. All rights reserved.
+          </span>
+        </div>
+
+        <div className="hidden lg:flex items-center justify-between content-container gap-2 h-16">
+          <span className="txt-compact-medium font-semibold text-ui-fg-subtle uppercase">
+            {STORE_NAME}
+          </span>
+          <MedusaCTA />
+        </div>
+      </footer>
     </div>
   )
 }

--- a/apps/storefront/src/lib/constants.tsx
+++ b/apps/storefront/src/lib/constants.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { CreditCard } from "@medusajs/icons"
+import type { HttpTypes } from "@medusajs/types"
 
 import Ideal from "@modules/common/icons/ideal"
 import Bancontact from "@modules/common/icons/bancontact"
@@ -67,6 +68,27 @@ export const isManual = (providerId?: string) => {
 }
 export const isPayU = (providerId?: string) => {
   return providerId?.startsWith("pp_payu")
+}
+
+const paymentSessionDataBuilders: Array<{
+  test: (providerId?: string) => boolean | undefined
+  isReady?: (cart: HttpTypes.StoreCart) => boolean
+  build: (cart: HttpTypes.StoreCart) => Record<string, unknown>
+}> = []
+
+export const buildPaymentSessionData = (
+  providerId: string | undefined,
+  cart: HttpTypes.StoreCart
+) => {
+  return paymentSessionDataBuilders.find((b) => b.test(providerId))?.build(cart)
+}
+
+export const isPaymentSessionReady = (
+  providerId: string | undefined,
+  cart: HttpTypes.StoreCart
+) => {
+  const entry = paymentSessionDataBuilders.find((b) => b.test(providerId))
+  return entry?.isReady ? entry.isReady(cart) : true
 }
 
 // Add currencies that don't need to be divided by 100

--- a/apps/storefront/src/lib/data/cart.ts
+++ b/apps/storefront/src/lib/data/cart.ts
@@ -492,6 +492,91 @@ export async function setAddresses(currentState: unknown, formData: FormData) {
   )
 }
 
+type AddressPayload = Partial<{
+  first_name: string
+  last_name: string
+  address_1: string
+  address_2: string
+  company: string
+  postal_code: string
+  city: string
+  country_code: string
+  province: string
+  phone: string
+}>
+
+export type SetCheckoutAddressesInput = {
+  shipping_address?: AddressPayload
+  email?: string
+  same_as_billing?: boolean
+}
+
+const ADDRESS_FIELDS = [
+  "first_name",
+  "last_name",
+  "address_1",
+  "address_2",
+  "company",
+  "postal_code",
+  "city",
+  "country_code",
+  "province",
+  "phone",
+] as const
+
+const mergeAddress = (
+  current: AddressPayload,
+  patch: AddressPayload = {}
+): AddressPayload =>
+  ADDRESS_FIELDS.reduce<AddressPayload>((address, field) => {
+    const value = patch[field] ?? current[field]
+    if (value != null) {
+      address[field] = value
+    }
+    return address
+  }, {})
+
+const isSameAddress = (a: AddressPayload, b: AddressPayload) =>
+  Boolean(a.address_1) &&
+  a.address_1 === b.address_1 &&
+  a.postal_code === b.postal_code &&
+  a.city === b.city &&
+  a.country_code === b.country_code
+
+/**
+ * Merge-and-save shipping/billing addresses without the redirect of the legacy
+ * `setAddresses` form action. Returns an error message on failure, or
+ * `undefined` on success. Used by the single-page checkout sheets.
+ */
+export async function setCheckoutAddresses(input: SetCheckoutAddressesInput) {
+  try {
+    const cartId = await getCartId()
+    if (!cartId) {
+      throw new Error("No existing cart found when setting addresses")
+    }
+
+    const cart = await retrieveCart(cartId, "*shipping_address, *billing_address")
+    const currentShipping = (cart?.shipping_address ?? {}) as AddressPayload
+    const currentBilling = (cart?.billing_address ?? {}) as AddressPayload
+
+    const shippingAddress = mergeAddress(currentShipping, input.shipping_address)
+
+    const data: HttpTypes.StoreUpdateCart = { shipping_address: shippingAddress }
+
+    if (input.email?.trim()) {
+      data.email = input.email
+    }
+
+    if (input.same_as_billing || isSameAddress(currentShipping, currentBilling)) {
+      data.billing_address = shippingAddress
+    }
+
+    await updateCart(data)
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+}
+
 /**
  * Places an order for a cart. If no cart ID is provided, it will use the cart ID from the cookies.
  * @param cartId - optional - The ID of the cart to place an order for.

--- a/apps/storefront/src/lib/data/customer.ts
+++ b/apps/storefront/src/lib/data/customer.ts
@@ -63,6 +63,37 @@ export const retrieveCustomer =
       .catch(() => null)
   }
 
+export const retrieveCustomerAddresses =
+  async (): Promise<HttpTypes.StoreCustomerAddress[] | null> => {
+    const authHeaders = await getAuthHeaders()
+
+    if (!authHeaders) return null
+
+    const headers = {
+      ...authHeaders,
+    }
+
+    const next = {
+      ...(await getCacheOptions("addresses")),
+    }
+
+    return await sdk.client
+      .fetch<{ addresses: HttpTypes.StoreCustomerAddress[] }>(
+        `/store/customers/me/addresses`,
+        {
+          method: "GET",
+          query: {
+            fields: "*addresses",
+          },
+          headers,
+          next,
+          cache: "force-cache",
+        }
+      )
+      .then(({ addresses }) => addresses)
+      .catch(() => null)
+  }
+
 export const updateCustomer = async (body: HttpTypes.StoreUpdateCustomer) => {
   const headers = {
     ...(await getAuthHeaders()),

--- a/apps/storefront/src/lib/util/fulfillment.ts
+++ b/apps/storefront/src/lib/util/fulfillment.ts
@@ -1,0 +1,31 @@
+import type { HttpTypes } from "@medusajs/types"
+
+export const isPickupShippingOption = (
+  option?: HttpTypes.StoreCartShippingOptionWithServiceZone | null
+) => {
+  return option?.service_zone?.fulfillment_set?.type === "pickup"
+}
+
+export type DeliveryDays = { min?: number; max?: number }
+
+const parseDay = (value: unknown): number | undefined => {
+  if (value === null || value === undefined || value === "") return undefined
+  const n = Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+export const getDeliveryDays = (
+  option?: HttpTypes.StoreCartShippingOption | null
+): DeliveryDays | null => {
+  const meta = (
+    option as { metadata?: Record<string, unknown> | null } | null
+  )?.metadata
+  if (!meta) return null
+
+  const min = parseDay(meta.delivery_days_min)
+  const max = parseDay(meta.delivery_days_max)
+
+  if (min === undefined && max === undefined) return null
+
+  return { min, max }
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-address-sheet/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-address-sheet/index.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import { useEffect, useState, type FormEvent } from "react"
+import { usePathname, useRouter } from "next/navigation"
+import { setCheckoutAddresses, updateRegion } from "@lib/data/cart"
+import type { HttpTypes } from "@medusajs/types"
+import Input from "@modules/common/components/input"
+import { CheckoutModal } from "@modules/checkout/components/checkout-modal"
+import ErrorMessage from "@modules/checkout/components/error-message"
+import { Button, RadioGroup } from "@medusajs/ui"
+
+interface CheckoutAddressSheetProps {
+  open: boolean
+  onClose: () => void
+  cart: HttpTypes.StoreCart
+  customer: HttpTypes.StoreCustomer | null
+  addresses: HttpTypes.StoreCustomerAddress[] | null
+}
+
+export default function CheckoutAddressSheet({
+  open,
+  onClose,
+  cart,
+  addresses,
+}: CheckoutAddressSheetProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const shippingAddress = cart.shipping_address
+
+  const savedAddresses = addresses ?? []
+  const hasSaved = savedAddresses.length > 0
+
+  const matchingAddress = savedAddresses.find(
+    (address) =>
+      address.address_1 === shippingAddress?.address_1 &&
+      address.postal_code === shippingAddress?.postal_code &&
+      address.city === shippingAddress?.city
+  )
+  const manualAddress =
+    !matchingAddress && shippingAddress?.address_1 ? shippingAddress : undefined
+  const initialMode = manualAddress || !hasSaved ? "new" : "select"
+
+  const [mode, setMode] = useState(initialMode)
+  const [selectedId, setSelectedId] = useState(matchingAddress?.id)
+  const [company, setCompany] = useState(manualAddress?.company ?? "")
+  const [addressFields, setAddressFields] = useState({
+    address_1: manualAddress?.address_1 ?? "",
+    postal_code: manualAddress?.postal_code ?? "",
+    city: manualAddress?.city ?? "",
+    province: manualAddress?.province ?? "",
+  })
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [applyingId, setApplyingId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    setMode(initialMode)
+    setSelectedId(matchingAddress?.id)
+    setAddressFields({
+      address_1: manualAddress?.address_1 ?? "",
+      postal_code: manualAddress?.postal_code ?? "",
+      city: manualAddress?.city ?? "",
+      province: manualAddress?.province ?? "",
+    })
+    setCompany(manualAddress?.company ?? "")
+    setError(null)
+  }, [open, initialMode, matchingAddress, manualAddress])
+
+  const countryName = (code?: string | null) =>
+    cart.region?.countries?.find((c) => c.iso_2 === code?.toLowerCase())
+      ?.display_name ||
+    code?.toUpperCase() ||
+    ""
+
+  const formatAddress = (address: HttpTypes.StoreCustomerAddress) =>
+    [
+      address.postal_code,
+      countryName(address.country_code),
+      address.city,
+      address.address_1,
+    ]
+      .filter(Boolean)
+      .join(", ")
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setAddressFields({ ...addressFields, [e.target.name]: e.target.value })
+  }
+
+  async function applySaved(address: HttpTypes.StoreCustomerAddress) {
+    setApplyingId(address.id)
+    setError(null)
+    const result = await setCheckoutAddresses({
+      shipping_address: {
+        company: address.company ?? undefined,
+        address_1: address.address_1 ?? undefined,
+        postal_code: address.postal_code ?? undefined,
+        city: address.city ?? undefined,
+        province: address.province ?? undefined,
+        country_code: address.country_code ?? undefined,
+      },
+    })
+    if (result) {
+      setError(result)
+      setApplyingId(null)
+      return
+    }
+    setApplyingId(null)
+    onClose()
+    if (
+      address.country_code &&
+      address.country_code !== shippingAddress?.country_code
+    ) {
+      await updateRegion(address.country_code, pathname)
+    } else {
+      router.refresh()
+    }
+  }
+
+  function handleSelect(value: string) {
+    setSelectedId(value)
+    const address = savedAddresses.find((address) => address.id === value)
+    if (address) applySaved(address)
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+    const result = await setCheckoutAddresses({
+      shipping_address: { ...addressFields, company },
+    })
+    setIsSubmitting(false)
+    if (result) {
+      setError(result)
+    } else {
+      onClose()
+      router.refresh()
+    }
+  }
+
+  return (
+    <CheckoutModal open={open} onClose={onClose} title="Shipping address">
+      {mode === "select" && hasSaved ? (
+        <div className="flex flex-col">
+          <RadioGroup
+            value={selectedId}
+            onValueChange={handleSelect}
+            disabled={!!applyingId}
+            className="flex flex-col gap-[10px]"
+          >
+            {savedAddresses.map((address) => (
+              <RadioGroup.ChoiceBox
+                key={address.id}
+                value={address.id}
+                label={address.address_name || address.company || "Address"}
+                description={formatAddress(address)}
+              />
+            ))}
+          </RadioGroup>
+
+          <ErrorMessage error={error} />
+
+          <Button
+            type="button"
+            onClick={() => setMode("new")}
+            size="large"
+            className="w-full mt-4"
+          >
+            Add new address
+          </Button>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="flex flex-col">
+          <div className="flex flex-col gap-y-3">
+            <Input
+              label="Address"
+              name="address_1"
+              autoComplete="address-line1"
+              value={addressFields.address_1}
+              onChange={handleChange}
+              required
+              data-testid="shipping-address-input"
+            />
+            <div className="grid grid-cols-2 gap-3">
+              <Input
+                label="Postal code"
+                name="postal_code"
+                autoComplete="postal-code"
+                value={addressFields.postal_code}
+                onChange={handleChange}
+                required
+                data-testid="shipping-postal-code-input"
+              />
+              <Input
+                label="City"
+                name="city"
+                autoComplete="address-level2"
+                value={addressFields.city}
+                onChange={handleChange}
+                required
+                data-testid="shipping-city-input"
+              />
+            </div>
+            <Input
+              label="State / Province"
+              name="province"
+              autoComplete="address-level1"
+              value={addressFields.province}
+              onChange={handleChange}
+              data-testid="shipping-province-input"
+            />
+            <Input
+              label="Company"
+              name="company"
+              autoComplete="organization"
+              value={company}
+              onChange={(e) => setCompany(e.target.value)}
+              data-testid="shipping-company-input"
+            />
+          </div>
+          <ErrorMessage error={error} />
+          <div className="flex gap-x-2 mt-4">
+            <Button
+              type="button"
+              onClick={() => (hasSaved ? setMode("select") : onClose())}
+              variant="secondary"
+              size="large"
+              className="w-full"
+            >
+              {hasSaved ? "Back" : "Close"}
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              size="large"
+              className="w-full"
+            >
+              {isSubmitting ? "Saving" : "Save"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </CheckoutModal>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-billing-sheet/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-billing-sheet/index.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import { useEffect, useState, type FormEvent } from "react"
+import { useRouter } from "next/navigation"
+import { updateCart } from "@lib/data/cart"
+import { Button, Checkbox, Text } from "@medusajs/ui"
+import type { HttpTypes } from "@medusajs/types"
+import Input from "@modules/common/components/input"
+import { CheckoutModal } from "@modules/checkout/components/checkout-modal"
+import ErrorMessage from "@modules/checkout/components/error-message"
+
+interface CheckoutBillingSheetProps {
+  open: boolean
+  onClose: () => void
+  initialSameAsShipping: boolean
+  onSaved?: (sameAsShipping: boolean) => void
+  cart: HttpTypes.StoreCart
+}
+
+export default function CheckoutBillingSheet({
+  open,
+  onClose,
+  initialSameAsShipping,
+  onSaved,
+  cart,
+}: CheckoutBillingSheetProps) {
+  const router = useRouter()
+  const shippingAddr = cart.shipping_address
+  const billingAddr = cart.billing_address
+
+  const [sameAsShipping, setSameAsShipping] = useState(initialSameAsShipping)
+  const [addressFields, setAddressFields] = useState({
+    address_1: billingAddr?.address_1 || "",
+    postal_code: billingAddr?.postal_code || "",
+    city: billingAddr?.city || "",
+    province: billingAddr?.province || "",
+  })
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setSameAsShipping(initialSameAsShipping)
+      setError(null)
+    }
+  }, [initialSameAsShipping, open])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setAddressFields({ ...addressFields, [e.target.name]: e.target.value })
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      if (sameAsShipping) {
+        await updateCart({
+          billing_address: {
+            first_name: shippingAddr?.first_name || "",
+            last_name: shippingAddr?.last_name || "",
+            address_1: shippingAddr?.address_1 || "",
+            company: shippingAddr?.company || "",
+            postal_code: shippingAddr?.postal_code || "",
+            city: shippingAddr?.city || "",
+            country_code: shippingAddr?.country_code || "",
+            province: shippingAddr?.province || "",
+            phone: shippingAddr?.phone || "",
+          },
+        })
+      } else {
+        await updateCart({
+          billing_address: {
+            first_name: shippingAddr?.first_name || "",
+            last_name: shippingAddr?.last_name || "",
+            address_1: addressFields.address_1,
+            company: shippingAddr?.company || "",
+            postal_code: addressFields.postal_code,
+            city: addressFields.city,
+            country_code: shippingAddr?.country_code || "",
+            province: addressFields.province,
+            phone: shippingAddr?.phone || "",
+          },
+        })
+      }
+      onSaved?.(sameAsShipping)
+      onClose()
+      router.refresh()
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <CheckoutModal open={open} onClose={onClose} title="Billing address">
+      <form onSubmit={handleSubmit} className="flex flex-col">
+        <div className="flex flex-col gap-y-3">
+          <div className="flex items-center gap-x-2">
+            <Checkbox
+              checked={sameAsShipping}
+              onCheckedChange={(checked) => setSameAsShipping(checked === true)}
+            />
+            <Text className="text-ui-fg-subtle">Same as shipping address</Text>
+          </div>
+
+          {!sameAsShipping && (
+            <div className="grid grid-cols-2 gap-3">
+              <Input
+                label="Address"
+                name="address_1"
+                autoComplete="address-line1"
+                value={addressFields.address_1}
+                onChange={handleChange}
+                required
+                data-testid="billing-address-input"
+              />
+              <Input
+                label="Postal code"
+                name="postal_code"
+                autoComplete="postal-code"
+                value={addressFields.postal_code}
+                onChange={handleChange}
+                required
+                data-testid="billing-postal-code-input"
+              />
+              <Input
+                label="City"
+                name="city"
+                autoComplete="address-level2"
+                value={addressFields.city}
+                onChange={handleChange}
+                required
+                data-testid="billing-city-input"
+              />
+              <Input
+                label="State / Province"
+                name="province"
+                autoComplete="address-level1"
+                value={addressFields.province}
+                onChange={handleChange}
+                data-testid="billing-province-input"
+              />
+            </div>
+          )}
+        </div>
+
+        <ErrorMessage error={error} />
+
+        <div className="flex gap-x-2 mt-4">
+          <Button
+            type="button"
+            onClick={onClose}
+            variant="secondary"
+            size="large"
+            className="w-full"
+          >
+            Close
+          </Button>
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            size="large"
+            className="w-full"
+          >
+            {isSubmitting ? "Saving" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </CheckoutModal>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-contacts-sheet/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-contacts-sheet/index.tsx
@@ -1,0 +1,205 @@
+"use client"
+
+import { useState, type FormEvent } from "react"
+import { useRouter } from "next/navigation"
+import { setCheckoutAddresses, updateCart } from "@lib/data/cart"
+import { Button, Checkbox, Text } from "@medusajs/ui"
+import type { HttpTypes } from "@medusajs/types"
+import Input from "@modules/common/components/input"
+import { CheckoutModal } from "@modules/checkout/components/checkout-modal"
+import ErrorMessage from "@modules/checkout/components/error-message"
+
+interface CheckoutContactsSheetProps {
+  open: boolean
+  onClose: () => void
+  cart: HttpTypes.StoreCart
+}
+
+export default function CheckoutContactsSheet({
+  open,
+  onClose,
+  cart,
+}: CheckoutContactsSheetProps) {
+  const router = useRouter()
+  const addr = cart.shipping_address
+  const meta = cart.metadata as Record<string, string> | null
+
+  const wasDifferentRecipient = meta?.has_different_recipient === "true"
+
+  const [isDifferentRecipient, setIsDifferentRecipient] = useState(
+    wasDifferentRecipient
+  )
+  const [formData, setFormData] = useState({
+    first_name: meta?.contact_first_name || "",
+    last_name: meta?.contact_last_name || "",
+    email: cart.email || "",
+    phone: meta?.contact_phone || "",
+    recipient_first_name: wasDifferentRecipient ? addr?.first_name || "" : "",
+    recipient_last_name: wasDifferentRecipient ? addr?.last_name || "" : "",
+    recipient_phone: wasDifferentRecipient ? addr?.phone || "" : "",
+  })
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value })
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError(null)
+
+    const contact = isDifferentRecipient
+      ? {
+          first_name: formData.recipient_first_name,
+          last_name: formData.recipient_last_name,
+          phone: formData.recipient_phone,
+        }
+      : {
+          first_name: formData.first_name,
+          last_name: formData.last_name,
+          phone: formData.phone,
+        }
+
+    const result = await setCheckoutAddresses({
+      shipping_address: contact,
+      email: formData.email,
+      same_as_billing: true,
+    })
+    if (result) {
+      setError(result)
+      setIsSubmitting(false)
+      return
+    }
+
+    await updateCart({
+      metadata: {
+        contact_first_name: formData.first_name,
+        contact_last_name: formData.last_name,
+        contact_phone: formData.phone,
+        has_different_recipient: isDifferentRecipient ? "true" : "false",
+      },
+    } as HttpTypes.StoreUpdateCart)
+
+    setIsSubmitting(false)
+    onClose()
+    router.refresh()
+  }
+
+  return (
+    <CheckoutModal open={open} onClose={onClose} title="Contact">
+      <form onSubmit={handleSubmit} className="flex flex-col">
+        <div className="flex flex-col gap-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <Input
+              label="First name"
+              name="first_name"
+              autoComplete="given-name"
+              value={formData.first_name}
+              onChange={handleChange}
+              required
+              data-testid="shipping-first-name-input"
+            />
+            <Input
+              label="Last name"
+              name="last_name"
+              autoComplete="family-name"
+              value={formData.last_name}
+              onChange={handleChange}
+              required
+              data-testid="shipping-last-name-input"
+            />
+          </div>
+
+          <Input
+            label="Email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            data-testid="shipping-email-input"
+          />
+
+          <Input
+            label="Phone"
+            name="phone"
+            autoComplete="tel"
+            value={formData.phone}
+            onChange={handleChange}
+            data-testid="shipping-phone-input"
+          />
+
+          <div className="flex items-center gap-x-2">
+            <Checkbox
+              checked={isDifferentRecipient}
+              onCheckedChange={(checked) =>
+                setIsDifferentRecipient(checked === true)
+              }
+            />
+            <Text className="text-ui-fg-subtle">
+              Shipping to a different recipient
+            </Text>
+          </div>
+
+          {isDifferentRecipient && (
+            <div className="flex flex-col gap-y-3 pt-1">
+              <p className="txt-compact-small-plus text-ui-fg-subtle">
+                Recipient details
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                <Input
+                  label="First name"
+                  name="recipient_first_name"
+                  autoComplete="given-name"
+                  value={formData.recipient_first_name}
+                  onChange={handleChange}
+                  required
+                />
+                <Input
+                  label="Last name"
+                  name="recipient_last_name"
+                  autoComplete="family-name"
+                  value={formData.recipient_last_name}
+                  onChange={handleChange}
+                  required
+                />
+              </div>
+              <Input
+                label="Phone"
+                name="recipient_phone"
+                autoComplete="tel"
+                value={formData.recipient_phone}
+                onChange={handleChange}
+              />
+            </div>
+          )}
+        </div>
+
+        <ErrorMessage error={error} />
+
+        <div className="flex gap-x-2 mt-4">
+          <Button
+            type="button"
+            onClick={onClose}
+            variant="secondary"
+            size="large"
+            className="w-full"
+          >
+            Close
+          </Button>
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            size="large"
+            className="w-full"
+          >
+            {isSubmitting ? "Saving" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </CheckoutModal>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-info-rows/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-info-rows/index.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { useState } from "react"
+import { ChevronRight } from "@medusajs/icons"
+import MapPin from "@modules/common/icons/map-pin"
+import User from "@modules/common/icons/user"
+import type { HttpTypes } from "@medusajs/types"
+import CheckoutAddressSheet from "@modules/checkout/components/checkout-address-sheet"
+import CheckoutContactsSheet from "@modules/checkout/components/checkout-contacts-sheet"
+import { isPickupShippingOption } from "@lib/util/fulfillment"
+import { clx } from "@medusajs/ui"
+
+interface CheckoutInfoRowsProps {
+  cart: HttpTypes.StoreCart
+  customer: HttpTypes.StoreCustomer | null
+  addresses: HttpTypes.StoreCustomerAddress[] | null
+  availableShippingMethods: HttpTypes.StoreCartShippingOptionWithServiceZone[] | null
+}
+
+export default function CheckoutInfoRows({
+  cart,
+  customer,
+  addresses,
+  availableShippingMethods,
+}: CheckoutInfoRowsProps) {
+  const [addressOpen, setAddressOpen] = useState(false)
+  const [contactsOpen, setContactsOpen] = useState(false)
+
+  const addr = cart.shipping_address
+  const meta = cart.metadata as Record<string, string> | null
+
+  const selectedShippingOptionId =
+    cart.shipping_methods?.at(-1)?.shipping_option_id
+  const selectedShippingOption = availableShippingMethods?.find(
+    (option) => option.id === selectedShippingOptionId
+  )
+  const isPickup = isPickupShippingOption(selectedShippingOption)
+
+  const hasAddress = !!addr?.address_1
+  const addressText = hasAddress
+    ? [addr?.address_1, addr?.city, addr?.postal_code]
+        .filter(Boolean)
+        .join(", ")
+    : null
+
+  const buyerFirstName = meta?.contact_first_name || ""
+  const buyerLastName = meta?.contact_last_name || ""
+  const buyerPhone = meta?.contact_phone || ""
+  const buyerName = [buyerFirstName, buyerLastName].filter(Boolean).join(" ")
+  const hasContacts = !!(buyerName || cart.email)
+
+  const hasDifferentRecipient = meta?.has_different_recipient === "true"
+  const recipientName = [addr?.first_name, addr?.last_name]
+    .filter(Boolean)
+    .join(" ")
+  const recipientPhone = addr?.phone || ""
+
+  return (
+    <div className="flex flex-col gap-y-6">
+      <div
+        className={clx("h-px bg-ui-border-base w-full", isPickup && "hidden")}
+      />
+
+      <button
+        onClick={() => !isPickup && setAddressOpen(true)}
+        disabled={isPickup}
+        className={clx(
+          "flex items-center justify-between w-full gap-x-2 py-2 text-start",
+          isPickup && "hidden"
+        )}
+        data-testid="checkout-address-row"
+      >
+        <div className="flex items-center gap-x-2">
+          <span className="flex-shrink-0 text-ui-fg-base">
+            <MapPin size={24} />
+          </span>
+          <div className="flex flex-col">
+            <h2 className="h2-docs text-ui-fg-muted">Shipping address</h2>
+            {isPickup ? (
+              <span className="txt-small text-ui-fg-muted">
+                Address not needed for pickup
+              </span>
+            ) : (
+              addressText && (
+                <span className="txt-small text-ui-fg-base">{addressText}</span>
+              )
+            )}
+          </div>
+        </div>
+        {!isPickup && (
+          <ChevronRight className="text-ui-fg-base flex-shrink-0 rtl:rotate-180" />
+        )}
+      </button>
+
+      <div className="h-px bg-ui-border-base w-full" />
+
+      <div className="flex flex-col gap-y-1">
+        <button
+          onClick={() => setContactsOpen(true)}
+          className="flex items-center justify-between w-full gap-x-2 py-2 text-start"
+          data-testid="checkout-contacts-row"
+        >
+          <div className="flex items-center gap-x-2">
+            <span className="flex-shrink-0 text-ui-fg-base">
+              <User size={24} />
+            </span>
+            <div className="flex flex-col">
+              <h2 className="h2-docs text-ui-fg-muted">Contact</h2>
+              {hasContacts && (
+                <span className="txt-small text-ui-fg-base flex gap-x-2">
+                  {buyerName && <span>{buyerName}</span>}
+                  {buyerPhone && (
+                    <span className="text-ui-fg-muted">{buyerPhone}</span>
+                  )}
+                </span>
+              )}
+              {hasDifferentRecipient &&
+                (recipientName || recipientPhone) && (
+                  <div className="flex items-center gap-x-2 mt-1">
+                    <span className="txt-small text-ui-fg-muted">Recipient</span>
+                    {recipientName && (
+                      <span className="txt-small text-ui-fg-base">
+                        {recipientName}
+                      </span>
+                    )}
+                    {recipientPhone && (
+                      <span className="txt-small text-ui-fg-muted">
+                        {recipientPhone}
+                      </span>
+                    )}
+                  </div>
+                )}
+            </div>
+          </div>
+          <ChevronRight className="text-ui-fg-base flex-shrink-0 rtl:rotate-180" />
+        </button>
+      </div>
+
+      <div className="h-px bg-ui-border-base w-full" />
+
+      <CheckoutAddressSheet
+        open={addressOpen}
+        onClose={() => setAddressOpen(false)}
+        cart={cart}
+        customer={customer}
+        addresses={addresses}
+      />
+
+      <CheckoutContactsSheet
+        open={contactsOpen}
+        onClose={() => setContactsOpen(false)}
+        cart={cart}
+      />
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-item-list/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-item-list/index.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useState } from "react"
+import Image from "next/image"
+import type { HttpTypes } from "@medusajs/types"
+import { convertToLocale } from "@lib/util/money"
+import { updateLineItem } from "@lib/data/cart"
+import { useCartUpdate } from "@modules/checkout/context/cart-update-context"
+import DeleteButton from "@modules/common/components/delete-button"
+import PlaceholderImage from "@modules/common/icons/placeholder-image"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { Loader } from "@medusajs/icons"
+
+interface CheckoutItemListProps {
+  cart: HttpTypes.StoreCart
+}
+
+function CheckoutItem({
+  item,
+  currencyCode,
+}: {
+  item: HttpTypes.StoreCartLineItem
+  currencyCode: string
+}) {
+  const [updating, setUpdating] = useState(false)
+  const { trackCartUpdate } = useCartUpdate()
+
+  const imageUrl =
+    item.thumbnail || item.variant?.product?.images?.[0]?.url || null
+
+  const total = convertToLocale({
+    amount: item.total ?? 0,
+    currency_code: currencyCode,
+  })
+
+  const unitPrice = convertToLocale({
+    amount: item.unit_price ?? 0,
+    currency_code: currencyCode,
+  })
+
+  const variantTitle = item.variant?.title
+  const maxQty = 10
+
+  const changeQuantity = async (quantity: number) => {
+    setUpdating(true)
+    await trackCartUpdate(() => updateLineItem({ lineId: item.id, quantity }))
+      .finally(() => setUpdating(false))
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-x-4">
+      <div className="flex items-center gap-x-4">
+        <LocalizedClientLink
+          href={`/products/${item.product_handle}`}
+          className="flex-shrink-0"
+        >
+          <div className="w-24 h-24 rounded-[6px] overflow-hidden bg-ui-bg-component shadow-elevation-card-rest flex items-center justify-center">
+            {imageUrl ? (
+              <Image
+                src={imageUrl}
+                alt={item.product_title ?? ""}
+                width={96}
+                height={96}
+                className="w-full h-full object-cover object-center"
+              />
+            ) : (
+              <PlaceholderImage size={24} />
+            )}
+          </div>
+        </LocalizedClientLink>
+
+        <div className="flex flex-col h-24 py-1 justify-between">
+          <span className="txt-medium text-ui-fg-base">
+            {item.product_title}
+          </span>
+          {variantTitle && (
+            <span className="txt-medium text-ui-fg-subtle">{variantTitle}</span>
+          )}
+          <div className="flex items-end h-[22.4px]">
+            <DeleteButton id={item.id} />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-end justify-end h-24 py-1 flex-shrink-0 gap-2">
+        <span className="txt-medium-plus text-ui-fg-base">
+          {item.quantity > 1 ? `${item.quantity} x ${unitPrice}` : total}
+        </span>
+
+        <div className="flex items-center justify-center gap-x-4 h-6 px-2 bg-ui-bg-component shadow-elevation-card-rest rounded-[6px]">
+          <button
+            type="button"
+            onClick={() => item.quantity > 1 && changeQuantity(item.quantity - 1)}
+            disabled={updating || item.quantity <= 1}
+            className="txt-compact-xlarge-plus text-ui-fg-subtle disabled:opacity-40 leading-none"
+          >
+            −
+          </button>
+          <span className="txt-compact-xsmall-plus text-ui-fg-subtle min-w-[12px] text-center">
+            {updating ? (
+              <Loader className="w-3 h-3 animate-spin" />
+            ) : (
+              item.quantity
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={() => item.quantity < maxQty && changeQuantity(item.quantity + 1)}
+            disabled={updating || item.quantity >= maxQty}
+            className="txt-compact-xlarge-plus text-ui-fg-subtle disabled:opacity-40 leading-none"
+          >
+            +
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function CheckoutItemList({ cart }: CheckoutItemListProps) {
+  const items = cart.items
+    ? [...cart.items].sort((a, b) =>
+        (a.created_at ?? "") > (b.created_at ?? "") ? -1 : 1
+      )
+    : []
+
+  return (
+    <div>
+      <h2 className="h2-docs mb-3">Order composition</h2>
+      <div className="flex flex-col">
+        {items.map((item, idx) => (
+          <div key={item.id}>
+            <CheckoutItem item={item} currencyCode={cart.currency_code} />
+            {idx < items.length - 1 && (
+              <div className="h-px bg-ui-border-base my-3" />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-modal/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-modal/index.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react"
+import { XMark } from "@medusajs/icons"
+
+interface CheckoutModalProps {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+}
+
+export function CheckoutModal({
+  open,
+  onClose,
+  title,
+  children,
+}: CheckoutModalProps) {
+  return (
+    <Transition show={open}>
+      <Dialog onClose={onClose} className="relative z-50">
+        {/* Backdrop */}
+        <TransitionChild
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div
+            className="fixed inset-0 bg-black/25 backdrop-blur-[2px]"
+            aria-hidden="true"
+          />
+        </TransitionChild>
+
+        {/* Panel wrapper — bottom on mobile, centered on sm+ */}
+        <div className="fixed inset-0 flex items-end sm:items-center justify-center">
+          <TransitionChild
+            enter="ease-out duration-250"
+            enterFrom="opacity-0 translate-y-8 sm:translate-y-0 sm:scale-95"
+            enterTo="opacity-100 translate-y-0 sm:scale-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+            leaveTo="opacity-0 translate-y-8 sm:translate-y-0 sm:scale-95"
+          >
+            <DialogPanel className="relative w-full sm:w-[540px] max-h-[90dvh] overflow-y-auto bg-ui-bg-base rounded-t-xl sm:rounded-xl shadow-elevation-modal">
+              <div className="flex items-center justify-between px-6 py-4">
+                <DialogTitle className="txt-xlarge text-ui-fg-base">
+                  {title}
+                </DialogTitle>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  aria-label="Close"
+                  className="text-ui-fg-muted hover:text-ui-fg-base transition-colors p-0.5"
+                >
+                  <XMark />
+                </button>
+              </div>
+              <div className="px-6 pb-4">{children}</div>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-payment-section/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-payment-section/index.tsx
@@ -1,0 +1,307 @@
+"use client"
+
+import { useState, useEffect, useRef, useContext } from "react"
+import { initiatePaymentSession, placeOrder } from "@lib/data/cart"
+import {
+  buildPaymentSessionData,
+  isPaymentSessionReady,
+  isStripeLike,
+  paymentInfoMap,
+} from "@lib/constants"
+import compareAddresses from "@lib/util/compare-addresses"
+import { CreditCard } from "@medusajs/icons"
+import type { HttpTypes } from "@medusajs/types"
+import { PaymentElement } from "@stripe/react-stripe-js"
+import PaymentButton from "@modules/checkout/components/payment-button"
+import ErrorMessage from "@modules/checkout/components/error-message"
+import SkeletonCardDetails from "@modules/skeletons/components/skeleton-card-details"
+import CheckoutBillingSheet from "@modules/checkout/components/checkout-billing-sheet"
+import { StripeContext } from "../payment-wrapper/stripe-wrapper"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { clx } from "@medusajs/ui"
+import { useRouter, useSearchParams } from "next/navigation"
+
+interface CheckoutPaymentSectionProps {
+  cart: HttpTypes.StoreCart
+  availablePaymentMethods: { id: string }[]
+}
+
+function providerSubLabel(id: string) {
+  if (id.includes("stripe")) return "Stripe"
+  if (id.includes("paypal")) return "PayPal"
+  if (id.includes("payu")) return "PayU"
+  return ""
+}
+
+export default function CheckoutPaymentSection({
+  cart,
+  availablePaymentMethods,
+}: CheckoutPaymentSectionProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const latestSession = cart.payment_collection?.payment_sessions?.[0]
+
+  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState(
+    latestSession?.provider_id ?? ""
+  )
+  const [error, setError] = useState<string | null>(null)
+  const [, setPaymentComplete] = useState(false)
+  const [billingOpen, setBillingOpen] = useState(false)
+  const [showBillingDetails, setShowBillingDetails] = useState(false)
+
+  const paidByGiftcard = !!(
+    (cart as unknown as Record<string, unknown>)?.gift_cards &&
+    (
+      (cart as unknown as Record<string, unknown>)?.gift_cards as unknown[]
+    )?.length > 0 &&
+    cart?.total === 0
+  )
+
+  // Re-initiate payment session when it gets cleared (e.g. after promo code change)
+  useEffect(() => {
+    if (
+      selectedPaymentMethod &&
+      !latestSession &&
+      !paidByGiftcard &&
+      isPaymentSessionReady(selectedPaymentMethod, cart)
+    ) {
+      initiatePaymentSession(cart, {
+        provider_id: selectedPaymentMethod,
+        data: buildPaymentSessionData(selectedPaymentMethod, cart),
+      }).catch((e) => setError(e instanceof Error ? e.message : String(e)))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cart.payment_collection?.payment_sessions])
+
+  const receiptContextKey = JSON.stringify({
+    shippingAddress: cart.shipping_address,
+    billingAddress: cart.billing_address,
+    email: cart.email,
+    shippingOptionIds: cart.shipping_methods?.map((m) => m.shipping_option_id),
+    regionId: cart.region?.id,
+  })
+
+  const hasMounted = useRef(false)
+  useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true
+      return
+    }
+
+    if (!selectedPaymentMethod || paidByGiftcard) {
+      return
+    }
+
+    if (!isPaymentSessionReady(selectedPaymentMethod, cart)) {
+      return
+    }
+
+    const sessionData = buildPaymentSessionData(selectedPaymentMethod, cart)
+    if (!sessionData) {
+      return
+    }
+
+    initiatePaymentSession(cart, {
+      provider_id: selectedPaymentMethod,
+      data: sessionData,
+    }).catch((e) => setError(e instanceof Error ? e.message : String(e)))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [receiptContextKey])
+
+  // Stripe redirect return (redirect-based methods send the shopper to Stripe
+  // and back to the checkout page with `?redirect_status=...`). On a successful
+  // return we finalise the order.
+  useEffect(() => {
+    const redirectStatus = searchParams.get("redirect_status")
+    if (!redirectStatus) return
+    if (redirectStatus === "succeeded") {
+      placeOrder().catch((err: any) =>
+        setError(err?.message ?? "Payment failed")
+      )
+    } else {
+      setError("Payment was not completed. Please try again.")
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams])
+
+  const handleSelectPayment = async (providerId: string) => {
+    setSelectedPaymentMethod(providerId)
+    setError(null)
+
+    if (!isPaymentSessionReady(providerId, cart)) {
+      return
+    }
+
+    try {
+      await initiatePaymentSession(cart, {
+        provider_id: providerId,
+        data: buildPaymentSessionData(providerId, cart),
+      })
+      router.refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  const billingAddr = cart.billing_address
+  const billingSameAsShipping = !!(
+    cart.shipping_address &&
+    billingAddr &&
+    compareAddresses(cart.shipping_address, billingAddr)
+  )
+  const billingText = billingAddr
+    ? [billingAddr.address_1, billingAddr.city, billingAddr.postal_code]
+        .filter(Boolean)
+        .join(", ")
+    : null
+
+  return (
+    <div className="flex flex-col gap-y-6">
+      {/* Payment methods */}
+      {!paidByGiftcard && availablePaymentMethods.length > 0 && (
+        <div className="flex flex-col gap-y-3">
+          <h2 className="h2-docs">Payment</h2>
+
+          <div className="flex gap-x-2 overflow-x-auto no-scrollbar pb-1">
+            {availablePaymentMethods.map((method) => {
+              const info = paymentInfoMap[method.id]
+              const isSelected = selectedPaymentMethod === method.id
+
+              return (
+                <button
+                  key={method.id}
+                  type="button"
+                  onClick={() => handleSelectPayment(method.id)}
+                  className={clx(
+                    "flex-shrink-0 w-[111px] p-[10px] rounded-[6px] border text-start transition-colors",
+                    isSelected
+                      ? "border-ui-border-interactive bg-ui-bg-base"
+                      : "border-ui-border-base bg-ui-bg-base hover:border-ui-border-interactive/50"
+                  )}
+                >
+                  <div className="flex flex-col gap-y-2">
+                    <div className="w-6 h-6 rounded-full bg-ui-bg-component border border-ui-border-base flex items-center justify-center">
+                      {info?.icon || <CreditCard className="w-3 h-3" />}
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="txt-compact-xsmall-plus text-ui-fg-base leading-tight">
+                        {info?.title ?? method.id}
+                      </span>
+                      <span className="txt-compact-xsmall text-ui-fg-subtle">
+                        {providerSubLabel(method.id)}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+
+          {/* Stripe card input */}
+          {isStripeLike(selectedPaymentMethod) && (
+            <StripeInlineContainer setError={setError} setPaymentComplete={setPaymentComplete} />
+          )}
+        </div>
+      )}
+
+      {paidByGiftcard && (
+        <div className="flex flex-col gap-y-1">
+          <h2 className="h2-docs">Payment</h2>
+          <p className="txt-compact-small text-ui-fg-subtle">Gift card</p>
+        </div>
+      )}
+
+      {/* Billing address */}
+      {billingSameAsShipping && !showBillingDetails ? (
+        <label className="flex items-center gap-x-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked
+            onChange={() => setShowBillingDetails(true)}
+            className="w-4 h-4 rounded border-ui-border-base accent-ui-fg-interactive"
+          />
+          <span className="txt-compact-small text-ui-fg-base">
+            Same as shipping address
+          </span>
+        </label>
+      ) : (
+        <div className="flex flex-col gap-y-2">
+          <div className="flex items-center justify-between">
+            <h2 className="h2-docs">Billing address</h2>
+            <button
+              type="button"
+              onClick={() => setBillingOpen(true)}
+              className="txt-compact-small-plus text-ui-fg-interactive hover:text-ui-fg-interactive-hover transition-colors"
+            >
+              Edit
+            </button>
+          </div>
+          {billingText ? (
+            <p className="txt-medium text-ui-fg-base">{billingText}</p>
+          ) : (
+            <p className="txt-compact-small text-ui-fg-subtle">
+              Same as shipping address
+            </p>
+          )}
+        </div>
+      )}
+
+      <CheckoutBillingSheet
+        open={billingOpen}
+        onClose={() => setBillingOpen(false)}
+        initialSameAsShipping={billingSameAsShipping && !showBillingDetails}
+        onSaved={(sameAsShipping) => setShowBillingDetails(!sameAsShipping)}
+        cart={cart}
+      />
+
+      <ErrorMessage error={error} data-testid="payment-method-error-message" />
+
+      <div className="flex flex-col gap-y-3">
+        <PaymentButton
+          cart={cart}
+          selectedPaymentMethod={selectedPaymentMethod}
+          data-testid="submit-order-button"
+        />
+        <p className="txt-compact-xsmall text-ui-fg-subtle text-center px-2">
+          By clicking the Place Order button, you confirm that you have read,
+          understand and accept our Terms of Use, Terms of Sale and Returns
+          Policy and acknowledge that you have read our{" "}
+          <LocalizedClientLink href="/privacy" className="underline">
+            Privacy Policy
+          </LocalizedClientLink>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function StripeInlineContainer({
+  setError,
+  setPaymentComplete,
+}: {
+  setError: (error: string | null) => void
+  setPaymentComplete: (complete: boolean) => void
+}) {
+  const stripeReady = useContext(StripeContext)
+
+  if (!stripeReady) {
+    return <SkeletonCardDetails />
+  }
+
+  return (
+    <div className="mt-2">
+      <PaymentElement
+        options={{ layout: "accordion" }}
+        onChange={(e) => {
+          setError(null)
+          setPaymentComplete(e.complete)
+        }}
+        onLoadError={(e) => {
+          setPaymentComplete(false)
+          setError(e.error?.message ?? "Failed to load payment element")
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-shipping-section/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-shipping-section/index.tsx
@@ -1,0 +1,382 @@
+"use client"
+
+import { useState, useEffect, useTransition, useMemo } from "react"
+import { setShippingMethod, updateCart, updateRegion } from "@lib/data/cart"
+import { calculatePriceForShippingOption } from "@lib/data/fulfillment"
+import { convertToLocale } from "@lib/util/money"
+import { getDeliveryDays, isPickupShippingOption } from "@lib/util/fulfillment"
+import { useCartUpdate } from "@modules/checkout/context/cart-update-context"
+import { Loader, CursorDefault } from "@medusajs/icons"
+import { DropdownMenu, RadioGroup, clx } from "@medusajs/ui"
+import type { HttpTypes } from "@medusajs/types"
+import { usePathname } from "next/navigation"
+
+type CountryOption = {
+  country: string
+  region: string
+  label: string
+}
+
+interface CheckoutShippingSectionProps {
+  cart: HttpTypes.StoreCart
+  availableShippingOptions:
+    | HttpTypes.StoreCartShippingOptionWithServiceZone[]
+    | null
+  regions: HttpTypes.StoreRegion[]
+  currentCountry: string
+}
+
+function getLocalizedCountryName(
+  isoCode: string,
+  fallback: string
+) {
+  try {
+    return (
+      new Intl.DisplayNames([], { type: "region" }).of(
+        isoCode.toUpperCase()
+      ) ?? fallback
+    )
+  } catch {
+    return fallback
+  }
+}
+
+export default function CheckoutShippingSection({
+  cart,
+  availableShippingOptions,
+  regions,
+  currentCountry,
+}: CheckoutShippingSectionProps) {
+  const currentPath = usePathname()
+  const [isPending, startTransition] = useTransition()
+  const { trackCartUpdate } = useCartUpdate()
+
+  const [isLoadingPrices, setIsLoadingPrices] = useState(true)
+  const [calculatedPricesMap, setCalculatedPricesMap] = useState<
+    Record<string, number>
+  >({})
+  const [shippingError, setShippingError] = useState<string | null>(null)
+  const [shippingMethodId, setShippingMethodId] = useState<string | null>(
+    cart.shipping_methods?.at(-1)?.shipping_option_id || null
+  )
+
+  const [now, setNow] = useState<Date | null>(null)
+  useEffect(() => {
+    setNow(new Date())
+  }, [])
+
+  const getDeliveryDate = (daysFromNow: number) => {
+    const date = new Date(now!)
+    date.setHours(0, 0, 0, 0)
+    date.setDate(date.getDate() + daysFromNow)
+    return date
+  }
+
+  const deliveryDateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        day: "numeric",
+        month: "long",
+      }),
+    []
+  )
+
+  const formatDeliveryDate = (daysFromNow: number) => {
+    return deliveryDateFormatter.format(getDeliveryDate(daysFromNow))
+  }
+
+  const formatDeliveryRange = (minDaysFromNow: number, maxDaysFromNow: number) => {
+    const startDate = getDeliveryDate(minDaysFromNow)
+    const endDate = getDeliveryDate(maxDaysFromNow)
+
+    if (typeof deliveryDateFormatter.formatRange === "function") {
+      return deliveryDateFormatter.formatRange(startDate, endDate)
+    }
+
+    return (
+      new Intl.DateTimeFormat(undefined, {
+        day: "numeric",
+        month: "long",
+      }).format(startDate) + ` – ${formatDeliveryDate(maxDaysFromNow)}`
+    )
+  }
+
+  const countryOptions = useMemo<CountryOption[]>(() => {
+    return regions
+      .flatMap((r) =>
+        (r.countries ?? []).map((c) => ({
+          country: c.iso_2 ?? "",
+          region: r.id,
+          label: getLocalizedCountryName(c.iso_2 ?? "", c.display_name ?? ""),
+        }))
+      )
+      .filter((o) => o.country)
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [regions])
+
+  const selectedCountryOption =
+    countryOptions.find((o) => o.country === currentCountry) ??
+    countryOptions[0]
+
+  const handleRegionChange = (countryCode: string) => {
+    const option = countryOptions.find((opt) => opt.country === countryCode)
+    if (!option) {
+      return
+    }
+
+    startTransition(() => {
+      updateRegion(option.country, currentPath)
+    })
+  }
+
+  const shippingOptions = availableShippingOptions
+
+  useEffect(() => {
+    setIsLoadingPrices(true)
+    if (!shippingOptions?.length) {
+      setIsLoadingPrices(false)
+      return
+    }
+
+    const calculatedMethods = shippingOptions.filter(
+      (sm) => sm.price_type === "calculated"
+    )
+
+    if (!calculatedMethods.length) {
+      setIsLoadingPrices(false)
+      return
+    }
+
+    Promise.allSettled(
+      calculatedMethods.map((sm) =>
+        calculatePriceForShippingOption(sm.id, cart.id)
+      )
+    ).then((results) => {
+      const pricesMap: Record<string, number> = {}
+      results.forEach((r) => {
+        if (r.status === "fulfilled" && r.value?.id) {
+          pricesMap[r.value.id] = r.value.amount ?? 0
+        }
+      })
+      setCalculatedPricesMap(pricesMap)
+      setIsLoadingPrices(false)
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [availableShippingOptions, cart.id])
+
+  const handleSelectShipping = async (id: string) => {
+    setShippingError(null)
+    const prev = shippingMethodId
+    setShippingMethodId(id)
+    const err = await trackCartUpdate(() =>
+      setShippingMethod({
+        cartId: cart.id,
+        shippingMethodId: id,
+      })
+    ).catch((e: Error) => e.message)
+    if (err) {
+      setShippingMethodId(prev)
+      setShippingError(err as string)
+      return
+    }
+
+    const selectedOption = shippingOptions?.find((option) => option.id === id)
+    const addr = cart.shipping_address
+    const hasDeliveryFields = !!(
+      addr?.address_1 ||
+      addr?.address_2 ||
+      addr?.city ||
+      addr?.postal_code ||
+      addr?.province ||
+      addr?.company
+    )
+
+    if (isPickupShippingOption(selectedOption) && hasDeliveryFields) {
+      await trackCartUpdate(() =>
+        updateCart({
+          shipping_address: {
+            first_name: addr?.first_name || "",
+            last_name: addr?.last_name || "",
+            phone: addr?.phone || "",
+            country_code: addr?.country_code || "",
+            company: "",
+            address_1: "",
+            address_2: "",
+            city: "",
+            postal_code: "",
+            province: "",
+          },
+        } as HttpTypes.StoreUpdateCart)
+      ).catch((e: Error) => setShippingError(e.message))
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex flex-row items-start justify-between gap-x-4">
+        <div className="flex flex-col">
+          <h2 className="h2-docs">Delivery</h2>
+          <p className="txt-compact-medium text-ui-fg-muted">
+            Select how you would like your order delivered
+          </p>
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenu.Trigger
+            className={clx(
+              "mb-6 flex items-center gap-x-1.5 txt-compact-medium-plus text-ui-fg-subtle hover:text-ui-fg-base transition-colors",
+              isPending && "opacity-60 cursor-wait"
+            )}
+            disabled={isPending}
+            data-testid="checkout-country-select"
+          >
+            {isPending ? (
+              <Loader className="h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                <CursorDefault />
+                <span>{selectedCountryOption?.label ?? "—"}</span>
+              </>
+            )}
+          </DropdownMenu.Trigger>
+
+          <DropdownMenu.Content
+            align="end"
+            className="w-48 max-h-60 overflow-y-auto no-scrollbar"
+          >
+            <DropdownMenu.RadioGroup
+              value={selectedCountryOption?.country}
+              onValueChange={handleRegionChange}
+            >
+              {countryOptions.map((opt) => (
+                <DropdownMenu.RadioItem key={opt.country} value={opt.country}>
+                  {opt.label}
+                </DropdownMenu.RadioItem>
+              ))}
+            </DropdownMenu.RadioGroup>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      </div>
+
+      {/* Shipping method cards */}
+      <div className="overflow-x-auto no-scrollbar px-px pb-1">
+        {shippingOptions && shippingOptions.length > 0 ? (
+          <RadioGroup
+            value={shippingMethodId ?? undefined}
+            onValueChange={handleSelectShipping}
+            className="flex items-stretch gap-x-2"
+          >
+            {shippingOptions.map((option) => {
+              const isSelected = option.id === shippingMethodId
+
+              const days = getDeliveryDays(option)
+              const deliveryLabel = !days
+                ? null
+                : days.max === 0
+                  ? "Delivery today"
+                  : !now
+                    ? null
+                    : days.min !== undefined && days.max !== undefined
+                      ? days.min === days.max
+                        ? formatDeliveryDate(days.min)
+                        : formatDeliveryRange(days.min, days.max)
+                      : days.max !== undefined
+                        ? `Delivery by ${formatDeliveryDate(days.max)}`
+                        : days.min !== undefined
+                          ? `Delivery from ${formatDeliveryDate(days.min)}`
+                          : null
+
+              const priceAmount =
+                option.price_type === "flat"
+                  ? option.amount!
+                  : calculatedPricesMap[option.id] !== undefined
+                    ? calculatedPricesMap[option.id]
+                    : null
+              const isFreeShipping = priceAmount === 0
+              const price = isFreeShipping
+                ? "Free"
+                : priceAmount !== null
+                  ? convertToLocale({
+                      amount: priceAmount,
+                      currency_code: cart.currency_code,
+                    })
+                  : isLoadingPrices
+                    ? null
+                    : "—"
+
+              return (
+                <div
+                  key={option.id}
+                  className={clx(
+                    "relative flex w-[180px] shrink-0 flex-col gap-2 justify-between rounded-md border bg-ui-bg-base p-3 text-start transition-colors hover:bg-ui-bg-base-hover",
+                    isSelected
+                      ? "border-ui-border-interactive"
+                      : "border-ui-border-base hover:border-ui-border-interactive/50"
+                  )}
+                  data-testid="delivery-option-radio"
+                >
+                  <RadioGroup.Item
+                    value={option.id}
+                    aria-label={option.name}
+                    className="absolute inset-0 z-10 h-full w-full cursor-pointer rounded-md bg-transparent outline-none [&>div]:hidden focus-visible:shadow-borders-interactive-with-focus"
+                  />
+                  <span className="txt-compact-medium-plus text-ui-fg-base">
+                    {option.name}
+                  </span>
+                  <div className="flex flex-col gap-y-0">
+                    <div className="min-h-[20px]">
+                      {deliveryLabel && (
+                        <span className="txt-compact-small text-ui-fg-subtle">
+                          {deliveryLabel}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-end justify-between gap-x-3">
+                      <div
+                        className={clx(
+                          "txt-compact-small-plus flex min-h-[20px] items-end",
+                          isFreeShipping
+                            ? "text-ui-tag-green-icon"
+                            : "text-ui-fg-subtle"
+                        )}
+                      >
+                        {price === null ? (
+                          <Loader className="h-3 w-3 animate-spin" />
+                        ) : (
+                          price
+                        )}
+                      </div>
+
+                      <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+                        <div
+                          className={clx(
+                            "flex h-3.5 w-3.5 items-center justify-center rounded-full border bg-ui-bg-base shadow-borders-base",
+                            isSelected
+                              ? "border-ui-border-interactive bg-ui-bg-interactive shadow-borders-interactive-with-shadow"
+                              : "border-ui-border-base"
+                          )}
+                        >
+                          {isSelected && (
+                            <div className="h-1.5 w-1.5 rounded-full bg-ui-bg-base shadow-details-contrast-on-bg-interactive" />
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </RadioGroup>
+        ) : (
+          <p className="txt-compact-small text-ui-fg-subtle">
+            Shipping unavailable
+          </p>
+        )}
+      </div>
+
+      {shippingError && (
+        <p className="txt-compact-small text-rose-500">{shippingError}</p>
+      )}
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-totals/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-totals/index.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { convertToLocale } from "@lib/util/money"
+import type { HttpTypes } from "@medusajs/types"
+import { useCartUpdate } from "@modules/checkout/context/cart-update-context"
+
+const CheckoutTotals = ({ cart }: { cart: HttpTypes.StoreCart }) => {
+  const { isCartUpdating } = useCartUpdate()
+
+  const { currency_code, total, item_subtotal, shipping_subtotal, tax_total } =
+    cart
+  const { discount_subtotal } = cart as typeof cart & {
+    discount_subtotal?: number
+  }
+  const itemCount = cart.items?.length ?? 0
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <div className="flex flex-col txt-medium text-ui-fg-subtle">
+        <div className="flex items-center justify-between">
+          <span>Items ({itemCount})</span>
+          <span data-testid="cart-subtotal">
+            {convertToLocale({
+              amount: item_subtotal ?? 0,
+              currency_code,
+            })}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span>Shipping</span>
+          <span data-testid="cart-shipping">
+            {convertToLocale({
+              amount: shipping_subtotal ?? 0,
+              currency_code,
+            })}
+          </span>
+        </div>
+
+        {!!discount_subtotal && (
+          <div className="flex items-center justify-between">
+            <span>Discount</span>
+            <span className="text-ui-fg-interactive" data-testid="cart-discount">
+              - {convertToLocale({ amount: discount_subtotal, currency_code })}
+            </span>
+          </div>
+        )}
+
+        {!!tax_total && (
+          <div className="flex items-center justify-between">
+            <span>Taxes</span>
+            <span data-testid="cart-taxes">
+              {convertToLocale({ amount: tax_total, currency_code })}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="h-px bg-ui-border-base" />
+
+      <div className="flex items-center justify-between">
+        <h2 className="h2-docs">Total</h2>
+        {isCartUpdating ? (
+          <span
+            className="inline-block w-28 h-7 rounded-xl bg-ui-border-base animate-pulse"
+            data-testid="cart-total-skeleton"
+          />
+        ) : (
+          <span className="txt-xlarge-plus text-ui-fg-base" data-testid="cart-total">
+            {convertToLocale({ amount: total ?? 0, currency_code })}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default CheckoutTotals

--- a/apps/storefront/src/modules/checkout/components/payment-button/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/payment-button/index.tsx
@@ -10,11 +10,13 @@ import ErrorMessage from "../error-message"
 
 type PaymentButtonProps = {
   cart: HttpTypes.StoreCart
+  selectedPaymentMethod?: string
   "data-testid": string
 }
 
 const PaymentButton: React.FC<PaymentButtonProps> = ({
   cart,
+  selectedPaymentMethod,
   "data-testid": dataTestId,
 }) => {
   const notReady =
@@ -26,8 +28,11 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
 
   const paymentSession = cart.payment_collection?.payment_sessions?.[0]
 
+  const activePaymentMethod =
+    selectedPaymentMethod ?? paymentSession?.provider_id ?? ""
+
   switch (true) {
-    case isStripeLike(paymentSession?.provider_id):
+    case isStripeLike(activePaymentMethod):
       return (
         <StripePaymentButton
           notReady={notReady}
@@ -35,7 +40,7 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
           data-testid={dataTestId}
         />
       )
-    case isPayU(paymentSession?.provider_id):
+    case isPayU(activePaymentMethod):
       return (
         <PayUPaymentButton
           notReady={notReady}
@@ -43,7 +48,7 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
           data-testid={dataTestId}
         />
       )
-    case isManual(paymentSession?.provider_id):
+    case isManual(activePaymentMethod):
       return (
         <ManualTestPaymentButton notReady={notReady} data-testid={dataTestId} />
       )
@@ -189,7 +194,7 @@ const StripePaymentButton = ({
     // `return_url` (the checkout page), where the Payment step's redirect-return
     // effect finalises the order. The billing details Stripe needs are collected
     // by the PaymentElement itself, so we no longer hand-build a payment_method.
-    const returnUrl = `${window.location.origin}${window.location.pathname}?step=review`
+    const returnUrl = `${window.location.origin}${window.location.pathname}`
 
     const { error, paymentIntent } = await stripe.confirmPayment({
       elements,

--- a/apps/storefront/src/modules/checkout/components/sign-in-prompt/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/sign-in-prompt/index.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@medusajs/ui"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+
+const SignInPrompt = () => {
+  return (
+    <>
+      <div className="bg-white flex items-center justify-between">
+        <div>
+          <h2 className="h2-docs">Already have an account?</h2>
+          <p className="txt-medium text-ui-fg-muted">
+            Sign in for a better experience.
+          </p>
+        </div>
+        <div>
+          <LocalizedClientLink href="/account">
+            <Button variant="secondary" size="large" data-testid="sign-in-button">
+              Sign in
+            </Button>
+          </LocalizedClientLink>
+        </div>
+      </div>
+      <div className="h-px bg-ui-border-base w-full" />
+    </>
+  )
+}
+
+export default SignInPrompt

--- a/apps/storefront/src/modules/checkout/context/cart-update-context.tsx
+++ b/apps/storefront/src/modules/checkout/context/cart-update-context.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { createContext, useCallback, useContext, useState } from "react"
+
+type CartUpdateContextValue = {
+  isCartUpdating: boolean
+  trackCartUpdate: <T>(update: () => Promise<T>) => Promise<T>
+}
+
+const CartUpdateContext = createContext<CartUpdateContextValue>({
+  isCartUpdating: false,
+  trackCartUpdate: (update) => update(),
+})
+
+export function CartUpdateProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [pendingCount, setPendingCount] = useState(0)
+
+  const trackCartUpdate = useCallback(
+    async <T,>(update: () => Promise<T>): Promise<T> => {
+      setPendingCount((c) => c + 1)
+      try {
+        return await update()
+      } finally {
+        setPendingCount((c) => c - 1)
+      }
+    },
+    []
+  )
+
+  return (
+    <CartUpdateContext.Provider
+      value={{ isCartUpdating: pendingCount > 0, trackCartUpdate }}
+    >
+      {children}
+    </CartUpdateContext.Provider>
+  )
+}
+
+export const useCartUpdate = () => useContext(CartUpdateContext)

--- a/apps/storefront/src/modules/checkout/templates/checkout-form/index.tsx
+++ b/apps/storefront/src/modules/checkout/templates/checkout-form/index.tsx
@@ -1,38 +1,53 @@
 import { listCartShippingMethods } from "@lib/data/fulfillment"
-import { listCartPaymentMethods } from "@lib/data/payment"
-import { HttpTypes } from "@medusajs/types"
-import Addresses from "@modules/checkout/components/addresses"
-import Payment from "@modules/checkout/components/payment"
-import Review from "@modules/checkout/components/review"
-import Shipping from "@modules/checkout/components/shipping"
+import { listRegions } from "@lib/data/regions"
+import { retrieveCustomerAddresses } from "@lib/data/customer"
+import type { HttpTypes } from "@medusajs/types"
+import CheckoutShippingSection from "@modules/checkout/components/checkout-shipping-section"
+import CheckoutInfoRows from "@modules/checkout/components/checkout-info-rows"
+import CheckoutItemList from "@modules/checkout/components/checkout-item-list"
+import SignInPrompt from "@modules/checkout/components/sign-in-prompt"
 
 export default async function CheckoutForm({
   cart,
   customer,
+  countryCode,
 }: {
   cart: HttpTypes.StoreCart | null
   customer: HttpTypes.StoreCustomer | null
+  countryCode: string
 }) {
-  if (!cart) {
-    return null
-  }
+  if (!cart) return null
 
-  const shippingMethods = await listCartShippingMethods(cart.id)
-  const paymentMethods = await listCartPaymentMethods(cart.region?.id ?? "")
+  const [shippingOptions, regions, addresses] = await Promise.all([
+    listCartShippingMethods(cart.id),
+    listRegions(),
+    retrieveCustomerAddresses(),
+  ])
 
-  if (!shippingMethods || !paymentMethods) {
-    return null
-  }
+  const resolvedCountry =
+    countryCode ||
+    cart.shipping_address?.country_code ||
+    cart.region?.countries?.[0]?.iso_2 ||
+    ""
 
   return (
-    <div className="w-full grid grid-cols-1 gap-y-8">
-      <Addresses cart={cart} customer={customer} />
+    <div className="flex flex-col px-4 py-6 lg:pe-10 lg:py-10 lg:ps-0 gap-y-6">
+      {!customer && <SignInPrompt />}
 
-      <Shipping cart={cart} availableShippingMethods={shippingMethods} />
+      <CheckoutShippingSection
+        cart={cart}
+        availableShippingOptions={shippingOptions}
+        regions={regions ?? []}
+        currentCountry={resolvedCountry}
+      />
+      <CheckoutInfoRows
+        cart={cart}
+        customer={customer}
+        addresses={addresses}
+        availableShippingMethods={shippingOptions}
+      />
 
-      <Payment cart={cart} availablePaymentMethods={paymentMethods} />
-
-      <Review cart={cart} />
+      <CheckoutItemList cart={cart} />
     </div>
   )
 }

--- a/apps/storefront/src/modules/checkout/templates/checkout-summary/index.tsx
+++ b/apps/storefront/src/modules/checkout/templates/checkout-summary/index.tsx
@@ -1,41 +1,35 @@
-import { Heading } from "@medusajs/ui"
-
-import ItemsPreviewTemplate from "@modules/cart/templates/preview"
+import { listCartPaymentMethods } from "@lib/data/payment"
+import type { HttpTypes } from "@medusajs/types"
 import DiscountCode from "@modules/checkout/components/discount-code"
-import CartTotals from "@modules/common/components/cart-totals"
-import Divider from "@modules/common/components/divider"
+import CheckoutPaymentSection from "@modules/checkout/components/checkout-payment-section"
+import CheckoutTotals from "@modules/checkout/components/checkout-totals"
 import QuoteCartNotice from "@modules/cart/components/quote-cart-notice"
 import type { QuoteCartTerms } from "types/quote-terms"
 
-const CheckoutSummary = ({
+const CheckoutSummary = async ({
   cart,
   quoteTerms,
 }: {
-  cart: any
+  cart: HttpTypes.StoreCart
   /** #1787 — null for an ordinary cart. */
   quoteTerms?: QuoteCartTerms | null
 }) => {
+  const paymentMethods = await listCartPaymentMethods(cart.region?.id ?? "")
+
   return (
-    <div className="sticky top-0 flex flex-col-reverse small:flex-col gap-y-8 py-8 small:py-0 ">
-      <div className="w-full bg-white flex flex-col">
-        <Divider className="my-6 small:hidden" />
-        <Heading
-          level="h2"
-          className="flex flex-row text-3xl-regular items-baseline"
-        >
-          In your Cart
-        </Heading>
-        <Divider className="my-6" />
-        {/* Directly under the totals: the buyer has just read the full
-            amount, and this is the moment the "due today" figure has to
-            appear — not two steps later at Review. */}
-        <QuoteCartNotice terms={quoteTerms ?? null} className="mb-6" />
-        <CartTotals totals={cart} />
-        <ItemsPreviewTemplate cart={cart} />
-        <div className="my-6">
-          <DiscountCode cart={cart} />
-        </div>
-      </div>
+    <div className="flex flex-col gap-y-8 px-4 py-4 lg:py-10 lg:ps-10 bg-neutral-100 lg:-me-[9999px] lg:pe-[9999px]">
+      <CheckoutTotals cart={cart} />
+
+      {/* Directly under the totals: the buyer has just read the full amount,
+          and this is the moment the "due today" figure has to appear. */}
+      <QuoteCartNotice terms={quoteTerms ?? null} />
+
+      <DiscountCode cart={cart} />
+
+      <CheckoutPaymentSection
+        cart={cart}
+        availablePaymentMethods={paymentMethods ?? []}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Ports the modern single-page checkout layout from [gorgojs/medusa-dtc-starter](https://github.com/gorgojs/medusa-dtc-starter) into `apps/storefront`, and bumps the `storefront-starter` submodule to the matching change.

## Changes

- **Layout** — two-column `7fr/5fr` grid with a full-bleed gray summary panel; new checkout header (back-to-cart / store name / sign-in) and footer.
- **Left column** — sign-in prompt, shipping-method cards (with delivery-date estimates + country selector), address/contact rows, and an inline item list with quantity stepper.
- **Right column** — totals (with cart-update skeleton), discount code, and the payment section.
- **New components** — `checkout-modal`, `checkout-address-sheet`, `checkout-billing-sheet`, `checkout-contacts-sheet`, `checkout-shipping-section`, `checkout-info-rows`, `checkout-item-list`, `checkout-totals`, `checkout-payment-section`, `sign-in-prompt`, and a `cart-update-context`.
- **Supporting** — `lib/util/fulfillment` (pickup/delivery-days helpers), `setCheckoutAddresses` in `cart.ts`, `retrieveCustomerAddresses` in `customer.ts`, `buildPaymentSessionData`/`isPaymentSessionReady` in `constants.tsx`.

## Adaptations

- No `next-intl` — translated strings replaced with plain English text.
- Payment flow keeps the existing Stripe Connect + PayU + manual providers; `payment-button` now accepts `selectedPaymentMethod`.
- Quote/deposit support (`QuoteCartNotice`, `retrieveQuoteTerms`) is preserved.

## Submodule

- Bumps `apps/storefront-starter` to `5dbf212` (nextjs-starter-medusa#32).

## Notes

- Both `next.config.js` set `ignoreBuildErrors`/`ignoreDuringBuilds`; verified no broken imports were introduced.
- Not smoke-tested against a live backend — worth a manual pass of the payment flow.