### PR TITLE
feat(census): weaver detail view + full state filter

### DIFF
--- a/apps/backend/integration-tests/http/persons-weavers.spec.ts
+++ b/apps/backend/integration-tests/http/persons-weavers.spec.ts
@@ -154,4 +154,33 @@ setupSharedTestSuite(() => {
       expect(res.status).toBe(403)
     })
   })
+
+  describe("GET /admin/census/states + /admin/census/weavers/:census_id", () => {
+    it("returns every geographic state from the census aggregates", async () => {
+      const res = await api.get("/admin/census/states", headers)
+
+      expect(res.status).toBe(200)
+      expect(res.data.states).toEqual([{ state: "KARNATAKA", count: null }])
+    })
+
+    it("returns the masked record for a single census_id", async () => {
+      const res = await api.get("/admin/census/weavers/1", headers)
+
+      expect(res.status).toBe(200)
+      expect(res.data.weaver).toMatchObject({
+        census_id: 1,
+        district: "BAGALKOT",
+        name: "Ramesh Patel",
+      })
+      expect(res.data.weaver.survey).toBeUndefined()
+    })
+
+    it("404s for an unknown census_id", async () => {
+      const res = await api
+        .get("/admin/census/weavers/999", headers)
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(404)
+    })
+  })
 })

--- a/apps/backend/src/admin/components/persons/weaver-census-section.tsx
+++ b/apps/backend/src/admin/components/persons/weaver-census-section.tsx
@@ -1,0 +1,65 @@
+import { Container, Heading, Text } from "@medusajs/ui"
+
+import { AdminWeaver } from "../../hooks/api/personandtype"
+
+// Already shown in the general section / header — don't repeat them here.
+const EXCLUDED = new Set([
+  "census_id",
+  "district",
+  "state",
+  "gender",
+  "age",
+  "education",
+  "village",
+  "block",
+  "mobile_masked",
+])
+
+const fmt = (v: any): string => (typeof v === "boolean" ? (v ? "Yes" : "No") : String(v))
+
+export const WeaverCensusSection = ({ weaver }: { weaver: AdminWeaver }) => {
+  const scalar = Object.entries(weaver).filter(
+    ([k, v]) => !EXCLUDED.has(k) && v != null && v !== "" && typeof v !== "object"
+  )
+  const objects = Object.entries(weaver).filter(
+    ([k, v]) => !EXCLUDED.has(k) && v != null && typeof v === "object"
+  )
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col px-6 py-4">
+        <Heading level="h2">Census details</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Additional survey fields for this weaver
+        </Text>
+      </div>
+      {scalar.length === 0 && objects.length === 0 ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            No additional fields
+          </Text>
+        </div>
+      ) : null}
+      {scalar.map(([k, v]) => (
+        <div key={k} className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+          <Text size="small" leading="compact" weight="plus">
+            {k.replace(/_/g, " ")}
+          </Text>
+          <Text size="small" leading="compact">
+            {fmt(v)}
+          </Text>
+        </div>
+      ))}
+      {objects.map(([k, v]) => (
+        <div key={k} className="px-6 py-4">
+          <Text size="small" leading="compact" weight="plus">
+            {k.replace(/_/g, " ")}
+          </Text>
+          <pre className="text-ui-fg-subtle mt-2 whitespace-pre-wrap break-all rounded border border-ui-border-base p-2 text-xs">
+            {JSON.stringify(v, null, 2)}
+          </pre>
+        </div>
+      ))}
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/persons/weaver-general-section.tsx
+++ b/apps/backend/src/admin/components/persons/weaver-general-section.tsx
@@ -1,0 +1,43 @@
+import { Container, Heading, Text } from "@medusajs/ui"
+
+import { AdminWeaver } from "../../hooks/api/personandtype"
+
+const GENERAL_FIELDS: { label: string; key: string }[] = [
+  { label: "District", key: "district" },
+  { label: "State", key: "state" },
+  { label: "Gender", key: "gender" },
+  { label: "Age", key: "age" },
+  { label: "Education", key: "education" },
+  { label: "Village", key: "village" },
+  { label: "Block", key: "block" },
+  { label: "Mobile (masked)", key: "mobile_masked" },
+]
+
+const fmt = (v: any): string => (typeof v === "boolean" ? (v ? "Yes" : "No") : String(v))
+
+export const WeaverGeneralSection = ({ weaver }: { weaver: AdminWeaver }) => {
+  const rows = GENERAL_FIELDS.filter(
+    ({ key }) => (weaver as any)[key] != null && (weaver as any)[key] !== ""
+  )
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col px-6 py-4">
+        <Heading>Weaver #{weaver.census_id}</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Handloom census record (masked)
+        </Text>
+      </div>
+      {rows.map(({ label, key }) => (
+        <div key={key} className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+          <Text size="small" leading="compact" weight="plus">
+            {label}
+          </Text>
+          <Text size="small" leading="compact">
+            {fmt((weaver as any)[key])}
+          </Text>
+        </div>
+      ))}
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/persons/weaver-reveal-section.tsx
+++ b/apps/backend/src/admin/components/persons/weaver-reveal-section.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react"
+import { Button, Container, Heading, Text } from "@medusajs/ui"
+
+import { sdk } from "../../lib/config"
+
+/**
+ * Section-level "Reveal" for the weaver detail view. Fetches one weaver's FULL
+ * PII from `GET /admin/census/weavers/:census_id/unmask`, which is MFA-gated +
+ * audit-logged server-side. The full record is shown inline and never persisted.
+ */
+export const WeaverRevealSection = ({ censusId }: { censusId: string | number }) => {
+  const [state, setState] = useState<{
+    status: "idle" | "loading" | "revealed" | "error"
+    data?: Record<string, any> | null
+    message?: string
+  }>({ status: "idle" })
+
+  const reveal = async () => {
+    setState({ status: "loading" })
+    try {
+      const res = await sdk.client.fetch<{ weaver: Record<string, any> }>(
+        `/admin/census/weavers/${censusId}/unmask`
+      )
+      setState({ status: "revealed", data: res.weaver })
+    } catch (e: any) {
+      const status = e?.response?.status
+      const message =
+        status === 403
+          ? "MFA required to reveal full PII"
+          : status === 404
+          ? "No record"
+          : e?.message || "Reveal failed"
+      setState({ status: "error", message })
+    }
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col px-6 py-4">
+        <Heading level="h2">Full PII</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          MFA-gated reveal from the encrypted sensitive core
+        </Text>
+      </div>
+      <div className="flex flex-col gap-y-2 px-6 py-4">
+        <Button
+          size="small"
+          variant="secondary"
+          className="w-fit"
+          onClick={reveal}
+          isLoading={state.status === "loading"}
+        >
+          Reveal
+        </Button>
+        {state.status === "error" ? (
+          <Text size="small" className="text-ui-fg-error">
+            {state.message}
+          </Text>
+        ) : null}
+        {state.status === "revealed" && state.data ? (
+          <pre className="text-ui-fg-subtle mt-2 whitespace-pre-wrap break-all rounded border border-ui-border-base p-2 text-xs">
+            {JSON.stringify(state.data, null, 2)}
+          </pre>
+        ) : null}
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/census.ts
+++ b/apps/backend/src/admin/hooks/api/census.ts
@@ -1,0 +1,43 @@
+import { FetchError } from "@medusajs/js-sdk"
+import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+import { AdminWeaver } from "./personandtype"
+
+export interface CensusState {
+  state: string
+  count: number | null
+}
+
+/** A single weaver's MASKED census record, for the weaver detail view. */
+export const useWeaver = (
+  censusId: string | number | undefined,
+  options?: Omit<
+    UseQueryOptions<{ weaver: AdminWeaver }, FetchError, { weaver: AdminWeaver }, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  return useQuery({
+    queryKey: ["census", "weaver", censusId],
+    queryFn: async () =>
+      sdk.client.fetch<{ weaver: AdminWeaver }>(`/admin/census/weavers/${censusId}`),
+    enabled: censusId !== undefined && censusId !== null && censusId !== "",
+    ...options,
+  })
+}
+
+/** Every geographic state in the census (from the aggregates). */
+export const useCensusStates = (
+  options?: Omit<
+    UseQueryOptions<{ states: CensusState[] }, FetchError, { states: CensusState[] }, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ["census", "states"],
+    queryFn: async () => sdk.client.fetch<{ states: CensusState[] }>(`/admin/census/states`),
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+  return { states: data?.states, ...rest }
+}

--- a/apps/backend/src/admin/routes/persons/page.tsx
+++ b/apps/backend/src/admin/routes/persons/page.tsx
@@ -6,6 +6,7 @@ type SortingState = { id: string; desc: boolean } | null
 import { Link, Outlet, useNavigate } from "react-router-dom";
 import CreateButton from "../../components/creates/create-button";
 import { usePersons } from "../../hooks/api/persons";
+import { useCensusStates } from "../../hooks/api/census";
 import { useMemo, useState, useCallback } from "react";
 import { usePersonTableColumns } from "../../hooks/columns/usePersonTableColumns";
 import { AdminPerson, AdminWeaver } from "../../hooks/api/personandtype";
@@ -154,6 +155,10 @@ const PersonsPage = () => {
   );
 
   const columns = useColumns();
+
+  // Full geographic-state list (from the census aggregates) for the weaver
+  // "Region state" filter — every state, not just the few on the current page.
+  const { states } = useCensusStates();
   
   const personFilterHelper = createDataTableFilterHelper<AdminPerson>();
   
@@ -240,11 +245,9 @@ const PersonsPage = () => {
       type: "select",
       label: "Region state",
       options: useMemo(() => {
-        if (!weavers?.length) return [];
-        return [...new Set(weavers.map(w => w.state).filter(Boolean))].map(
-          (s) => ({ label: s as string, value: s as string })
-        );
-      }, [weavers]),
+        if (!states?.length) return [];
+        return states.map((s) => ({ label: s.state, value: s.state }));
+      }, [states]),
     }),
     weaverFilterHelper.accessor("education", {
       type: "select",
@@ -269,9 +272,11 @@ const PersonsPage = () => {
     columns: tableColumns,
     data: tableData,
     getRowId: (row) => String(row.id ?? row.census_id),
-    // Weavers have no detail page; only DB persons navigate.
+    // Persons open the person detail; weavers open the census-record detail.
     onRowClick: includeWeavers
-      ? undefined
+      ? (_, row) => {
+          navigate(`/persons/weavers/${row.original.census_id}`);
+        }
       : (_, row) => {
           navigate(`/persons/${row.id}`);
         },

--- a/apps/backend/src/admin/routes/persons/weavers/[census_id]/loader.ts
+++ b/apps/backend/src/admin/routes/persons/weavers/[census_id]/loader.ts
@@ -1,0 +1,12 @@
+import { sdk } from "../../../../lib/config"
+import { queryClient } from "../../../../lib/query-client"
+
+export const weaverLoader = async ({ params }: any) => {
+  const censusId = params.census_id
+
+  return queryClient.ensureQueryData({
+    queryKey: ["census", "weaver", censusId],
+    queryFn: async () =>
+      sdk.client.fetch<{ weaver: any }>(`/admin/census/weavers/${censusId}`),
+  })
+}

--- a/apps/backend/src/admin/routes/persons/weavers/[census_id]/page.tsx
+++ b/apps/backend/src/admin/routes/persons/weavers/[census_id]/page.tsx
@@ -1,0 +1,48 @@
+import { LoaderFunctionArgs, UIMatch, useLoaderData, useParams } from "react-router-dom"
+
+import { useWeaver } from "../../../../hooks/api/census"
+import { TwoColumnPage } from "../../../../components/pages/two-column-pages"
+import { TwoColumnPageSkeleton } from "../../../../components/table/skeleton"
+import { WeaverGeneralSection } from "../../../../components/persons/weaver-general-section"
+import { WeaverCensusSection } from "../../../../components/persons/weaver-census-section"
+import { WeaverRevealSection } from "../../../../components/persons/weaver-reveal-section"
+import { weaverLoader } from "./loader"
+
+const WeaverDetailPage = () => {
+  const { census_id } = useParams()
+  const initialData = useLoaderData() as Awaited<{ weaver: any }>
+
+  const { data, isPending, isError, error } = useWeaver(census_id, { initialData })
+
+  if (isPending || !data?.weaver) {
+    return <TwoColumnPageSkeleton mainSections={2} sidebarSections={1} showJSON />
+  }
+
+  if (isError) {
+    throw error
+  }
+
+  const weaver = data.weaver
+
+  return (
+    <TwoColumnPage data={weaver} hasOutlet={false} showJSON>
+      <TwoColumnPage.Main>
+        <WeaverGeneralSection weaver={weaver} />
+        <WeaverCensusSection weaver={weaver} />
+      </TwoColumnPage.Main>
+      <TwoColumnPage.Sidebar>
+        <WeaverRevealSection censusId={census_id!} />
+      </TwoColumnPage.Sidebar>
+    </TwoColumnPage>
+  )
+}
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  return await weaverLoader({ params })
+}
+
+export const handle = {
+  breadcrumb: (match: UIMatch<{ census_id: string }>) => `Weaver ${match.params.census_id}`,
+}
+
+export default WeaverDetailPage

--- a/apps/backend/src/api/admin/census/states/route.ts
+++ b/apps/backend/src/api/admin/census/states/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { CENSUS_MODULE } from "../../../../modules/census"
+import type CensusModuleService from "../../../../modules/census/service"
+
+/**
+ * GET /admin/census/states
+ *
+ * The complete list of geographic states present in the census, sourced from the
+ * pre-computed aggregates (O(1), no per-record scan). Used to populate the weaver
+ * "Region state" filter with EVERY state, not just the few on the current page.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const census = req.scope.resolve(CENSUS_MODULE) as CensusModuleService
+
+  if (!census.connected) {
+    return res.status(503).json({ states: [] })
+  }
+
+  const stats = await census.getStats()
+  const states = Object.entries(stats.state ?? {})
+    .map(([state, count]) => ({ state, count }))
+    .sort((a, b) => a.state.localeCompare(b.state))
+
+  res.json({ states })
+}

--- a/apps/backend/src/api/admin/census/weavers/[census_id]/route.ts
+++ b/apps/backend/src/api/admin/census/weavers/[census_id]/route.ts
@@ -1,0 +1,33 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { CENSUS_MODULE } from "../../../../../modules/census"
+import type CensusModuleService from "../../../../../modules/census/service"
+
+/**
+ * GET /admin/census/weavers/:census_id
+ *
+ * A single weaver's MASKED census record (PII-free — name/mobile/coords/religion
+ * live only in the sensitive core, surfaced separately via …/unmask). Used by the
+ * weaver detail view in the admin persons section.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const census = req.scope.resolve(CENSUS_MODULE) as CensusModuleService
+
+  if (!census.connected) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "census P2P reader not connected — try again shortly"
+    )
+  }
+
+  const weaver = await census.retrieveWeaver(req.params.census_id)
+  if (!weaver) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `no census weaver with id ${req.params.census_id}`
+    )
+  }
+
+  res.json({ weaver })
+}


### PR DESCRIPTION
## What

Follow-up to #1845 — a dedicated **weaver detail view** and a **complete state filter**:

1. **Weaver detail view.** Clicking a census weaver in the Persons list now opens `/persons/weavers/:census_id`, reusing the `TwoColumnPage` section layout:
   - **General** — census_id + district, state, gender, age, education, village, block, masked mobile.
   - **Census details** — every remaining survey field (household, looms, ownership, sales, income band, yarn consumption) in its own section.
   - **Full PII** — the MFA-gated unmask as a proper sidebar section.

2. **Full state filter.** New `GET /admin/census/states` (from the census aggregates) populates the weaver "Region state" filter with **every** state, instead of only the few on the current page.

New backend: `GET /admin/census/weavers/:census_id` (masked record) and `GET /admin/census/states`.

## Tests

- `persons-weavers.spec.ts` — 8 cases (added states-list, weaver-by-id, 404; existing list/unmask cases still green).
- `tsc --noEmit` clean on changed files.

## Deploy note

No migration. Frontend route + two admin endpoints only.
