### PR TITLE
fix(auth): MFA challenges were written to one task's memory and verified on another

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -164,6 +164,35 @@ module.exports = defineConfig({
         ],
       },
     },  
+    /**
+     * 🔴 The legacy CACHE module, on Redis. Load-bearing for auth, and NOT the
+     * same thing as `@medusajs/medusa/caching` registered above.
+     *
+     * `Modules.CACHE` ("cache") and `Modules.CACHING` ("caching") are distinct
+     * keys. Registering only `caching` leaves `cache` on Medusa's default
+     * in-memory fallback — measured, not assumed:
+     *
+     *   RESOLVED cache:   InMemoryCacheService
+     *   AUTH cache_:      InMemoryCacheService
+     *
+     * `@medusajs/auth` keeps two pieces of CROSS-REQUEST state in `cache`:
+     *
+     *   auth:mfa:challenge:<id>   the MFA challenge (createAuthMfaChallenge_ →
+     *                             verifyAuthMfaChallenge_)
+     *   OAuth `setState`/`getState` for providers that require state
+     *
+     * Prod runs TWO medusa-server tasks behind the ALB, so an in-memory cache
+     * means the challenge is written to one task's process memory and the
+     * verify request lands on the other roughly half the time — surfacing as
+     * `MFA challenge with id "..." was not found`, and as an intermittent OAuth
+     * state failure. It cannot reproduce on a single-process dev machine.
+     */
+    {
+      resolve: "@medusajs/medusa/cache-redis",
+      options: {
+        redisUrl: process.env.REDIS_URL,
+      },
+    },
     {
       resolve: "@medusajs/medusa/event-bus-redis",
       options: {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -253,7 +253,18 @@ module.exports = defineConfig({
       resolve: "./src/modules/investor",
     },
 
-    // Production-ready modules
+    // Production-ready modules.
+    //
+    // ⚠️ These stay OFF here on purpose — a dev machine is one process, so the
+    // in-memory fallbacks behave identically and nobody needs Redis running to
+    // boot the app. `medusa-config.prod.ts` DOES register `cache-redis`, and
+    // that divergence is deliberate rather than drift.
+    //
+    // 🔴 It is also why the MFA lockout could not reproduce locally: MFA
+    // challenges live in `Modules.CACHE` (`auth:mfa:challenge:<id>`), not in
+    // Postgres, so with two server tasks behind the ALB an in-memory cache
+    // loses the challenge whenever the verify request lands on the other task.
+    // One process here, one cache, always found.
     // {
     //   resolve: "@medusajs/medusa/cache-redis",
     //   options: {


### PR DESCRIPTION
fix(auth): MFA challenges were written to one task's memory and verified on another

Reported from prod after enabling the MFA challenge on login:

    MFA challenge with id "authmfachal_01M1T27Q79AJ2BK2JWNZANPKMY" was not found

## Mechanism

MFA challenges are NOT in Postgres. `@medusajs/auth` keeps them in the CACHE
module under `auth:mfa:challenge:<id>` with a TTL (`challenge_ttl_seconds`,
default 300) — `createAuthMfaChallenge_` writes, `verifyAuthMfaChallenge_`
reads, and a miss raises exactly that message.

`Modules.CACHE` ("cache") and `Modules.CACHING` ("caching") are DIFFERENT keys.
The prod config registered only `@medusajs/medusa/caching` on Redis, so `cache`
fell through to Medusa's in-memory default. Measured, not inferred:

    RESOLVED cache:   InMemoryCacheService
    RESOLVED caching: undefined
    AUTH cache_:      InMemoryCacheService

Prod runs TWO medusa-server tasks (`desiredCount: 2, runningCount: 2`) behind
the ALB. So the challenge is written to one task's process memory and the
verify request lands on the other roughly half the time. It cannot reproduce on
a one-process dev machine, which is why it shipped.

Medusa's own docs list Cache as an Auth module dependency but say nothing about
where challenges live or about multi-instance deployments.

## Also fixed by this, silently broken until now

The same cache backs OAuth `setState`/`getState` for providers that require
state — an intermittent, identical coin flip on social login.

## The fix

Register the legacy CACHE module on the existing Redis, alongside (not instead
of) `caching`. `AUTH_MFA_ENCRYPTION_KEY` was already in SSM, correctly tagged
and wired into the server manifest — the MFA setup itself was right.

Left OFF in `medusa-config.ts` on purpose: one dev process, one cache, so the
in-memory fallback is equivalent and nobody needs Redis to boot. That
divergence is now commented in both files rather than left to look like drift.

Prediction that confirms the diagnosis: before this deploys, retrying the login
should succeed roughly half the time.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4

