### PR TITLE
fix(starfleet): the host defaults to prod — the cautious default was the broken one

### DIFF
--- a/apps/backend/src/modules/shipping-providers/starfleet/__tests__/client.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/__tests__/client.unit.spec.ts
@@ -221,19 +221,26 @@ describe("starfleetTrackingUrl", () => {
  * warehouse (gotcha #3), so it surfaces as a manifestation error instead.
  */
 describe("starfleetBaseUrl", () => {
-  it("defaults to staging when unset, so prod is never reached by accident", () => {
-    expect(starfleetBaseUrl(undefined)).toContain("api-stage-starfleet")
-    expect(starfleetBaseUrl("")).toContain("api-stage-starfleet")
+  /**
+   * 🔴 The default is PROD, and these assertions are the inverse of what they
+   * were (#1843). The old "never reach prod by accident" default was measured
+   * to be the broken one: the account's credentials do not exist in the sandbox
+   * and staging answers 403 `User profile is not active / User not found`.
+   */
+  it("defaults to prod when unset, because the account only exists there", () => {
+    expect(starfleetBaseUrl(undefined)).toBe("https://api-starfleet.delhivery.com")
+    expect(starfleetBaseUrl("")).toBe("https://api-starfleet.delhivery.com")
   })
 
-  it("selects the prod host only on an explicit 'prod'", () => {
-    expect(starfleetBaseUrl("prod")).toBe("https://api-starfleet.delhivery.com")
-    expect(starfleetBaseUrl(" PROD ")).toBe("https://api-starfleet.delhivery.com")
-  })
-
-  it("treats anything else as staging rather than guessing", () => {
-    for (const v of ["staging", "stage", "production", "live", "true", "1"]) {
+  it("still selects the sandbox on an explicit staging alias", () => {
+    for (const v of ["staging", "stage", "sandbox", " STAGING ", "Stage"]) {
       expect(starfleetBaseUrl(v)).toContain("api-stage-starfleet")
+    }
+  })
+
+  it("keeps prod on 'prod' and on anything it does not recognise", () => {
+    for (const v of ["prod", " PROD ", "production", "live", "true", "1"]) {
+      expect(starfleetBaseUrl(v)).toBe("https://api-starfleet.delhivery.com")
     }
   })
 })

--- a/apps/backend/src/modules/shipping-providers/starfleet/client.ts
+++ b/apps/backend/src/modules/shipping-providers/starfleet/client.ts
@@ -61,18 +61,33 @@ import { normalizeHsCode } from "../hs-code-resolution"
  * warehouse that is not there, and the failure surfaces as a manifestation
  * error rather than as "you are pointed at the wrong environment".
  *
- * Defaults to STAGING, so nothing changes for anyone until the var is set —
- * enabling prod is a deliberate act, not a side effect of deploying.
+ * 🔴 DEFAULTS TO PROD (#1843). This read "defaults to STAGING, so prod is never
+ * reached by accident" — but the account's credentials are PROD credentials and
+ * do not exist in the sandbox at all, so the cautious default was the BROKEN
+ * one. Measured with the same four secrets:
+ *
+ *   api-stage-starfleet → 403 {"error": User profile is not active / User not found}
+ *   api-starfleet       → token, expires_in 86400
+ *
+ * A 403 read for a session as a wallet or scope problem was the wrong host all
+ * along. Nothing in SSM sets `STARFLEET_ENV` either, so a staging default meant
+ * prod would have pointed at the sandbox too — failing at MANIFEST time on a
+ * warehouse that is not in that environment's registry, which reads like bad
+ * shipment data rather than a misconfigured host.
+ *
+ * `STARFLEET_ENV=staging` (or `stage`) still selects the sandbox explicitly.
  */
 const STARFLEET_HOSTS = {
   staging: "https://api-stage-starfleet.delhivery.com",
   prod: "https://api-starfleet.delhivery.com",
 } as const
 
+const STAGING_ALIASES = new Set(["staging", "stage", "sandbox"])
+
 export const starfleetBaseUrl = (env?: string): string =>
-  String(env ?? "").trim().toLowerCase() === "prod"
-    ? STARFLEET_HOSTS.prod
-    : STARFLEET_HOSTS.staging
+  STAGING_ALIASES.has(String(env ?? "").trim().toLowerCase())
+    ? STARFLEET_HOSTS.staging
+    : STARFLEET_HOSTS.prod
 
 const HOST = starfleetBaseUrl(process.env.STARFLEET_ENV)
 const AUTH_URL = `${HOST}/auth/token`


### PR DESCRIPTION
fix(starfleet): the host defaults to prod — the cautious default was the broken one

`starfleetBaseUrl()` defaulted to STAGING, on the reasoning that "prod is never
reached by accident". Measured with the four secrets now in `.env`, that default
is what was broken: the account's credentials are PROD credentials and do not
exist in the sandbox at all.

  api-stage-starfleet → 403 {"error": User profile is not active / User not found}
  api-starfleet       → token, len 860, expires_in 86400

So the 403 recorded in session 59 as proving "nothing about the recharge or the
trimmed OAuth scope" was the wrong host all along, not a wallet or a permission
problem.

## Why the default and not just the env var

- Nothing in SSM sets `STARFLEET_ENV` — there is no `/jyt/prod/STARFLEET_*`
  parameter at all. A staging default meant PROD would have pointed at the
  sandbox too, and per-environment warehouse registries mean that fails at
  MANIFEST time on a warehouse the carrier has never heard of, reading like bad
  shipment data. This removes a required-but-absent parameter from the path.
- The DOMESTIC Delhivery client already defaults to prod
  (`resolver.ts:150` — sandbox only on `mode === "test"` or
  `DELHIVERY_SANDBOX=true`). `carrier-pickups.ts:70` requires the two to agree,
  since the domestic client is what REGISTERS the warehouse StarFleet then
  manifests against. They now agree by default rather than by remembering a var.

`STARFLEET_ENV=staging` (also `stage`, `sandbox`) still selects the sandbox
explicitly. Anything unrecognised now stays on prod, which is the inverse of the
old rule.

## Verified

- Live, with `STARFLEET_ENV` UNSET: host `api-starfleet.delhivery.com`, token
  minted, and `track()` — which uses the scope's own
  `^/package/auth-track/.+:GET$` — returned 200 with a well-formed
  "waybill not found". Not a 401.
- The three `starfleetBaseUrl` specs are inverted, not deleted. Confirmed they
  FAIL against the old source (2 of 3 red) and pass against the new one; the
  suite is 20/20.
- `check:prod-build` is unchanged from its baseline: the only error is the
  pre-existing, local-only `@jest/core` TS2307 in an untouched spec.

Refs #1843

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
