### PR TITLE
fix(messaging): show date on previous messages, not just time

### DIFF
--- a/apps/backend/src/admin/routes/messaging/components/message-bubble.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/message-bubble.tsx
@@ -96,7 +96,23 @@ const RichContent = ({ text, isOutbound }: { text: string; isOutbound: boolean }
 
 function formatTime(dateStr: string): string {
   const d = new Date(dateStr)
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+  const time = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+
+  const now = new Date()
+  const startOfDay = (x: Date) =>
+    new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime()
+  // Calendar-day diff (Math.round absorbs DST 23/25-hour days).
+  const dayDiff = Math.round((startOfDay(now) - startOfDay(d)) / 86_400_000)
+
+  if (dayDiff <= 0) return time
+  if (dayDiff === 1) return `Yesterday · ${time}`
+
+  const date = d.toLocaleDateString([], {
+    day: "numeric",
+    month: "short",
+    ...(d.getFullYear() !== now.getFullYear() ? { year: "numeric" } : {}),
+  })
+  return `${date} · ${time}`
 }
 
 function statusIcon(status: string): string {


### PR DESCRIPTION
## What

Message bubbles only showed the time of day. Messages from earlier days now include their date.

## Changes

- `message-bubble.tsx` `formatTime` now renders:
  - today → time only (unchanged)
  - yesterday → `Yesterday · 3:45 PM`
  - older → `Sep 3 · 3:45 PM` (adds the year when it differs)

## Test plan

- `npx tsc --noEmit -p src/admin/tsconfig.json` — clean.