### PR TITLE
fix(build): the prod image stopped building at Medusa 2.20.1 — nothing has deployed since `0fe3ea76a`

### DIFF
--- a/apps/backend/src/workflows/payments/request-order-balance.ts
+++ b/apps/backend/src/workflows/payments/request-order-balance.ts
@@ -79,7 +79,7 @@ const ensureBalanceCollectionStep = createStep(
     }
 
     const { schedule_id, order_id, amount } = input.plan
-    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
 
     /**
@@ -159,7 +159,7 @@ const ensureBalanceSessionStep = createStep(
       return new StepResponse({ ok: false })
     }
 
-    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const { data: collections } = await query.graph({
       entity: "payment_collection",
       fields: ["id", "payment_sessions.id", "payment_sessions.provider_id"],


### PR DESCRIPTION
**Nothing has reached prod since `0fe3ea76a`.** Every deploy since then dies in `Build & Push Image`, so `Migrate DB`, both service deploys and the health check never run — they show as `skipped`, not `failed`, which is why the failure reads quieter than it is.

That means **#1811 (`f8e063587`) and everything in PR #1815 (`87b4d6eb5`) are merged but not live.**

## The two errors

```
src/workflows/payments/request-order-balance.ts:97:36   error TS18046: 'query' is of type 'unknown'.
src/workflows/payments/request-order-balance.ts:163:41  error TS18046: 'query' is of type 'unknown'.
```

## Why now

The code is from #1792 and it built fine on 2.19 — `2748b8f1b` **is** an ancestor of the last green image (`0fe3ea76`).

**Medusa 2.20.1 (`a445ba85a`) changed what `container.resolve(ContainerRegistrationKeys.QUERY)` returns.** It is `unknown` now, and both call sites dereference it.

2.20.1's own deploy run was **cancelled**, so the first deploy to actually compile against 2.20.1 was `f8e06358` (#1811) — the failure surfaced one merge downstream of the commit that caused it, in a file that PR never touched.

The other ~15 resolves of the same key in `src/workflows/` all annotate the result. These two were the only ones that did not.

## Verification

`pnpm run build` — the image's own command, not `check:prod-build`:

- with this change: **exit 0**, "Backend build completed successfully"
- reverted: **exit 1**, with exactly the two errors above

`check:prod-build` was green through all of it. It does not compile what the image compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4