### PR TITLE
fix(payments): automatic capture, and #1839's Stripe fix never reached prod

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -296,6 +296,30 @@ module.exports = defineConfig({
             options: {
               apiKey: process.env.STRIPE_API_KEY,
               webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+              /**
+               * 🔴 THIS FILE IS THE ONE PROD RUNS. `apps/backend/Dockerfile`
+               * does `cp medusa-config.prod.ts medusa-config.ts` before the
+               * build, so an option added only to `medusa-config.ts` is
+               * DISCARDED in the image. #1839 added `automaticPaymentMethods`
+               * to that file alone — it never reached prod. Both options below
+               * have TWO HOMES; change them in both or the change is inert.
+               *
+               * `automaticPaymentMethods` — without it the intent is created
+               * with neither `payment_method_types` nor
+               * `automatic_payment_methods`, and Stripe answers
+               * `payment_method_types: ["card"]`. There is no account-level
+               * default. (`./src/modules/stripe-connect-payment` has always set
+               * this on its own intents, which is why a Connect cart looked
+               * fine while the stock provider did not.)
+               *
+               * `capture` — false/absent creates MANUAL-capture intents, and
+               * Stripe then excludes every method whose funds move at
+               * authorisation. Measured: eur automatic → card, bancontact, eps,
+               * giropay, ideal, klarna, link, satispay; manual → card, klarna,
+               * link, satispay. The charge is now taken at checkout (#1840).
+               */
+              automaticPaymentMethods: true,
+              capture: true,
             },
           },
          ...(process.env.STRIPE_API_KEY &&

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -403,6 +403,32 @@ module.exports = defineConfig({
                            * catching up with the one beside it.
                            */
                           automaticPaymentMethods: true,
+
+                          /**
+                           * 🔴 Without this the provider creates **manual-capture**
+                           * intents (`this.options_.capture ? "automatic" : "manual"`),
+                           * and Stripe excludes every method that cannot be
+                           * authorised-now-captured-later. Measured on the live API,
+                           * eur loses four:
+                           *
+                           *   automatic → card, bancontact, eps, giropay, ideal,
+                           *               klarna, link, satispay
+                           *   manual    → card, klarna, link, satispay
+                           *
+                           * iDeal, Bancontact, EPS and Giropay are single-use bank
+                           * redirects: funds move at authorisation, so they cannot
+                           * exist inside a manual-capture intent at all. No amount of
+                           * Dashboard configuration brings them back.
+                           *
+                           * 🔑 `./src/modules/stripe-connect-payment` beside this one
+                           * never sets `capture_method`, so Stripe defaults it to
+                           * automatic — the two providers serving the same storefront
+                           * disagreed. This is the stock one catching up, again.
+                           *
+                           * The charge is now taken at checkout rather than
+                           * authorised and captured later (#1840).
+                           */
+                          capture: true,
                         },
                       },
                     ]


### PR DESCRIPTION
fix(payments): automatic capture, and #1839's Stripe fix never reached prod

Two things, both on the stock Stripe provider.

## The decision: automatic capture (#1840 §1)

Our config never set `capture`, so the provider created MANUAL-capture
intents (`this.options_.capture ? "automatic" : "manual"`). Stripe then
excludes every method whose funds move at authorisation. Measured on the
live API:

  automatic → card, bancontact, eps, giropay, ideal, klarna, link, satispay
  manual    → card, klarna, link, satispay

iDeal, Bancontact, EPS and Giropay could not have been recovered any other
way — they are single-use bank redirects and cannot exist inside a
manual-capture intent at all, whatever the Dashboard allows.

The trade is accepted knowingly: the charge is now taken at checkout rather
than authorised and captured later.

Verified in the installed 2.20.1 sources rather than assumed:

  stripe-base.js:38-41   capture_method → "automatic"
  stripe-base.js:~410    intent `succeeded` → PaymentSessionStatus.CAPTURED
  payment-module.js:249  authorize accepts CAPTURED as well as AUTHORIZED
  payment-module.js:277  CAPTURED → AUTHORIZED + a capture is RECORDED
  payment-module.js:330  `is_captured` skips the provider — no second charge
  payment-module.js:357  a captured payment returns early — the partner
                         capture route stays idempotent

So the books still show a captured payment, and
POST /partners/payments/:id/capture neither errors nor double-charges.

## 🔴 The one that was already broken: #1839 never reached prod

`apps/backend/Dockerfile:65` does

    cp apps/backend/medusa-config.prod.ts apps/backend/medusa-config.ts

before the build, so `medusa-config.prod.ts` is the file the image runs and
an option added only to `medusa-config.ts` is DISCARDED.

#1839 added `automaticPaymentMethods: true` to `medusa-config.ts` alone. Its
server half has therefore never been live: the stock provider in prod still
creates intents with neither `payment_method_types` nor
`automatic_payment_methods`, which Stripe answers card-only.

The live check that "confirmed" it is explained by
`STRIPE_CONNECT_ENABLED=true` in prod (SSM): `stripe-connect` has always set
APM on its own intents, so the intent that was measured came from the
provider that was never broken.

This is one isolated slip, not general drift — `git log` on the two configs
is identical except for 66d3bde0e (#1839). Every other config change since
went to both homes.

Both options now carry a comment naming the second home.

## Gate

`check:prod-build` fails identically before and after these edits: the only
error is the pre-existing, local-only
`src/scripts/__tests__/generate-integration-test.e2e.spec.ts` TS2307 on
`@jest/core`. No new error, and the prod config parses and builds.

Refs #1840

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
