### PR TITLE
feat(#1816): a review screen for a batch of ID cards — the bell finally links somewhere

### DIFF
--- a/apps/backend/src/api/partners/people/id-extraction/batch/route.ts
+++ b/apps/backend/src/api/partners/people/id-extraction/batch/route.ts
@@ -143,13 +143,22 @@ export const GET = async (
         const items = await service.listIdExtractionBatchItems({ batch_id: b.id })
         const by = (s: string) =>
           items.filter((i: any) => i.status === s).length
+        const failed = by("failed")
+        const pending = by("pending")
         return {
           ...b,
           total: items.length,
           completed: by("completed"),
-          failed: by("failed"),
+          failed,
           approved: by("approved"),
-          pending: by("pending"),
+          pending,
+          /**
+           * Same field, same meaning as the detail route: what is left to do,
+           * derived from the item rows. A list that showed only `status` could
+           * not tell a finished batch from one whose background loop a deploy
+           * killed while the row still said `running` (#1742).
+           */
+          outstanding: pending + failed,
         }
       } catch (e) {
         logger?.warn?.(`[id-extraction-batch] count failed for ${b.id}: ${e}`)

--- a/apps/backend/src/workflows/ai/__tests__/id-extraction-batch.unit.spec.ts
+++ b/apps/backend/src/workflows/ai/__tests__/id-extraction-batch.unit.spec.ts
@@ -5,6 +5,7 @@ import {
   MAX_ID_BATCH_INTERVAL_MS,
   MAX_ID_BATCH_IMAGES,
   buildIdBatchBellMessage,
+  idBatchReviewUrl,
 } from "../id-extraction-batch"
 
 /**
@@ -134,5 +135,25 @@ describe("buildIdBatchBellMessage", () => {
     expect(title).toBe("ID card batch could not be read")
     expect(description).toContain("Nothing was added")
     expect(description).not.toContain("Review the drafts")
+  })
+})
+
+/**
+ * The bell row's deep link (#1816).
+ *
+ * It shipped pointing at `/assistant?batch=<id>` — a route that existed and
+ * ignored the parameter, so the notification led to a screen that said nothing
+ * about the batch. What is asserted here is therefore not the string but the
+ * property that was missing: it addresses the batch, and it is not the chat.
+ */
+describe("idBatchReviewUrl", () => {
+  it("addresses the batch it belongs to", () => {
+    expect(idBatchReviewUrl("batch_01ABC")).toContain("batch_01ABC")
+  })
+
+  it("points at the review screen, not the assistant", () => {
+    const url = idBatchReviewUrl("batch_01ABC")
+    expect(url).toBe("/settings/people/id-batches/batch_01ABC")
+    expect(url.startsWith("/assistant")).toBe(false)
   })
 })

--- a/apps/backend/src/workflows/ai/id-extraction-batch.ts
+++ b/apps/backend/src/workflows/ai/id-extraction-batch.ts
@@ -444,6 +444,19 @@ export const idExtractionBatchProcessingWorkflow = createWorkflow(
  * read or none did, which is the failure mode worth a test: a summary that
  * cannot say anything went wrong.
  */
+/**
+ * Where a batch notification sends the partner.
+ *
+ * 🔴 One definition, used by both the success and the failure bell rows. The
+ * first version of this feature pointed them at `/assistant?batch=<id>` — a
+ * route that existed but ignored the parameter, so the deep link answered
+ * nothing. It is a constant here so the two rows cannot drift apart, and so a
+ * change to it is a change to a named thing rather than to two template
+ * literals four hundred lines apart.
+ */
+export const idBatchReviewUrl = (batchId: string): string =>
+  `/settings/people/id-batches/${batchId}`
+
 export const buildIdBatchBellMessage = (counts: {
   total: number;
   readable: number;
@@ -517,13 +530,13 @@ const notifyPartnerOfIdBatchStep = createStep(
        */
       idempotency_key: `id_extraction_batch:${input.batch_id}:${readable}:${failed}:${outstanding}`,
       /**
-       * ⚠️ Points at a route that EXISTS. There is no batch screen yet (#1816
-       * shipped API + workflow only), and a bell row that 404s is worse than
-       * one that does not link. `/assistant` is where the operator can ask
-       * `get_id_extraction_batch` for the same report, which is the flow the
-       * founder asked for: read the bell, go back to the chat, ask.
+       * ⚠️ Points at a route that EXISTS — now the review screen itself, which
+       * lists every draft with the reader's own warnings and the approve
+       * button. It replaced `/assistant?batch=`, and rows already in partners'
+       * bells still carry that older link: the assistant redirects it here
+       * rather than leaving them on a screen that ignores the parameter.
        */
-      url: `/assistant?batch=${input.batch_id}`,
+      url: idBatchReviewUrl(input.batch_id),
       data: { batch_id: input.batch_id, total, completed: readable, failed, outstanding, approved },
     });
 
@@ -579,7 +592,7 @@ export const idExtractionBatchWorkflow = createWorkflow(
         data: {
           title: "ID card batch could not be read",
           description: `Batch ${d.created.batch_id} stopped before it could read the cards. Nobody was added to your people.`,
-          url: `/assistant?batch=${d.created.batch_id}`,
+          url: idBatchReviewUrl(d.created.batch_id),
           batch_id: d.created.batch_id,
         },
       },

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -1102,6 +1102,33 @@ export function getPartnerRouteMap(): RouteObject[] {
                   ],
                 },
                 {
+                  // #1816 — where a stack of photographed ID cards is reviewed.
+                  // The batch notification deep-links straight to the detail;
+                  // it pointed at a screen that did not exist until now.
+                  path: "people/id-batches",
+                  handle: { breadcrumb: () => "ID card batches" },
+                  children: [
+                    {
+                      path: "",
+                      lazy: () =>
+                        import(
+                          "../../routes/settings/people/id-batches/id-batch-list"
+                        ),
+                    },
+                    {
+                      path: ":id",
+                      handle: {
+                        breadcrumb: (match?: UIMatch) =>
+                          match?.params?.id || "Batch",
+                      },
+                      lazy: () =>
+                        import(
+                          "../../routes/settings/people/id-batches/id-batch-detail"
+                        ),
+                    },
+                  ],
+                },
+                {
                   path: "payments",
                   lazy: () => import("../../routes/settings/payments"),
                   children: [

--- a/apps/partner-ui/src/hooks/api/id-extraction-batch.tsx
+++ b/apps/partner-ui/src/hooks/api/id-extraction-batch.tsx
@@ -1,5 +1,12 @@
 import { FetchError } from "@medusajs/js-sdk"
-import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 
 import { sdk } from "../../lib/client"
 import { queryKeysFactory } from "../../lib/query-key-factory"
@@ -112,3 +119,184 @@ export const fetchIdExtractionBatch = (id: string) =>
     `/partners/people/id-extraction/batch/${id}`,
     { method: "GET" },
   )
+
+/**
+ * A row from the list route.
+ *
+ * ⚠️ The counts are optional here and required on the detail response, and
+ * that is not sloppiness: the list computes them per batch inside a try/catch
+ * and returns the bare row if the item fetch throws. A type that promised them
+ * would make `0 of 0 read` out of a failure.
+ */
+export type IdExtractionBatchSummary = Omit<
+  IdExtractionBatch,
+  "total" | "completed" | "failed" | "approved" | "pending" | "outstanding"
+> &
+  Partial<
+    Pick<
+      IdExtractionBatch,
+      "total" | "completed" | "failed" | "approved" | "pending" | "outstanding"
+    >
+  > & {
+    created_at?: string | null
+  }
+
+export type IdExtractionBatchListResponse = {
+  batches: IdExtractionBatchSummary[]
+  count: number
+  limit: number
+  offset: number
+}
+
+/** The partner's own batches, newest first. Never takes a partner id — the
+ * route scopes on the authenticated actor and a body that could name another
+ * partner is the cross-tenant read this platform guards against. */
+export const useIdExtractionBatches = (
+  query?: { limit?: number; offset?: number },
+  options?: Omit<
+    UseQueryOptions<
+      IdExtractionBatchListResponse,
+      FetchError,
+      IdExtractionBatchListResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >,
+) =>
+  useQuery({
+    queryKey: idExtractionBatchQueryKeys.list(query ?? {}),
+    queryFn: () =>
+      sdk.client.fetch<IdExtractionBatchListResponse>(
+        "/partners/people/id-extraction/batch",
+        { method: "GET", query: query as Record<string, unknown> },
+      ),
+    ...options,
+  })
+
+export type ApproveIdExtractionBatchPayload = {
+  /** Omitted means "every item with a usable draft". */
+  item_ids?: string[]
+  /** Operator fixes, keyed by item id — the only place a corrected name lands. */
+  corrections?: Record<string, Record<string, unknown>>
+}
+
+export type ApproveIdExtractionBatchResponse = {
+  message: string
+  batch_id: string
+  approved: number
+  skipped: number
+  results: {
+    item_id: string
+    status: string
+    person_id?: string | null
+    reason?: string | null
+  }[]
+}
+
+/**
+ * 🔴 The only door from a draft to a person.
+ *
+ * ⚠️ `...options` goes BEFORE `onSuccess`, not after. Spread last it silently
+ * replaces the invalidation and the screen keeps showing pre-approval drafts
+ * until a hard refresh — the #1800 shape, which is still live in
+ * `partner-goods-transfers.tsx` a few files over.
+ */
+export const useApproveIdExtractionBatch = (
+  batchId: string,
+  options?: UseMutationOptions<
+    ApproveIdExtractionBatchResponse,
+    FetchError,
+    ApproveIdExtractionBatchPayload
+  >,
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: ApproveIdExtractionBatchPayload) =>
+      sdk.client.fetch<ApproveIdExtractionBatchResponse>(
+        `/partners/people/id-extraction/batch/${batchId}/approve`,
+        { method: "POST", body: payload },
+      ),
+    ...options,
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: idExtractionBatchQueryKeys.all,
+      })
+      options?.onSuccess?.(...args)
+    },
+  })
+}
+
+export type RetryIdExtractionBatchResponse = {
+  success: boolean
+  message: string
+  batch_id: string
+  /** Present only when there was nothing outstanding — a no-op, not a failure. */
+  nothing_to_do?: boolean
+  scope?: "failed" | "pending"
+  outstanding?: number
+}
+
+/**
+ * Re-run what is outstanding. `failed` re-reads only the failures; `pending`
+ * also picks up photographs never attempted — the shape a batch is left in
+ * when a deploy kills the background loop and the row keeps saying `running`
+ * (#1742). It is a resume: already-read photographs are not paid for twice.
+ */
+export const useRetryIdExtractionBatch = (
+  batchId: string,
+  options?: UseMutationOptions<
+    RetryIdExtractionBatchResponse,
+    FetchError,
+    { scope?: "failed" | "pending" } | void
+  >,
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (vars) =>
+      sdk.client.fetch<RetryIdExtractionBatchResponse>(
+        `/partners/people/id-extraction/batch/${batchId}/retry`,
+        { method: "POST", query: { scope: vars?.scope ?? "failed" } },
+      ),
+    ...options,
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: idExtractionBatchQueryKeys.all,
+      })
+      options?.onSuccess?.(...args)
+    },
+  })
+}
+
+export type ConfirmIdExtractionBatchResponse = {
+  success: boolean
+  message: string
+  batch_id: string
+  /** Confirming twice is a double-click, not an error. */
+  already?: boolean
+}
+
+/** Starts the read on a batch still waiting at `pending_confirmation`. */
+export const useConfirmIdExtractionBatch = (
+  batchId: string,
+  options?: UseMutationOptions<
+    ConfirmIdExtractionBatchResponse,
+    FetchError,
+    void
+  >,
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      sdk.client.fetch<ConfirmIdExtractionBatchResponse>(
+        `/partners/people/id-extraction/batch/${batchId}/confirm`,
+        { method: "POST" },
+      ),
+    ...options,
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: idExtractionBatchQueryKeys.all,
+      })
+      options?.onSuccess?.(...args)
+    },
+  })
+}

--- a/apps/partner-ui/src/lib/__tests__/id-batch-approval.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/id-batch-approval.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildApprovePayload,
+  buildItemCorrection,
+  isApprovable,
+} from "../id-batch-approval"
+import type { IdExtractionDraft } from "../../hooks/api/id-extraction-batch"
+
+const draft = (over: Partial<IdExtractionDraft> = {}): IdExtractionDraft => ({
+  first_name: "Tarun",
+  last_name: "Debnath",
+  gender: "male",
+  date_of_birth: "1988-04-02",
+  id_type: "aadhaar",
+  id_last4: "4021",
+  address: {
+    street: "12 Weavers Lane",
+    city: "Shantipur",
+    state: "West Bengal",
+    postal_code: "741404",
+    country: "IN",
+  },
+  ...over,
+})
+
+describe("buildItemCorrection", () => {
+  it("sends nothing when the operator changed nothing", () => {
+    expect(
+      buildItemCorrection(draft(), {
+        first_name: "Tarun",
+        address: { city: "Shantipur" },
+      })
+    ).toBeNull()
+  })
+
+  it("sends only the field that actually changed", () => {
+    expect(
+      buildItemCorrection(draft(), { first_name: "Tarun ", last_name: "Dey" })
+    ).toEqual({ last_name: "Dey" })
+  })
+
+  it("treats a field the operator emptied as a clear, not as untouched", () => {
+    expect(buildItemCorrection(draft(), { gender: "  " })).toEqual({
+      gender: null,
+    })
+  })
+
+  it("carries the WHOLE address when one address field is edited", () => {
+    // 🔴 The regression this file exists for. The server merges shallowly, so
+    // a correction of `{ address: { city } }` deletes the four fields the
+    // reader got right. Anything less than the full address here is a bug.
+    const correction = buildItemCorrection(draft(), {
+      address: { city: "Kolkata" },
+    })
+
+    expect(correction).toEqual({
+      address: {
+        street: "12 Weavers Lane",
+        city: "Kolkata",
+        state: "West Bengal",
+        postal_code: "741404",
+        country: "IN",
+      },
+    })
+  })
+
+  it("does not send an address at all when only untouched address fields are held", () => {
+    expect(
+      buildItemCorrection(draft(), { address: { state: "West Bengal" } })
+    ).toBeNull()
+  })
+
+  it("builds an address from nothing when the reader found none", () => {
+    expect(
+      buildItemCorrection(draft({ address: null }), {
+        address: { city: "Kolkata" },
+      })
+    ).toEqual({
+      address: {
+        street: null,
+        city: "Kolkata",
+        state: null,
+        postal_code: null,
+        country: null,
+      },
+    })
+  })
+})
+
+describe("buildApprovePayload", () => {
+  const items = [
+    { id: "item_1", draft: draft() },
+    { id: "item_2", draft: draft({ first_name: "Tapas", last_name: "Gui" }) },
+    { id: "item_3", draft: null },
+  ]
+
+  it("names the selected items explicitly, even when everything is selected", () => {
+    // Omitting item_ids means "everything with a usable draft" server-side —
+    // a different set if a retry lands between the render and the click.
+    const payload = buildApprovePayload(
+      items,
+      ["item_1", "item_2", "item_3"],
+      {}
+    )
+    expect(payload.item_ids).toEqual(["item_1", "item_2", "item_3"])
+    expect(payload.corrections).toBeUndefined()
+  })
+
+  it("ignores edits belonging to items that were not selected", () => {
+    const payload = buildApprovePayload(items, ["item_1"], {
+      item_1: { last_name: "Dey" },
+      item_2: { last_name: "Guin" },
+    })
+    expect(payload.item_ids).toEqual(["item_1"])
+    expect(payload.corrections).toEqual({ item_1: { last_name: "Dey" } })
+  })
+
+  it("drops ids that are not in the batch rather than passing them through", () => {
+    expect(buildApprovePayload(items, ["item_1", "nope"], {}).item_ids).toEqual([
+      "item_1",
+    ])
+  })
+})
+
+describe("isApprovable", () => {
+  it("refuses a draft with no name", () => {
+    expect(
+      isApprovable({
+        id: "i",
+        status: "completed",
+        draft: draft({ first_name: null, last_name: null }),
+      })
+    ).toBe(false)
+  })
+
+  it("lets a correction rescue a draft the reader refused", () => {
+    expect(
+      isApprovable(
+        {
+          id: "i",
+          status: "completed",
+          draft: draft({ first_name: null, last_name: null }),
+        },
+        { first_name: "Tarun" }
+      )
+    ).toBe(true)
+  })
+
+  it("refuses an item that was already approved", () => {
+    expect(
+      isApprovable({ id: "i", status: "approved", draft: draft() })
+    ).toBe(false)
+  })
+
+  it("refuses an item that was never read", () => {
+    expect(isApprovable({ id: "i", status: "failed", draft: null })).toBe(false)
+  })
+})

--- a/apps/partner-ui/src/lib/id-batch-approval.ts
+++ b/apps/partner-ui/src/lib/id-batch-approval.ts
@@ -1,0 +1,165 @@
+import type {
+  IdExtractionBatchItem,
+  IdExtractionDraft,
+} from "../hooks/api/id-extraction-batch"
+
+/**
+ * Turning what an operator typed into the approve call's `corrections` (#1816).
+ *
+ * The same ID card read five times in prod did not split the name identically
+ * (4x `first_name: "Tarun Debnath"`, 1x `"Tarun"`). Correcting that by hand is
+ * the entire purpose of the review screen, so this is the function that decides
+ * what the server is told — and there are two ways to get it wrong quietly.
+ *
+ * 🔴 The server applies a correction as a SHALLOW merge over the draft:
+ * `{ ...draft, ...correction }`. So a correction naming `address` REPLACES the
+ * whole address. Sending `{ address: { city: "Kolkata" } }` because the city
+ * was the only field touched would silently delete the street, state, postal
+ * code and country the reader got right. Every address edit therefore carries
+ * the whole merged address, never the changed key alone.
+ *
+ * 🔑 And an untouched field is never sent. A correction that echoes the draft
+ * back is indistinguishable from an operator's confirmation, which is fine
+ * until the draft changes underneath (a retry re-reads the photograph) — then
+ * the echo overwrites the newer read with the older one.
+ */
+
+/** The flat fields the review form edits. Address is handled separately. */
+export const EDITABLE_DRAFT_FIELDS = [
+  "first_name",
+  "last_name",
+  "gender",
+  "date_of_birth",
+  "id_type",
+] as const
+
+export type EditableDraftField = (typeof EDITABLE_DRAFT_FIELDS)[number]
+
+export const EDITABLE_ADDRESS_FIELDS = [
+  "street",
+  "city",
+  "state",
+  "postal_code",
+  "country",
+] as const
+
+export type EditableAddressField = (typeof EDITABLE_ADDRESS_FIELDS)[number]
+
+/** What the form holds for one item: only the fields somebody typed into. */
+export type ItemEdits = {
+  [K in EditableDraftField]?: string
+} & {
+  address?: { [K in EditableAddressField]?: string }
+}
+
+export type BatchEdits = Record<string, ItemEdits>
+
+export type DraftCorrection = Record<string, unknown>
+
+/** Trim, and treat a field emptied by the operator as an explicit clear. */
+const normalise = (v: string): string | null => {
+  const t = v.trim()
+  return t.length ? t : null
+}
+
+const sameValue = (a: unknown, b: unknown): boolean => {
+  const norm = (v: unknown) =>
+    v === undefined || v === null || v === "" ? null : String(v).trim()
+  return norm(a) === norm(b)
+}
+
+/**
+ * The correction for one item, or `null` when nothing was actually changed.
+ *
+ * Exported on its own because "did this item change?" is also the question the
+ * screen asks to decide whether to show an edited marker.
+ */
+export const buildItemCorrection = (
+  draft: IdExtractionDraft | null | undefined,
+  edits: ItemEdits | undefined,
+): DraftCorrection | null => {
+  if (!edits) return null
+
+  const correction: DraftCorrection = {}
+
+  for (const field of EDITABLE_DRAFT_FIELDS) {
+    const typed = edits[field]
+    if (typed === undefined) continue
+    const next = normalise(typed)
+    if (sameValue(next, draft?.[field])) continue
+    correction[field] = next
+  }
+
+  if (edits.address) {
+    const current = draft?.address ?? {}
+    let changed = false
+    // 🔴 Whole address, always — see the shallow-merge note above.
+    const merged: Record<string, string | null> = {}
+    for (const field of EDITABLE_ADDRESS_FIELDS) {
+      const typed = edits.address[field]
+      const existing = (current as Record<string, unknown>)[field]
+      if (typed === undefined) {
+        merged[field] = (existing ?? null) as string | null
+        continue
+      }
+      const next = normalise(typed)
+      merged[field] = next
+      if (!sameValue(next, existing)) changed = true
+    }
+    if (changed) correction.address = merged
+  }
+
+  return Object.keys(correction).length ? correction : null
+}
+
+export type ApprovePayload = {
+  item_ids: string[]
+  corrections?: Record<string, DraftCorrection>
+}
+
+/**
+ * The body for `POST .../batch/:id/approve`.
+ *
+ * ⚠️ `item_ids` is always sent explicitly, even when the operator selected
+ * everything. Omitting it means "every item with a usable draft" server-side,
+ * which is a different set the moment a retry finishes between the render and
+ * the click — the operator would approve a draft they never saw.
+ */
+export const buildApprovePayload = (
+  items: Pick<IdExtractionBatchItem, "id" | "draft">[],
+  selectedIds: string[],
+  edits: BatchEdits,
+): ApprovePayload => {
+  const selected = new Set(selectedIds)
+  const chosen = items.filter((i) => selected.has(i.id))
+
+  const corrections: Record<string, DraftCorrection> = {}
+  for (const item of chosen) {
+    const correction = buildItemCorrection(item.draft, edits[item.id])
+    if (correction) corrections[item.id] = correction
+  }
+
+  return {
+    item_ids: chosen.map((i) => i.id),
+    ...(Object.keys(corrections).length ? { corrections } : {}),
+  }
+}
+
+/**
+ * An item can be approved when it carries a draft with a name — the server's
+ * own rule, recomputed here so the screen does not offer a button that will
+ * come back as "skipped".
+ *
+ * 🔑 It reads the EDITED name, not the draft's: supplying a missing name is
+ * exactly how a correction rescues a draft the reader itself refused.
+ */
+export const isApprovable = (
+  item: Pick<IdExtractionBatchItem, "id" | "status" | "draft">,
+  edits?: ItemEdits,
+): boolean => {
+  if (item.status === "approved") return false
+  if (!item.draft) return false
+  const first = edits?.first_name ?? item.draft.first_name ?? ""
+  const last = edits?.last_name ?? item.draft.last_name ?? ""
+  return Boolean(String(first).trim() || String(last).trim())
+}

--- a/apps/partner-ui/src/routes/assistant/assistant.tsx
+++ b/apps/partner-ui/src/routes/assistant/assistant.tsx
@@ -14,6 +14,7 @@
  *     the full viewport width on small screens.
  */
 import { useCallback, useEffect, useState } from "react"
+import { Navigate, useSearchParams } from "react-router-dom"
 import { Container, Heading, Text, Button, IconButton, toast } from "@medusajs/ui"
 import { Sparkles, Plus, Trash, Spinner, SidebarLeft, BarsThree, XMark } from "@medusajs/icons"
 
@@ -21,11 +22,21 @@ import { sdk } from "../../lib/client"
 import {
   usePartnerConversations,
   useDeleteConversation,
+  type ConversationSummary,
   type StoredMessage,
 } from "../../hooks/api/assistant-conversations"
 import { ChatThread } from "./components/chat-thread"
 
 export const Assistant = () => {
+  /**
+   * ID card batch notifications posted before the review screen existed carry
+   * `/assistant?batch=<id>` (#1816). The parameter was never read, so those
+   * bell rows landed the partner on a chat that said nothing about the batch.
+   * They are sent on to the screen that answers the question instead.
+   */
+  const [searchParams] = useSearchParams()
+  const legacyBatchId = searchParams.get("batch")
+
   const { conversations, isPending } = usePartnerConversations()
   const [activeId, setActiveId] = useState<string | null>(null)
   const [threadKey, setThreadKey] = useState(0)
@@ -110,6 +121,16 @@ export const Assistant = () => {
     window.addEventListener("keydown", onKey)
     return () => window.removeEventListener("keydown", onKey)
   }, [mobileOpen])
+
+  /**
+   * After every hook, never before — an early return above them would change
+   * the hook order between renders the moment the parameter appears.
+   */
+  if (legacyBatchId) {
+    return (
+      <Navigate replace to={`/settings/people/id-batches/${legacyBatchId}`} />
+    )
+  }
 
   const historyPanel = (
     <HistoryPanel
@@ -219,7 +240,12 @@ function HistoryPanel({
   onOpen,
   onDelete,
 }: {
-  conversations: any[]
+  /**
+   * Optional because the hook returns `undefined` until the first fetch lands —
+   * the panel already renders an empty state for it, and typing it as a
+   * present array made two call sites type-error.
+   */
+  conversations?: ConversationSummary[]
   isPending: boolean
   activeId: string | null
   isMobile: boolean

--- a/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
+++ b/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
@@ -30,6 +30,7 @@
  *     going without exceeding the model's context budget.
  */
 import { useEffect, useRef, useState, useCallback, useMemo } from "react"
+import { useNavigate } from "react-router-dom"
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport } from "ai"
 import { Button, Text, IconButton, toast, Tooltip, Label, Kbd } from "@medusajs/ui"
@@ -201,6 +202,7 @@ export const ChatThread = ({
   onCreated,
   onCompacted,
 }: ChatThreadProps) => {
+  const navigate = useNavigate()
   const [input, setInput] = useState("")
   const [compacting, setCompacting] = useState(false)
   const [showContextBanner, setShowContextBanner] = useState(false)
@@ -387,13 +389,17 @@ export const ChatThread = ({
                 queryKey: notificationQueryKeys.all,
               })
             },
+            // The finished toast's "Review drafts" action. It was accepted by
+            // the watcher from the start and never supplied, because there was
+            // nowhere to send anybody (#1816).
+            onReview: (id) => navigate(`/settings/people/id-batches/${id}`),
           })
         }
 
         void sendMessage({ text: approvalNote(name, result) })
       }
     },
-    [setMessages, sendMessage]
+    [setMessages, sendMessage, navigate]
   )
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-detail/id-batch-detail.tsx
+++ b/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-detail/id-batch-detail.tsx
@@ -1,0 +1,319 @@
+import { useMemo, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { ArrowPath } from "@medusajs/icons"
+import { Badge, Button, Container, Heading, Text, toast } from "@medusajs/ui"
+
+import { SingleColumnPage } from "../../../../../components/layout/pages"
+import {
+  isBatchSettled,
+  useApproveIdExtractionBatch,
+  useConfirmIdExtractionBatch,
+  useIdExtractionBatch,
+  useRetryIdExtractionBatch,
+  type IdExtractionBatch,
+} from "../../../../../hooks/api/id-extraction-batch"
+import { extractErrorMessage } from "../../../../../lib/extract-error-message"
+import {
+  buildApprovePayload,
+  isApprovable,
+  type BatchEdits,
+  type ItemEdits,
+} from "../../../../../lib/id-batch-approval"
+import { IdBatchItemCard } from "./id-batch-item-card"
+
+/** While the server is still working, ask again. Cheap read, well under the
+ *  ~20s pace at which photographs are read. */
+const POLL_MS = 6_000
+
+const BATCH_STATUS: Record<
+  IdExtractionBatch["status"],
+  { label: string; color: "grey" | "orange" | "green" | "red" }
+> = {
+  pending_confirmation: { label: "Waiting to start", color: "grey" },
+  running: { label: "Reading", color: "orange" },
+  completed: { label: "Finished", color: "green" },
+  failed: { label: "Failed", color: "red" },
+}
+
+/**
+ * The batch review screen (#1816).
+ *
+ * The batch notification has always deep-linked somewhere; until now there was
+ * no screen at the other end, so the only way to see what ten photographs
+ * produced was to ask the assistant. This is that screen: every draft, the
+ * reader's own doubts, and the one button that turns a draft into a person.
+ *
+ * 🔴 Nothing here creates a person on its own. Approval is a separate act
+ * because the reader's field assignment varies between runs of the SAME card,
+ * and at ten photographs the review is exactly what gets skipped.
+ */
+export const IdBatchDetail = () => {
+  const { id = "" } = useParams()
+  const navigate = useNavigate()
+
+  const [edits, setEdits] = useState<BatchEdits>({})
+  const [selected, setSelected] = useState<string[]>([])
+
+  const { batch, items, isPending, isError, error } = useIdExtractionBatch(id, {
+    /**
+     * 🔑 Polling stops on the batch's own settled status, not on a count.
+     * A batch whose background loop a deploy killed keeps saying `running`
+     * (#1742) — that is what `outstanding` below is for, and it is reported
+     * rather than polled at forever.
+     */
+    refetchInterval: (query) =>
+      isBatchSettled(query.state.data?.batch) ? false : POLL_MS,
+  })
+
+  const { mutateAsync: confirm, isPending: isConfirming } =
+    useConfirmIdExtractionBatch(id)
+  const { mutateAsync: retry, isPending: isRetrying } =
+    useRetryIdExtractionBatch(id)
+  const { mutateAsync: approve, isPending: isApproving } =
+    useApproveIdExtractionBatch(id)
+
+  if (isError) throw error
+
+  const rows = items ?? []
+
+  const approvable = useMemo(
+    () => rows.filter((i) => isApprovable(i, edits[i.id])),
+    [rows, edits]
+  )
+
+  /**
+   * ⚠️ Selection is intersected with what is still approvable on every render.
+   * An item selected while it was a draft can be approved by another tab, or
+   * re-read by a retry, between the click and the submit — carrying a stale id
+   * into the payload turns a partial success into a confusing "skipped".
+   */
+  const effectiveSelection = useMemo(() => {
+    const usable = new Set(approvable.map((i) => i.id))
+    return selected.filter((s) => usable.has(s))
+  }, [selected, approvable])
+
+  const handleApprove = async () => {
+    const payload = buildApprovePayload(rows, effectiveSelection, edits)
+    if (!payload.item_ids.length) return
+
+    try {
+      const res = await approve(payload)
+      setSelected([])
+      if (res.approved > 0) {
+        toast.success(res.message, {
+          description: res.skipped
+            ? `${res.skipped} skipped — the reasons are on each photograph.`
+            : undefined,
+          action: {
+            label: "See people",
+            altText: "Open the people list",
+            onClick: () => navigate("/settings/people"),
+          },
+        })
+      } else {
+        toast.warning(res.message)
+      }
+    } catch (e) {
+      toast.error(extractErrorMessage(e, "Could not add these people."))
+    }
+  }
+
+  const handleRetry = async (scope: "failed" | "pending") => {
+    try {
+      const res = await retry({ scope })
+      if (res.nothing_to_do) {
+        toast.info(res.message)
+      } else {
+        toast.success(res.message)
+      }
+    } catch (e) {
+      toast.error(extractErrorMessage(e, "Could not restart the reading."))
+    }
+  }
+
+  const handleConfirm = async () => {
+    try {
+      const res = await confirm()
+      toast.success(res.message)
+    } catch (e) {
+      toast.error(extractErrorMessage(e, "Could not start the reading."))
+    }
+  }
+
+  if (isPending && !batch) {
+    return (
+      <SingleColumnPage widgets={{ before: [], after: [] }}>
+        <Container className="p-6">
+          <Text size="small" className="text-ui-fg-subtle">
+            Loading this batch…
+          </Text>
+        </Container>
+      </SingleColumnPage>
+    )
+  }
+
+  if (!batch) {
+    return (
+      <SingleColumnPage widgets={{ before: [], after: [] }}>
+        <Container className="p-6">
+          <Heading level="h2">Batch not found</Heading>
+          <Text size="small" className="text-ui-fg-subtle mt-1">
+            It may belong to another partner, or have been removed.
+          </Text>
+          <Button
+            className="mt-4"
+            size="small"
+            variant="secondary"
+            onClick={() => navigate("/settings/people/id-batches")}
+          >
+            All batches
+          </Button>
+        </Container>
+      </SingleColumnPage>
+    )
+  }
+
+  const status = BATCH_STATUS[batch.status] ?? BATCH_STATUS.running
+  const read = batch.completed + batch.approved
+  /**
+   * 🔴 `outstanding` disagrees with `status` exactly when a deploy killed the
+   * in-process loop while the row still says `running`. Saying so, with the
+   * button that fixes it, is the whole reason it is on the response.
+   */
+  const stalled = isBatchSettled(batch) && batch.outstanding > 0
+
+  return (
+    <SingleColumnPage widgets={{ before: [], after: [] }}>
+      <Container className="divide-y p-0">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-x-2">
+              <Heading>ID cards</Heading>
+              <Badge size="2xsmall" color={status.color}>
+                {status.label}
+              </Badge>
+            </div>
+            <Text size="small" className="text-ui-fg-subtle">
+              {read} of {batch.total} read
+              {batch.failed ? ` · ${batch.failed} failed` : ""}
+              {batch.approved ? ` · ${batch.approved} added to people` : ""}
+              {batch.status === "running" && batch.pending
+                ? ` · one photograph roughly every ${Math.round(batch.interval_ms / 1000)}s`
+                : ""}
+            </Text>
+            {batch.notes && (
+              <Text size="xsmall" className="text-ui-fg-muted mt-1">
+                {batch.notes}
+              </Text>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            {batch.status === "pending_confirmation" && (
+              <Button size="small" isLoading={isConfirming} onClick={handleConfirm}>
+                Start reading
+              </Button>
+            )}
+            {batch.failed > 0 && (
+              <Button
+                size="small"
+                variant="secondary"
+                isLoading={isRetrying}
+                onClick={() => handleRetry("failed")}
+              >
+                <ArrowPath className="mr-1" />
+                Re-read {batch.failed} failed
+              </Button>
+            )}
+            <Button
+              size="small"
+              isLoading={isApproving}
+              disabled={effectiveSelection.length === 0}
+              onClick={handleApprove}
+            >
+              {effectiveSelection.length
+                ? `Add ${effectiveSelection.length} to people`
+                : "Add to people"}
+            </Button>
+          </div>
+        </div>
+
+        {stalled && (
+          <div className="bg-ui-bg-subtle px-6 py-3">
+            <Text size="small">
+              This batch says it finished, but {batch.outstanding} photograph(s)
+              were never read — the background run was interrupted.
+            </Text>
+            <Button
+              size="small"
+              variant="secondary"
+              className="mt-2"
+              isLoading={isRetrying}
+              onClick={() => handleRetry("pending")}
+            >
+              <ArrowPath className="mr-1" />
+              Finish the outstanding {batch.outstanding}
+            </Button>
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-2 px-6 py-3">
+          <Text size="small" className="text-ui-fg-subtle">
+            Nobody is added to your people until you approve them here. Correct
+            anything the reader got wrong first — the edit is what gets saved.
+          </Text>
+          <div className="flex items-center gap-x-2">
+            <Button
+              size="small"
+              variant="transparent"
+              disabled={!approvable.length}
+              onClick={() => setSelected(approvable.map((i) => i.id))}
+            >
+              Select all {approvable.length ? `(${approvable.length})` : ""}
+            </Button>
+            <Button
+              size="small"
+              variant="transparent"
+              disabled={!effectiveSelection.length}
+              onClick={() => setSelected([])}
+            >
+              Clear
+            </Button>
+          </div>
+        </div>
+
+        <div className="divide-y">
+          {rows.map((item) => (
+            <IdBatchItemCard
+              key={item.id}
+              item={item}
+              edits={edits[item.id]}
+              selected={effectiveSelection.includes(item.id)}
+              onSelect={(isSelected) =>
+                setSelected((prev) =>
+                  isSelected
+                    ? [...new Set([...prev, item.id])]
+                    : prev.filter((s) => s !== item.id)
+                )
+              }
+              onEdit={(next: ItemEdits) =>
+                setEdits((prev) => ({ ...prev, [item.id]: next }))
+              }
+              onRetry={
+                item.status === "failed" ? () => handleRetry("failed") : undefined
+              }
+              isRetrying={isRetrying}
+            />
+          ))}
+          {!rows.length && (
+            <div className="px-6 py-8">
+              <Text size="small" className="text-ui-fg-subtle">
+                This batch has no photographs in it.
+              </Text>
+            </div>
+          )}
+        </div>
+      </Container>
+    </SingleColumnPage>
+  )
+}

--- a/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-detail/id-batch-item-card.tsx
+++ b/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-detail/id-batch-item-card.tsx
@@ -1,0 +1,279 @@
+import { Badge, Button, Checkbox, Input, Text } from "@medusajs/ui"
+import { ExclamationCircle } from "@medusajs/icons"
+
+import type { IdExtractionBatchItem } from "../../../../../hooks/api/id-extraction-batch"
+import {
+  EDITABLE_ADDRESS_FIELDS,
+  isApprovable,
+  type EditableAddressField,
+  type ItemEdits,
+} from "../../../../../lib/id-batch-approval"
+
+const STATUS: Record<
+  IdExtractionBatchItem["status"],
+  { label: string; color: "grey" | "orange" | "green" | "red" | "blue" }
+> = {
+  pending: { label: "Not read yet", color: "grey" },
+  processing: { label: "Reading", color: "blue" },
+  completed: { label: "Draft ready", color: "orange" },
+  failed: { label: "Failed", color: "red" },
+  approved: { label: "Added to people", color: "green" },
+}
+
+const ADDRESS_LABELS: Record<EditableAddressField, string> = {
+  street: "Street",
+  city: "City",
+  state: "State",
+  postal_code: "Postal code",
+  country: "Country",
+}
+
+type Props = {
+  item: IdExtractionBatchItem
+  edits?: ItemEdits
+  selected: boolean
+  onSelect: (selected: boolean) => void
+  onEdit: (edits: ItemEdits) => void
+  onRetry?: () => void
+  isRetrying?: boolean
+}
+
+const Field = ({
+  label,
+  value,
+  placeholder,
+  disabled,
+  onChange,
+}: {
+  label: string
+  value: string
+  placeholder?: string
+  disabled?: boolean
+  onChange: (v: string) => void
+}) => (
+  <div>
+    <Text size="xsmall" className="text-ui-fg-subtle mb-1">
+      {label}
+    </Text>
+    <Input
+      size="small"
+      value={value}
+      placeholder={placeholder}
+      /**
+       * 🔴 Locked once the person exists. Corrections are only ever applied on
+       * the way from a draft to a person, so an editable box on an approved
+       * card invites an edit that is silently discarded — the person is on the
+       * roster and this screen is no longer the way to change them.
+       */
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  </div>
+)
+
+/**
+ * One photograph from a batch (#1816).
+ *
+ * The fields are editable in place because the reader's field ASSIGNMENT is
+ * what varies, not its reading: the same card read five times in prod put the
+ * whole name in `first_name` four times and split it once. The operator fixing
+ * that is the point of this screen, so the correction is typed where the wrong
+ * value is shown rather than in a separate dialog.
+ *
+ * 🔴 The reader's own warnings are rendered verbatim. They are the only signal
+ * that a name was kept whole or a field dropped, and summarising them away is
+ * how a review becomes a rubber stamp.
+ */
+export const IdBatchItemCard = ({
+  item,
+  edits,
+  selected,
+  onSelect,
+  onEdit,
+  onRetry,
+  isRetrying,
+}: Props) => {
+  const status = STATUS[item.status] ?? STATUS.pending
+  const draft = item.draft
+  const approvable = isApprovable(item, edits)
+  const locked = item.status === "approved"
+
+  const valueOf = (field: keyof ItemEdits & string): string => {
+    const typed = (edits as Record<string, unknown> | undefined)?.[field]
+    if (typeof typed === "string") return typed
+    const fromDraft = (draft as Record<string, unknown> | undefined)?.[field]
+    return fromDraft == null ? "" : String(fromDraft)
+  }
+
+  const addressValueOf = (field: EditableAddressField): string => {
+    const typed = edits?.address?.[field]
+    if (typeof typed === "string") return typed
+    const fromDraft = draft?.address?.[field]
+    return fromDraft == null ? "" : String(fromDraft)
+  }
+
+  const setField = (field: string, v: string) =>
+    onEdit({ ...(edits ?? {}), [field]: v })
+
+  const setAddress = (field: EditableAddressField, v: string) =>
+    onEdit({ ...(edits ?? {}), address: { ...(edits?.address ?? {}), [field]: v } })
+
+  return (
+    <div className="flex flex-col gap-y-4 px-6 py-5 sm:flex-row sm:gap-x-5">
+      <div className="flex items-start gap-x-3">
+        <Checkbox
+          checked={selected}
+          disabled={!approvable}
+          onCheckedChange={(v) => onSelect(!!v)}
+          aria-label={`Approve photograph ${item.position + 1}`}
+        />
+        <a
+          href={item.image_url}
+          target="_blank"
+          rel="noreferrer"
+          className="block shrink-0"
+          title="Open the original photograph"
+        >
+          <img
+            src={item.image_url}
+            alt={`ID card ${item.position + 1}`}
+            className="h-24 w-24 rounded-lg border border-ui-border-base object-cover bg-ui-bg-subtle"
+          />
+        </a>
+      </div>
+
+      <div className="flex-1">
+        <div className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1">
+          <Text size="small" weight="plus">
+            Photograph {item.position + 1}
+          </Text>
+          <Badge size="2xsmall" color={status.color}>
+            {status.label}
+          </Badge>
+          {item.attempts > 1 && (
+            <Text size="xsmall" className="text-ui-fg-muted">
+              {item.attempts} attempts
+            </Text>
+          )}
+          {item.person_id && (
+            <Text size="xsmall" className="text-ui-fg-muted">
+              {item.person_id}
+            </Text>
+          )}
+        </div>
+
+        {item.status === "failed" && (
+          <div className="mb-3 flex items-start gap-x-2 rounded-lg bg-ui-bg-subtle px-3 py-2">
+            <ExclamationCircle className="text-ui-fg-error mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <Text size="small">{item.error || "Could not be read."}</Text>
+              {onRetry && (
+                <Button
+                  size="small"
+                  variant="transparent"
+                  className="mt-1 px-0"
+                  isLoading={isRetrying}
+                  onClick={onRetry}
+                >
+                  Re-read this batch's failures
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {!draft && item.status !== "failed" && (
+          <Text size="small" className="text-ui-fg-subtle">
+            {item.status === "processing"
+              ? "Being read now."
+              : "Waiting its turn — photographs are read one at a time."}
+          </Text>
+        )}
+
+        {draft && (
+          <>
+            {draft.warnings?.length ? (
+              <ul className="mb-3 list-inside list-disc rounded-lg bg-ui-bg-subtle px-3 py-2">
+                {draft.warnings.map((w, i) => (
+                  <li key={i}>
+                    <Text size="xsmall" className="text-ui-fg-subtle inline">
+                      {w}
+                    </Text>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field
+                label="First name"
+                value={valueOf("first_name")}
+                placeholder="Not read"
+                disabled={locked}
+                onChange={(v) => setField("first_name", v)}
+              />
+              <Field
+                label="Last name"
+                value={valueOf("last_name")}
+                placeholder="Not read"
+                disabled={locked}
+                onChange={(v) => setField("last_name", v)}
+              />
+              <Field
+                label="Gender"
+                value={valueOf("gender")}
+                placeholder="Not read"
+                disabled={locked}
+                onChange={(v) => setField("gender", v)}
+              />
+              <Field
+                label="Date of birth"
+                value={valueOf("date_of_birth")}
+                placeholder="YYYY-MM-DD"
+                disabled={locked}
+                onChange={(v) => setField("date_of_birth", v)}
+              />
+              <Field
+                label="ID type"
+                value={valueOf("id_type")}
+                placeholder="Not read"
+                disabled={locked}
+                onChange={(v) => setField("id_type", v)}
+              />
+              <div>
+                <Text size="xsmall" className="text-ui-fg-subtle mb-1">
+                  ID number
+                </Text>
+                <Text size="small" className="py-1.5">
+                  {/* Only the last four digits are ever stored, and they are
+                      not editable — a corrected middle digit could not survive
+                      into the record anyway. */}
+                  {draft.id_number_masked || (draft.id_last4 ? `••••${draft.id_last4}` : "—")}
+                </Text>
+              </div>
+            </div>
+
+            <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              {EDITABLE_ADDRESS_FIELDS.map((f) => (
+                <Field
+                  key={f}
+                  label={ADDRESS_LABELS[f]}
+                  value={addressValueOf(f)}
+                  placeholder="Not read"
+                  disabled={locked}
+                  onChange={(v) => setAddress(f, v)}
+                />
+              ))}
+            </div>
+
+            {!approvable && item.status !== "approved" && (
+              <Text size="xsmall" className="text-ui-fg-error mt-3">
+                A first or last name is needed before this one can be added.
+              </Text>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-detail/index.ts
+++ b/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-detail/index.ts
@@ -1,0 +1,1 @@
+export { IdBatchDetail as Component } from "./id-batch-detail.tsx"

--- a/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-list/id-batch-list.tsx
+++ b/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-list/id-batch-list.tsx
@@ -1,0 +1,131 @@
+import { useNavigate } from "react-router-dom"
+import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
+
+import { SingleColumnPage } from "../../../../../components/layout/pages"
+import {
+  useIdExtractionBatches,
+  type IdExtractionBatchSummary,
+} from "../../../../../hooks/api/id-extraction-batch"
+
+const STATUS: Record<
+  IdExtractionBatchSummary["status"],
+  { label: string; color: "grey" | "orange" | "green" | "red" }
+> = {
+  pending_confirmation: { label: "Waiting to start", color: "grey" },
+  running: { label: "Reading", color: "orange" },
+  completed: { label: "Finished", color: "green" },
+  failed: { label: "Failed", color: "red" },
+}
+
+const when = (v?: string | null) =>
+  v
+    ? new Date(v).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "—"
+
+/**
+ * Every batch of ID cards this partner has sent for reading (#1816).
+ *
+ * A batch is created by asking the assistant to read a stack of photographs;
+ * this is where they are found afterwards, which the notification's deep link
+ * has needed since the feature shipped.
+ */
+export const IdBatchList = () => {
+  const navigate = useNavigate()
+  const { data, isPending, isError, error } = useIdExtractionBatches({
+    limit: 20,
+  })
+
+  if (isError) throw error
+
+  const batches = data?.batches ?? []
+
+  return (
+    <SingleColumnPage widgets={{ before: [], after: [] }}>
+      <Container className="divide-y p-0">
+        <div className="px-6 py-4">
+          <Heading>ID card batches</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Photographs read one at a time in the background. Nobody joins your
+            people until you approve the drafts.
+          </Text>
+        </div>
+
+        {isPending && (
+          <div className="px-6 py-8">
+            <Text size="small" className="text-ui-fg-subtle">
+              Loading…
+            </Text>
+          </div>
+        )}
+
+        {!isPending && !batches.length && (
+          <div className="px-6 py-8">
+            <Text size="small" className="text-ui-fg-subtle">
+              No batches yet. Send a stack of ID photographs to the assistant
+              and it will read them here.
+            </Text>
+            <Button
+              size="small"
+              variant="secondary"
+              className="mt-3"
+              onClick={() => navigate("/assistant")}
+            >
+              Open the assistant
+            </Button>
+          </div>
+        )}
+
+        <div className="divide-y">
+          {batches.map((b) => {
+            const status = STATUS[b.status] ?? STATUS.running
+            const read = (b.completed ?? 0) + (b.approved ?? 0)
+            return (
+              <button
+                key={b.id}
+                type="button"
+                className="flex w-full flex-col gap-y-1 px-6 py-4 text-left transition-colors hover:bg-ui-bg-base-hover"
+                onClick={() =>
+                  navigate(`/settings/people/id-batches/${b.id}`)
+                }
+              >
+                <div className="flex flex-wrap items-center gap-x-2">
+                  <Text size="small" weight="plus">
+                    {b.total ?? 0} photograph{(b.total ?? 0) === 1 ? "" : "s"}
+                  </Text>
+                  <Badge size="2xsmall" color={status.color}>
+                    {status.label}
+                  </Badge>
+                  {/* Reported whenever it disagrees with the status — a batch
+                      that says "finished" with work left is the shape a killed
+                      background run leaves behind (#1742). */}
+                  {(b.outstanding ?? 0) > 0 && b.status !== "running" && (
+                    <Badge size="2xsmall" color="red">
+                      {b.outstanding} outstanding
+                    </Badge>
+                  )}
+                </div>
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  {read} read
+                  {b.failed ? ` · ${b.failed} failed` : ""}
+                  {b.approved ? ` · ${b.approved} added` : ""}
+                  {" · "}
+                  {when(b.created_at)}
+                </Text>
+                {b.notes && (
+                  <Text size="xsmall" className="text-ui-fg-muted">
+                    {b.notes}
+                  </Text>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </Container>
+    </SingleColumnPage>
+  )
+}

--- a/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-list/index.ts
+++ b/apps/partner-ui/src/routes/settings/people/id-batches/id-batch-list/index.ts
@@ -1,0 +1,1 @@
+export { IdBatchList as Component } from "./id-batch-list.tsx"


### PR DESCRIPTION
Closes the "no UI" tail on #1816 — item 5 in the session-59 handoff on #352.

## What was missing

The batch feature shipped as API + workflow. Its notification deep-linked to `/assistant?batch=<id>` — a route that **existed and ignored the parameter**, so a partner who read the bell landed on a chat that said nothing about their batch. The only way to see what ten photographs produced was to ask the assistant for it.

## The screen

- **`/settings/people/id-batches`** — the partner's batches, newest first.
- **`/settings/people/id-batches/:id`** — the review: every photograph, its draft, the reader's own warnings *verbatim*, and the one button that turns a draft into a person. Polls while the batch is still being read and stops on its settled status.

Fields are editable in place, because the reader's field **assignment** is what varies rather than its reading — the same card read five times in prod put the whole name in `first_name` four times and split it once. A correction can also **rescue** a draft the reader itself refused for having no name: approvability is recomputed from the edited name, so the checkbox lights up the moment a name is typed.

## Two ways to get corrections wrong

Both are the kind that pass every test and lose data in production:

1. **The server applies a correction as a shallow merge** (`{...draft, ...correction}`). Sending `{ address: { city } }` because the city was the only field touched would silently delete the street, state, postal code and country the reader got right. Every address edit therefore carries the whole merged address.
2. **`item_ids` is always sent explicitly**, even when everything is selected. Omitting it means "every item with a usable draft" server-side — a different set the moment a retry finishes between the render and the click, and the operator would approve a draft they never saw.

`buildApprovePayload` / `buildItemCorrection` / `isApprovable` are pure and covered by 13 tests. Each was **mutation-checked**: reverting the whole-address merge, the explicit `item_ids`, and the correction-aware approvability each turns the matching test red.

## Also in here

- One `idBatchReviewUrl` used by both the success and failure bell rows, so they cannot drift. Rows already in partners' bells carry the old link, so `/assistant?batch=` now **redirects** to the review screen.
- The finished toast's **"Review drafts"** action — accepted by the watcher since day one and never supplied, because there was nowhere to send anybody.
- The list route returns `outstanding`, as the detail route already did. A batch whose background loop a deploy killed keeps saying `running` (#1742); the list now shows that disagreement, and the detail screen offers "Finish the outstanding N".
- Fields are **locked on an already-approved card**. Corrections only apply on the way from draft to person, so an editable box there invites an edit that is discarded.
- `HistoryPanel.conversations` is typed — two pre-existing errors in a file this branch touches, and partner-ui CI fails on *any* error in a changed file.

## Verified by rendering it, not just by testing it

A six-item batch covering every state (draft, unnamed draft, failed, approved, not yet read) was seeded on the local DB and driven in a real browser:

- list and detail render, **no console errors**;
- `/assistant?batch=…` redirects to the review screen;
- "Select all (2)" correctly excludes the unnamed draft, and becomes "Add 3 to people" once it is given a name;
- **Approve created the people**, and the counts updated without a refresh (invalidation intact — `...options` is spread *before* `onSuccess`, the #1800 shape);
- a corrected city landed as `Kolkata` **while `West Bengal` and `IN` survived** — the shallow-merge case, end to end.

All local test rows were removed afterwards.

## Checks

- `vitest` — 103 partner-ui lib tests green (13 new).
- `jest` — 18 green on `id-extraction-batch.unit`, including the new deep-link assertions.
- `tsc` on changed files (the gate CI applies) — clean.
- `pnpm --filter @jyt/partner-ui build` — green.
- `check:prod-build` — fails only on `src/scripts/__tests__/generate-integration-test.e2e.spec.ts` importing `@jest/core`, which is not installed anywhere in the workspace and predates this branch by months. No error in any file this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
