### PR TITLE
fix(shipping): StarFleet stops asking for the deprecated KYC upload scope

### DIFF
--- a/apps/backend/src/modules/shipping-providers/starfleet/__tests__/client.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/__tests__/client.unit.spec.ts
@@ -4,6 +4,7 @@ import {
   normalizeStarfleetTracking,
   scanTypeForAction,
   shipmentTypeForReason,
+  starfleetAuthScope,
   starfleetBaseUrl,
   starfleetTrackingUrl,
 } from "../client"
@@ -233,6 +234,48 @@ describe("starfleetBaseUrl", () => {
   it("treats anything else as staging rather than guessing", () => {
     for (const v of ["staging", "stage", "production", "live", "true", "1"]) {
       expect(starfleetBaseUrl(v)).toContain("api-stage-starfleet")
+    }
+  })
+})
+
+/**
+ * The OAuth scope, which is the single most breakable string in this client.
+ *
+ * A malformed scope does not get refused — it mints a token that 401s on every
+ * /package endpoint (gotcha #1), so the failure appears at the far end as an
+ * authorisation problem with the shipment rather than with the request for the
+ * token. That makes it worth asserting rather than eyeballing.
+ */
+describe("AUTH_SCOPE", () => {
+  it("no longer asks for the deprecated KYC upload path", () => {
+    expect(starfleetAuthScope()).not.toContain("upload-kyc-doc")
+  })
+
+  it("still asks for every endpoint the client actually calls", () => {
+    const scope = starfleetAuthScope()
+    for (const path of [
+      "^/package/batchGeneratePackages:POST$",
+      "^/package/batchGeneratePackages/.+:GET$",
+      "^/package/auth-track/.+:GET$",
+      "^/package/.+/invoice:GET$",
+      "^/package/.+/shipping-label:GET$",
+    ]) {
+      expect(scope).toContain(path)
+    }
+  })
+
+  /**
+   * Every entry is anchored at both ends. The KYC entry was the one exception —
+   * it opened with `^` and never closed with `$` — and it is also the one that
+   * turned out to be dead.
+   */
+  it("anchors every package rule at both ends", () => {
+    const rules = starfleetAuthScope()
+      .split(" ")
+      .filter((p) => p.startsWith("^/package"))
+    expect(rules.length).toBeGreaterThan(0)
+    for (const rule of rules) {
+      expect(rule.endsWith("$")).toBe(true)
     }
   })
 })

--- a/apps/backend/src/modules/shipping-providers/starfleet/client.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/client.ts
@@ -12,7 +12,6 @@
  *   GET  /package/auth-track/{id}          → scans for 1..15 waybills
  *   GET  /package/{id}/shipping-label      → PDF  (⚠️ gated — see below)
  *   GET  /package/{id}/invoice             → PDF  (⚠️ gated — see below)
- *   POST /package/{id}/upload-kyc-doc      → KYC  (⚠️ gated — see below)
  *
  * Live-verified against api-stage-starfleet (a real AWB `DL001113245XB` was
  * manifested end-to-end). The full contract is in
@@ -36,8 +35,8 @@
  *  - invoice + shipping-label return `403 Unauthorized User` even with a valid
  *    token (per-user id_token, or shipment not label-ready). Methods exist but
  *    surface the carrier's 403 until Delhivery resolves it.
- *  - upload-kyc-doc returns `502 Internal server error` on their side. Method
- *    exists but surfaces it.
+ *  - upload-kyc-doc is DEPRECATED by Delhivery and not in use. It is not
+ *    called, and its path has been dropped from the requested OAuth scope.
  *  - No cancellation endpoint exists in the StarFleet surface — `cancelShipment`
  *    throws.
  */
@@ -82,12 +81,27 @@ const AUTH_AUDIENCE = "StarFleet"
 /**
  * The scope is wrapped in literal double-quotes on purpose — see gotcha #1.
  * Do NOT remove the quotes; a bare scope mints a token that 401s everywhere.
+ *
+ * ⚠️ `^/package/.+/upload-kyc-doc:POST` was here and has been REMOVED: Delhivery
+ * confirmed the KYC upload API is DEPRECATED and not in use. It was also the one
+ * entry with no trailing `$`, and the 502 it returned was read here as "their
+ * server is having a bad day" — it was a retired endpoint answering the only way
+ * it could. Requesting scope for a path the authorisation server may stop
+ * recognising puts the whole token mint at risk, and the token is what every
+ * other call depends on.
+ *
+ * 🔴 This exact string has NOT been re-verified against a live /auth/token since
+ * the removal. The scope is minted as a unit and a bad one fails by returning a
+ * token that 401s on every endpoint — not by refusing — so confirm one manifest
+ * against staging before relying on it in prod.
  */
 const AUTH_SCOPE =
   'starfleet openid profile email ^/package/batchGeneratePackages:POST$ ' +
   '^/package/batchGeneratePackages/.+:GET$ ^/package/auth-track/.+:GET$ ' +
-  '^/package/.+/invoice:GET$ ^/package/.+/shipping-label:GET$ ' +
-  '^/package/.+/upload-kyc-doc:POST'
+  '^/package/.+/invoice:GET$ ^/package/.+/shipping-label:GET$'
+
+/** The scope as sent, exposed so the shape can be asserted (see the spec). */
+export const starfleetAuthScope = (): string => AUTH_SCOPE
 /** Refresh a little under the documented 86400s (24h) so a token never expires
  *  mid-request. */
 const TOKEN_TTL_MS = 23 * 60 * 60 * 1000

--- a/apps/backend/src/modules/shipping-providers/starfleet/stub-fetch.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/stub-fetch.ts
@@ -28,7 +28,6 @@ export const starfleetStubState: {
   lastBatchBody?: any
   lastTrackPath?: string
   lastLabelPath?: string
-  lastKycPath?: string
 } = {}
 
 const parseBody = (init: any): any => {
@@ -116,10 +115,13 @@ export function createStarfleetStubFetch(): FetchLike {
       } as any
     }
 
-    if (url.endsWith("/upload-kyc-doc")) {
-      starfleetStubState.lastKycPath = url
-      return json({ success: true, message: "ok" })
-    }
+    /**
+     * ⚠️ `/upload-kyc-doc` deliberately has NO branch: Delhivery deprecated the
+     * endpoint. It falls through to the 404 below, which is what a retired path
+     * should look like to anything that still calls it. A stub that answers
+     * `{ success: true }` for an endpoint that no longer exists is worse than
+     * no stub — it certifies a call the carrier will never honour.
+     */
 
     return json({ message: "stub: not found" }, 404)
   }

--- a/apps/docs/notes/STARFLEET_API.md
+++ b/apps/docs/notes/STARFLEET_API.md
@@ -19,7 +19,7 @@ grant_type=password
 username=<account>          # staging: JaalYantraTextilesPr-in-B2C · prod: 8e2306-JaalYantraTextilesPr-in
 password=<password>
 audience=StarFleet
-scope="starfleet openid profile email ^/package/batchGeneratePackages:POST$ ^/package/batchGeneratePackages/.+:GET$ ^/package/auth-track/.+:GET$ ^/package/.+/invoice:GET$ ^/package/.+/shipping-label:GET$ ^/package/.+/upload-kyc-doc:POST$"
+scope="starfleet openid profile email ^/package/batchGeneratePackages:POST$ ^/package/batchGeneratePackages/.+:GET$ ^/package/auth-track/.+:GET$ ^/package/.+/invoice:GET$ ^/package/.+/shipping-label:GET$"
 client_id=<client_id>
 client_secret=<client_secret>
 ```
@@ -52,7 +52,7 @@ value is also visible in the token's `client_name` claim (decode the JWT).
 | Track | GET | `/package/auth-track/{id}` | ✅ verified |
 | Invoice | GET | `/package/{id}/invoice` | ⚠️ 403 `Unauthorized User` |
 | Shipping label | GET | `/package/{id}/shipping-label` | ⚠️ 403 `Unauthorized User` |
-| Upload KYC | POST | `/package/{id}/upload-kyc-doc` | ⚠️ 502 `Internal server error` |
+| ~~Upload KYC~~ | ~~POST~~ | ~~`/package/{id}/upload-kyc-doc`~~ | 🔴 **DEPRECATED by Delhivery, not in use.** Removed from the requested scope; the client never calls it. The 502 it returned was a retired endpoint, not an outage. |
 
 `auth-track/{id}` accepts up to 15 comma-separated waybills.
 
@@ -114,8 +114,11 @@ bank block is account-level KYC (config), mandatory for `commercial` shipments.
   correctly-scoped token (track with the same token is 200). Either a per-user
   `id_token` requirement (our `id_token == access_token`, a client-level token
   with `user_type: "CL"`) or the shipment not being label/invoice-ready.
-- **upload-kyc-doc** → `502 Internal server error` (their gateway) for PNG and
-  PDF alike. Request contract is `dlv-image-type: Front|Back` +
+- **upload-kyc-doc** → 🔴 DEPRECATED by Delhivery and not in use. The `502` seen
+  during verification was a retired endpoint, not their gateway having a bad
+  day. Dropped from the OAuth scope; do not re-add it. ⚠️ This does NOT affect
+  the *consignor KYC fields* on the payload (gotcha #5) — those are still
+  mandatory for `commercial` shipments.
   `Content-Type: image/jpeg|png|jpg|application/pdf` + binary body →
   `{ success, message }`.
 
@@ -138,3 +141,13 @@ at the staging host do NOT fail at auth. They authenticate, and then
 `pickup_warehouse_id` resolves against a registry that has never heard of that
 warehouse — surfacing as a manifestation error that reads like bad shipment
 data. If a manifest fails on an unknown warehouse, check the host first.
+## ⚠️ The scope in this document and the scope in the code disagreed
+
+Until the KYC removal, this note showed `^/package/.+/upload-kyc-doc:POST$` with
+a closing `$` while `client.ts` sent it **without** one — the only entry in
+either list that was not anchored at both ends. Nobody noticed because a
+malformed scope does not fail at `/auth/token`; it mints a token that 401s on
+every `/package` call afterwards, so the symptom appears at the shipment.
+
+If you change the scope, change it in both places and verify with one real
+manifest. A green unit test cannot tell you the authorisation server accepted it.


### PR DESCRIPTION
Delhivery confirmed the KYC upload API is **deprecated and not in use**. #1748 recorded it as `502 Internal server error` on their side — read as their outage. It was a retired endpoint answering the only way it could.

There is no `uploadKycDoc` method, so nothing called it. What existed was the part that mattered: `^/package/.+/upload-kyc-doc:POST` in the **OAuth scope**, sent on every token mint. Requesting scope for a path the authorisation server may stop recognising risks the whole mint — and the token is what every other call depends on.

Also removed the stub's `/upload-kyc-doc` branch, which answered `{ success: true }`. A stub that certifies a call the carrier will never honour is worse than no stub.

⚠️ **Not** the consignor KYC *fields* (gotcha #5 — pan, gstin, iec, bank block). Those stay mandatory for `commercial` shipments and are untouched.

## Two things this turned up

🔴 **The code and the API note disagreed on the scope string.** The note had `...upload-kyc-doc:POST$`; the code sent it with **no trailing `$`** — the only entry in either list not anchored at both ends. Unnoticed because a malformed scope does not fail at `/auth/token`: it mints a token that 401s on every `/package` call, so the symptom lands at the shipment. There is now a test asserting every package rule is anchored at both ends.

🔴 **The removal is not live-verified.** The scope is minted as a unit and a bad one fails silently in exactly that way. One real manifest against staging should confirm it before prod use. The test proves the shape, not that the authorisation server accepted it.

## Checks

3 new tests, 20 in the suite. `check:prod-build`'s **backend** half passes. Its frontend half fails on a pre-existing local pnpm artifact (`@medusajs/js-sdk` unresolvable from `@jytextiles/medusa-plugin-etsy-sync`'s admin bundle) that **reproduces on a clean stashed tree** and does not occur in CI — the `a8eb74429` deploy went green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4