### PR TITLE
feat(dtdc): let the caller choose the service type, like every other carrier

### DIFF
--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -129,8 +129,19 @@ export type CreateShipmentInput = {
    * carrier client fills retail-sale defaults. Ignored on domestic shipments.
    */
   customs?: CustomsDeclaration
-  /** Aggregator courier choice (Shiprocket `courier_company_id`). Ignored by
-   *  single-carrier providers. When omitted, the provider auto-selects. */
+  /**
+   * The operator's chosen carrier service. When omitted, the provider
+   * auto-selects.
+   *
+   * - Shiprocket (aggregator): the `courier_company_id` from a serviceability
+   *   call — WHICH courier carries it.
+   * - DTDC (single carrier, six services): the service type — `B2C PRIORITY`,
+   *   `B2C GROUND ECONOMY` and so on. Accepts an id or a name.
+   *
+   * ⚠️ No longer "ignored by single-carrier providers": DTDC reads it, so a
+   * value set for one carrier is not inert if the shipment is rebooked with
+   * another. An unrecognised value is ignored rather than forwarded.
+   */
   preferred_courier_id?: string | number
   product_description?: string
   /**

--- a/packages/medusa-plugin-dtdc-shipping/package.json
+++ b/packages/medusa-plugin-dtdc-shipping/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-dtdc-shipping",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-dtdc-shipping/src/__tests__/service-type-selection.spec.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/__tests__/service-type-selection.spec.ts
@@ -1,0 +1,104 @@
+import { DtdcProviderAdapter } from "../providers/dtdc/adapter"
+import type { CreateShipmentInput } from "../lib/provider-interface"
+
+/**
+ * Who picks the DTDC service.
+ *
+ * The adapter used to return one of two HARDCODED values from a weight
+ * heuristic, unconditionally. That meant `default_service_type` had no effect
+ * on this path and a caller could not choose at all — and the two values are
+ * the SANDBOX products. A live B2C account lists `B2C PRIORITY` and does not
+ * list bare `PRIORITY`, so the heuristic could send a service the account does
+ * not have, refused at booking rather than at configuration.
+ */
+const baseInput = (over: Partial<CreateShipmentInput> = {}): CreateShipmentInput =>
+  ({
+    reference_id: "ord_1",
+    payment_mode: "prepaid",
+    pickup_location_name: "WH-1",
+    to: {
+      name: "Buyer",
+      phone: "9999999999",
+      address_1: "1 Road",
+      city: "Delhi",
+      state: "Delhi",
+      pincode: "110042",
+    },
+    items: [],
+    weight_grams: 500,
+    ...over,
+  }) as CreateShipmentInput
+
+/** Capture what the adapter asks the carrier for, without a network. */
+function captureServiceType(
+  options: any,
+  input: CreateShipmentInput
+): string | undefined {
+  const adapter = new DtdcProviderAdapter({
+    customer_code: "CC",
+    api_key: "k",
+    ...options,
+  })
+  let seen: any
+  ;(adapter as any).client = {
+    createShipment: async (p: any) => {
+      seen = p.service_type_id
+      return { awb_number: "A1", reference_number: "ord_1" }
+    },
+  }
+  return (adapter as any)
+    .createShipment(input)
+    .then(() => seen)
+    .catch(() => seen)
+}
+
+describe("DTDC service-type selection", () => {
+  it("uses the CALLER's choice above everything else", async () => {
+    const seen = await captureServiceType(
+      { default_service_type: "B2C GROUND ECONOMY" },
+      baseInput({ preferred_courier_id: "B2C PREMIUM" } as any)
+    )
+    expect(seen).toBe("B2C PREMIUM")
+  })
+
+  it("accepts the caller's choice by name, separators and case aside", async () => {
+    const seen = await captureServiceType(
+      {},
+      baseInput({ preferred_courier_id: "b2c_smart_express" } as any)
+    )
+    expect(seen).toBe("B2C SMART EXPRESS")
+  })
+
+  /**
+   * 🔴 The regression that mattered: a configured default was silently
+   * overridden by the heuristic. Deferring means `undefined` reaches the
+   * client, which applies the configured value.
+   */
+  it("defers to the configured default instead of guessing", async () => {
+    const seen = await captureServiceType(
+      { default_service_type: "B2C PRIORITY" },
+      baseInput({ weight_grams: 25000 })
+    )
+    expect(seen).toBeUndefined()
+  })
+
+  it("falls back to the weight heuristic only when nothing is configured", async () => {
+    expect(await captureServiceType({}, baseInput({ weight_grams: 25000 }))).toBe(
+      "GROUND_EXPRESS"
+    )
+    expect(await captureServiceType({}, baseInput({ weight_grams: 500 }))).toBe(
+      "PRIORITY"
+    )
+  })
+
+  it("ignores an unrecognised caller choice rather than forwarding a typo", async () => {
+    const seen = await captureServiceType(
+      {},
+      baseInput({
+        preferred_courier_id: "B2C SUPER EXPRESS",
+        weight_grams: 500,
+      } as any)
+    )
+    expect(seen).toBe("PRIORITY")
+  })
+})

--- a/packages/medusa-plugin-dtdc-shipping/src/lib/provider-interface.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/lib/provider-interface.ts
@@ -41,6 +41,18 @@ export type CreateShipmentInput = {
   currency?: string
   product_description?: string
   tax_id?: string
+  /**
+   * The operator's chosen carrier service, mirroring the backend's
+   * `preferred_courier_id` (which Shiprocket reads as `courier_company_id`).
+   *
+   * DTDC is a single carrier with SIX services, so the choice that matters here
+   * is which product carries the parcel — `B2C PRIORITY` vs `B2C GROUND
+   * ECONOMY` and so on. Accepts an id or a name; see `service-types.ts`.
+   *
+   * When omitted the provider falls back to the configured default, and only
+   * then to the weight/size heuristic.
+   */
+  preferred_courier_id?: string | number
 }
 
 export type ShipmentRef = {

--- a/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/adapter.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/adapter.ts
@@ -6,6 +6,10 @@ import {
 } from "../../lib/dtdc-client"
 import { DtdcOptions, DtdcServiceType } from "../../lib/types"
 import {
+  DTDC_SERVICE_TYPES,
+  resolveDtdcServiceType,
+} from "../../lib/service-types"
+import {
   CreateShipmentInput,
   LabelResult,
   ShipmentRef,
@@ -15,19 +19,55 @@ import {
   TrackingResult,
 } from "../../lib/provider-interface"
 
-/** Service-type inference: large/heavy consignments go surface, else air. */
-function serviceTypeFor(input: CreateShipmentInput): DtdcServiceType {
+/**
+ * Which DTDC service carries this parcel.
+ *
+ * Three sources, in order:
+ *
+ *  1. The CALLER's choice (`preferred_courier_id`) — the same field an operator
+ *     already picks a Shiprocket courier with, so the admin/partner path that
+ *     chooses a carrier service needs no new plumbing.
+ *  2. The CONFIGURED default (`default_service_type`), by returning undefined
+ *     and letting the client apply it.
+ *  3. Only then the weight/size heuristic.
+ *
+ * 🔴 Order 1 and 2 are the fix. This function used to return one of two
+ * hardcoded values unconditionally, so `default_service_type` had NO effect on
+ * this path and a caller could not choose at all. Those two values are the
+ * SANDBOX products; a live B2C account lists `B2C PRIORITY` and friends and
+ * does not list bare `PRIORITY`, so the heuristic could send a service the
+ * account does not have — and that is refused at booking, not at config time.
+ */
+function serviceTypeFor(
+  input: CreateShipmentInput,
+  hasConfiguredDefault: boolean
+): DtdcServiceType | undefined {
+  const chosen = resolveDtdcServiceType(
+    input.preferred_courier_id == null ? null : String(input.preferred_courier_id)
+  )
+  if (chosen) return chosen
+
+  // Defer to the configured default rather than overriding it with a guess.
+  if (hasConfiguredDefault) return undefined
+
   const length = input.dimensions_cm?.length ?? 0
   const heavy = input.weight_grams >= 10000 || length > 100
-  return heavy ? "GROUND_EXPRESS" : "PRIORITY"
+  return heavy
+    ? DTDC_SERVICE_TYPES.GROUND_EXPRESS
+    : DTDC_SERVICE_TYPES.PRIORITY
 }
 
 export class DtdcProviderAdapter implements ShippingProviderClient {
   readonly carrier = "dtdc"
   private client: DtdcClient
+  /** Whether the integrator chose a service, so the heuristic stays out of it. */
+  private hasConfiguredDefault: boolean
 
   constructor(options: DtdcOptions) {
     this.client = new DtdcClient(options)
+    this.hasConfiguredDefault = Boolean(
+      resolveDtdcServiceType(options.default_service_type)
+    )
   }
 
   async checkServiceability(destinationPincode: string): Promise<boolean> {
@@ -48,7 +88,7 @@ export class DtdcProviderAdapter implements ShippingProviderClient {
 
   async createShipment(input: CreateShipmentInput): Promise<ShipmentResult> {
     const result = await this.client.createShipment({
-      service_type_id: serviceTypeFor(input),
+      service_type_id: serviceTypeFor(input, this.hasConfiguredDefault),
       length: input.dimensions_cm?.length ?? 30,
       width: input.dimensions_cm?.width ?? 25,
       height: input.dimensions_cm?.height ?? 5,

--- a/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/service.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/service.ts
@@ -10,6 +10,7 @@ import {
 } from "@medusajs/framework/types"
 import { DtdcClient } from "../../lib/dtdc-client"
 import { DtdcOptions } from "../../lib/types"
+import { resolveDtdcServiceType } from "../../lib/service-types"
 import { Logger } from "@medusajs/framework/types"
 
 type InjectedDeps = { logger: Logger }
@@ -191,7 +192,14 @@ class DtdcFulfillmentService extends AbstractFulfillmentProviderService {
         return sum + unitPrice * ((item as any).quantity || 1)
       }, 0)
 
-      const serviceType = (data?.service_type as any) ?? "PRIORITY"
+      /**
+       * The fulfillment's own choice, else the CONFIGURED default — not a
+       * hardcoded "PRIORITY", which ignored `default_service_type` entirely and
+       * is not even a service a live B2C account lists. Undefined lets the
+       * client apply the configured value.
+       */
+      const serviceType =
+        resolveDtdcServiceType(data?.service_type as any) ?? undefined
       const result = await this.client.createShipment({
         service_type_id: serviceType,
         length: maxLength || 30,


### PR DESCRIPTION
Send the service type from the client, the way the other providers already work. Two things were in the way, and both were bugs.

## 1. The adapter ignored everyone

`serviceTypeFor` returned one of two **hardcoded** values from a weight heuristic, unconditionally:

```ts
return heavy ? "GROUND_EXPRESS" : "PRIORITY"
```

So a caller could not choose — **and** `default_service_type` had no effect on this path at all, making the option added in #1833 inert here. Worse, those two are the **sandbox** products: a live B2C account lists `B2C PRIORITY` and friends and does *not* list bare `PRIORITY`, so the heuristic could send a service the account does not have. That is refused at booking time, with an error about the shipment rather than the configuration.

Now three sources in order:
1. the caller's `preferred_courier_id`
2. the configured default (return `undefined`, let the client apply it)
3. the heuristic — only when nothing is configured, so existing unconfigured setups behave exactly as before

`preferred_courier_id` is deliberately the **same field** an operator already picks a Shiprocket courier with, so the admin and partner paths need no new plumbing. The backend interface doc claimed it was *"ignored by single-carrier providers"* — no longer true, and it now says so.

## 2. The fulfillment path hardcoded PRIORITY

`service.ts` read `data?.service_type ?? "PRIORITY"` — same problem, different door. It now resolves the fulfillment's own value and otherwise defers to the configured default.

🔑 An unrecognised caller value is **ignored, not forwarded**. A typo must not reach a waybill; the service types are a closed set per account.

## Verified

5 new tests, **40 green** in the plugin. Both branches **mutation-checked** — the test helper swallows errors in a `.catch`, so passing on broken code was a real risk: disabling the caller branch turns 2 red, disabling the default deferral turns 1.

Version `0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4