### PR TITLE
feat(census): weavers in admin persons search + MFA-gated PII unmask

### DIFF
--- a/apps/backend/integration-tests/http/persons-weavers.spec.ts
+++ b/apps/backend/integration-tests/http/persons-weavers.spec.ts
@@ -1,0 +1,157 @@
+import { brotliCompressSync } from "node:zlib"
+
+import { censusReader } from "../../src/modules/census/reader"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(90000)
+
+const enc = (r: Record<string, any>) => brotliCompressSync(Buffer.from(JSON.stringify(r)))
+const padId = (id: string | number) => String(id).padStart(10, "0")
+
+// Minimal in-memory Hyperbee stand-in (rec + agg + idx + meta) so the reader
+// exercises its indexed fast path without the native hypercore stack.
+function makeBee(subs: Record<string, Array<[string, any]>>) {
+  const sorted: Record<string, Array<[string, any]>> = {}
+  for (const [name, entries] of Object.entries(subs)) {
+    sorted[name] = [...entries].sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+  }
+  return {
+    sub(name: string) {
+      const entries = sorted[name] || []
+      return {
+        async get(key: string) {
+          const hit = entries.find(([k]) => k === key)
+          return hit ? { value: hit[1] } : null
+        },
+        async *createReadStream(range?: { gte?: string; gt?: string; lt?: string; lte?: string }) {
+          for (const [key, value] of entries) {
+            if (range?.gte !== undefined && key < range.gte) continue
+            if (range?.gt !== undefined && key <= range.gt) continue
+            if (range?.lt !== undefined && key >= range.lt) continue
+            if (range?.lte !== undefined && key > range.lte) continue
+            yield { key, value }
+          }
+        },
+      }
+    },
+  }
+}
+
+const RECORDS = [
+  {
+    census_id: 1,
+    state: "KARNATAKA",
+    district: "BAGALKOT",
+    gender: "Male",
+    education: "Middle",
+    survey: { Name: "Ramesh Patel", Latitude: "16.1", Longitude: "75.1" },
+  },
+  {
+    census_id: 2,
+    state: "KARNATAKA",
+    district: "BELGAUM",
+    gender: "Female",
+    education: "Primary",
+    survey: { Name: "Sunita Devi", Latitude: "16.2", Longitude: "75.2" },
+  },
+]
+
+function buildSubs(records: Array<Record<string, any>>) {
+  const rec: Array<[string, any]> = records.map((r) => [String(r.census_id), enc(r)])
+
+  const agg = new Map<string, number>()
+  const bump = (k: string) => agg.set(k, (agg.get(k) || 0) + 1)
+  for (const r of records) {
+    bump(`total/weavers`)
+    bump(`state/${r.state}`)
+    bump(`gender/${r.gender}`)
+    bump(`district/${r.state}|${r.district}`)
+  }
+
+  const idx: Array<[string, any]> = []
+  for (const r of records) {
+    const p = padId(r.census_id)
+    idx.push([`all/${p}`, Buffer.from("")])
+    idx.push([`state/${r.state}/${p}`, Buffer.from("")])
+    idx.push([`gender/${r.gender}/${p}`, Buffer.from("")])
+    idx.push([`sd/${r.state}|${r.district}/${p}`, Buffer.from("")])
+  }
+
+  return {
+    rec,
+    agg: [...agg].map(([k, v]) => [k, String(v)]),
+    idx,
+    meta: [["idx-version", "idx-v1"], ["idx-all-version", "idxall-v1"]],
+  } as Record<string, Array<[string, any]>>
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+  let headers: any
+
+  beforeAll(() => {
+    ;(censusReader as any).proxyUrl = null
+    censusReader.setBee(makeBee(buildSubs(RECORDS)))
+  })
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+  })
+
+  describe("GET /admin/persons — include weavers (census node)", () => {
+    it("returns masked census weavers alongside persons when include_weavers=true", async () => {
+      const res = await api.get("/admin/persons?include_weavers=true&limit=10&offset=0", headers)
+
+      expect(res.status).toBe(200)
+      expect(res.data.census_connected).toBe(true)
+      expect(Array.isArray(res.data.weavers)).toBe(true)
+      expect(res.data.weavers_count).toBe(2)
+      expect(res.data.weavers.map((w: any) => w.census_id).sort()).toEqual([1, 2])
+      for (const w of res.data.weavers) {
+        expect(w.survey).toBeUndefined() // raw survey bag stripped
+        expect(typeof w.name).toBe("string") // display name promoted
+      }
+    })
+
+    it("omits weavers when include_weavers is false", async () => {
+      const res = await api.get("/admin/persons?limit=10&offset=0", headers)
+
+      expect(res.status).toBe(200)
+      expect(res.data.weavers).toBeUndefined()
+      expect(res.data.weavers_count).toBeUndefined()
+    })
+
+    it("filters weavers by name (q) and district", async () => {
+      const res = await api.get(
+        "/admin/persons?include_weavers=true&q=ramesh&district=BAGALKOT&limit=10&offset=0",
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.weavers.map((w: any) => w.census_id)).toEqual([1])
+    })
+
+    it("maps region_state to the census geographic state", async () => {
+      const res = await api.get(
+        "/admin/persons?include_weavers=true&region_state=KARNATAKA&limit=10&offset=0",
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.weavers.map((w: any) => w.census_id).sort()).toEqual([1, 2])
+    })
+  })
+
+  describe("GET /admin/census/weavers/:census_id/unmask — MFA gate", () => {
+    it("fails closed (403) when the caller has no MFA factor", async () => {
+      const res = await api
+        .get("/admin/census/weavers/1/unmask", headers)
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(403)
+    })
+  })
+})

--- a/apps/backend/src/admin/hooks/api/personandtype.ts
+++ b/apps/backend/src/admin/hooks/api/personandtype.ts
@@ -89,6 +89,31 @@ export interface AdminPersonsListResponse {
   persons: AdminPerson[];
 }
 
+/**
+ * A masked (PII-redacted) census weaver record, returned by GET /admin/persons
+ * when `include_weavers` is on. Shape mirrors the census reader's public
+ * projection: name + coords promoted, raw survey bag and contact/id values
+ * already stripped server-side.
+ */
+export interface AdminWeaver {
+  census_id: string | number;
+  name?: string | null;
+  state?: string | null;
+  district?: string | null;
+  block?: string | null;
+  village?: string | null;
+  gender?: string | null;
+  education?: string | null;
+  rural_urban?: string | null;
+  own_looms?: boolean | null;
+  natural_dye_used?: boolean | null;
+  mobile_masked?: string | null;
+  aadhaar_card_available?: boolean | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  [key: string]: any;
+}
+
 export interface AdminPersonsListParams {
   limit: number;
   offset: number;
@@ -102,6 +127,20 @@ export interface AdminPersonsListParams {
   updated_at?: string;
   q?: string;
   withDeleted?: boolean;
+  include_weavers?: boolean;
+  region_state?: string;
+  district?: string;
+  block?: string;
+  village?: string;
+  gender?: string;
+  rural_urban?: string;
+  own_looms?: string;
+  natural_dye_used?: string;
+  education?: string;
+  ownership_type?: string;
+  household_type?: string;
+  dwelling_type?: string;
+  electricity?: string;
 }
 
 export interface AdminPersonType {

--- a/apps/backend/src/admin/hooks/api/persons.ts
+++ b/apps/backend/src/admin/hooks/api/persons.ts
@@ -19,6 +19,7 @@ import {
   AdminPersonDeleteResponse,
   AdminPersonResponse,
   AdminUpdatePerson,
+  AdminWeaver,
 } from "./personandtype";
 
 export interface PersonDetails {
@@ -64,13 +65,25 @@ export const usePerson = (
   return { person: data?.person, ...rest };
 };
 
+export interface AdminPersonsListResponse {
+  persons: AdminPerson[];
+  count: number;
+  offset: number;
+  limit: number;
+  weavers?: AdminWeaver[];
+  weavers_count?: number;
+  census_connected?: boolean;
+  weavers_next?: string | null;
+  weavers_capped?: boolean;
+}
+
 export const usePersons = (
   query?: Record<string, any>,
   options?: Omit<
     UseQueryOptions<
-      PaginatedResponse<{ persons: AdminPerson[] }>,
+      AdminPersonsListResponse,
       FetchError,
-      PaginatedResponse<{ persons: AdminPerson[] }>,
+      AdminPersonsListResponse,
       QueryKey
     >,
     "queryFn" | "queryKey"
@@ -78,17 +91,21 @@ export const usePersons = (
 ) => {
   const { data, ...rest } = useQuery({
     queryFn: async () =>
-      sdk.client.fetch<PaginatedResponse<{ persons: AdminPerson[] }>>(
-        `/admin/persons`,
-        {
-          method: "GET",
-          query,
-        },
-      ),
+      sdk.client.fetch<AdminPersonsListResponse>(`/admin/persons`, {
+        method: "GET",
+        query,
+      }),
     queryKey: personsQueryKeys.list(query),
     ...options,
   });
-  return { persons: data?.persons, count: data?.count, ...rest };
+  return {
+    persons: data?.persons,
+    count: data?.count,
+    weavers: data?.weavers,
+    weaversCount: data?.weavers_count,
+    censusConnected: data?.census_connected,
+    ...rest,
+  };
 };
 
 export const useCreatePerson = (

--- a/apps/backend/src/admin/routes/persons/components/weaver-reveal-cell.tsx
+++ b/apps/backend/src/admin/routes/persons/components/weaver-reveal-cell.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react"
+import { Button, Text } from "@medusajs/ui"
+import { sdk } from "../../../lib/config"
+
+/**
+ * Per-row "Reveal" action for the census weavers view. Fetches a single
+ * weaver's FULL PII from `GET /admin/census/weavers/:census_id/unmask`, which is
+ * MFA-gated + audit-logged server-side. The full record is shown inline and is
+ * NOT persisted anywhere client-side.
+ */
+export const WeaverRevealCell = ({ censusId }: { censusId: string | number }) => {
+  const [state, setState] = useState<{
+    status: "idle" | "loading" | "revealed" | "error"
+    data?: Record<string, any> | null
+    message?: string
+  }>({ status: "idle" })
+
+  const reveal = async () => {
+    setState({ status: "loading" })
+    try {
+      const res = await sdk.client.fetch<{ weaver: Record<string, any> }>(
+        `/admin/census/weavers/${censusId}/unmask`
+      )
+      setState({ status: "revealed", data: res.weaver })
+    } catch (e: any) {
+      const status = e?.response?.status
+      const message =
+        status === 403
+          ? "MFA required to reveal"
+          : status === 404
+          ? "No record"
+          : e?.message || "Reveal failed"
+      setState({ status: "error", message })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-1">
+      <Button size="small" variant="secondary" onClick={reveal} isLoading={state.status === "loading"}>
+        Reveal
+      </Button>
+      {state.status === "revealed" && state.data ? (
+        <pre className="text-ui-fg-subtle text-xs whitespace-pre-wrap break-all max-w-sm max-h-40 overflow-auto rounded border border-ui-border-base p-2">
+          {JSON.stringify(state.data, null, 2)}
+        </pre>
+      ) : null}
+      {state.status === "error" ? (
+        <Text size="xsmall" className="text-ui-fg-error">
+          {state.message}
+        </Text>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/persons/page.tsx
+++ b/apps/backend/src/admin/routes/persons/page.tsx
@@ -1,5 +1,5 @@
 import { EllipsisHorizontal } from "@medusajs/icons"
-import { Container, Heading, Text, DataTable, useDataTable, createDataTableFilterHelper, DataTablePaginationState, DataTableFilteringState, Button, DropdownMenu, IconButton } from "@medusajs/ui";
+import { Container, Heading, Text, DataTable, useDataTable, createDataTableFilterHelper, createDataTableColumnHelper, DataTablePaginationState, DataTableFilteringState, Button, DropdownMenu, IconButton } from "@medusajs/ui";
 
 // Sort state is a single active sort — `null` means default backend order.
 type SortingState = { id: string; desc: boolean } | null
@@ -8,7 +8,8 @@ import CreateButton from "../../components/creates/create-button";
 import { usePersons } from "../../hooks/api/persons";
 import { useMemo, useState, useCallback } from "react";
 import { usePersonTableColumns } from "../../hooks/columns/usePersonTableColumns";
-import { AdminPerson, AdminPersonsListParams } from "../../hooks/api/personandtype";
+import { AdminPerson, AdminWeaver } from "../../hooks/api/personandtype";
+import { WeaverRevealCell } from "./components/weaver-reveal-cell";
 import debounce from "lodash/debounce";
 
 
@@ -24,6 +25,58 @@ export const useColumns = () => {
   );
 };
 
+// Person filters (exact-match fields the persons API understands).
+const PERSON_FILTER_FIELDS = ["email", "first_name", "last_name", "state"] as const;
+
+// Weaver filters — forwarded to the census reader when weavers are included.
+const WEAVER_FILTER_FIELDS = ["district", "gender", "region_state", "education"] as const;
+
+const weaverColumnHelper = createDataTableColumnHelper<AdminWeaver>();
+
+const weaverColumns = [
+  weaverColumnHelper.accessor("name", {
+    header: "Name",
+    cell: ({ getValue }) => (
+      <Text size="small">{getValue() || "—"}</Text>
+    ),
+  }),
+  weaverColumnHelper.accessor("district", {
+    header: "District",
+    cell: ({ getValue }) => (
+      <Text size="small" className="text-ui-fg-subtle">{getValue() || "—"}</Text>
+    ),
+  }),
+  weaverColumnHelper.accessor("state", {
+    header: "State",
+    cell: ({ getValue }) => (
+      <Text size="small" className="text-ui-fg-subtle">{getValue() || "—"}</Text>
+    ),
+  }),
+  weaverColumnHelper.accessor("gender", {
+    header: "Gender",
+    cell: ({ getValue }) => (
+      <Text size="small" className="text-ui-fg-subtle">{getValue() || "—"}</Text>
+    ),
+  }),
+  weaverColumnHelper.accessor("village", {
+    header: "Village",
+    cell: ({ getValue }) => (
+      <Text size="small" className="text-ui-fg-subtle">{getValue() || "—"}</Text>
+    ),
+  }),
+  weaverColumnHelper.accessor("education", {
+    header: "Education",
+    cell: ({ getValue }) => (
+      <Text size="small" className="text-ui-fg-subtle">{getValue() || "—"}</Text>
+    ),
+  }),
+  weaverColumnHelper.display({
+    id: "reveal",
+    header: "",
+    cell: ({ row }) => <WeaverRevealCell censusId={row.original.census_id} />,
+  }),
+];
+
 const PersonsPage = () => {
   const navigate = useNavigate();
   
@@ -34,6 +87,7 @@ const PersonsPage = () => {
   const [filtering, setFiltering] = useState<DataTableFilteringState>({});
   const [search, setSearch] = useState<string>("");
   const [includeDeleted, setIncludeDeleted] = useState<boolean>(false);
+  const [includeWeavers, setIncludeWeavers] = useState<boolean>(false);
   const [sorting, setSorting] = useState<SortingState>(null);
   
   // Debounced filter change handler to prevent rapid re-renders and API calls
@@ -56,14 +110,32 @@ const PersonsPage = () => {
   const offset = pagination.pageIndex * pagination.pageSize;
   
   // Sort state → backend `order` string. The API parses both
-  // "created_at:DESC" and "-created_at" shapes.
+  // "created_at:DESC" and "-created_at" shapes. Weavers are not orderable; the
+  // sort is only sent for the DB persons list.
   const orderParam = sorting?.id
     ? `${sorting.id}:${sorting.desc ? "DESC" : "ASC"}`
     : undefined
 
+  // Collapse the DataTable filter state (values can arrive as arrays) into the
+  // flat exact-match query params. Person and weaver filters are disjoint key
+  // sets, so a single reduction over the active mode is safe.
+  const filterParams = useMemo(() => {
+    const out: Record<string, string> = {};
+    const fields = includeWeavers ? WEAVER_FILTER_FIELDS : PERSON_FILTER_FIELDS;
+    for (const field of fields) {
+      const v = filtering[field];
+      const value = Array.isArray(v) ? v[0] : v;
+      if (typeof value === "string" && value !== "") out[field] = value;
+    }
+    return out;
+  }, [filtering, includeWeavers]);
+
   const {
     persons,
     count,
+    weavers,
+    weaversCount,
+    censusConnected,
     isLoading,
   } = usePersons(
     {
@@ -71,25 +143,9 @@ const PersonsPage = () => {
       offset: offset,
       q: search || undefined,
       withDeleted: includeDeleted,
+      include_weavers: includeWeavers || undefined,
       ...(orderParam ? { order: orderParam } : {}),
-      // Apply filtering only for known fields
-      ...(Object.keys(filtering).length > 0 ? 
-        Object.entries(filtering).reduce((acc: AdminPersonsListParams, [key, value]) => {
-          if (!value) return acc;
-          
-          // Handle different filter types appropriately
-          if (key === 'email') {
-            // Ensure email is a string, not an array
-            acc.email = Array.isArray(value) && value.length > 0 ? value[0] : value as string;
-          } else if (key === 'state') {
-            acc.state = Array.isArray(value) && value.length > 0 ? value[0] : value as string;
-          } else if (key === 'first_name') {
-            acc.first_name = Array.isArray(value) && value.length > 0 ? value[0] : value as string;
-          } else if (key === 'last_name') {
-            acc.last_name = Array.isArray(value) && value.length > 0 ? value[0] : value as string;
-          }
-          return acc;
-        }, {} as AdminPersonsListParams) : {}),
+      ...filterParams,
     },
     {
       // Use the staleTime option instead of keepPreviousData
@@ -99,11 +155,11 @@ const PersonsPage = () => {
 
   const columns = useColumns();
   
-  const filterHelper = createDataTableFilterHelper<AdminPerson>();
+  const personFilterHelper = createDataTableFilterHelper<AdminPerson>();
   
   // Create filters using the filterHelper
-  const filters = [
-    filterHelper.accessor("email", {
+  const personFilters = [
+    personFilterHelper.accessor("email", {
       type: "select",
       label: "Email",
       options: useMemo(() => {
@@ -119,7 +175,7 @@ const PersonsPage = () => {
         }));
       }, [persons]),
     }),
-    filterHelper.accessor("first_name", {
+    personFilterHelper.accessor("first_name", {
       type: "select",
       label: "First Name",
       options: useMemo(() => {
@@ -131,7 +187,7 @@ const PersonsPage = () => {
         }));
       }, [persons]),
     }),
-    filterHelper.accessor("last_name", {
+    personFilterHelper.accessor("last_name", {
       type: "select",
       label: "Last Name",
       options: useMemo(() => {
@@ -143,7 +199,7 @@ const PersonsPage = () => {
         }));
       }, [persons]),
     }),
-    filterHelper.accessor("state", {
+    personFilterHelper.accessor("state", {
       type: "select",
       label: "State",
       options: [
@@ -156,16 +212,72 @@ const PersonsPage = () => {
 
   ];
 
+  const weaverFilterHelper = createDataTableFilterHelper<AdminWeaver>();
+
+  // Weaver filters, options derived from the loaded (masked) weaver page.
+  const weaverFilters = [
+    weaverFilterHelper.accessor("district", {
+      type: "select",
+      label: "District",
+      options: useMemo(() => {
+        if (!weavers?.length) return [];
+        return [...new Set(weavers.map(w => w.district).filter(Boolean))].map(
+          (d) => ({ label: d as string, value: d as string })
+        );
+      }, [weavers]),
+    }),
+    weaverFilterHelper.accessor("gender", {
+      type: "select",
+      label: "Gender",
+      options: useMemo(() => {
+        if (!weavers?.length) return [];
+        return [...new Set(weavers.map(w => w.gender).filter(Boolean))].map(
+          (g) => ({ label: g as string, value: g as string })
+        );
+      }, [weavers]),
+    }),
+    weaverFilterHelper.accessor("region_state", {
+      type: "select",
+      label: "Region state",
+      options: useMemo(() => {
+        if (!weavers?.length) return [];
+        return [...new Set(weavers.map(w => w.state).filter(Boolean))].map(
+          (s) => ({ label: s as string, value: s as string })
+        );
+      }, [weavers]),
+    }),
+    weaverFilterHelper.accessor("education", {
+      type: "select",
+      label: "Education",
+      options: useMemo(() => {
+        if (!weavers?.length) return [];
+        return [...new Set(weavers.map(w => w.education).filter(Boolean))].map(
+          (e) => ({ label: e as string, value: e as string })
+        );
+      }, [weavers]),
+    }),
+  ];
+
+  // The table renders either DB persons or census weavers, never both at once.
+  // (Cast to `any` so the person/weaver column+data unions don't fight the
+  // DataTable's generic inference — the two shapes are never rendered together.)
+  const tableData = (includeWeavers ? (weavers ?? []) : (persons ?? [])) as any[];
+  const tableColumns = (includeWeavers ? weaverColumns : columns) as any;
+  const tableRowCount = includeWeavers ? (weaversCount ?? 0) : (count ?? 0);
+
   const table = useDataTable({
-    columns,
-    data: persons ?? [],
-    getRowId: (row) => row.id as string,
-    onRowClick: (_, row) => {
-      navigate(`/persons/${row.id}`);
-    },
-    rowCount: count ?? 0,
+    columns: tableColumns,
+    data: tableData,
+    getRowId: (row) => String(row.id ?? row.census_id),
+    // Weavers have no detail page; only DB persons navigate.
+    onRowClick: includeWeavers
+      ? undefined
+      : (_, row) => {
+          navigate(`/persons/${row.id}`);
+        },
+    rowCount: tableRowCount,
     isLoading: isLoading ?? false,
-    filters,
+    filters: includeWeavers ? weaverFilters : personFilters,
     pagination: {
       state: pagination,
       onPaginationChange: setPagination,
@@ -178,7 +290,7 @@ const PersonsPage = () => {
       state: filtering,
       onFilteringChange: handleFilterChange,
     },
-    sorting: {
+    sorting: includeWeavers ? undefined : {
       state: sorting,
       onSortingChange: setSorting,
     },
@@ -193,7 +305,9 @@ const PersonsPage = () => {
             <div>
               <Heading>Persons</Heading>
               <Text className="text-ui-fg-subtle" size="small">
-                Manage all your relationships from here
+                {includeWeavers
+                  ? "Handloom census weavers (masked records)"
+                  : "Manage all your relationships from here"}
               </Text>
             </div>
             <div className="flex items-center justify-center gap-x-2">
@@ -222,7 +336,7 @@ const PersonsPage = () => {
           {/* Search and filter section in its own container with divider */}
           <div className="flex items-start justify-between gap-x-4 px-6 py-4 border-t border-ui-border-base">
             <div className="w-full max-w-[60%] flex items-center gap-x-4">
-              <DataTable.FilterMenu tooltip="Filter persons" />
+              <DataTable.FilterMenu tooltip={includeWeavers ? "Filter weavers" : "Filter persons"} />
               <div className="flex items-center gap-x-2">
                 <input 
                   type="checkbox" 
@@ -235,11 +349,36 @@ const PersonsPage = () => {
                   Include deleted persons
                 </label>
               </div>
+              <div className="flex items-center gap-x-2">
+                <input 
+                  type="checkbox" 
+                  id="include-weavers" 
+                  checked={includeWeavers}
+                  onChange={(e) => {
+                    setIncludeWeavers(e.target.checked);
+                    setFiltering({});
+                  }}
+                  className="h-4 w-4 rounded border-ui-border-base text-ui-fg-interactive"
+                />
+                <label htmlFor="include-weavers" className="text-ui-fg-subtle text-sm">
+                  Include weavers
+                </label>
+              </div>
             </div>
             <div className="flex shrink-0 items-center gap-x-2">
-              <DataTable.Search placeholder="Search persons..." />
+              <DataTable.Search placeholder={includeWeavers ? "Search weavers..." : "Search persons..."} />
             </div>
           </div>
+
+          {includeWeavers && censusConnected === false && (
+            <div className="px-6 py-3 border-t border-ui-border-base">
+              <Text size="small" className="text-ui-fg-subtle">
+                Census reader not connected — weaver records are unavailable. The
+                service connects once the census P2P core replicates (or a
+                CENSUS_READER_URL proxy is configured).
+              </Text>
+            </div>
+          )}
           
           <DataTable.Table />
           <DataTable.Pagination />
@@ -260,4 +399,3 @@ export default PersonsPage;
 export const handle = {
   breadcrumb: () => "People",
 };
-

--- a/apps/backend/src/api/admin/census/weavers/[census_id]/unmask/route.ts
+++ b/apps/backend/src/api/admin/census/weavers/[census_id]/unmask/route.ts
@@ -1,0 +1,57 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { CENSUS_MODULE } from "../../../../../../modules/census"
+import type CensusModuleService from "../../../../../../modules/census/service"
+import { isMfaEnabled } from "../../../../social-platforms/secrets"
+
+/**
+ * GET /admin/census/weavers/:census_id/unmask
+ *
+ * Reveal a single weaver's FULL (unredacted) PII from the encrypted sensitive
+ * core. Two independent gates, both fail closed:
+ *
+ *   1. MFA — the caller's auth identity must have an ENABLED Medusa MFA factor
+ *      (same gate as social-platform secret reveal, isMfaEnabled).
+ *   2. CENSUS_UNMASK_TOKEN — the reader node only decrypts when Medusa presents
+ *      the shared bearer (the encryption key itself never leaves the node).
+ *
+ * Every successful reveal writes a `census_unmask_audit` row (best-effort: a
+ * logging failure never blocks the reveal). The FULL PII is deliberately
+ * per-record and on-demand — never bulk, never in the list response.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const censusId = req.params.census_id
+
+  if (!(await isMfaEnabled(req))) {
+    throw new MedusaError(
+      MedusaError.Types.FORBIDDEN,
+      "MFA is required to reveal a weaver's full PII"
+    )
+  }
+
+  const census = req.scope.resolve(CENSUS_MODULE) as CensusModuleService
+  const weaver = await census.unmaskWeaver(censusId)
+
+  if (!weaver) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `no census weaver with id ${censusId}`
+    )
+  }
+
+  // Durable audit — best-effort, never fails the reveal.
+  const actorId = (req as any).auth_context?.actor_id ?? "unknown"
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    await census.createCensusUnmaskAudits({
+      census_id: String(censusId),
+      actor_id: actorId,
+      fields: { keys: Object.keys(weaver) },
+    })
+  } catch (e: any) {
+    logger.error(`[census/unmask] audit persist failed: ${e?.message ?? e}`)
+  }
+
+  res.status(200).json({ weaver })
+}

--- a/apps/backend/src/api/admin/persons/route.ts
+++ b/apps/backend/src/api/admin/persons/route.ts
@@ -145,6 +145,39 @@ import { Person, ListPersonsQuery } from "./validators";
 import createPersonWorkflow from "../../../workflows/create-person";
 import { PersonAllowedFields, refetchPerson } from "./helpers";
 import { listAndCountPersonsWithFilterWorkflow } from "../../../workflows/persons/list-and-count-with-filter/list-and-count-with-filter";
+import { CENSUS_MODULE } from "../../../modules/census";
+import type CensusModuleService from "../../../modules/census/service";
+import type { WeaverFilters } from "../../../modules/census/reader";
+
+// Query-param → census record field map for the weaver (census node) filters.
+// `region_state` names the census record's geographic state, kept distinct from
+// the person lifecycle `state` filter so the two never collide on one endpoint.
+const WEAVER_FILTER_MAP: Record<string, keyof WeaverFilters> = {
+  region_state: "state",
+  district: "district",
+  block: "block",
+  village: "village",
+  gender: "gender",
+  rural_urban: "rural_urban",
+  own_looms: "own_looms",
+  natural_dye_used: "natural_dye_used",
+  education: "education",
+  ownership_type: "ownership_type",
+  household_type: "household_type",
+  dwelling_type: "dwelling_type",
+  electricity: "electricity",
+};
+
+const buildWeaverFilters = (query: Record<string, any>): WeaverFilters => {
+  const filters: WeaverFilters = {};
+  for (const [param, field] of Object.entries(WEAVER_FILTER_MAP)) {
+    const v = query[param];
+    if (v !== undefined && v !== "") filters[field] = v;
+  }
+  // Free-text search also matches a weaver's (masked) display name.
+  if (query.q !== undefined && query.q.trim() !== "") filters.name = query.q.trim();
+  return filters;
+};
 
 export const POST = async (
   req: MedusaRequest<Person> & {
@@ -219,11 +252,44 @@ export const GET = async (req: MedusaRequest<ListPersonsQuery>, res: MedusaRespo
     })
 
     
+    // When weavers are requested, resolve the census module and page the masked
+    // (PII-redacted) public records in parallel with the DB persons list. The
+    // reader is non-fatal: if it hasn't connected yet we return empty weavers and
+    // a `census_connected:false` flag so the UI can say why the column is empty.
+    let weavers: Record<string, any>[] = [];
+    let weaversCount = 0;
+    let censusConnected = false;
+    let weaversNext: string | null | undefined = undefined;
+    let weaversCapped = false;
+    if (query.include_weavers) {
+      const census = req.scope.resolve(CENSUS_MODULE) as CensusModuleService;
+      censusConnected = census.connected;
+      if (censusConnected) {
+        const result = await census.listAndCountWeavers(buildWeaverFilters(query), {
+          limit: query.limit,
+          offset: query.offset,
+        });
+        weavers = result.weavers;
+        weaversCount = result.count;
+        weaversNext = result.next;
+        weaversCapped = result.capped;
+      }
+    }
+
     res.status(200).json({
       persons: persons.data,
       count: persons.metadata?.count,
       offset: req.query.offset || 0,
       limit: req.query.limit || 10,
+      ...(query.include_weavers
+        ? {
+            weavers,
+            weavers_count: weaversCount,
+            census_connected: censusConnected,
+            ...(weaversNext ? { weavers_next: weaversNext } : {}),
+            ...(weaversCapped ? { weavers_capped: true } : {}),
+          }
+        : {}),
     });
   } catch (error) {
     res.status(400).json({ error: error.message });

--- a/apps/backend/src/api/admin/persons/validators.ts
+++ b/apps/backend/src/api/admin/persons/validators.ts
@@ -37,6 +37,29 @@ export const listPersonsQuerySchema = z.object({
     (val) => val === "true",
     z.boolean().optional().default(false)
   ),
+  // Toggle to include census (weavers node) records in the response. When true
+  // the route also resolves the `census` module and returns a masked `weavers`
+  // array alongside `persons`. See the route for the field mapping.
+  include_weavers: z.preprocess(
+    (val) => val === "true" || val === true,
+    z.boolean().optional().default(false)
+  ),
+  // Weaver filters (forwarded to the census reader when include_weavers is on).
+  // `region_state` is the census record's geographic state — kept distinct from
+  // the person lifecycle `state` field above so the two never collide.
+  region_state: z.string().optional(),
+  district: z.string().optional(),
+  block: z.string().optional(),
+  village: z.string().optional(),
+  gender: z.string().optional(),
+  rural_urban: z.string().optional(),
+  own_looms: z.string().optional(),
+  natural_dye_used: z.string().optional(),
+  education: z.string().optional(),
+  ownership_type: z.string().optional(),
+  household_type: z.string().optional(),
+  dwelling_type: z.string().optional(),
+  electricity: z.string().optional(),
   offset: z.preprocess(
     (val) => (val !== undefined && val !== null ? Number(val) : undefined),
     z.number().int().min(0).default(0)

--- a/apps/backend/src/api/admin/social-platforms/secrets.ts
+++ b/apps/backend/src/api/admin/social-platforms/secrets.ts
@@ -153,6 +153,15 @@ async function mfaEnabledForRequest(req: MedusaRequest): Promise<boolean> {
 }
 
 /**
+ * True only when the request's auth identity has an ENABLED Medusa MFA factor.
+ * The census unmask endpoint reuses this gate (with the reveal being the request
+ * itself, no `reveal_secrets` flag needed). Fails closed on any error.
+ */
+export async function isMfaEnabled(req: MedusaRequest): Promise<boolean> {
+  return mfaEnabledForRequest(req)
+}
+
+/**
  * Merge incoming `api_config` over `existing`, restoring any secret the caller
  * omitted or left blank from the existing row (both plaintext and ciphertext
  * variants, plus nested OAuth1 bags). Returns the merged config.

--- a/apps/backend/src/modules/census/__tests__/reader.unit.spec.ts
+++ b/apps/backend/src/modules/census/__tests__/reader.unit.spec.ts
@@ -1,0 +1,171 @@
+import { createServer } from "node:http"
+
+import { matchesWeaverFilters, censusReader } from "../reader"
+
+describe("matchesWeaverFilters", () => {
+  const rec = {
+    census_id: 42,
+    name: "Mohd Shahid",
+    state: "UTTAR PRADESH",
+    district: "SITAPUR",
+    gender: "Male",
+    own_looms: true,
+  }
+
+  it("matches exact equality on ordinary fields", () => {
+    expect(matchesWeaverFilters(rec, { state: "UTTAR PRADESH" })).toBe(true)
+    expect(matchesWeaverFilters(rec, { state: "KARNATAKA" })).toBe(false)
+    expect(matchesWeaverFilters(rec, { own_looms: true })).toBe(true)
+    expect(matchesWeaverFilters(rec, { own_looms: false })).toBe(false)
+  })
+
+  it("matches `name` as a case-insensitive substring", () => {
+    expect(matchesWeaverFilters(rec, { name: "shahid" })).toBe(true)
+    expect(matchesWeaverFilters(rec, { name: "MOHD" })).toBe(true)
+    expect(matchesWeaverFilters(rec, { name: "Kumar" })).toBe(false)
+  })
+
+  it("treats an empty `name` needle as no constraint", () => {
+    expect(matchesWeaverFilters(rec, { name: "" })).toBe(true)
+    expect(matchesWeaverFilters(rec, { name: "   " })).toBe(true)
+  })
+
+  it("ANDs multiple filters", () => {
+    expect(matchesWeaverFilters(rec, { state: "UTTAR PRADESH", name: "shahid" })).toBe(true)
+    expect(matchesWeaverFilters(rec, { state: "KARNATAKA", name: "shahid" })).toBe(false)
+  })
+
+  it("is lenient when the record lacks the name field", () => {
+    expect(matchesWeaverFilters({ census_id: 1 }, { name: "x" })).toBe(false)
+    expect(matchesWeaverFilters({ census_id: 1 }, { name: "" })).toBe(true)
+  })
+})
+
+describe("CensusReader.unmaskWeaver (proxy path)", () => {
+  const realFetch = globalThis.fetch
+  const prevProxy = (censusReader as any).proxyUrl
+  const prevToken = process.env.CENSUS_UNMASK_TOKEN
+
+  afterAll(() => {
+    globalThis.fetch = realFetch
+    ;(censusReader as any).proxyUrl = prevProxy
+    if (prevToken === undefined) delete process.env.CENSUS_UNMASK_TOKEN
+    else process.env.CENSUS_UNMASK_TOKEN = prevToken
+  })
+
+  it("sends the bearer token and returns the full record", async () => {
+    ;(censusReader as any).proxyUrl = "http://node"
+    process.env.CENSUS_UNMASK_TOKEN = "sekret"
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ weaver: { census_id: 1, mobile: "9812345678" } }),
+    }) as any
+
+    const out = await censusReader.unmaskWeaver(1)
+    expect(out).toEqual({ census_id: 1, mobile: "9812345678" })
+    expect(globalThis.fetch).toHaveBeenCalledWith("http://node/census/unmask/1", {
+      headers: { accept: "application/json", authorization: "Bearer sekret" },
+    })
+  })
+
+  it("returns null on 404", async () => {
+    ;(censusReader as any).proxyUrl = "http://node"
+    process.env.CENSUS_UNMASK_TOKEN = "sekret"
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as any
+    await expect(censusReader.unmaskWeaver(999)).resolves.toBeNull()
+  })
+
+  it("throws on 401 (token mismatch)", async () => {
+    ;(censusReader as any).proxyUrl = "http://node"
+    process.env.CENSUS_UNMASK_TOKEN = "sekret"
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401 }) as any
+    await expect(censusReader.unmaskWeaver(1)).rejects.toThrow(/unauthorized/)
+  })
+
+  it("throws when no token is configured", async () => {
+    ;(censusReader as any).proxyUrl = "http://node"
+    delete process.env.CENSUS_UNMASK_TOKEN
+    await expect(censusReader.unmaskWeaver(1)).rejects.toThrow(/CENSUS_UNMASK_TOKEN/)
+  })
+
+  it("throws in embedded mode (no proxy)", async () => {
+    ;(censusReader as any).proxyUrl = null
+    process.env.CENSUS_UNMASK_TOKEN = "sekret"
+    await expect(censusReader.unmaskWeaver(1)).rejects.toThrow(/embedded mode/)
+  })
+})
+
+// Real-HTTP round trip: a live local server plays the OCI node's
+// token-gated /census/unmask/:id contract, and the reader talks to it with the
+// REAL global fetch (no jest.fn). Proves the URL/header/status contract the node
+// implements matches what the reader sends.
+describe("CensusReader.unmaskWeaver against a real HTTP node", () => {
+  let server: ReturnType<typeof createServer>
+  let url = ""
+  const TOKEN = "test-token"
+  const prevProxy = (censusReader as any).proxyUrl
+  const prevToken = process.env.CENSUS_UNMASK_TOKEN
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      const m = (req.url || "").match(/^\/census\/unmask\/(.+)$/)
+      if (!m) {
+        res.writeHead(404).end()
+        return
+      }
+      if (req.headers["authorization"] !== `Bearer ${TOKEN}`) {
+        res.writeHead(401, { "content-type": "application/json" })
+        res.end(JSON.stringify({ message: "unauthorized" }))
+        return
+      }
+      const id = decodeURIComponent(m[1])
+      if (id === "999") {
+        res.writeHead(404, { "content-type": "application/json" })
+        res.end(JSON.stringify({ message: "not found" }))
+        return
+      }
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(
+        JSON.stringify({
+          weaver: { census_id: id, name: "Real Name", mobile: "9812345678", religion: "Hindu", social_group: "OBC" },
+        })
+      )
+    })
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()))
+    const addr = server.address()
+    url = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`
+  })
+
+  afterAll(async () => {
+    await new Promise<void>((r) => server.close(() => r()))
+    ;(censusReader as any).proxyUrl = prevProxy
+    if (prevToken === undefined) delete process.env.CENSUS_UNMASK_TOKEN
+    else process.env.CENSUS_UNMASK_TOKEN = prevToken
+  })
+
+  it("round-trips the full record with the bearer", async () => {
+    ;(censusReader as any).proxyUrl = url
+    process.env.CENSUS_UNMASK_TOKEN = TOKEN
+    const out = await censusReader.unmaskWeaver(42)
+    expect(out).toEqual({
+      census_id: "42",
+      name: "Real Name",
+      mobile: "9812345678",
+      religion: "Hindu",
+      social_group: "OBC",
+    })
+  })
+
+  it("throws on a token mismatch (401)", async () => {
+    ;(censusReader as any).proxyUrl = url
+    process.env.CENSUS_UNMASK_TOKEN = "wrong-token"
+    await expect(censusReader.unmaskWeaver(42)).rejects.toThrow(/unauthorized/)
+  })
+
+  it("returns null for an unknown id (404)", async () => {
+    ;(censusReader as any).proxyUrl = url
+    process.env.CENSUS_UNMASK_TOKEN = TOKEN
+    await expect(censusReader.unmaskWeaver(999)).resolves.toBeNull()
+  })
+})

--- a/apps/backend/src/modules/census/migrations/Migration20260905000000.ts
+++ b/apps/backend/src/modules/census/migrations/Migration20260905000000.ts
@@ -1,0 +1,18 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Census unmask audit — the one Postgres table in the census module. Records
+ * each admin reveal of a weaver's full (sensitive-core) PII: who asked, which
+ * census_id, and which sensitive keys came back. Queryable + durable, independent
+ * of the P2P core.
+ */
+export class Migration20260905000000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "census_unmask_audit" ("id" text not null, "census_id" text not null, "actor_id" text null, "fields" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "census_unmask_audit_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_census_unmask_audit_deleted_at" ON "census_unmask_audit" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "census_unmask_audit" cascade;`);
+  }
+}

--- a/apps/backend/src/modules/census/models/census-unmask-audit.ts
+++ b/apps/backend/src/modules/census/models/census-unmask-audit.ts
@@ -1,0 +1,22 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Durable audit row for one admin reveal of a weaver's FULL PII (the encrypted
+ * sensitive core, unmasked via the reader node). Written on every
+ * `GET /admin/census/weavers/:census_id/unmask` — best-effort, never blocks the
+ * reveal itself. `census_id` is the record revealed; `actor_id` is the admin
+ * who asked; `fields` is `{ keys: string[] }` — the names of the sensitive keys
+ * returned — so a review can see WHAT leaked without re-storing the values.
+ *
+ * This is the ONLY Postgres table in the otherwise read-only (P2P) census
+ * module — the audit trail must be queryable and durable independent of the
+ * P2P core.
+ */
+const CensusUnmaskAudit = model.define("census_unmask_audit", {
+  id: model.id().primaryKey(),
+  census_id: model.text(),
+  actor_id: model.text().nullable(),
+  fields: model.json().nullable(),
+})
+
+export default CensusUnmaskAudit

--- a/apps/backend/src/modules/census/reader.ts
+++ b/apps/backend/src/modules/census/reader.ts
@@ -147,6 +147,32 @@ export function maskWeaver<T extends Record<string, any> | null | undefined>(rec
   return out as T
 }
 
+/**
+ * Match a decoded record against a filter bag.
+ *
+ * `name` is a case-insensitive substring match over the promoted display name
+ * (the free-text search path — a weaver's name is not an indexed facet, so it
+ * must ride the residual predicate). Every other key is an exact equality, which
+ * is what the index families and the agg cells line up with. Shared by BOTH the
+ * bounded scan fallback and the index residual path so a `name` filter behaves
+ * identically on each.
+ */
+export function matchesWeaverFilters(
+  r: Record<string, any>,
+  filters: WeaverFilters
+): boolean {
+  for (const [k, v] of Object.entries(filters)) {
+    if (k === "name") {
+      const needle = String(v).trim().toLowerCase()
+      const hay = String(r.name ?? "").toLowerCase()
+      if (needle && !hay.includes(needle)) return false
+      continue
+    }
+    if (String(r[k]) !== String(v)) return false
+  }
+  return true
+}
+
 // Zero-pad census ids so the secondary index sorts lexicographically = numerically
 // (ids are < 10^10). MUST match the seeder/backfill's padding width.
 const ID_PAD = 10
@@ -270,6 +296,38 @@ export class CensusReader {
     }
     const rec = this.requireBee().sub("rec", { valueEncoding: "binary" })
     return await this.getDecoded(rec, String(id))
+  }
+
+  /**
+   * Resolve the FULL (unredacted) PII record for a census_id from the encrypted
+   * SENSITIVE core — proxy mode only. The decryption happens on the standalone
+   * reader node (which holds the sensitive core + HANDLOOM_ENCRYPTION_KEY), never
+   * in-process; Medusa just forwards the census_id with a bearer token.
+   *
+   * Fails closed: no proxy, no token, or a token mismatch all throw rather than
+   * return a masked record as if it were the real thing.
+   */
+  async unmaskWeaver(id: string | number): Promise<Record<string, any> | null> {
+    if (!this.proxyUrl) {
+      throw new Error(
+        "census unmask unavailable in embedded mode — set CENSUS_READER_URL to the reader node"
+      )
+    }
+    const token = process.env.CENSUS_UNMASK_TOKEN
+    if (!token) {
+      throw new Error("census unmask not configured — set CENSUS_UNMASK_TOKEN")
+    }
+    const res = await fetch(
+      `${this.proxyUrl}/census/unmask/${encodeURIComponent(String(id))}`,
+      { headers: { accept: "application/json", authorization: `Bearer ${token}` } }
+    )
+    if (res.status === 404) return null
+    if (res.status === 401) {
+      throw new Error("census unmask unauthorized — CENSUS_UNMASK_TOKEN mismatch")
+    }
+    if (!res.ok) throw new Error(`census unmask proxy → HTTP ${res.status}`)
+    const { weaver } = (await res.json()) as { weaver: Record<string, any> | null }
+    return weaver ?? null
   }
 
   /**
@@ -402,10 +460,6 @@ export class CensusReader {
     // Fallback: bounded in-memory scan over rec/* (only when the driver's index
     // family hasn't been backfilled yet). Decodes off-thread + yields to the
     // event loop so it can't freeze the server even at the MAX_SCAN ceiling.
-    const entries = Object.entries(filters)
-    const match = (r: Record<string, any>) =>
-      entries.every(([k, v]) => String(r[k]) === String(v))
-
     const weavers: Record<string, any>[] = []
     let count = 0
     let scanned = 0
@@ -417,7 +471,7 @@ export class CensusReader {
       }
       if (scanned % YIELD_EVERY === 0) await new Promise((r) => setImmediate(r))
       const r = maskWeaver(await this.decode(value))
-      if (!match(r)) continue
+      if (!matchesWeaverFilters(r, filters)) continue
       if (count >= offset && weavers.length < limit) weavers.push(r)
       count++
       // Early-exit once the page is full. Without a secondary index we can't
@@ -451,10 +505,7 @@ export class CensusReader {
     geoReady = false
   ) {
     const idx = bee.sub("idx", { valueEncoding: "binary" })
-    const residualEntries = Object.entries(driver.residual)
-    const hasResidual = residualEntries.length > 0
-    const residualMatch = (r: Record<string, any>) =>
-      residualEntries.every(([k, v]) => String(r[k]) === String(v))
+    const hasResidual = Object.keys(driver.residual).length > 0
 
     // Hydrate a page of index rows. With the geo payload backfilled, decode the
     // inline value carried on each row — no random rec/* seek, no fat-record
@@ -514,7 +565,7 @@ export class CensusReader {
         const hydrated = await hydratePage(batch)
         for (let j = 0; j < hydrated.length; j++) {
           const r = hydrated[j]
-          if (!r || !residualMatch(r)) continue
+          if (!r || !matchesWeaverFilters(r, driver.residual)) continue
           if (count >= offset && weavers.length < limit) {
             weavers.push(r)
             next = batch[j].id

--- a/apps/backend/src/modules/census/service.ts
+++ b/apps/backend/src/modules/census/service.ts
@@ -1,12 +1,18 @@
+import { MedusaService } from "@medusajs/framework/utils"
+
 import { censusReader, type WeaverFilters, type ListOptions } from "./reader"
+import CensusUnmaskAudit from "./models/census-unmask-audit"
 
 /**
- * Census module service — a thin, read-only query surface over the P2P public
- * core (no Postgres, no data model). It delegates to the module-singleton
- * CensusReader that the loader wires to the live Hyperbee. Routes resolve this
- * from the container as `census` and call these methods like any module service.
+ * Census module service — a read-only query surface over the P2P public core
+ * (no Postgres data model for weavers themselves) PLUS one Postgres table,
+ * `census_unmask_audit`, that records admin reveals of a weaver's full PII.
+ * It delegates weaver reads to the module-singleton CensusReader that the loader
+ * wires to the live Hyperbee. Routes resolve this from the container as `census`.
  */
-class CensusModuleService {
+class CensusModuleService extends MedusaService({
+  CensusUnmaskAudit,
+}) {
   get connected(): boolean {
     return censusReader.ready
   }
@@ -21,6 +27,14 @@ class CensusModuleService {
 
   getStats(options: { minCell?: number } = {}) {
     return censusReader.getStats(options)
+  }
+
+  /**
+   * Resolve a weaver's FULL (unredacted) PII from the encrypted sensitive core
+   * via the reader node. Proxy-mode only; fails closed without a proxy + token.
+   */
+  unmaskWeaver(id: string | number) {
+    return censusReader.unmaskWeaver(id)
   }
 }
 

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -203,6 +203,11 @@ secrets:
   # CRM_NODE_URL (variables, above). Store the SSM SecureString BEFORE the first
   # deploy that carries CRM_NODE_URL, else task start fails resolving this secret.
   CRM_NODE_TOKEN: /jyt/prod/CRM_NODE_TOKEN
+  # Census unmask — bearer for the reader node's token-gated /census/unmask/:id
+  # (decrypts the sensitive core; the HANDLOOM_ENCRYPTION_KEY itself never leaves
+  # the OCI node). Same value as CENSUS_UNMASK_TOKEN on the OCI census-node.service
+  # env. Store the SSM SecureString before the first deploy that uses unmask.
+  CENSUS_UNMASK_TOKEN: /jyt/prod/CENSUS_UNMASK_TOKEN
   DATABASE_URL: /jyt/prod/DATABASE_URL
   # DTDC domestic (India) — @jytextiles/medusa-plugin-dtdc-shipping.
   # 🔴 DTDC_API_KEY is the GATE: medusa-config registers the provider only when

--- a/scripts/handloom-scrape/hyperbee-slice/census_reader_node.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/census_reader_node.mjs
@@ -23,6 +23,7 @@
 // Public, PII-free data → no auth (the proxy sends none).
 
 import { createServer } from "node:http";
+import { brotliDecompressSync } from "node:zlib";
 
 import Corestore from "corestore";
 import Hyperswarm from "hyperswarm";
@@ -42,13 +43,29 @@ if (!keys.length) {
   process.exit(2);
 }
 
+// The SENSITIVE core (index 1) is opened WITH the encryption key when provided,
+// so /census/unmask can decrypt it. Absent the key it stays opaque — durability
+// mirror only, exactly as before. The key never leaves this host.
+const encHex = (process.env.HANDLOOM_ENCRYPTION_KEY || "").trim();
+const encryptionKey = encHex ? b4a.from(encHex, "hex") : null;
+
 const store = new Corestore(STORE_DIR);
 await store.ready();
 
-// read-only replicas of each core (no encryptionKey → sensitive stays opaque)
-const cores = keys.map((hex) => store.get({ key: b4a.from(hex, "hex") }));
+const cores = keys.map((hex, i) => {
+  if (i === 1 && encryptionKey) return store.get({ key: b4a.from(hex, "hex"), encryptionKey });
+  return store.get({ key: b4a.from(hex, "hex") });
+});
 await Promise.all(cores.map((c) => c.ready()));
 const publicCore = cores[0];
+const sensitiveCore = keys.length > 1 ? cores[1] : null;
+
+// Decryptable read handle over the sensitive core (only when the key is present).
+let sensBee = null;
+if (sensitiveCore && encryptionKey) {
+  sensBee = new Hyperbee(sensitiveCore, { keyEncoding: "utf-8", valueEncoding: "binary" });
+  await sensBee.ready();
+}
 
 const swarm = new Hyperswarm();
 swarm.on("connection", (conn) => {
@@ -160,6 +177,23 @@ const server = createServer(async (req, res) => {
       return send(res, 200, { stats: await reader.getStats(minCell != null ? { minCell } : {}) });
     }
 
+    // Token-gated unmask: full PII for one census_id, decrypted from the
+    // sensitive core with the encryption key held ONLY on this host.
+    if (parts[0] === "census" && parts[1] === "unmask") {
+      const token = process.env.CENSUS_UNMASK_TOKEN;
+      if (!token || !sensBee) {
+        return send(res, 503, { message: "unmask unavailable — set HANDLOOM_ENCRYPTION_KEY + CENSUS_UNMASK_TOKEN" });
+      }
+      if (req.headers["authorization"] !== `Bearer ${token}`) {
+        return send(res, 401, { message: "unauthorized" });
+      }
+      const id = decodeURIComponent(parts[2] || "");
+      if (!id) return send(res, 400, { message: "census_id required" });
+      const node = await sensBee.sub("rec", { valueEncoding: "binary" }).get(String(id));
+      if (!node) return send(res, 404, { message: `no census weaver with id ${id}` });
+      return send(res, 200, { weaver: JSON.parse(brotliDecompressSync(node.value).toString()) });
+    }
+
     if (parts[0] === "census" && parts[1] === "weavers") {
       if (parts[2]) {
         return send(res, 200, { weaver: await reader.retrieveWeaver(decodeURIComponent(parts[2])) });
@@ -197,4 +231,8 @@ const report = () => {
 setInterval(report, 5 * 60 * 1000);
 await new Promise((r) => setTimeout(r, 3000));
 report();
-console.log("census reader node: replicating + persisting all cores; serving public read API (sensitive stays opaque)");
+console.log(
+  sensBee
+    ? "census reader node: replicating + persisting all cores; serving public read API + token-gated /census/unmask"
+    : "census reader node: replicating + persisting all cores; serving public read API (no HANDLOOM_ENCRYPTION_KEY → unmask disabled)"
+);

--- a/scripts/handloom-scrape/hyperbee-slice/unmask_cli.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/unmask_cli.mjs
@@ -1,0 +1,43 @@
+// Unmask CLI — resolve one weaver's FULL PII from the encrypted sensitive core,
+// locally, wherever the seeder's store lives (the OCI node). This is the
+// "query it" path for an operator with the encryption key — no HTTP, no Medusa.
+//
+//   HANDLOOM_ENCRYPTION_KEY=<64-hex> [P2P_STORE=./p2p-store] \
+//     node unmask_cli.mjs 2904500
+//
+// The key is the SAME 64-hex value the seeder (seed_p2p.mjs) uses; it never
+// leaves this host. The sensitive core is opened by NAME (what the seeder
+// created) so the operator doesn't need the core's hex key.
+
+import Corestore from "corestore";
+import Hyperbee from "hyperbee";
+import b4a from "b4a";
+import { brotliDecompressSync } from "node:zlib";
+
+const id = process.argv[2];
+if (!id) {
+  console.error("usage: node unmask_cli.mjs <census_id>");
+  process.exit(2);
+}
+
+const encHex = (process.env.HANDLOOM_ENCRYPTION_KEY || "").trim();
+if (!encHex || encHex.length !== 64) {
+  console.error("set HANDLOOM_ENCRYPTION_KEY (64-hex)");
+  process.exit(2);
+}
+const STORE_DIR = process.env.P2P_STORE || "./p2p-store";
+
+const store = new Corestore(STORE_DIR);
+await store.ready();
+const core = store.get({ name: "handloom-sensitive-v1", encryptionKey: b4a.from(encHex, "hex") });
+await core.ready();
+const bee = new Hyperbee(core, { keyEncoding: "utf-8", valueEncoding: "binary" });
+await bee.ready();
+
+const node = await bee.sub("rec", { valueEncoding: "binary" }).get(String(id));
+if (!node) {
+  console.error(`no census weaver with id ${id}`);
+  process.exit(1);
+}
+console.log(JSON.stringify(JSON.parse(brotliDecompressSync(node.value).toString()), null, 2));
+await store.close();

--- a/scripts/handloom-scrape/hyperbee-slice/unmask_self_test.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/unmask_self_test.mjs
@@ -1,0 +1,89 @@
+// Self-test for the unmask path — runs the REAL decrypt→unmask mechanism over a
+// synthetic sensitive core (no live data, no network). Proves the two properties
+// the unmask feature depends on:
+//
+//   1. The sensitive core is OPAQUE without the encryption key.
+//   2. Opening it WITH the key (exactly what unmask_cli.mjs does) returns the
+//      full PII, brotli-decoded, keyed by census_id.
+//
+//   node unmask_self_test.mjs
+//
+// Mirrors seed_p2p.mjs's core layout (name "handloom-sensitive-v1", rec\<0>id
+// keys, brotli JSON values) so it exercises the same read path as the CLI and
+// the reader node's /census/unmask endpoint.
+
+import { rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { brotliCompressSync, brotliDecompressSync } from "node:zlib";
+import { randomBytes } from "node:crypto";
+
+import Corestore from "corestore";
+import Hyperbee from "hyperbee";
+import b4a from "b4a";
+import assert from "node:assert";
+
+const NAME = "handloom-sensitive-v1";
+const KEY = randomBytes(32).toString("hex");
+const STORE_DIR = mkdtempSync(join(tmpdir(), "unmask-self-test-"));
+const SEP = Buffer.from([0]);
+const subKey = (name, k) => Buffer.concat([Buffer.from(name), SEP, Buffer.from(String(k))]);
+
+const ROWS = [
+  { census_id: "2904500", name: "MOHD SHAHID", mobile: "9812345678", latitude: 27.28, longitude: 81.17, religion: "Hindu", social_group: "OBC" },
+  { census_id: "2904501", name: "REKHA DEVI", mobile: "9876543210", latitude: 27.5, longitude: 81.4, religion: "Muslim", social_group: "General" },
+];
+
+let pass = 0;
+const ok = (label, cond) => { assert(cond, `FAIL: ${label}`); console.log(`  ✓ ${label}`); pass++; };
+
+// ── seed the synthetic sensitive core (encrypted) ─────────────────────────────
+{
+  const store = new Corestore(STORE_DIR);
+  const core = store.get({ name: NAME, encryptionKey: b4a.from(KEY, "hex") });
+  await core.ready();
+  const bee = new Hyperbee(core, { keyEncoding: "binary", valueEncoding: "binary" });
+  const batch = bee.batch({ keyEncoding: "binary", valueEncoding: "binary" });
+  for (const r of ROWS) {
+    await batch.put(subKey("rec", r.census_id), brotliCompressSync(Buffer.from(JSON.stringify(r))));
+  }
+  await batch.flush();
+  await store.close();
+}
+
+// ── 1. opaque without the key ─────────────────────────────────────────────────
+{
+  const store = new Corestore(STORE_DIR);
+  const noKey = store.get({ name: NAME });
+  await noKey.ready();
+  let leaked = false;
+  try {
+    const raw = await noKey.get(0);
+    leaked = raw != null && b4a.toString(raw).includes("mobile");
+  } catch { leaked = false; }
+  ok("sensitive core is OPAQUE without the encryption key", !leaked);
+  await store.close();
+}
+
+// ── 2. with the key, unmask resolves the full PII (unmask_cli.mjs's read path) ──
+{
+  const store = new Corestore(STORE_DIR);
+  const core = store.get({ name: NAME, encryptionKey: b4a.from(KEY, "hex") });
+  await core.ready();
+  const bee = new Hyperbee(core, { keyEncoding: "utf-8", valueEncoding: "binary" });
+  await bee.ready();
+
+  for (const want of ROWS) {
+    const node = await bee.sub("rec", { valueEncoding: "binary" }).get(want.census_id);
+    ok(`rec/<${want.census_id}> present`, !!node);
+    const rec = JSON.parse(brotliDecompressSync(node.value).toString());
+    ok(`unmask(${want.census_id}) returns full PII`, rec.mobile === want.mobile && rec.religion === want.religion && rec.name === want.name);
+  }
+
+  const missing = await bee.sub("rec", { valueEncoding: "binary" }).get("9999999");
+  ok("unknown census_id → null", missing == null);
+  await store.close();
+}
+
+rmSync(STORE_DIR, { recursive: true, force: true });
+console.log(`\n✅ ${pass}/${pass} — decrypt→unmask mechanism holds against a real Hypercore.`);


### PR DESCRIPTION
## What

Two related handloom-census capabilities in the admin:

1. **Search weavers from Persons.** `GET /admin/persons` accepts `include_weavers=true` and returns masked census weavers (`weavers` / `weavers_count`) alongside DB persons, with weaver filters (`district`, `region_state`, `gender`, `education`, …) and free-text `q` name matching. The Persons UI gains an "Include weavers" toggle that swaps the table to masked weaver columns.

2. **On-demand unredacted reveal (unmask).** `GET /admin/census/weavers/:census_id/unmask` reveals one weaver's full PII, gated by **MFA** (fails closed) and written to a new `census_unmask_audit` table. Decryption happens on the OCI reader node (`/census/unmask/:id`, token-gated); the `HANDLOOM_ENCRYPTION_KEY` never leaves the node.

## Security model

- List/search = masked only (unchanged).
- Full PII = per-record, on-demand, MFA-gated, audit-logged.
- Medusa → node over the Cloudflare Tunnel with a `CENSUS_UNMASK_TOKEN` bearer (mirrors `CRM_NODE_TOKEN`).

## Provisioned (already live)

- OCI `handloom-mirror`: updated `census_reader_node.mjs`, `/etc/census/node.env` (root:600) with `HANDLOOM_ENCRYPTION_KEY` + `CENSUS_UNMASK_TOKEN`, systemd drop-in, service restarted.
- AWS SSM: `/jyt/prod/CENSUS_UNMASK_TOKEN` (SecureString).
- Verified end-to-end via `https://census-node.jaalyantra.com/census/unmask/:id` (200 with token, 401 otherwise).

## Tests

- `reader.unit.spec.ts` — 13 cases incl. a real-HTTP unmask round-trip.
- `persons-weavers.spec.ts` — 5 cases incl. the MFA 403 gate.
- `unmask_self_test.mjs` — decrypt→unmask against a real Hypercore.

## Deploy note

Runs the new `census_unmask_audit` migration (`yarn predeploy`).
