### PR TITLE
fix(ai): the SDK sends `developer` where every provider but OpenAI expects `system`

### DIFF
--- a/apps/backend/src/mastra/services/__tests__/developer-role-rewrite.unit.spec.ts
+++ b/apps/backend/src/mastra/services/__tests__/developer-role-rewrite.unit.spec.ts
@@ -1,0 +1,102 @@
+import { rewriteDeveloperRole, isOpenAiHost } from "../ai-platforms"
+
+/**
+ * `@ai-sdk/openai` renames the `system` role to `developer` for anything it
+ * decides is a "reasoning model", and it decides that by NAME:
+ *
+ *   isReasoningModel = !(modelId.startsWith("gpt-3") || startsWith("gpt-4")
+ *                        || startsWith("chatgpt-4o") || startsWith("gpt-5-chat"))
+ *
+ * Every model id on this platform fails that test. Most OpenAI-compatible
+ * endpoints shrug at the unknown role; Groq's chat template raises:
+ *
+ *   minijinja: rendering failed: raise_exception: Unexpected message role.
+ *
+ * 🔑 This was invisible from the outside. Hand-built requests to the same key
+ * and model succeeded in plain, `json_schema` AND tool modes — because they all
+ * said `system`. It only reproduced by running the real `generateObject` behind
+ * a fetch interceptor, which printed `ROLES: developer -> user`.
+ */
+describe("rewriteDeveloperRole", () => {
+  const body = (roles: string[]) =>
+    JSON.stringify({
+      model: "qwen/qwen3.8-27b",
+      messages: roles.map((role) => ({ role, content: "x" })),
+    })
+
+  it("renames developer to system", () => {
+    const out = JSON.parse(rewriteDeveloperRole(body(["developer", "user"])))
+    expect(out.messages.map((m: any) => m.role)).toEqual(["system", "user"])
+  })
+
+  it("leaves every other role alone", () => {
+    const out = JSON.parse(
+      rewriteDeveloperRole(body(["system", "user", "assistant", "tool"]))
+    )
+    expect(out.messages.map((m: any) => m.role)).toEqual([
+      "system",
+      "user",
+      "assistant",
+      "tool",
+    ])
+  })
+
+  it("returns the body UNCHANGED when there is nothing to rewrite", () => {
+    // Identity matters: re-serialising every request would reorder keys and
+    // churn bodies for no reason.
+    const original = body(["system", "user"])
+    expect(rewriteDeveloperRole(original)).toBe(original)
+  })
+
+  it("passes through a body it cannot parse", () => {
+    // This is a compatibility shim, not a gate — it must never be the thing
+    // that fails a request.
+    expect(rewriteDeveloperRole("not json")).toBe("not json")
+    expect(rewriteDeveloperRole("")).toBe("")
+  })
+
+  it("passes through a body with no messages array", () => {
+    const b = JSON.stringify({ model: "x", input: "y" })
+    expect(rewriteDeveloperRole(b)).toBe(b)
+  })
+
+  it("survives a malformed message entry", () => {
+    const b = JSON.stringify({ messages: [null, { role: "developer" }, 42] })
+    const out = JSON.parse(rewriteDeveloperRole(b))
+    expect(out.messages[1].role).toBe("system")
+  })
+})
+
+describe("isOpenAiHost", () => {
+  /**
+   * ⚠️ The rewrite must NOT reach genuine OpenAI: its real reasoning models
+   * require `developer` and reject `system`, so applying the shim there would
+   * break the one provider the SDK's behaviour is correct for.
+   */
+  it("recognises OpenAI itself", () => {
+    expect(isOpenAiHost("https://api.openai.com/v1")).toBe(true)
+  })
+
+  it.each([
+    ["groq", "https://api.groq.com/openai/v1"],
+    ["bazaarlink", "https://bazaarlink.ai/api/v1"],
+    ["dashscope", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"],
+    ["nvidia nim", "https://integrate.api.nvidia.com/v1"],
+  ])("treats %s as compatible-but-not-OpenAI", (_label, url) => {
+    expect(isOpenAiHost(url)).toBe(false)
+  })
+
+  it("is not fooled by a lookalike host", () => {
+    // `api.openai.com.evil.test` must not match, and a path mentioning openai
+    // (as Groq's does) must not either.
+    expect(isOpenAiHost("https://api.openai.com.evil.test/v1")).toBe(false)
+    expect(isOpenAiHost("https://api.groq.com/openai/v1")).toBe(false)
+  })
+
+  it("handles a missing or unparseable base url", () => {
+    expect(isOpenAiHost(undefined)).toBe(false)
+    expect(isOpenAiHost(null)).toBe(false)
+    expect(isOpenAiHost("")).toBe(false)
+    expect(isOpenAiHost("not a url")).toBe(false)
+  })
+})

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -371,6 +371,86 @@ import { createOpenAI } from "@ai-sdk/openai"
 import { createOpenRouter } from "@openrouter/ai-sdk-provider"
 
 /**
+ * 🔴 `@ai-sdk/openai` rewrites the `system` role to `developer`, and every
+ * provider we point it at is NOT OpenAI.
+ *
+ * The SDK decides a model is a "reasoning model" purely by name:
+ *
+ *   isReasoningModel = !(modelId.startsWith("gpt-3") || startsWith("gpt-4")
+ *                        || startsWith("chatgpt-4o") || startsWith("gpt-5-chat"))
+ *
+ * — and for a reasoning model it sends `systemMessageMode: "developer"`. So
+ * EVERY model id on this platform fails that test and gets `role: "developer"`
+ * on the wire: `qwen/qwen3.8-27b`, `@cf/meta/llama-3.2-11b-vision-instruct`,
+ * `qwen-vl-max`, all of them.
+ *
+ * Most OpenAI-compatible endpoints tolerate the unknown role. Groq does not —
+ * its chat template raises, and the caller sees:
+ *
+ *   failed to template request: failed to render text output:
+ *   minijinja: rendering failed: raise_exception: Unexpected message role.
+ *
+ * Captured by running the real `generateObject` against Groq with a fetch
+ * interceptor: `ROLES: developer -> user`. Hand-built requests using `system`
+ * succeed against the same key and model in plain, `json_schema` and tool
+ * modes — which is why this looked like a model problem and was not.
+ *
+ * `chat(modelId)` takes no settings, so the mode cannot be overridden through
+ * the SDK's API. `@ai-sdk/openai-compatible` would be the clean fix but the
+ * installed 2.0.30 implements spec v3 while `ai@5.0.138` requires v2.
+ *
+ * So the rewrite happens on the way out, which is provider-agnostic and
+ * survives an SDK upgrade changing the heuristic again.
+ *
+ * ⚠️ NOT applied to genuine OpenAI: real reasoning models there REQUIRE
+ * `developer` and reject `system`.
+ */
+const OPENAI_HOSTS = ["api.openai.com"]
+
+export const isOpenAiHost = (baseUrl?: string | null): boolean => {
+  if (!baseUrl) return false
+  try {
+    return OPENAI_HOSTS.includes(new URL(baseUrl).host.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Rewrites `developer` back to `system` in an outgoing chat-completions body.
+ * Exported for the unit tests — the behaviour is worth asserting directly
+ * rather than only through a live provider.
+ */
+export const rewriteDeveloperRole = (body: string): string => {
+  try {
+    const parsed = JSON.parse(body)
+    if (!Array.isArray(parsed?.messages)) return body
+    let changed = false
+    for (const m of parsed.messages) {
+      if (m?.role === "developer") {
+        m.role = "system"
+        changed = true
+      }
+    }
+    return changed ? JSON.stringify(parsed) : body
+  } catch {
+    // A body we cannot parse is passed through untouched — this is a
+    // compatibility shim, not a gate.
+    return body
+  }
+}
+
+const systemRoleFetch: typeof fetch = async (input: any, init?: any) => {
+  if (init?.body && typeof init.body === "string") {
+    const next = rewriteDeveloperRole(init.body)
+    if (next !== init.body) {
+      init = { ...init, body: next }
+    }
+  }
+  return fetch(input, init)
+}
+
+/**
  * Build an AI SDK chat/language model from a resolved platform config.
  * Used with generateObject, generateText, streamText.
  *
@@ -395,6 +475,9 @@ export const buildChatModel = (
   const client = createOpenAI({
     baseURL: config.baseUrl,
     apiKey: config.apiKey,
+    // See `rewriteDeveloperRole` above: everything here is an OpenAI-COMPATIBLE
+    // endpoint, not OpenAI, and the SDK's `developer` role breaks Groq outright.
+    ...(isOpenAiHost(config.baseUrl) ? {} : { fetch: systemRoleFetch }),
   })
   // Use the chat-completions API explicitly. In @ai-sdk/openai v2 the default
   // callable `client(id)` targets the Responses API (sends an `input` field),
@@ -453,6 +536,9 @@ export const buildEmbeddingModel = (
   const client = createOpenAI({
     baseURL: config.baseUrl,
     apiKey: config.apiKey,
+    // See `rewriteDeveloperRole` above: everything here is an OpenAI-COMPATIBLE
+    // endpoint, not OpenAI, and the SDK's `developer` role breaks Groq outright.
+    ...(isOpenAiHost(config.baseUrl) ? {} : { fetch: systemRoleFetch }),
   })
   return client.embedding(id)
 }


### PR DESCRIPTION
Closes #1828.

## The error

```
[id-extraction] rung failed (groq/qwen/qwen3.8-27b):
  failed to template request: failed to render text output:
  minijinja: rendering failed: raise_exception: Unexpected message role.
```

## The cause

`@ai-sdk/openai` renames the `system` role to `developer` for anything it decides is a "reasoning model" — and it decides that **by name**:

```js
isReasoningModel = !(modelId.startsWith("gpt-3") || modelId.startsWith("gpt-4")
                   || modelId.startsWith("chatgpt-4o") || modelId.startsWith("gpt-5-chat"))
```

🔴 **Every model id on this platform fails that test.** `qwen/qwen3.8-27b`, `@cf/meta/llama-3.2-11b-vision-instruct`, `qwen-vl-max`, `meta/llama-3.2-90b-vision-instruct` — all of them have been going out with `role: "developer"` on every system message. Most OpenAI-compatible endpoints shrug at the unknown role; Groq's chat template raises.

So this is **not a Groq bug and not a model bug**. It's `buildChatModel` using the *OpenAI* provider for endpoints that are only OpenAI-**compatible**, and it has been latent on Cloudflare and DashScope the whole time.

## Why it hid so well

Hand-built requests to the same key, model and image **succeeded in all three shapes** — plain, `response_format: json_schema` (strict), and forced tool-calling. Every one of them said `system`. On that evidence I concluded the cause was unknowable and filed #1828 saying so.

It reproduced on the first run once I stopped hand-building requests and drove the real `generateObject` behind a fetch interceptor:

```
ROLES: developer -> user
```

The lesson is narrow and worth keeping: **probing a provider with your own request shape tests your shape, not the code's.** Instrument the real call path.

## The fix

`chat(modelId)` accepts no settings, so `systemMessageMode` can't be overridden through the SDK's API. `@ai-sdk/openai-compatible` would be the clean answer, but the installed `2.0.30` implements spec **v3** while `ai@5.0.138` requires **v2** (`Unsupported model version v3 for provider "groq.chat"`).

So the rename is undone on the way out, through the `fetch` hook `createOpenAI` already exposes. Provider-agnostic, and it survives the SDK changing its heuristic again.

⚠️ **Deliberately not applied to `api.openai.com`** — genuine reasoning models there *require* `developer` and reject `system`, so the shim would break the one provider whose behaviour the SDK gets right.

## Verified

- **13 unit tests** on the rewrite and the host guard — including that an unchanged body comes back byte-identical (no pointless re-serialisation) and that `api.openai.com.evil.test` doesn't match.
- **End to end through the real `generateObject` against live Groq:** `794ms`, `{"first_name":"TARUN","last_name":"DEBNATH","id_number":"4821 9930 7712"}`. Before the fix: the minijinja error above.
- `check:prod-build` exit 0; 30 tests green across the AI suites.

## Worth knowing

This likely improves more than Groq. Cloudflare and DashScope have been receiving `developer` and tolerating it; they now get the role they document. Nothing about their behaviour was measured as broken, so this is stated as a probable improvement rather than a claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4