### PR TITLE
fix(shipping): Shiprocket quoted RUPEES as the cart's currency (₹890 → A$890)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -347,7 +347,13 @@ module.exports = defineConfig({
        *
        * Drop these and the symptom returns silently.
        */
-      dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE],
+      /**
+       * 🔴 `fx_rates` is here because Shiprocket quotes in RUPEES while
+       * `calculated_amount` is denominated in the CART's currency. Prod measured
+       * an AU cart being quoted ₹890 as A$890. Drop this key and the provider
+       * stops converting and falls back. See shiprocket/rate-currency.ts.
+       */
+      dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE, "fx_rates"],
       options: {
         providers: [
           {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -447,7 +447,14 @@ module.exports = defineConfig({
              * Drop these and the symptom returns silently. The service logs
              * loudly on the missing branch for that reason.
              */
-            dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE],
+            /**
+             * 🔴 `fx_rates` is here because Shiprocket quotes in RUPEES while
+             * `calculated_amount` is denominated in the CART's currency. Prod
+             * measured an AU cart being quoted ₹890 as A$890. Drop this key and
+             * the provider stops converting and falls back — loudly, but it
+             * stops quoting live rates. See shiprocket/rate-currency.ts.
+             */
+            dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE, "fx_rates"],
             options: {
               providers: [
                 {

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/rate-currency.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/rate-currency.unit.spec.ts
@@ -1,0 +1,86 @@
+import {
+  SHIPROCKET_RATE_CURRENCY,
+  applyRateToCarrierAmount,
+  hasKnownCurrency,
+  needsRateConversion,
+} from "../rate-currency"
+
+/**
+ * The currency of a Shiprocket quote (#1417 follow-up).
+ *
+ * Reproduced on prod 2026-09-05: an AU-region cart with a Melbourne address was
+ * quoted `calculated_amount: 890`. Shiprocket answers in rupees, so that is
+ * ₹890 — about A$16 — charged as **A$890**. The same option's configured AUD
+ * fallback is 55, so the fallback was right and the live path was ~55× wrong.
+ */
+describe("needsRateConversion", () => {
+  it("leaves an INR cart alone — a rate of 1.0 from a cache is worse than not asking", () => {
+    expect(needsRateConversion("inr")).toBe(false)
+    expect(needsRateConversion("INR")).toBe(false)
+    expect(needsRateConversion(" inr ")).toBe(false)
+  })
+
+  it("converts for every other currency", () => {
+    for (const c of ["aud", "eur", "usd", "gbp", "idr", "ils"]) {
+      expect(needsRateConversion(c)).toBe(true)
+    }
+  })
+
+  it("treats an unknown currency as needing conversion, so it can never pass through raw", () => {
+    expect(needsRateConversion(undefined)).toBe(true)
+    expect(needsRateConversion(null)).toBe(true)
+    expect(needsRateConversion("")).toBe(true)
+  })
+})
+
+describe("hasKnownCurrency", () => {
+  it("is false when the cart currency never arrived", () => {
+    expect(hasKnownCurrency(undefined)).toBe(false)
+    expect(hasKnownCurrency(null)).toBe(false)
+    expect(hasKnownCurrency("   ")).toBe(false)
+  })
+
+  it("is true for a real code", () => {
+    expect(hasKnownCurrency("aud")).toBe(true)
+  })
+})
+
+describe("applyRateToCarrierAmount", () => {
+  /**
+   * The exact figure from the prod reproduction. At roughly 0.018 AUD per INR,
+   * ₹890 is about A$16 — not A$890.
+   */
+  it("turns the measured ₹890 into a plausible AUD amount", () => {
+    const out = applyRateToCarrierAmount(890, 0.018)
+    expect(out).toBeCloseTo(16.02, 2)
+    expect(out!).toBeLessThan(100)
+  })
+
+  it("rounds to 2dp, because this lands on an invoice", () => {
+    expect(applyRateToCarrierAmount(3119, 0.0182)).toBe(56.77)
+  })
+
+  /**
+   * 🔴 A zero or NaN rate would produce free shipping — the silent zero the
+   * flat fallback was built to end. It must not return through this door.
+   */
+  it("refuses a rate that would make shipping free", () => {
+    expect(applyRateToCarrierAmount(890, 0)).toBeNull()
+    expect(applyRateToCarrierAmount(890, -1)).toBeNull()
+    expect(applyRateToCarrierAmount(890, Number.NaN)).toBeNull()
+    expect(applyRateToCarrierAmount(890, Number.POSITIVE_INFINITY)).toBeNull()
+  })
+
+  it("refuses an unusable amount", () => {
+    expect(applyRateToCarrierAmount(Number.NaN, 0.018)).toBeNull()
+    expect(applyRateToCarrierAmount(-5, 0.018)).toBeNull()
+  })
+
+  it("keeps a genuine zero-cost quote at zero rather than rejecting it", () => {
+    expect(applyRateToCarrierAmount(0, 0.018)).toBe(0)
+  })
+
+  it("names the currency the carrier actually answers in", () => {
+    expect(SHIPROCKET_RATE_CURRENCY).toBe("INR")
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/rate-currency.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/rate-currency.ts
@@ -1,0 +1,75 @@
+/**
+ * Shiprocket quotes in RUPEES. `calculated_amount` is denominated in the CART's
+ * currency. Nothing in between converted.
+ *
+ * ## The bug this exists to fix
+ *
+ * `calculatePrice` returned the carrier's number raw:
+ *
+ *     return { calculated_amount: Number(recommended.amount), ... }
+ *
+ * Measured on prod 2026-09-05 — an AU-region cart, Melbourne address:
+ *
+ *     POST /store/shipping-options/so_01M0J.../calculate → calculated_amount: 890
+ *
+ * That is ₹890 (≈ A$16) presented to the buyer as **A$890**. The same option's
+ * own configured fallback for AUD is 55, so the fallback was right and the live
+ * rate was ~55× wrong. The client's own live-verified notes state the unit
+ * plainly — "SRX Economy Pro ₹3119", "Aramex ₹8477 → ₹57,937".
+ *
+ * The method's docblock already said `calculated_amount` is in the cart's
+ * currency, and it threaded `currency_code` carefully into the FALLBACK path
+ * while ignoring it entirely on the success path. `flat-fallback.ts` predicted
+ * this exact door: "leaning on live international rates is exactly what makes
+ * it reachable."
+ *
+ * ## Why an unconvertible rate falls back rather than shipping raw
+ *
+ * The honest answers to "I have a number but not in the currency I must quote"
+ * are to convert it or to not use it. Returning it anyway is the bug. So when
+ * the currency is unknown, or no INR→target rate exists, the caller drops to
+ * the per-currency flat fallback — which is a number somebody chose, in the
+ * right currency — instead of a carrier figure wearing the wrong denomination.
+ *
+ * 🔑 An INR cart needs no conversion and must not be given one: multiplying by
+ * a rate of 1.0 that came from a cache is strictly worse than not asking.
+ */
+
+/** The currency Shiprocket's rate endpoints answer in, domestic and international. */
+export const SHIPROCKET_RATE_CURRENCY = "INR"
+
+/**
+ * Whether a quote in `SHIPROCKET_RATE_CURRENCY` has to be converted before it
+ * can be returned as `calculated_amount` for a cart in `target`.
+ *
+ * Returns false for an INR cart (already right) and true for everything else
+ * INCLUDING an unknown target — the caller must then decide, and its decision
+ * is to fall back rather than guess.
+ */
+export const needsRateConversion = (target?: string | null): boolean =>
+  String(target ?? "").trim().toUpperCase() !== SHIPROCKET_RATE_CURRENCY
+
+/** True when we know what currency the cart is in at all. */
+export const hasKnownCurrency = (target?: string | null): boolean =>
+  String(target ?? "").trim().length > 0
+
+/**
+ * Apply an FX rate to a carrier amount.
+ *
+ * `rate` is target units per 1 INR, matching `FxRatesService.getRate(from, to)`.
+ * Rounds to 2dp — this is a money value that goes on an invoice.
+ *
+ * Returns null for a rate that is not a usable positive number. A zero or NaN
+ * rate would silently produce free shipping, which is the failure mode the flat
+ * fallback was introduced to end; it must not come back in through here.
+ */
+export const applyRateToCarrierAmount = (
+  amount: number,
+  rate: number
+): number | null => {
+  const a = Number(amount)
+  const r = Number(rate)
+  if (!Number.isFinite(a) || a < 0) return null
+  if (!Number.isFinite(r) || r <= 0) return null
+  return Math.round(a * r * 100) / 100
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -14,6 +14,12 @@ import { CreateShipmentInput, ShipmentItem } from "../provider-interface"
 import { deriveShiprocketRateContext } from "./rate-context"
 import { resolveShipmentPaymentMode } from "./payment-mode"
 import { FlatFallbackConfig, resolveFlatFallbackAmount } from "./flat-fallback"
+import {
+  SHIPROCKET_RATE_CURRENCY,
+  applyRateToCarrierAmount,
+  hasKnownCurrency,
+  needsRateConversion,
+} from "./rate-currency"
 
 /**
  * 🔴 `socials` and `encryption` reach the provider ONLY because the fulfillment
@@ -29,6 +35,14 @@ type InjectedDeps = {
   logger: Logger
   socials?: any
   encryption?: any
+  /**
+   * Reaches the provider the same way — via `dependencies` on the fulfillment
+   * module. Needed because Shiprocket quotes in rupees and `calculated_amount`
+   * is denominated in the cart's currency; see `rate-currency.ts`. Optional, and
+   * its absence sends a quote to the per-currency flat fallback rather than
+   * returning a rupee figure labelled as dollars.
+   */
+  fx_rates?: any
 }
 
 /**
@@ -270,8 +284,28 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
         )
       }
 
+      /**
+       * 🔴 The carrier answers in RUPEES; this must be returned in the CART's
+       * currency. Prod measured an AU cart being quoted ₹890 as A$890.
+       */
+      const quoted = await this.toCartCurrency(
+        Number(recommended.amount),
+        currencyCode
+      )
+
+      if (quoted == null) {
+        return this.flatFallback(
+          destinationCountry,
+          `Shiprocket quoted ${recommended.amount} ${SHIPROCKET_RATE_CURRENCY} and it could not be converted to ${
+            currencyCode ?? "an unknown cart currency"
+          }`,
+          optionData,
+          currencyCode
+        )
+      }
+
       return {
-        calculated_amount: Number(recommended.amount),
+        calculated_amount: quoted,
         is_calculated_price_tax_inclusive: true,
       }
     } catch (e: any) {
@@ -282,6 +316,57 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
         optionData,
         currencyCode
       )
+    }
+  }
+
+  /**
+   * Convert a rupee quote into the cart's currency, or answer null.
+   *
+   * Null means "do not use this number" and the caller drops to the flat
+   * fallback. It is deliberately null — not the raw amount — for an unknown
+   * currency, a missing FX module and an unavailable rate alike: those are all
+   * cases where the only figure available is in the wrong denomination, and
+   * returning it is the defect this replaces.
+   */
+  protected async toCartCurrency(
+    amount: number,
+    currencyCode: string | null
+  ): Promise<number | null> {
+    if (!hasKnownCurrency(currencyCode)) {
+      this.logger.warn(
+        `[shiprocket] rate ${amount} ${SHIPROCKET_RATE_CURRENCY} has no cart currency to convert into; using the flat fallback instead of quoting it raw.`
+      )
+      return null
+    }
+
+    if (!needsRateConversion(currencyCode)) {
+      return Number.isFinite(Number(amount)) ? Number(amount) : null
+    }
+
+    const target = String(currencyCode).toUpperCase()
+    const fx = this.deps.fx_rates
+
+    if (!fx?.getRate) {
+      this.logger.warn(
+        `[shiprocket] no fx_rates module in the provider cradle — declare it in the fulfillment module's \`dependencies\`. Falling back rather than quoting ${SHIPROCKET_RATE_CURRENCY} as ${target}.`
+      )
+      return null
+    }
+
+    try {
+      const rate = await fx.getRate(SHIPROCKET_RATE_CURRENCY, target)
+      const converted = applyRateToCarrierAmount(amount, rate)
+      if (converted == null) {
+        this.logger.warn(
+          `[shiprocket] unusable ${SHIPROCKET_RATE_CURRENCY}->${target} rate (${rate}); falling back.`
+        )
+      }
+      return converted
+    } catch (e: any) {
+      this.logger.warn(
+        `[shiprocket] no ${SHIPROCKET_RATE_CURRENCY}->${target} rate (${e?.message}); falling back.`
+      )
+      return null
     }
   }
 


### PR DESCRIPTION
Reproduced on prod today. An AU-region cart, Melbourne address:

```
POST /store/shipping-options/so_01M0J.../calculate  →  { "calculated_amount": 890 }
```

Shiprocket answers in **rupees**. `calculated_amount` is denominated in the **cart's** currency. Nothing converted — so ₹890 (≈ A$16) was charged as **A$890**, roughly **55×**, at checkout, to live buyers.

The same option's configured AUD fallback is `55`, so the *fallback* was right and the live path was wrong. `calculatePrice` already threaded `currency_code` carefully into `flatFallback`, then ignored it on the success path:

```ts
return { calculated_amount: Number(recommended.amount), ... }
```

The unit was never in doubt — the client's own live-verified notes say it: *"SRX Economy Pro ₹3119"*, *"Aramex ₹8477 → ₹57,937"*. And `flat-fallback.ts` named this door: *"leaning on live international rates is exactly what makes it reachable."*

## Fix

`fx_rates` reaches the provider via `dependencies` on the fulfillment module — the same route `socials`/`encryption` already take, since a provider is built with the parent module's cradle.

- 🔑 An **INR cart is not converted**. Multiplying by a cached 1.0 is worse than not asking.
- 🔴 When conversion is impossible — unknown cart currency, no `fx_rates` in the cradle, no INR→target rate, or a rate that is zero/NaN — the quote drops to the **per-currency flat fallback** rather than returning the rupee figure. A zero rate would produce free shipping, the silent zero the fallback exists to end, so it is refused explicitly.

## Verified

11 new tests; **194 green** across the shiprocket suites. **Mutation-checked**: making `applyRateToCarrierAmount` return the amount unconverted — the original bug exactly — turns 2 red, including the assertion on the measured ₹890.

⚠️ After deploy, confirm the FX cache holds an INR→AUD path. Without it every international lane falls to the flat fallback — right currency and safe, but not a live rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4