### PR TITLE
feat(admin): textile library thumbnail grid + inline edit modal

### DIFF
--- a/apps/backend/src/admin/hooks/api/textile-analyses.ts
+++ b/apps/backend/src/admin/hooks/api/textile-analyses.ts
@@ -1,4 +1,10 @@
-import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
+import {
+  QueryKey,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { FetchError } from "@medusajs/js-sdk"
 import { sdk } from "../../lib/config"
 
@@ -19,6 +25,7 @@ export type AdminTextileAnalysis = {
   season?: string[] | null
   occasion?: string[] | null
   care_instructions?: string[] | null
+  target_audience?: string | null
   analyzed_at?: string | null
   media?: {
     id: string
@@ -33,10 +40,32 @@ export type AdminTextileAnalysisListResponse = {
   count: number
 }
 
+export type AdminTextileAnalysisResponse = {
+  textile_analysis: AdminTextileAnalysis
+}
+
 export type AdminTextileAnalysesQuery = {
   media_id?: string
   limit?: number
   offset?: number
+}
+
+export type AdminUpdateTextileAnalysis = {
+  source?: string
+  confidence?: number | null
+  cloth_type?: string | null
+  category?: string | null
+  pattern?: string | null
+  fabric_weight?: string | null
+  weave_or_knit?: string | null
+  primary_color?: string | null
+  title?: string | null
+  description?: string | null
+  target_audience?: string | null
+  colors?: string[] | null
+  season?: string[] | null
+  occasion?: string[] | null
+  care_instructions?: string[] | null
 }
 
 /**
@@ -64,5 +93,59 @@ export const useTextileAnalyses = (
         { method: "GET", query: query ?? {} }
       ),
     ...options,
+  })
+}
+
+/**
+ * Fetch a single analysis, hydrated with its media file. Used by the edit
+ * modal at `/textile-analyses/:id`.
+ */
+export const useTextileAnalysis = (
+  id?: string,
+  options?: Omit<
+    UseQueryOptions<
+      AdminTextileAnalysis,
+      FetchError,
+      AdminTextileAnalysis,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  return useQuery({
+    queryKey: ["textile-analysis", id],
+    queryFn: async () => {
+      const res = await sdk.client.fetch<AdminTextileAnalysisResponse>(
+        `/admin/textile-analyses/${id}`
+      )
+      return res.textile_analysis
+    },
+    enabled: !!id,
+    ...options,
+  })
+}
+
+/**
+ * Correct a single analysis. Invalidates both the list and the single row so
+ * the library grid reflects the edit when the modal closes.
+ */
+export const useUpdateTextileAnalysis = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      ...data
+    }: { id: string } & AdminUpdateTextileAnalysis) => {
+      const res = await sdk.client.fetch<AdminTextileAnalysisResponse>(
+        `/admin/textile-analyses/${id}`,
+        { method: "PATCH", body: data }
+      )
+      return res.textile_analysis
+    },
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({ queryKey: ["textile-analyses"] })
+      queryClient.invalidateQueries({ queryKey: ["textile-analysis", updated.id] })
+    },
   })
 }

--- a/apps/backend/src/admin/routes/operations/page.tsx
+++ b/apps/backend/src/admin/routes/operations/page.tsx
@@ -109,6 +109,11 @@ export default function OperationsHub() {
           description="Media folders, uploads, and shared assets."
           to="/medias"
         />
+        <QuickLinkCard
+          title="Textile library"
+          description="What a vision model saw in every fabric photo — correctable."
+          to="/textile-analyses"
+        />
       </Section>
     </Container>
   )

--- a/apps/backend/src/admin/routes/textile-analyses/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/textile-analyses/[id]/page.tsx
@@ -1,0 +1,448 @@
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "@medusajs/framework/zod"
+import {
+  Button,
+  Heading,
+  Input,
+  Select,
+  Skeleton,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { useParams } from "react-router-dom"
+import { RouteFocusModal } from "../../../components/modal/route-focus-modal"
+import { KeyboundForm } from "../../../components/utilitites/key-bound-form"
+import { useRouteModal } from "../../../components/modal/use-route-modal"
+import { Form } from "../../../components/common/form"
+import {
+  useTextileAnalysis,
+  useUpdateTextileAnalysis,
+} from "../../../hooks/api/textile-analyses"
+import { getThumbUrl, isImageUrl } from "../../../lib/media"
+
+const SOURCE_OPTIONS = [
+  { value: "internal_extraction", label: "Internal extraction" },
+  { value: "storefront_reference", label: "Storefront reference" },
+  { value: "partner_upload", label: "Partner upload" },
+  { value: "manual", label: "Manual" },
+] as const
+
+const schema = z.object({
+  title: z.string(),
+  description: z.string(),
+  source: z.enum(["internal_extraction", "storefront_reference", "partner_upload", "manual"]),
+  cloth_type: z.string(),
+  category: z.string(),
+  pattern: z.string(),
+  fabric_weight: z.string(),
+  weave_or_knit: z.string(),
+  primary_color: z.string(),
+  confidence: z.string(),
+  colors: z.string(),
+  season: z.string(),
+  occasion: z.string(),
+  care_instructions: z.string(),
+  target_audience: z.string(),
+})
+
+type FormValues = z.infer<typeof schema>
+
+const toText = (s: string): string | null => (s.trim() ? s.trim() : null)
+
+const toList = (s: string): string[] | null => {
+  const list = s.split(",").map((x) => x.trim()).filter(Boolean)
+  return list.length ? list : null
+}
+
+const DEFAULT_VALUES: FormValues = {
+  title: "",
+  description: "",
+  source: "internal_extraction",
+  cloth_type: "",
+  category: "",
+  pattern: "",
+  fabric_weight: "",
+  weave_or_knit: "",
+  primary_color: "",
+  confidence: "",
+  colors: "",
+  season: "",
+  occasion: "",
+  care_instructions: "",
+  target_audience: "",
+}
+
+const EditTextileAnalysisComponent = () => {
+  const { id } = useParams()
+  const { data, isLoading } = useTextileAnalysis(id)
+  const { handleSuccess } = useRouteModal()
+  const { mutateAsync, isPending } = useUpdateTextileAnalysis()
+
+  const form = useForm<FormValues>({
+    defaultValues: DEFAULT_VALUES,
+    resolver: zodResolver(schema),
+  })
+
+  useEffect(() => {
+    if (!data) return
+    form.reset({
+      title: data.title ?? "",
+      description: data.description ?? "",
+      source: (data.source as FormValues["source"]) ?? "internal_extraction",
+      cloth_type: data.cloth_type ?? "",
+      category: data.category ?? "",
+      pattern: data.pattern ?? "",
+      fabric_weight: data.fabric_weight ?? "",
+      weave_or_knit: data.weave_or_knit ?? "",
+      primary_color: data.primary_color ?? "",
+      confidence:
+        typeof data.confidence === "number" ? String(data.confidence) : "",
+      colors: (data.colors ?? []).join(", "),
+      season: (data.season ?? []).join(", "),
+      occasion: (data.occasion ?? []).join(", "),
+      care_instructions: (data.care_instructions ?? []).join(", "),
+      target_audience: data.target_audience ?? "",
+    })
+  }, [data, form])
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      await mutateAsync({
+        id: id!,
+        title: toText(values.title),
+        description: toText(values.description),
+        source: values.source,
+        cloth_type: toText(values.cloth_type),
+        category: toText(values.category),
+        pattern: toText(values.pattern),
+        fabric_weight: toText(values.fabric_weight),
+        weave_or_knit: toText(values.weave_or_knit),
+        primary_color: toText(values.primary_color),
+        confidence: values.confidence.trim() ? Number(values.confidence) : null,
+        colors: toList(values.colors),
+        season: toList(values.season),
+        occasion: toList(values.occasion),
+        care_instructions: toList(values.care_instructions),
+        target_audience: toText(values.target_audience),
+      })
+      toast.success("Textile analysis updated")
+      handleSuccess()
+    } catch (e: any) {
+      toast.error(e?.message ?? "Failed to update")
+    }
+  })
+
+  const image = data?.media?.file_path
+
+  return (
+    <RouteFocusModal.Form form={form}>
+      <KeyboundForm onSubmit={onSubmit} className="flex flex-1 flex-col overflow-hidden">
+        <RouteFocusModal.Header />
+        <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto px-4 py-8 md:px-6 md:py-10">
+          <div className="flex w-full max-w-[720px] flex-col gap-y-6">
+            {isLoading ? (
+              <div className="flex flex-col gap-4">
+                <Skeleton className="h-8 w-64" />
+                <Skeleton className="aspect-square w-full rounded-lg" />
+                <Skeleton className="h-40 w-full" />
+              </div>
+            ) : !data ? (
+              <Text>This analysis could not be found.</Text>
+            ) : (
+              <>
+                <div className="flex items-start gap-4">
+                  {image && isImageUrl(image) ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={getThumbUrl(image, { width: 384, quality: 75, fit: "cover" })}
+                      alt={data.title ?? data.media?.file_name ?? ""}
+                      className="size-24 shrink-0 rounded-lg object-cover"
+                    />
+                  ) : (
+                    <div className="bg-ui-bg-base-pressed flex size-24 shrink-0 items-center justify-center rounded-lg">
+                      <Text size="xsmall" className="text-ui-fg-muted">
+                        no image
+                      </Text>
+                    </div>
+                  )}
+                  <div>
+                    <Heading className="text-xl md:text-2xl">Edit textile analysis</Heading>
+                    <Text size="small" className="text-ui-fg-subtle mt-1">
+                      Correct what the vision model saw in this fabric.
+                    </Text>
+                  </div>
+                </div>
+
+                <div>
+                  <Heading level="h2" className="text-lg">Identification</Heading>
+                  <div className="mt-3 grid grid-cols-1 gap-4">
+                    <Form.Field
+                      control={form.control}
+                      name="title"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label>Title</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="description"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Description</Form.Label>
+                          <Form.Control>
+                            <Textarea rows={3} {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="target_audience"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Target audience</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <Heading level="h2" className="text-lg">Classification</Heading>
+                  <div className="mt-3 grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <Form.Field
+                      control={form.control}
+                      name="source"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label>Source</Form.Label>
+                          <Form.Control>
+                            <Select value={field.value} onValueChange={field.onChange}>
+                              <Select.Trigger>
+                                <Select.Value />
+                              </Select.Trigger>
+                              <Select.Content>
+                                {SOURCE_OPTIONS.map((o) => (
+                                  <Select.Item key={o.value} value={o.value}>
+                                    {o.label}
+                                  </Select.Item>
+                                ))}
+                              </Select.Content>
+                            </Select>
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="confidence"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Confidence (0–1)</Form.Label>
+                          <Form.Control>
+                            <Input
+                              autoComplete="off"
+                              type="number"
+                              step="0.01"
+                              min="0"
+                              max="1"
+                              {...field}
+                            />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="cloth_type"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Garment</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="top, saree, trousers…" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="category"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Category</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="tops, bottoms, outerwear…" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="pattern"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Pattern</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="floral, stripe, solid…" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="fabric_weight"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Weight</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="light-weight, medium-weight…" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="weave_or_knit"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Construction</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="woven, knit" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="primary_color"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Primary colour</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="red, beige…" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <Heading level="h2" className="text-lg">Lists</Heading>
+                  <Text size="small" className="text-ui-fg-subtle mt-1">
+                    Comma-separated.
+                  </Text>
+                  <div className="mt-3 grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <Form.Field
+                      control={form.control}
+                      name="colors"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Colours</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="red, indigo, gold" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="season"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Season</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="summer, monsoon" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="occasion"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Occasion</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="festive, everyday" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                    <Form.Field
+                      control={form.control}
+                      name="care_instructions"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>Care instructions</Form.Label>
+                          <Form.Control>
+                            <Input autoComplete="off" placeholder="dry clean, hand wash" {...field} />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </RouteFocusModal.Body>
+        <RouteFocusModal.Footer className="px-4 py-3 md:px-6 md:py-4">
+          <div className="flex w-full flex-col-reverse items-center justify-end gap-2 sm:flex-row">
+            <RouteFocusModal.Close asChild>
+              <Button size="small" variant="secondary" className="w-full sm:w-auto">
+                Cancel
+              </Button>
+            </RouteFocusModal.Close>
+            <Button
+              size="small"
+              variant="primary"
+              type="submit"
+              isLoading={isPending}
+              disabled={isLoading || !data}
+              className="w-full sm:w-auto"
+            >
+              Save
+            </Button>
+          </div>
+        </RouteFocusModal.Footer>
+      </KeyboundForm>
+    </RouteFocusModal.Form>
+  )
+}
+
+const EditTextileAnalysisModal = () => {
+  return (
+    <RouteFocusModal>
+      <EditTextileAnalysisComponent />
+    </RouteFocusModal>
+  )
+}
+
+export default EditTextileAnalysisModal

--- a/apps/backend/src/admin/routes/textile-analyses/page.tsx
+++ b/apps/backend/src/admin/routes/textile-analyses/page.tsx
@@ -1,8 +1,6 @@
 import { useMemo, useState } from "react"
-import { defineRouteConfig } from "@medusajs/admin-sdk"
-import { Swatch } from "@medusajs/icons"
+import { Link } from "react-router-dom"
 import {
-  Badge,
   Container,
   Heading,
   Input,
@@ -12,26 +10,7 @@ import {
 } from "@medusajs/ui"
 import { useQuery } from "@tanstack/react-query"
 import { sdk } from "../../lib/config"
-
-/**
- * Fabrics and garments, browsable by what a vision model saw in them.
- *
- * ## Why this screen exists
- *
- * The analysis was collected 37 times and read zero times. It lived in
- * `MediaFile.metadata.textile_extraction` — a JSON blob `query.graph` cannot
- * filter into — so the question it exists to answer ("what else do we have like
- * this?") could not be asked, and nothing anywhere rendered it. Every one of
- * those files also had a good title inside the blob and an EMPTY
- * `MediaFile.title` beside it.
- *
- * Typed columns made the question askable. This is the screen that asks it.
- *
- * 🔑 Pictures, not rows of text. The thing being chosen is cloth; a table of
- * `cloth_type | pattern | weight` describes fabric to someone who needs to SEE
- * it. The filters are the typed columns, and each is indexed — which is the
- * whole argument for them being columns.
- */
+import { getThumbUrl, isImageUrl } from "../../lib/media"
 
 type TextileAnalysis = {
   id: string
@@ -104,8 +83,7 @@ const TextileAnalysesPage = () => {
   /**
    * ⚠️ Blank values are DROPPED rather than sent. A `cloth_type=` in the query
    * string filters for the empty string and returns nothing — a filter that has
-   * been opened and cleared would silently empty the catalogue, which reads as
-   * "we hold no fabric like that" rather than "you asked for nothing".
+   * been opened and cleared would silently empty the catalogue.
    */
   const queryString = useMemo(() => {
     const params = new URLSearchParams()
@@ -113,7 +91,7 @@ const TextileAnalysesPage = () => {
       if (v && v !== ANY) params.set(k, v)
     }
     if (search.trim()) params.set("q", search.trim())
-    params.set("limit", "60")
+    params.set("limit", "200")
     return params.toString()
   }, [filters, search])
 
@@ -132,7 +110,8 @@ const TextileAnalysesPage = () => {
           <Heading level="h2">Textile library</Heading>
           <Text className="text-ui-fg-subtle" size="small">
             What a vision model saw in every fabric and garment photo we hold —
-            filterable by garment, pattern, weight and construction.
+            filterable by garment, pattern, weight and construction. Click a
+            tile to correct it.
           </Text>
         </div>
 
@@ -179,9 +158,9 @@ const TextileAnalysesPage = () => {
 
       <div className="px-6 py-4">
         {isLoading ? (
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <Skeleton key={i} className="aspect-square w-full rounded-lg" />
+          <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
+            {Array.from({ length: 16 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-square w-full rounded-md" />
             ))}
           </div>
         ) : rows.length === 0 ? (
@@ -189,11 +168,6 @@ const TextileAnalysesPage = () => {
             <Text className="text-ui-fg-subtle">
               Nothing matches those filters.
             </Text>
-            {/*
-              🔑 Says WHY it might be empty. Until the backfill runs, this table
-              holds only what has been analysed since the module shipped — an
-              empty grid otherwise reads as "we own no such fabric".
-            */}
             <Text size="xsmall" className="text-ui-fg-muted">
               Photos analysed before this library existed are migrated by the
               `backfill-textile-analysis` maintenance job.
@@ -205,74 +179,40 @@ const TextileAnalysesPage = () => {
               {data?.count ?? rows.length} match
               {(data?.count ?? rows.length) === 1 ? "" : "es"}
             </Text>
-            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-              {rows.map((row) => (
-                <div
-                  key={row.id}
-                  className="shadow-elevation-card-rest bg-ui-bg-component flex flex-col gap-2 rounded-lg p-2"
-                  data-testid="textile-card"
-                >
-                  {row.media?.file_path ? (
-                    /* eslint-disable-next-line @next/next/no-img-element */
-                    <img
-                      src={row.media.file_path}
-                      alt={row.title ?? row.media.file_name}
-                      className="aspect-square w-full rounded-md object-cover"
-                    />
-                  ) : (
-                    <div className="bg-ui-bg-base-pressed flex aspect-square w-full items-center justify-center rounded-md">
-                      <Text size="xsmall" className="text-ui-fg-muted">
-                        no image
-                      </Text>
-                    </div>
-                  )}
-
-                  <Text size="xsmall" weight="plus" className="line-clamp-2">
-                    {row.title ?? row.media?.file_name ?? "Untitled"}
-                  </Text>
-
-                  <div className="flex flex-wrap gap-1">
-                    {row.cloth_type && (
-                      <Badge size="2xsmall" color="blue">
-                        {row.cloth_type}
-                      </Badge>
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
+              {rows.map((row) => {
+                const name = row.title ?? row.media?.file_name ?? "Untitled"
+                return (
+                  <Link
+                    key={row.id}
+                    to={`/textile-analyses/${row.id}`}
+                    className="group relative block aspect-square overflow-hidden rounded-md outline-none focus-visible:shadow-borders-interactive-with-focus"
+                    aria-label={name}
+                    title={name}
+                    data-testid="textile-card"
+                  >
+                    {row.media?.file_path && isImageUrl(row.media.file_path) ? (
+                      /* eslint-disable-next-line @next/next/no-img-element */
+                      <img
+                        src={getThumbUrl(row.media.file_path, {
+                          width: 256,
+                          quality: 65,
+                          fit: "cover",
+                        })}
+                        alt={name}
+                        loading="lazy"
+                        className="size-full object-cover transition-transform group-hover:scale-105"
+                      />
+                    ) : (
+                      <div className="bg-ui-bg-base-pressed flex size-full items-center justify-center rounded-md">
+                        <Text size="xsmall" className="text-ui-fg-muted">
+                          no image
+                        </Text>
+                      </div>
                     )}
-                    {row.pattern && (
-                      <Badge size="2xsmall" color="purple">
-                        {row.pattern}
-                      </Badge>
-                    )}
-                    {row.fabric_weight && (
-                      <Badge size="2xsmall" color="grey">
-                        {row.fabric_weight.replace(/-/g, " ")}
-                      </Badge>
-                    )}
-                    {/*
-                      Where this reading came from. Our own extraction over
-                      stock we hold and a stranger's storefront upload deserve
-                      different trust, and before the module the only thing
-                      telling them apart was which metadata key someone wrote.
-                    */}
-                    {row.source === "storefront_reference" && (
-                      <Badge size="2xsmall" color="orange">
-                        customer photo
-                      </Badge>
-                    )}
-                  </div>
-
-                  {/*
-                    ⚠️ Rendered only when the extractor actually gave a number.
-                    `confidence` is nullable and 0 is a real answer — printing
-                    "0%" for "did not say" would read as certainty about being
-                    wrong.
-                  */}
-                  {typeof row.confidence === "number" && (
-                    <Text size="xsmall" className="text-ui-fg-muted">
-                      {Math.round(row.confidence * 100)}% confident
-                    </Text>
-                  )}
-                </div>
-              ))}
+                  </Link>
+                )
+              })}
             </div>
           </>
         )}
@@ -280,10 +220,5 @@ const TextileAnalysesPage = () => {
     </Container>
   )
 }
-
-export const config = defineRouteConfig({
-  label: "Textile library",
-  icon: Swatch,
-})
 
 export default TextileAnalysesPage

--- a/apps/backend/src/api/admin/textile-analyses/[id]/route.ts
+++ b/apps/backend/src/api/admin/textile-analyses/[id]/route.ts
@@ -1,0 +1,157 @@
+/**
+ * Read and correct a single `textile_analysis` row.
+ *
+ *   GET   /admin/textile-analyses/:id   → the row, hydrated with its media file
+ *   PATCH /admin/textile-analyses/:id   → edit what the vision model saw
+ *
+ * The list route (`./route.ts`) exists so the library can be filtered. This
+ * route exists so a person can FIX one row — before it, the only writer was
+ * the extractor and everything it misread stayed misread. The edit surface is
+ * deliberately the same fields the list renders as badges, plus the prose that
+ * mirrors onto `MediaFile.title`/`description` (see `lib/persist.ts` for why
+ * the mirror matters: the media columns are searchable and sat empty while the
+ * blob held the answers).
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import mediaTextileAnalysisLink from "../../../../links/media-textile-analysis-link"
+import { MEDIA_MODULE } from "../../../../modules/media"
+import { TEXTILE_ANALYSIS_MODULE } from "../../../../modules/textile-analysis"
+import { AdminUpdateTextileAnalysisSchema } from "../validators"
+
+/** Filter/decide columns: trim + lowercase, as `normalise.ts` does. */
+const norm = (v: unknown): string | undefined => {
+  if (typeof v !== "string") return undefined
+  const s = v.trim().toLowerCase()
+  return s.length ? s : undefined
+}
+
+/** Prose: trim only, preserving case. */
+const trim = (v: unknown): string | undefined => {
+  if (typeof v !== "string") return undefined
+  const s = v.trim()
+  return s.length ? s : undefined
+}
+
+const strArray = (v: unknown): string[] | null => {
+  if (!Array.isArray(v)) return null
+  const out = v
+    .map((x) => (typeof x === "string" ? x.trim() : ""))
+    .filter(Boolean)
+  return out.length ? out : null
+}
+
+/** Attach the analysis's linked media file, mirroring the list route. */
+const hydrateMedia = async (
+  req: MedusaRequest,
+  analysisId: string
+): Promise<Record<string, any> | null> => {
+  const mediaService: any = req.scope.resolve(MEDIA_MODULE)
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: links = [] } = await query.graph({
+    entity: mediaTextileAnalysisLink.entryPoint,
+    fields: ["media_file_id", "textile_analysis_id"],
+    filters: { textile_analysis_id: analysisId },
+  })
+
+  const mediaId = (links as any[]).find(Boolean)?.media_file_id
+  if (!mediaId) return null
+
+  const files: any[] = await mediaService.listMediaFiles(
+    { id: mediaId },
+    { take: 1 }
+  )
+  const file = files[0]
+  if (!file) return null
+
+  return {
+    id: file.id,
+    file_name: file.file_name,
+    file_path: file.file_path,
+    title: file.title,
+  }
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(TEXTILE_ANALYSIS_MODULE)
+  const { id } = req.params as Record<string, string>
+
+  const rows: any[] = await service.listTextileAnalyses({ id }, { take: 1 })
+  const row = rows[0]
+  if (!row) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Textile analysis ${id} not found`
+    )
+  }
+
+  const media = await hydrateMedia(req, id)
+
+  res.json({ textile_analysis: { ...row, media } })
+}
+
+export const PATCH = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(TEXTILE_ANALYSIS_MODULE)
+  const mediaService: any = req.scope.resolve(MEDIA_MODULE)
+  const { id } = req.params as Record<string, string>
+
+  const parsed = AdminUpdateTextileAnalysisSchema.parse(req.validatedBody ?? req.body)
+
+  const updateData: Record<string, any> = {}
+
+  if (parsed.source !== undefined) updateData.source = parsed.source
+  if (parsed.confidence !== undefined) updateData.confidence = parsed.confidence
+
+  // Filter columns: normalised the way the extractor normalises them.
+  for (const field of [
+    "cloth_type",
+    "category",
+    "pattern",
+    "fabric_weight",
+    "weave_or_knit",
+    "primary_color",
+  ] as const) {
+    if (parsed[field] !== undefined) updateData[field] = norm(parsed[field]) ?? null
+  }
+
+  // Prose.
+  if (parsed.title !== undefined) updateData.title = trim(parsed.title) ?? null
+  if (parsed.description !== undefined)
+    updateData.description = trim(parsed.description) ?? null
+  if (parsed.target_audience !== undefined)
+    updateData.target_audience = trim(parsed.target_audience) ?? null
+
+  for (const field of [
+    "colors",
+    "season",
+    "occasion",
+    "care_instructions",
+  ] as const) {
+    if (parsed[field] !== undefined) updateData[field] = strArray(parsed[field])
+  }
+
+  const updated = await service.updateTextileAnalyses({ id, ...updateData })
+  const row = Array.isArray(updated) ? updated[0] : updated
+
+  // Mirror title/description onto the linked media file — the searchable
+  // columns that persist.ts keeps in step on the write path. Guarded, since a
+  // failed mirror must never cost the correction itself.
+  if (row && (updateData.title !== undefined || updateData.description !== undefined)) {
+    const media = await hydrateMedia(req, id)
+    if (media) {
+      const mirror: Record<string, any> = {}
+      if (updateData.title !== undefined) mirror.title = updateData.title
+      if (updateData.description !== undefined) {
+        mirror.description = updateData.description
+        mirror.alt_text = updateData.description
+      }
+      await mediaService.updateMediaFiles({ id: media.id, ...mirror }).catch(() => {})
+    }
+  }
+
+  const media = await hydrateMedia(req, id)
+
+  res.json({ textile_analysis: { ...row, media } })
+}

--- a/apps/backend/src/api/admin/textile-analyses/validators.ts
+++ b/apps/backend/src/api/admin/textile-analyses/validators.ts
@@ -1,0 +1,43 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * What a human can correct on a `textile_analysis` row.
+ *
+ * The FILTER columns (`cloth_type`, `pattern`, `fabric_weight`,
+ * `weave_or_knit`, `primary_color`) are what a search branches on, so the
+ * route lowercases/trims them — the same discipline `normalise.ts` applies to
+ * extractor payloads, so a hand-correction and a model output compare equal.
+ * The prose (`title`, `description`, `target_audience`) is only trimmed.
+ */
+
+export const TEXTILE_ANALYSIS_SOURCE_ENUM = [
+  "internal_extraction",
+  "storefront_reference",
+  "partner_upload",
+  "manual",
+] as const
+
+const strOrNull = z.string().trim().optional().nullable()
+const strArrayOrNull = z.array(z.string()).optional().nullable()
+
+export const AdminUpdateTextileAnalysisSchema = z.object({
+  source: z.enum(TEXTILE_ANALYSIS_SOURCE_ENUM).optional(),
+  confidence: z.number().min(0).max(1).optional().nullable(),
+  cloth_type: strOrNull,
+  category: strOrNull,
+  pattern: strOrNull,
+  fabric_weight: strOrNull,
+  weave_or_knit: strOrNull,
+  primary_color: strOrNull,
+  title: strOrNull,
+  description: strOrNull,
+  target_audience: strOrNull,
+  colors: strArrayOrNull,
+  season: strArrayOrNull,
+  occasion: strArrayOrNull,
+  care_instructions: strArrayOrNull,
+})
+
+export type AdminUpdateTextileAnalysisInput = z.infer<
+  typeof AdminUpdateTextileAnalysisSchema
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -20,6 +20,7 @@ import { z } from "@medusajs/framework/zod";
 import { personSchema, listPersonsQuerySchema, UpdatePersonSchema, ReadPersonQuerySchema } from "./admin/persons/validators";
 import { OpsMaintenanceRunSchema, OpsMaintenanceRunsQuerySchema, OpsMaintenanceBatchSchema, OpsMaintenanceBatchesQuerySchema } from "./admin/ops/maintenance-jobs/validators";
 import { AdminPostLocationOwnershipReq } from "./admin/location-ownership/validators";
+import { AdminUpdateTextileAnalysisSchema } from "./admin/textile-analyses/validators";
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
 import { AdminGetOrdersOrderParams } from "@medusajs/medusa/api/admin/orders/validators";
 import { retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig } from "@medusajs/medusa/api/admin/orders/query-config";
@@ -4738,6 +4739,21 @@ export default defineMiddlewares({
       matcher: "/admin/textile-analyses",
       method: "GET",
       middlewares: [],
+    },
+    {
+      // Single row, hydrated with its media file, for the edit modal.
+      matcher: "/admin/textile-analyses/:id",
+      method: "GET",
+      middlewares: [],
+    },
+    {
+      // Correct one analysis. Until this, the only writer was the extractor —
+      // a misread garment / pattern / weight could not be fixed by a human.
+      matcher: "/admin/textile-analyses/:id",
+      method: "PATCH",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(AdminUpdateTextileAnalysisSchema)),
+      ],
     },
     {
       matcher: "/admin/designs/:id/consumption-logs",


### PR DESCRIPTION
## What

Moves the textile library out of the sidebar and into the Operations **Tools** hub, and makes each row directly editable.

## Changes

- **Hide from sidebar, surface in Tools** — removed `defineRouteConfig` from `textile-analyses/page.tsx` and added a `Textile library` quick-link card to `operations/page.tsx` (the same hub pattern as Visual Flows / Medias). The route stays at `/textile-analyses`.
- **Thumbnail grid** — replaced the large cards with a denser, lazy-loaded grid. Images now load through `getThumbUrl` (Cloudflare `cdn-cgi` resize, 256px) with `loading="lazy"`.
- **Edit modal** — new `RouteFocusModal` at `/textile-analyses/:id` to correct what the vision model saw (title, description, source, confidence, garment/category/pattern/weight/construction/colour, and the comma-separated lists).
- **API** — new `GET` (single, media-hydrated) and `PATCH` (normalises + updates, mirrors title/description onto the linked media file) at `/admin/textile-analyses/:id`, plus a validator and middleware matcher entries.
- **Hooks** — `useTextileAnalysis` and `useUpdateTextileAnalysis`.

## Test plan

- `npx tsc --noEmit -p src/admin/tsconfig.json` — clean for all touched files.
- Manual: Operations → Tools → Textile library → click a tile → edit → Save.