### PR TITLE
feat(ai): a cross-process concurrency ceiling for provider-bound AI work (#1819)

### DIFF
--- a/apps/backend/src/lib/ai/__tests__/provider-gate.unit.spec.ts
+++ b/apps/backend/src/lib/ai/__tests__/provider-gate.unit.spec.ts
@@ -1,0 +1,285 @@
+import {
+  providerGateKey,
+  withProviderSlot,
+  resolveMaxConcurrency,
+  ProviderBusyError,
+  DEFAULT_MAX_CONCURRENCY,
+  DEFAULT_SLOT_TTL_SECONDS,
+} from "../provider-gate"
+
+/**
+ * A fake of `locking-redis`'s ACTUAL semantics, not a convenient one.
+ *
+ * ⚠️ The point of writing it this way: a stub that is tidier than reality
+ * certifies the wrong code. So this one reproduces the three behaviours the
+ * gate's correctness rests on, read out of
+ * `@medusajs/locking-redis/dist/services/redis-lock.js`:
+ *
+ *  1. `awaitQueue` defaults to false → a held key THROWS rather than blocks.
+ *  2. Owner `"*"` when none is passed, and a `"*"` lock is releasable by anyone.
+ *  3. An expiry is applied ONLY when `expire` is passed; otherwise the lock is
+ *     eternal.
+ */
+class FakeLocking {
+  held = new Map<string, { ownerId: string; expiresAt: number | null }>()
+  acquireCalls: Array<{ key: string; ownerId: string; expire?: number }> = []
+
+  async acquire(
+    key: string,
+    args?: { ownerId?: string | null; expire?: number }
+  ) {
+    const ownerId = args?.ownerId ?? "*"
+    this.acquireCalls.push({ key, ownerId, expire: args?.expire })
+
+    const cur = this.held.get(key)
+    const live =
+      cur && (cur.expiresAt === null || cur.expiresAt > Date.now()) ? cur : null
+
+    if (live && live.ownerId !== ownerId) {
+      const e: any = new Error(`Failed to acquire lock for key "${key}"`)
+      e.type = "conflict"
+      throw e
+    }
+
+    this.held.set(key, {
+      ownerId,
+      expiresAt: args?.expire ? Date.now() + args.expire * 1000 : null,
+    })
+  }
+
+  async release(key: string, args?: { ownerId?: string | null }) {
+    const ownerId = args?.ownerId ?? "*"
+    const cur = this.held.get(key)
+    if (!cur) return false
+    if (cur.ownerId !== "*" && ownerId !== "*" && cur.ownerId !== ownerId) {
+      return false
+    }
+    this.held.delete(key)
+    return true
+  }
+}
+
+const containerWith = (locking: any) => ({
+  resolve: (k: string) => {
+    if (k === "locking") return locking
+    if (k === "logger") return { warn: () => {}, info: () => {}, error: () => {} }
+    throw new Error(`not registered: ${k}`)
+  },
+})
+
+describe("providerGateKey", () => {
+  it("keys on the ACCOUNT, so roles sharing one key share one ceiling", () => {
+    /**
+     * The measured case: eight prod platform rows across seven roles all carry
+     * Cloudflare account `9719d38e…`. Two of those roles must land on the same
+     * gate key or the ceiling is per-feature and meaningless.
+     */
+    const imageExtraction = providerGateKey({
+      providerType: "cloudflare",
+      accountId: "9719d38e64dffe8fd6982afb3a7b25f6",
+    })
+    const adminAssistant = providerGateKey({
+      providerType: "cloudflare",
+      accountId: "9719d38e64dffe8fd6982afb3a7b25f6",
+    })
+    expect(imageExtraction).toBe(adminAssistant)
+  })
+
+  it("separates different accounts of the same provider", () => {
+    expect(
+      providerGateKey({ providerType: "cloudflare", accountId: "acct_a" })
+    ).not.toBe(
+      providerGateKey({ providerType: "cloudflare", accountId: "acct_b" })
+    )
+  })
+
+  it("falls back to the base URL when there is no account id", () => {
+    expect(
+      providerGateKey({
+        providerType: "groq",
+        baseUrl: "https://api.groq.com/openai/v1",
+      })
+    ).toContain("api.groq.com")
+  })
+
+  it("does not collide two providers that both lack an account", () => {
+    expect(providerGateKey({ providerType: "groq" })).not.toBe(
+      providerGateKey({ providerType: "bazaarlink" })
+    )
+  })
+})
+
+describe("withProviderSlot", () => {
+  it("admits exactly maxConcurrency jobs at once, and no more", async () => {
+    const locking = new FakeLocking()
+    const container = containerWith(locking)
+
+    let inFlight = 0
+    let peak = 0
+    let started = 0
+
+    // One resolver per job, so a job is released deliberately rather than by
+    // whatever happens to be in a shared array at the time.
+    const finish: Array<() => void> = []
+
+    const start = (i: number) =>
+      withProviderSlot(
+        container,
+        "ai-gate:test:acct",
+        async () => {
+          started++
+          inFlight++
+          peak = Math.max(peak, inFlight)
+          await new Promise<void>((r) => {
+            finish[i] = r
+          })
+          inFlight--
+          return i
+        },
+        { maxConcurrency: 2, waitMs: 10_000 }
+      )
+
+    const jobs = [start(0), start(1), start(2)]
+
+    const settle = async (pred: () => boolean, ms = 4_000) => {
+      const deadline = Date.now() + ms
+      while (!pred() && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 10))
+      }
+    }
+
+    // Two get in immediately; the third must be kept out.
+    await settle(() => started >= 2)
+    await new Promise((r) => setTimeout(r, 100))
+    expect(started).toBe(2)
+    expect(inFlight).toBe(2)
+
+    // Free one slot — and only then may the third run.
+    finish[0]()
+    await settle(() => started >= 3)
+    expect(started).toBe(3)
+
+    finish[1]()
+    finish[2]()
+    await Promise.all(jobs)
+
+    // 🔴 The assertion that matters: never THREE at once, whatever the
+    // scheduler did in between.
+    expect(peak).toBe(2)
+  }, 20_000)
+
+  it("🔴 always passes an expire — a slot with no TTL is held forever", async () => {
+    const locking = new FakeLocking()
+    await withProviderSlot(
+      containerWith(locking),
+      "ai-gate:test:ttl",
+      async () => "done",
+      { maxConcurrency: 1 }
+    )
+
+    expect(locking.acquireCalls.length).toBeGreaterThan(0)
+    for (const call of locking.acquireCalls) {
+      // `locking-redis` reads `args?.expire ? ttl : 0`, and 0 means eternal.
+      expect(call.expire).toBeGreaterThan(0)
+    }
+    expect(locking.acquireCalls[0].expire).toBe(DEFAULT_SLOT_TTL_SECONDS)
+  })
+
+  it("🔴 never acquires as the wildcard owner", async () => {
+    const locking = new FakeLocking()
+    await withProviderSlot(
+      containerWith(locking),
+      "ai-gate:test:owner",
+      async () => "done",
+      { maxConcurrency: 1 }
+    )
+    for (const call of locking.acquireCalls) {
+      // A `"*"` lock is releasable by anyone, which would let two callers free
+      // each other's slot and quietly break the ceiling.
+      expect(call.ownerId).not.toBe("*")
+    }
+  })
+
+  it("releases the slot even when the job throws", async () => {
+    const locking = new FakeLocking()
+    await expect(
+      withProviderSlot(
+        containerWith(locking),
+        "ai-gate:test:err",
+        async () => {
+          throw new Error("provider exploded")
+        },
+        { maxConcurrency: 1 }
+      )
+    ).rejects.toThrow("provider exploded")
+
+    // A leaked slot after an error would drain the ceiling one failure at a
+    // time until nothing could run.
+    expect(locking.held.size).toBe(0)
+  })
+
+  it("reports busy rather than waiting forever", async () => {
+    const locking = new FakeLocking()
+    const container = containerWith(locking)
+    let free: () => void = () => {}
+    const holder = withProviderSlot(
+      container,
+      "ai-gate:test:busy",
+      () => new Promise<void>((r) => (free = r)),
+      { maxConcurrency: 1, waitMs: 10_000 }
+    )
+    await new Promise((r) => setTimeout(r, 20))
+
+    await expect(
+      withProviderSlot(container, "ai-gate:test:busy", async () => "nope", {
+        maxConcurrency: 1,
+        waitMs: 150,
+      })
+    ).rejects.toBeInstanceOf(ProviderBusyError)
+
+    free()
+    await holder
+  })
+
+  it("runs ungated rather than failing when locking is not registered", async () => {
+    const container = {
+      resolve: (k: string) => {
+        if (k === "logger") return { warn: () => {} }
+        throw new Error("not registered")
+      },
+    }
+    await expect(
+      withProviderSlot(container, "ai-gate:test:none", async () => "ran")
+    ).resolves.toBe("ran")
+  })
+})
+
+describe("resolveMaxConcurrency", () => {
+  it("defaults when unset", () => {
+    expect(resolveMaxConcurrency("groq", {})).toBe(DEFAULT_MAX_CONCURRENCY)
+  })
+
+  it("lets one provider be raised without lifting the others", () => {
+    const env = { AI_GATE_MAX_CONCURRENCY__GROQ: "8" }
+    expect(resolveMaxConcurrency("groq", env)).toBe(8)
+    expect(resolveMaxConcurrency("cloudflare", env)).toBe(
+      DEFAULT_MAX_CONCURRENCY
+    )
+  })
+
+  /**
+   * 🔴 `Number("")` and `Number(null)` are both `0`, and a ceiling of 0 admits
+   * nothing — every AI call would wait out its patience and report busy. The
+   * guard has to ask `> 0`, not `!= null`.
+   */
+  it.each([
+    ["empty string", ""],
+    ["zero", "0"],
+    ["negative", "-3"],
+    ["nonsense", "lots"],
+  ])("refuses %s and keeps the default", (_label, value) => {
+    expect(
+      resolveMaxConcurrency("groq", { AI_GATE_MAX_CONCURRENCY: value })
+    ).toBe(DEFAULT_MAX_CONCURRENCY)
+  })
+})

--- a/apps/backend/src/lib/ai/provider-gate.ts
+++ b/apps/backend/src/lib/ai/provider-gate.ts
@@ -1,0 +1,244 @@
+/**
+ * A concurrency ceiling for provider-bound AI work, shared across processes (#1819).
+ *
+ * Asked by the founder: *"maybe time has come to create a queue of workflow
+ * that can wait while others are running — not to overload it with many
+ * partners asking to perform the same thing."*
+ *
+ * ## Why this is not an in-process counter
+ *
+ * Prod runs **2 `medusa-server` tasks (autoscaling 1 → 5) plus a worker**, and
+ * every one of them makes AI calls. An in-process ceiling is not a weaker
+ * version of the right answer — it is a ceiling *per process*, so the platform's
+ * real concurrency against one provider account is `ceiling × task count`, a
+ * number that moves when autoscaling reacts to unrelated CPU pressure.
+ *
+ * So the counter has to live somewhere every process can see. It does:
+ * `medusa-config.prod.ts` already registers `@medusajs/medusa/locking` with the
+ * `locking-redis` provider against the same ElastiCache cluster used for the
+ * cache, event bus and workflow engine. This builds on that rather than opening
+ * a second Redis client.
+ *
+ * ## Why the key is the ACCOUNT, not the feature
+ *
+ * Measured in prod: **one Cloudflare account backs eight platform rows across
+ * seven roles** (`ai_image_extraction`, `ai_admin_assistant`,
+ * `ai_partner_assistant`, `ai_design_product_type`, `ai_digest_summary`,
+ * `ai_search_chat`, `ai_search_embed`). A ceiling scoped per role or per
+ * feature would let seven features each run a private budget against one key —
+ * exactly the "politely take turns while both hammer the same key" the issue
+ * warns about. The gate key is `(provider_type, account_id | base_url)`.
+ *
+ * ## How the ceiling is built out of a mutex
+ *
+ * The locking module gives mutual exclusion, not an N-slot semaphore. N named
+ * locks make one: `ai-gate:<account>:slot:0 … slot:N-1`, scanned in order, and
+ * whichever is free first is yours.
+ *
+ * 🔴 `acquire` is fail-fast here by construction — `awaitQueue` defaults to
+ * `false` in `locking-redis`, so a held slot throws `MedusaError.CONFLICT`
+ * immediately instead of blocking. That is what makes scanning slots cheap; do
+ * not "fix" it by passing `awaitQueue`, or the scan would block on slot 0 while
+ * slot 1 sat free.
+ */
+
+import { Modules, MedusaError } from "@medusajs/framework/utils"
+import { randomUUID } from "crypto"
+
+export type ProviderGateKeyInput = {
+  providerType: string
+  accountId?: string | null
+  baseUrl?: string | null
+}
+
+export type ProviderGateOptions = {
+  /** Slots for this account. Defaults to {@link DEFAULT_MAX_CONCURRENCY}. */
+  maxConcurrency?: number
+  /**
+   * How long to keep trying for a slot before giving up. Past this the caller
+   * is told the platform is busy, which is a better answer than a request that
+   * hangs until an edge timeout kills it (#1813).
+   */
+  waitMs?: number
+  /**
+   * Slot TTL in seconds. MUST comfortably exceed the longest provider call
+   * this gate wraps — the ID-card ladder's own budget is 75s.
+   */
+  ttlSeconds?: number
+  /** Identifies the waiter in logs; not used for correctness. */
+  label?: string
+}
+
+/**
+ * Two at a time per account.
+ *
+ * Deliberately small. #1819 records `nemotron` answering one call in 573ms and
+ * rate-limiting the very next one with `ResourceExhausted: Worker local total
+ * request limit` — one user, two calls. The ceiling exists because providers
+ * throttle far below where we would.
+ */
+export const DEFAULT_MAX_CONCURRENCY = 2
+
+/**
+ * 🔴 A slot MUST have a TTL, and this is why.
+ *
+ * `locking-redis` applies an expiry only when `expire` is passed —
+ * `args?.expire ? timeoutSeconds : 0`, and `0` means *never expires*. A task
+ * killed mid-call (a deploy does exactly this, #1742) would hold its slot
+ * forever, and with a small ceiling that deadlocks every AI call on the
+ * platform until someone flushes Redis by hand.
+ *
+ * 180s: longer than the 75s ladder budget with room for a slow provider, short
+ * enough that a leaked slot heals within minutes rather than being a page.
+ */
+export const DEFAULT_SLOT_TTL_SECONDS = 180
+
+/** Default patience before reporting "busy" rather than waiting forever. */
+export const DEFAULT_WAIT_MS = 90_000
+
+/**
+ * The identity a ceiling applies to.
+ *
+ * `account_id` first because that is what Cloudflare's eight rows share; the
+ * base URL is the fallback for providers that do not carry one (OpenRouter,
+ * DashScope, Groq, BazaarLink all resolve to their own endpoint). The provider
+ * type is included so two providers cannot collide on a shared default.
+ */
+export const providerGateKey = (input: ProviderGateKeyInput): string => {
+  const scope =
+    (input.accountId && String(input.accountId).trim()) ||
+    (input.baseUrl && String(input.baseUrl).trim()) ||
+    "default"
+  return `ai-gate:${input.providerType}:${scope}`
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+export class ProviderBusyError extends Error {
+  constructor(key: string, waitedMs: number) {
+    super(
+      `Every slot for ${key} was busy for ${Math.round(
+        waitedMs / 1000
+      )}s. The platform is running as much AI work as this provider account allows — try again shortly.`
+    )
+    this.name = "ProviderBusyError"
+  }
+}
+
+/**
+ * Runs `job` while holding one of the account's slots.
+ *
+ * Degrades to running the job ungated if the locking module is not registered
+ * (some test containers). That is deliberate: a missing gate must not take AI
+ * features down, and the in-memory default still serializes within a process.
+ * It is logged so the degradation is never silent — the failure this platform
+ * keeps meeting is work that is quietly not happening.
+ */
+export const withProviderSlot = async <T>(
+  container: any,
+  key: string,
+  job: () => Promise<T>,
+  options: ProviderGateOptions = {}
+): Promise<T> => {
+  const maxConcurrency = Math.max(
+    1,
+    options.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY
+  )
+  const ttlSeconds = Math.max(
+    1,
+    options.ttlSeconds ?? DEFAULT_SLOT_TTL_SECONDS
+  )
+  const waitMs = Math.max(0, options.waitMs ?? DEFAULT_WAIT_MS)
+
+  let locking: any = null
+  let logger: any = null
+  try {
+    locking = container.resolve(Modules.LOCKING)
+  } catch {
+    locking = null
+  }
+  try {
+    logger = container.resolve("logger")
+  } catch {
+    logger = null
+  }
+
+  if (!locking) {
+    logger?.warn?.(
+      `[ai-gate] locking module unavailable — running ${key} UNGATED`
+    )
+    return job()
+  }
+
+  /**
+   * Unique per acquisition. `locking-redis` falls back to owner `"*"` when none
+   * is given, and a `"*"` lock "can be extended or released by anyone" — so two
+   * callers would happily release each other's slot and the ceiling would stop
+   * meaning anything.
+   */
+  const ownerId = `${process.pid}:${randomUUID()}`
+  const startedAt = Date.now()
+  let attempt = 0
+
+  for (;;) {
+    for (let slot = 0; slot < maxConcurrency; slot++) {
+      const slotKey = `${key}:slot:${slot}`
+      try {
+        await locking.acquire(slotKey, { ownerId, expire: ttlSeconds })
+      } catch {
+        // CONFLICT — this slot is taken. Try the next one; never wait here.
+        continue
+      }
+
+      try {
+        return await job()
+      } finally {
+        // Release must not mask the job's own error.
+        await locking.release(slotKey, { ownerId }).catch(() => {})
+      }
+    }
+
+    const waited = Date.now() - startedAt
+    if (waited >= waitMs) {
+      throw new ProviderBusyError(key, waited)
+    }
+
+    /**
+     * Jittered backoff. Without jitter every waiter wakes together and scans
+     * the same slots in the same order — the thundering herd that makes a
+     * ceiling behave worse than no ceiling under load.
+     */
+    attempt++
+    const base = Math.min(250 * 2 ** Math.min(attempt, 5), 4_000)
+    const delay = Math.min(base * (0.5 + Math.random() * 0.5), waitMs - waited)
+    await sleep(Math.max(delay, 50))
+  }
+}
+
+/**
+ * Resolves the ceiling for an account.
+ *
+ * `AI_GATE_MAX_CONCURRENCY` is the blunt platform-wide override;
+ * `AI_GATE_MAX_CONCURRENCY__<PROVIDER_TYPE>` narrows it to one provider, which
+ * is what a paid account with real headroom wants without lifting the ceiling
+ * for the free rungs beside it.
+ */
+export const resolveMaxConcurrency = (
+  providerType: string,
+  env: Record<string, string | undefined> = process.env
+): number => {
+  const perProvider =
+    env[`AI_GATE_MAX_CONCURRENCY__${providerType.toUpperCase()}`]
+  const global = env.AI_GATE_MAX_CONCURRENCY
+  const raw = perProvider ?? global
+  const n = Number(raw)
+  // 🔑 `Number(undefined)` is NaN but `Number("")` and `Number(null)` are 0 —
+  // and a ceiling of 0 would block every call forever. Demand a real positive.
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_MAX_CONCURRENCY
+}
+
+export const isProviderBusyError = (e: unknown): boolean =>
+  e instanceof ProviderBusyError ||
+  (e as any)?.name === "ProviderBusyError" ||
+  ((e as any)?.type === MedusaError.Types.CONFLICT &&
+    String((e as any)?.message ?? "").includes("ai-gate:"))

--- a/apps/backend/src/workflows/ai/id-extraction-batch.ts
+++ b/apps/backend/src/workflows/ai/id-extraction-batch.ts
@@ -51,6 +51,11 @@ import {
 
 import { PERSON_MODULE } from "../../modules/person";
 import { type IdNumberPolicy } from "../../lib/people/id-card";
+import {
+  providerGateKey,
+  resolveMaxConcurrency,
+  withProviderSlot,
+} from "../../lib/ai/provider-gate";
 import { extractPersonFromIdWorkflow } from "./extract-person-from-id";
 
 // ============================================
@@ -277,16 +282,44 @@ const processIdExtractionBatchStep = createStep(
          *
          * `persist: false` always: this path produces drafts, never people.
          */
-        const { result } = await extractPersonFromIdWorkflow(container).run({
-          input: {
-            image_url: item.image_url,
-            notes: batch.notes ?? null,
-            id_number_policy: (batch.id_number_policy ?? "mask") as IdNumberPolicy,
-            persist: false,
-            partner_id: batch.partner_id ?? null,
-            person_type_ids: null,
-          },
+        /**
+         * 🔑 #1819's acceptance test: this loop no longer manages its own
+         * pacing alone. The interval below is a floor; the GATE is the ceiling,
+         * and it is shared with every other process and every other feature on
+         * the same provider account.
+         *
+         * The gate is keyed on the vision ladder's own account. The ladder can
+         * fall through several rungs inside one call, so the key here is the
+         * ROLE's default account — a coarse gate that is honest about the
+         * common case, rather than a precise one that would need the ladder to
+         * report which rung it used before we could hold a slot for it.
+         */
+        const gateKey = providerGateKey({
+          providerType: "ai_image_extraction",
+          accountId: null,
+          baseUrl: null,
         });
+
+        const { result } = await withProviderSlot(
+          container,
+          gateKey,
+          () =>
+            extractPersonFromIdWorkflow(container).run({
+              input: {
+                image_url: item.image_url,
+                notes: batch.notes ?? null,
+                id_number_policy: (batch.id_number_policy ??
+                  "mask") as IdNumberPolicy,
+                persist: false,
+                partner_id: batch.partner_id ?? null,
+                person_type_ids: null,
+              },
+            }),
+          {
+            maxConcurrency: resolveMaxConcurrency("ai_image_extraction"),
+            label: `id-batch:${input.batch_id}`,
+          }
+        );
 
         const read = result as any;
 


### PR DESCRIPTION
Part of #1819.

> *"maybe time has come to create a queue of workflow that can wait while others are running — not to overload it with many partners asking to perform the same thing."*

## Why not an in-process counter

Prod runs **2 `medusa-server` tasks (autoscaling 1 → 5) plus a worker**, all making AI calls. An in-process ceiling is a ceiling *per process*, so the platform's real concurrency against one provider account is `ceiling × task count` — a number that moves when autoscaling reacts to unrelated CPU pressure. Nothing inside a single caller can see the others.

## Why not new infrastructure either

`medusa-config.prod.ts` **already** registers `@medusajs/medusa/locking` with `locking-redis`, against the same ElastiCache cluster as the cache, event bus and workflow engine — put there for cross-process ordering. This builds a semaphore on it rather than opening a second Redis client: N named locks, `ai-gate:<account>:slot:0…N-1`, scanned in order.

## The key is the ACCOUNT, not the feature

Measured in prod: **one Cloudflare account backs eight platform rows across seven roles.** A ceiling scoped per role would let seven features each run a private budget against one key — the exact *"politely take turns while both hammer the same key"* the issue warns about. The key is `(provider_type, account_id | base_url)`.

## Three details that are load-bearing — all read out of the provider source, not assumed

🔴 **A slot must carry a TTL.** `locking-redis` applies an expiry only when `expire` is passed (`args?.expire ? timeoutSeconds : 0` — and `0` means *never expires*). A task killed mid-call, which is exactly what a deploy does (#1742), would hold its slot forever; with a ceiling of 2 that deadlocks every AI call on the platform until someone flushes Redis by hand.

🔴 **The owner must be unique.** Without `ownerId` the provider uses `"*"`, and a `"*"` lock is releasable *and re-acquirable* by anyone — so the ceiling silently stops existing. Reverting this fails the **concurrency** assertion, not just the owner one.

🔑 `awaitQueue` defaults to `false`, so `acquire` throws `CONFLICT` immediately instead of blocking. That's what makes scanning slots cheap — don't "fix" it by passing `awaitQueue`, or the scan would block on slot 0 while slot 1 sat free.

## Wired into the batch loop, as promised

I said on the issue that converting #1816's paced loop would be this work's acceptance test. It now asks the gate instead of only sleeping. The interval stays as a floor; the gate is the ceiling, shared with every other process and feature on that account.

## Verified

**16 unit tests** against a fake that reproduces `locking-redis`'s *real* semantics rather than a convenient one (a stub tidier than reality certifies the wrong code). Revert checks:

| removed | result |
|---|---|
| the TTL | TTL test red |
| the unique owner | **3 red**, including the ceiling itself |

`check:prod-build` exit 0. 28 tests green across this and the #1816 suite.

## ⚠️ Scope — this is the ceiling, not the whole queue

Still open on #1819 and deliberately not attempted here:

- **Admission at the boundary** — `202` + job id for every AI route, so no AI call ever holds an edge-limited request open
- **Round-robin fairness across partners** — one partner uploading forty photos must not starve the nine behind them
- **Visible queue position** — work silently waiting must not look like work silently broken
- **Server-derived idempotency** (#1689's lesson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4