### PR TITLE
fix(checkout): Stripe offered only a card, behind a tile named after Stripe

### DIFF
--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -381,6 +381,28 @@ module.exports = defineConfig({
                         options: {
                           apiKey: process.env.STRIPE_API_KEY,
                           webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+                          /**
+                           * 🔴 Without this the intent is created with NEITHER
+                           * `payment_method_types` NOR `automatic_payment_methods`,
+                           * and Stripe answers `payment_method_types: ["card"]`.
+                           * Measured, not assumed — an intent created exactly
+                           * the way this provider creates one came back card-only
+                           * every time. So the Payment Element could only ever
+                           * render a card field, in every region this provider
+                           * serves (America, Australia, Indonesia, Israel and
+                           * half of Europe).
+                           *
+                           * Enabled, Stripe returns what the account actually
+                           * supports for the currency: eur → card, klarna, link,
+                           * satispay; aud/usd → card, link. The rest is a
+                           * Dashboard setting, not a code change.
+                           *
+                           * 🔑 `./src/modules/stripe-connect-payment` has always
+                           * set `automatic_payment_methods: { enabled: true }`
+                           * on its own intents. This is the stock provider
+                           * catching up with the one beside it.
+                           */
+                          automaticPaymentMethods: true,
                         },
                       },
                     ]

--- a/apps/storefront/src/lib/constants.tsx
+++ b/apps/storefront/src/lib/constants.tsx
@@ -12,14 +12,16 @@ export const paymentInfoMap: Record<
   { title: string; icon: React.JSX.Element }
 > = {
   
+  // Named for what the shopper does, not for who processes it. "Stripe" told
+  // a buyer nothing about how they were paying, and sat above a card field.
   pp_stripe_stripe: {
-    title: "Stripe",
+    title: "Card & more",
     icon: <CreditCard />,
   },
   // Single buyer-facing "Stripe" — Connect (merchant-direct) + standard resolve
   // per the owning partner's onboarding status; the buyer never sees the split (#985).
   "pp_stripe-connect_stripe-connect": {
-    title: "Stripe",
+    title: "Card & more",
     icon: <CreditCard />,
   },
   "pp_medusa-payments_default": {

--- a/apps/storefront/src/lib/util/__tests__/payment-methods.test.ts
+++ b/apps/storefront/src/lib/util/__tests__/payment-methods.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  foldPaymentMethods,
+  shouldShowMethodChooser,
+} from "../payment-methods"
+
+const STRIPE = { id: "pp_stripe_stripe" }
+const CONNECT = { id: "pp_stripe-connect_stripe-connect" }
+const PAYU = { id: "pp_payu_payu" }
+const IDEAL = { id: "pp_stripe-ideal_stripe" }
+
+describe("foldPaymentMethods", () => {
+  it("leaves a region with a single provider alone", () => {
+    expect(foldPaymentMethods([STRIPE]).map((m) => m.id)).toEqual([
+      "pp_stripe_stripe",
+    ])
+  })
+
+  it("folds the two generic Stripe providers into one entry", () => {
+    // Europe carries both; they differ only in where the money settles, and
+    // #985 says the buyer never sees that split.
+    expect(foldPaymentMethods([STRIPE, CONNECT]).map((m) => m.id)).toEqual([
+      "pp_stripe_stripe",
+    ])
+  })
+
+  it("keeps the provider the cart is already paying through", () => {
+    // 🔴 The fold must never move an in-flight payment between settlement
+    // routes. If a session exists on Connect, Connect survives the fold.
+    expect(
+      foldPaymentMethods([STRIPE, CONNECT], "pp_stripe-connect_stripe-connect")
+        .map((m) => m.id)
+    ).toEqual(["pp_stripe-connect_stripe-connect"])
+  })
+
+  it("holds the folded entry in the position of the first Stripe provider", () => {
+    const folded = foldPaymentMethods(
+      [PAYU, STRIPE, CONNECT],
+      "pp_stripe-connect_stripe-connect"
+    )
+    expect(folded.map((m) => m.id)).toEqual([
+      "pp_payu_payu",
+      "pp_stripe-connect_stripe-connect",
+    ])
+  })
+
+  it("does not fold the method-specific Stripe providers", () => {
+    // iDeal and Bancontact are real, distinguishable choices to a shopper —
+    // unlike "Stripe", which is a processor.
+    expect(foldPaymentMethods([STRIPE, IDEAL]).map((m) => m.id)).toEqual([
+      "pp_stripe_stripe",
+      "pp_stripe-ideal_stripe",
+    ])
+  })
+
+  it("keeps non-Stripe providers untouched", () => {
+    expect(foldPaymentMethods([PAYU, STRIPE]).map((m) => m.id)).toEqual([
+      "pp_payu_payu",
+      "pp_stripe_stripe",
+    ])
+  })
+
+  it("falls back to the raw id when nothing names the provider", () => {
+    expect(foldPaymentMethods([{ id: "pp_unknown_x" }])[0].title).toBe(
+      "pp_unknown_x"
+    )
+  })
+})
+
+describe("shouldShowMethodChooser", () => {
+  it("hides the chooser when the region offers one way to pay", () => {
+    expect(shouldShowMethodChooser(foldPaymentMethods([STRIPE]))).toBe(false)
+    // The whole point: Europe's two "Stripe" tiles are one choice, not two.
+    expect(shouldShowMethodChooser(foldPaymentMethods([STRIPE, CONNECT]))).toBe(
+      false
+    )
+  })
+
+  it("shows it when there is a real choice", () => {
+    expect(shouldShowMethodChooser(foldPaymentMethods([PAYU, STRIPE]))).toBe(
+      true
+    )
+  })
+
+  it("hides it when the region offers nothing", () => {
+    expect(shouldShowMethodChooser([])).toBe(false)
+  })
+})

--- a/apps/storefront/src/lib/util/payment-methods.ts
+++ b/apps/storefront/src/lib/util/payment-methods.ts
@@ -1,0 +1,83 @@
+import { isStripeLike, paymentInfoMap } from "@lib/constants"
+
+/**
+ * What the shopper is actually asked to choose between at checkout.
+ *
+ * The raw list is the region's payment PROVIDERS, which is an implementation
+ * detail with a processor's brand on it. Two things went wrong when it was
+ * rendered directly:
+ *
+ * 🔴 A region with one provider still drew a chooser — a single tile reading
+ * "Stripe", above a card field. There is no choice to make there, and naming
+ * the processor tells the shopper nothing about how they are going to pay.
+ *
+ * 🔴 Europe carries BOTH `pp_stripe_stripe` and
+ * `pp_stripe-connect_stripe-connect`, so it drew two tiles, both titled
+ * "Stripe". The split between platform and merchant-direct settlement is
+ * deliberate and #985 says the buyer never sees it — but the UI showed it
+ * twice and gave the two halves the same name.
+ *
+ * So Stripe-like providers fold into ONE buyer-facing entry. Card, wallets and
+ * whatever else Stripe offers for the currency are then chosen inside the
+ * Payment Element, which is where a shopper can actually see them.
+ */
+
+export type BuyerPaymentMethod = {
+  /** The provider id the session is initiated with. */
+  id: string
+  title: string
+}
+
+/** The generic Stripe entries, which differ only in how we settle. */
+const isGenericStripe = (id: string) =>
+  isStripeLike(id) &&
+  id !== "pp_stripe-ideal_stripe" &&
+  id !== "pp_stripe-bancontact_stripe"
+
+/**
+ * Fold the region's providers into the choices worth showing.
+ *
+ * ⚠️ `activeProviderId` — the provider of a session the cart already has —
+ * wins the fold. Otherwise a shopper who has already started paying through
+ * one Stripe provider could be silently moved onto the other by a re-render,
+ * and that decides where the money settles.
+ */
+export const foldPaymentMethods = (
+  methods: { id: string }[],
+  activeProviderId?: string
+): BuyerPaymentMethod[] => {
+  const out: BuyerPaymentMethod[] = []
+  let stripeSlot = -1
+
+  for (const method of methods) {
+    const title = paymentInfoMap[method.id]?.title ?? method.id
+
+    if (!isGenericStripe(method.id)) {
+      out.push({ id: method.id, title })
+      continue
+    }
+
+    if (stripeSlot === -1) {
+      stripeSlot = out.length
+      out.push({ id: method.id, title })
+      continue
+    }
+
+    // A second generic Stripe provider: keep the one the cart is already
+    // paying through, otherwise leave the first in place.
+    if (method.id === activeProviderId) {
+      out[stripeSlot] = { id: method.id, title }
+    }
+  }
+
+  return out
+}
+
+/**
+ * A chooser is worth drawing only when there is something to choose. With one
+ * method the tile is pure decoration — and, being a processor's name, worse
+ * than decoration.
+ */
+export const shouldShowMethodChooser = (
+  folded: BuyerPaymentMethod[]
+): boolean => folded.length > 1

--- a/apps/storefront/src/modules/checkout/components/checkout-payment-section/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-payment-section/index.tsx
@@ -9,6 +9,10 @@ import {
   paymentInfoMap,
 } from "@lib/constants"
 import compareAddresses from "@lib/util/compare-addresses"
+import {
+  foldPaymentMethods,
+  shouldShowMethodChooser,
+} from "@lib/util/payment-methods"
 import { CreditCard } from "@medusajs/icons"
 import type { HttpTypes } from "@medusajs/types"
 import {
@@ -58,6 +62,18 @@ export default function CheckoutPaymentSection({
   const [, setPaymentComplete] = useState(false)
   const [billingOpen, setBillingOpen] = useState(false)
   const [showBillingDetails, setShowBillingDetails] = useState(false)
+
+  /**
+   * What the shopper is asked to choose between — providers folded to real
+   * choices. A region with one way to pay gets no chooser at all: the tile
+   * said "Stripe", which is the processor's name and not an answer to "how am
+   * I paying?", and it sat above the card field doing nothing.
+   */
+  const buyerMethods = foldPaymentMethods(
+    availablePaymentMethods,
+    latestSession?.provider_id
+  )
+  const showMethodChooser = shouldShowMethodChooser(buyerMethods)
 
   const paidByGiftcard = !!(
     (cart as unknown as Record<string, unknown>)?.gift_cards &&
@@ -118,6 +134,24 @@ export default function CheckoutPaymentSection({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [receiptContextKey])
 
+  /**
+   * With no chooser there is nobody to click the tile, so the single method is
+   * selected here and its session opened — otherwise the card field would wait
+   * forever for a selection that cannot be made.
+   *
+   * ⚠️ Guarded on `!selectedPaymentMethod`: this must fire once, not on every
+   * render, and never over a selection the shopper (or a live session) already
+   * has.
+   */
+  useEffect(() => {
+    if (showMethodChooser || paidByGiftcard) return
+    if (selectedPaymentMethod) return
+    const only = buyerMethods[0]
+    if (!only) return
+    void handleSelectPayment(only.id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showMethodChooser, paidByGiftcard, selectedPaymentMethod, buyerMethods[0]?.id])
+
   // Stripe redirect return (redirect-based methods send the shopper to Stripe
   // and back to the checkout page with `?redirect_status=...`). On a successful
   // return we finalise the order.
@@ -172,8 +206,9 @@ export default function CheckoutPaymentSection({
         <div className="flex flex-col gap-y-3">
           <h2 className="h2-docs">Payment</h2>
 
+          {showMethodChooser && (
           <div className="flex gap-x-2 overflow-x-auto no-scrollbar pb-1">
-            {availablePaymentMethods.map((method) => {
+            {buyerMethods.map((method) => {
               const info = paymentInfoMap[method.id]
               const isSelected = selectedPaymentMethod === method.id
 
@@ -206,6 +241,7 @@ export default function CheckoutPaymentSection({
               )
             })}
           </div>
+          )}
 
           {/* Stripe card input */}
           {isStripeLike(selectedPaymentMethod) && (
@@ -286,6 +322,17 @@ export default function CheckoutPaymentSection({
   )
 }
 
+/**
+ * 🔴 The guard has to live in its own component, above the hooks.
+ *
+ * `useStripe()` THROWS when there is no `<Elements>` provider — it does not
+ * return null — so calling it before checking the context took the whole
+ * checkout page down with a runtime error rather than showing a skeleton. The
+ * check that was meant to prevent that sat two lines too late, which nothing
+ * noticed while a shopper had to click a tile before this rendered at all.
+ * With the tile gone it renders on load, so a missing `NEXT_PUBLIC_STRIPE_KEY`
+ * would break every checkout instead of degrading.
+ */
 function StripeInlineContainer({
   setError,
   setPaymentComplete,
@@ -294,12 +341,28 @@ function StripeInlineContainer({
   setPaymentComplete: (complete: boolean) => void
 }) {
   const stripeReady = useContext(StripeContext)
-  const stripe = useStripe()
-  const elements = useElements()
 
   if (!stripeReady) {
     return <SkeletonCardDetails />
   }
+
+  return (
+    <StripeInlineFields
+      setError={setError}
+      setPaymentComplete={setPaymentComplete}
+    />
+  )
+}
+
+function StripeInlineFields({
+  setError,
+  setPaymentComplete,
+}: {
+  setError: (error: string | null) => void
+  setPaymentComplete: (complete: boolean) => void
+}) {
+  const stripe = useStripe()
+  const elements = useElements()
 
   const returnUrl =
     typeof window !== "undefined"
@@ -373,7 +436,25 @@ function StripeInlineContainer({
       <LinkAuthenticationElement />
 
       <PaymentElement
-        options={{ layout: "accordion" }}
+        options={{
+          /**
+           * Card open, everything else listed under it.
+           *
+           * `defaultCollapsed: false` is the half that matters: a collapsed
+           * accordion opens on a row of method NAMES, so a shopper who only
+           * wants to type a card number has to pick "Card" first. Open, the
+           * card fields are already there and the other methods — whatever
+           * Stripe offers for this currency — are visible underneath.
+           */
+          layout: {
+            type: "accordion",
+            defaultCollapsed: false,
+            radios: true,
+            spacedAccordionItems: false,
+          },
+          // Card leads regardless of the order Stripe returns.
+          paymentMethodOrder: ["card"],
+        }}
         onChange={(e) => {
           setError(null)
           setPaymentComplete(e.complete)


### PR DESCRIPTION
The rebranded checkout showed, in every non-INR region, a tile reading **"Stripe"** and behind it a card field and nothing else. That is two separate faults with one symptom.

---

## 1. Only a card was ever on offer — a server fault

The stock Stripe provider was configured with **neither** `payment_method_types` **nor** `automatic_payment_methods`.

I measured what Stripe does with that, rather than assuming. An intent created exactly the way this provider creates one:

```
POST /v1/payment_intents  amount=5000 currency=usd capture_method=manual
→ payment_method_types: ["card"]
→ automatic_payment_methods: null
```

**Card only.** The Payment Element could not have rendered anything else, whatever the Dashboard allowed. This is the whole of "it's only showing card".

`automaticPaymentMethods: true` fixes it — and is what `src/modules/stripe-connect-payment` has always set on its own intents. This is the stock provider catching up with the one beside it in the same config block.

**Verified end to end on a real cart**, through the real provider:

```
cart_…  sgd 109 → pi_3UCHeK…
   payment_method_types: ["card", "link"]
   automatic_payment_methods: { enabled: true, allow_redirects: "always" }
```

The account has no such default — the raw intent above proves it — so the flag is doing the work.

What each currency actually gains (measured, manual capture, which is what our config produces):

| currency | methods |
|---|---|
| eur | card, klarna, link, satispay |
| usd / aud / sgd | card, link |

⚠️ **Beyond this is a Stripe Dashboard setting, not code.** If you want Afterpay/Zip on AUD or more on USD, they have to be switched on for the account. Also note EUR gains 4 more (bancontact, eps, giropay, ideal) if the intent ever moves to **automatic** capture — today `capture` is unset, so we create manual-capture intents and those four are excluded by Stripe.

The redirect plumbing these methods need already exists: `confirmPayment` passes a `return_url` and the section handles `?redirect_status=` on the way back.

---

## 2. The tile named the processor — a client fault

A region whose only provider is Stripe **still drew a chooser** — one tile, saying "Stripe". There was nothing to choose, and the processor's name tells a shopper nothing about how they are paying.

Europe was worse: it carries both `pp_stripe_stripe` and `pp_stripe-connect_stripe-connect`, so it drew **two tiles, both titled "Stripe"** — showing the platform/merchant-direct split that #985 says the buyer never sees, twice, under one name.

- Stripe-like providers **fold into one buyer-facing entry**; the chooser is drawn only when a real choice exists. 🔴 A provider the cart already has a session with **wins the fold**, so an in-flight payment is never moved between settlement routes.
- With no chooser, the single method is **selected on mount and its session opened** — otherwise the card field waits for a click that can no longer happen.
- The Payment Element **opens on the card** (`defaultCollapsed: false`, `paymentMethodOrder: ["card"]`) with everything else listed under it.
- Generic Stripe entries are titled **"Card & more"** for the mixed-provider case, where a label is still needed.

`foldPaymentMethods` / `shouldShowMethodChooser` are pure, with 10 tests, mutation-checked (dropping the active-session preference and loosening the chooser threshold each turn a test red).

---

## 3. 🔴 A crash this uncovered

`useStripe()` was called **above** the `stripeReady` guard. It *throws* when there is no `<Elements>` provider rather than returning null, so the guard below never ran.

Nothing hit it before, because a shopper had to click a tile for this component to render at all. With the tile gone it renders on load — so a missing `NEXT_PUBLIC_STRIPE_KEY` would take **the whole checkout page** down with a runtime error instead of showing a skeleton. Found by rendering the page with the key unset; the guard now lives in its own component above the hooks.

---

## Verified by rendering

A Singapore cart (SGD 109, Stripe as the only provider — prod's exact shape) driven in a browser against a local backend:

- the word **"Stripe" no longer appears** anywhere on the checkout;
- no chooser is drawn;
- **the auto-select works** — the cart came back with a `pp_stripe_stripe` session carrying a real `client_secret`, so a shopper is not stranded without a payment session. This was the one way this change could have broken checkout outright.

The Payment Element's own appearance could not be confirmed locally: there is no Stripe **publishable** test key on this machine (`NEXT_PUBLIC_STRIPE_KEY` is empty, and the only one findable is a live key I won't use). The card-first options are type-checked against the installed `@stripe/stripe-js` typings — worth an eyeball on the preview deploy.

## The other home

`apps/storefront` is a fork of the `storefront-starter` submodule and they drift, so the client change is mirrored in **Jaal-Yantra-Textiles/nextjs-starter-medusa#37**. This PR deliberately does **not** bump the submodule pointer — that happens once #37 merges, so the pointer never names an unmerged commit.

## Checks

- `pnpm --filter @jyt/storefront build` and `@jyt/storefront-starter build` — both green.
- `vitest` — 10 new tests green.
- (`tsc` on the storefront is not a signal: 903 pre-existing `TS2786` errors tree-wide from duplicate `@types/react`, in untouched files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
