### PR TITLE
fix(checkout): guard Stripe button against a missing Elements provider

### DIFF
--- a/apps/storefront/src/modules/checkout/components/payment-button/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/payment-button/index.tsx
@@ -5,8 +5,9 @@ import { placeOrder } from "@lib/data/cart"
 import { HttpTypes } from "@medusajs/types"
 import { Button } from "@medusajs/ui"
 import { useElements, useStripe } from "@stripe/react-stripe-js"
-import React, { useState } from "react"
+import React, { useContext, useState } from "react"
 import ErrorMessage from "../error-message"
+import { StripeContext } from "../payment-wrapper/stripe-wrapper"
 
 type PaymentButtonProps = {
   cart: HttpTypes.StoreCart
@@ -31,14 +32,23 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
   const activePaymentMethod =
     selectedPaymentMethod ?? paymentSession?.provider_id ?? ""
 
+  const stripeReady = useContext(StripeContext)
+
   switch (true) {
     case isStripeLike(activePaymentMethod):
-      return (
+      // `useStripe()`/`useElements()` throw outside an <Elements> provider, so
+      // never mount the Stripe button until PaymentWrapper has actually wrapped
+      // us (i.e. a Stripe session is pending and Stripe is loaded).
+      return stripeReady ? (
         <StripePaymentButton
           notReady={notReady}
           cart={cart}
           data-testid={dataTestId}
         />
+      ) : (
+        <Button disabled size="large">
+          Select a payment method
+        </Button>
       )
     case isPayU(activePaymentMethod):
       return (


### PR DESCRIPTION
## Summary

Fixes a crash on `/checkout?step=payment` (and any checkout load with a stale/non-pending Stripe session):

```
Could not find Elements context; You need to wrap the part of your app
that calls useStripe() in an <Elements> provider.
```

## Root cause

`payment-button` dispatched to its Stripe variant (which calls `useStripe()`/`useElements()`) whenever the selected method was stripe-like, but `PaymentWrapper` only mounts `<Elements>` when a Stripe session is *pending*. Those conditions diverged on a stale session, so `useStripe()` ran outside the provider.

## Fix

Read `StripeContext` in `payment-button` and only render the Stripe button once we are actually inside the `<Elements>` provider; otherwise show a disabled placeholder.

The matching storefront-starter fix is in nextjs-starter-medusa#35; the submodule bump is left to #1821 (deps pin) to avoid a lockfile conflict.