### PR TITLE
fix(checkout): a card-only region showed "or pay with card" above nothing

### DIFF
--- a/apps/storefront/src/lib/util/__tests__/payment-methods.test.ts
+++ b/apps/storefront/src/lib/util/__tests__/payment-methods.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   foldPaymentMethods,
+  hasExpressMethods,
   shouldShowMethodChooser,
 } from "../payment-methods"
 
@@ -85,5 +86,44 @@ describe("shouldShowMethodChooser", () => {
 
   it("hides it when the region offers nothing", () => {
     expect(shouldShowMethodChooser([])).toBe(false)
+  })
+})
+
+describe("hasExpressMethods", () => {
+  it("says no before the element has reported", () => {
+    // The pre-ready state. Saying yes here flashes a wallet row and an
+    // "or pay with card" divider onto a card-only checkout.
+    expect(hasExpressMethods(null)).toBe(false)
+  })
+
+  it("says no when Stripe reports nothing available", () => {
+    // Stripe's own shape for "no payment methods can show".
+    expect(hasExpressMethods(undefined)).toBe(false)
+  })
+
+  it("says no when every wallet is false", () => {
+    expect(
+      hasExpressMethods({
+        applePay: false,
+        googlePay: false,
+        link: false,
+        paypal: false,
+        amazonPay: false,
+        klarna: false,
+      })
+    ).toBe(false)
+  })
+
+  it("says yes when a single wallet is available", () => {
+    expect(
+      hasExpressMethods({
+        applePay: false,
+        googlePay: true,
+        link: false,
+        paypal: false,
+        amazonPay: false,
+        klarna: false,
+      })
+    ).toBe(true)
   })
 })

--- a/apps/storefront/src/lib/util/payment-methods.ts
+++ b/apps/storefront/src/lib/util/payment-methods.ts
@@ -81,3 +81,25 @@ export const foldPaymentMethods = (
 export const shouldShowMethodChooser = (
   folded: BuyerPaymentMethod[]
 ): boolean => folded.length > 1
+
+/**
+ * Does the Express Checkout element have anything to show?
+ *
+ * 🔴 Stripe reports "nothing available" as `undefined`, not as an object of
+ * falses — but it is allowed to hand back an object, so both are checked. Get
+ * this wrong in the optimistic direction and the checkout renders a divider
+ * reading "or pay with card" with an empty space above it, which is the exact
+ * thing it was there to separate the card FROM.
+ *
+ * Until the element reports (the value is `null` here) the answer is no, so
+ * the wallet row and its divider never flash in and out on a card-only region.
+ */
+export const hasExpressMethods = (
+  available:
+    | Record<string, boolean>
+    | undefined
+    | null
+): boolean => {
+  if (!available) return false
+  return Object.values(available).some(Boolean)
+}

--- a/apps/storefront/src/modules/checkout/components/checkout-payment-section/index.tsx
+++ b/apps/storefront/src/modules/checkout/components/checkout-payment-section/index.tsx
@@ -11,6 +11,7 @@ import {
 import compareAddresses from "@lib/util/compare-addresses"
 import {
   foldPaymentMethods,
+  hasExpressMethods,
   shouldShowMethodChooser,
 } from "@lib/util/payment-methods"
 import { CreditCard } from "@medusajs/icons"
@@ -22,7 +23,10 @@ import {
   useElements,
   useStripe,
 } from "@stripe/react-stripe-js"
-import type { StripeExpressCheckoutElementConfirmEvent } from "@stripe/stripe-js"
+import type {
+  StripeExpressCheckoutElementConfirmEvent,
+  StripeExpressCheckoutElementReadyEvent,
+} from "@stripe/stripe-js"
 import PaymentButton from "@modules/checkout/components/payment-button"
 import ErrorMessage from "@modules/checkout/components/error-message"
 import SkeletonCardDetails from "@modules/skeletons/components/skeleton-card-details"
@@ -364,6 +368,17 @@ function StripeInlineFields({
   const stripe = useStripe()
   const elements = useElements()
 
+  /**
+   * `null` until the Express Checkout element reports. A region where Stripe
+   * offers nothing but a card — which is most of them — should show the card
+   * and nothing else: no wallet row, and above all no "or pay with card"
+   * divider separating the card from an empty space.
+   */
+  const [expressMethods, setExpressMethods] = useState<
+    Record<string, boolean> | undefined | null
+  >(null)
+  const showExpress = hasExpressMethods(expressMethods)
+
   const returnUrl =
     typeof window !== "undefined"
       ? `${window.location.origin}${window.location.pathname}`
@@ -413,27 +428,57 @@ function StripeInlineFields({
 
   return (
     <div className="mt-2 flex flex-col gap-y-4">
-      <ExpressCheckoutElement
-        options={{
-          paymentMethods: {
-            applePay: "auto",
-            googlePay: "auto",
-            link: "auto",
-            paypal: "never",
-          },
-        }}
-        onConfirm={handleExpressConfirm}
-      />
-
-      <div className="flex items-center gap-x-3">
-        <span className="h-px flex-1 bg-ui-border-base" />
-        <span className="txt-compact-xsmall text-ui-fg-muted">
-          or pay with card
-        </span>
-        <span className="h-px flex-1 bg-ui-border-base" />
+      {/*
+        ⚠️ Always mounted, never conditionally rendered: `onReady` is the only
+        thing that says whether any wallet is available, and an element that is
+        not mounted never reports. So it stays in the tree and is collapsed to
+        nothing until it says it has something — height, not `display: none`,
+        so Stripe can still measure and paint it.
+      */}
+      <div
+        className={
+          showExpress
+            ? ""
+            : // `-mb-4` cancels the parent's `gap-y-4`: a zero-height child is
+              // still a flex child, so without it a card-only checkout keeps a
+              // 16px hole where the wallets would have been.
+              "h-0 overflow-hidden opacity-0 pointer-events-none -mb-4"
+        }
+      >
+        <ExpressCheckoutElement
+          options={{
+            paymentMethods: {
+              applePay: "auto",
+              googlePay: "auto",
+              link: "auto",
+              paypal: "never",
+            },
+          }}
+          onReady={(event: StripeExpressCheckoutElementReadyEvent) =>
+            setExpressMethods(event.availablePaymentMethods)
+          }
+          onConfirm={handleExpressConfirm}
+        />
       </div>
 
-      <LinkAuthenticationElement />
+      {/*
+        The divider and the Link email box exist to separate the wallets from
+        the card. With no wallets there is nothing to separate, and the shopper
+        should just be looking at the card.
+      */}
+      {showExpress && (
+        <>
+          <div className="flex items-center gap-x-3">
+            <span className="h-px flex-1 bg-ui-border-base" />
+            <span className="txt-compact-xsmall text-ui-fg-muted">
+              or pay with card
+            </span>
+            <span className="h-px flex-1 bg-ui-border-base" />
+          </div>
+
+          <LinkAuthenticationElement />
+        </>
+      )}
 
       <PaymentElement
         options={{


### PR DESCRIPTION
Follow-up to #1839.

## The problem

The wallet row (Apple Pay / Google Pay / Link) and the **"or pay with card"** divider were rendered unconditionally. In a region where Stripe offers nothing but a card — measured, that is usd, aud and sgd — the Express Checkout element draws nothing, so the checkout showed:

```
   [ empty ]
── or pay with card ──
   [ card fields ]
```

A divider separating the card from nothing, announcing an alternative that isn't there.

## The fix

`ExpressCheckoutElement` reports through `onReady`, whose `availablePaymentMethods` is **`undefined`** when no wallet can show. With nothing available, neither the divider nor the Link email box renders — the shopper sees the card, and only the card.

## Two implementation notes

- ⚠️ **The element stays mounted** and is collapsed to zero height rather than conditionally rendered. `onReady` is the only signal for this, so rendering the element conditionally on the answer it is meant to give would mean it never gives one. Height rather than `display: none`, so Stripe can still measure and paint.
- `-mb-4` cancels the parent's `gap-y-4`: a zero-height flex child still takes its gap, leaving a 16px hole exactly where the wallets weren't.

`hasExpressMethods` is pure and tested — including the pre-ready (`null`) state, `undefined`, and the all-false object Stripe is allowed to return instead.

## Checks

- `pnpm --filter @jyt/storefront build` and `@jyt/storefront-starter build` — both green.
- `vitest` — 14 tests green (4 new).
- Checkout page re-rendered in a browser: no runtime error (the same component took the page down in #1839, so this is not a formality).

⚠️ **The wallet-hiding itself could not be exercised locally.** There is no Stripe *publishable* test key on this machine, so Stripe.js never mounts and the Express element never reports. The logic is pure and tested; the visual result needs one eyeball on a real non-INR checkout.

## The other home

Bumps `apps/storefront-starter` to the **already-merged** nextjs-starter-medusa@2c566bf (#38), which carries the same change — `apps/storefront` is a fork of that submodule and they drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
