### PR TITLE
refactor(shipping): move the estimate cache off the deprecated Cache module

### DIFF
--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -253,6 +253,28 @@ module.exports = defineConfig({
       resolve: "./src/modules/investor",
     },
 
+    /**
+     * The CACHING module (`Modules.CACHING`) — the replacement for the
+     * deprecated Cache module. Registered with NO provider on purpose: the
+     * module ships a memory provider as its default, so dev needs no Redis.
+     * `medusa-config.prod.ts` gives it the Redis provider.
+     *
+     * ⚠️ Distinct from `cache-redis` below, which is the DEPRECATED Cache
+     * module and stays registered in prod only because `@medusajs/auth` still
+     * reads it for MFA challenges and OAuth state (#1849). Measured, with
+     * prod's exact module set: registering `caching` leaves `cache` on the
+     * in-memory fallback, and Auth holds that fallback.
+     */
+    {
+      resolve: "@medusajs/medusa/caching",
+      options: {
+        // 🔴 `in_memory.enable` is REQUIRED. The module does NOT fall back to
+        // its memory provider on its own — with no providers and this unset it
+        // THROWS at boot: "No providers have been configured and the built in
+        // memory cache has not been enabled." Verified by booting without it.
+        in_memory: { enable: true },
+      },
+    },
     // Production-ready modules.
     //
     // ⚠️ These stay OFF here on purpose — a dev machine is one process, so the

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -761,7 +761,17 @@ export async function buildShippingEstimate(
   let calculatedError: string | null = null
   let cacheHit = false
 
-  const cacheService: any = scope.resolve(Modules.CACHE)
+  /**
+   * The CACHING module, not the deprecated Cache module — its API is an
+   * options object, NOT the old positional `get(key)` / `set(key, value, ttl)`.
+   * The migration guide says "get/set remain the same"; that is the NAMES, and
+   * the signatures differ:
+   *
+   *   get({ key })                 not  get(key)
+   *   set({ key, data, ttl })      not  set(key, data, ttl)
+   *   clear({ key })               not  invalidate(key)
+   */
+  const cacheService: any = scope.resolve(Modules.CACHING)
 
   /**
    * One carrier call per LEG, cached per leg.
@@ -786,7 +796,7 @@ export async function buildShippingEstimate(
     const legKey =
       `shipping-estimate:${carrier}:${q.origin_pincode}:` +
       `${q.destination_pincode}:${q.destination_country || ""}:${q.weight_grams}`
-    const hit = await cacheService.get(legKey).catch(() => null)
+    const hit = await cacheService.get({ key: legKey }).catch(() => null)
     if (hit) {
       cacheHit = true
       return hit as any[]
@@ -799,7 +809,9 @@ export async function buildShippingEstimate(
       )
     }
     const rates = (await provider.getRates(q)) || []
-    await cacheService.set(legKey, rates, 900).catch(() => {})
+    await cacheService
+      .set({ key: legKey, data: rates, ttl: 900 })
+      .catch(() => {})
     return rates
   }
 


### PR DESCRIPTION
refactor(shipping): move the estimate cache off the deprecated Cache module

`Modules.CACHE` is deprecated — "The Cache Module is now deprecated and has
been replaced by the Caching Module." `shipping-estimate.ts` was the only place
in our own code resolving it without a fallback, so it moves to
`Modules.CACHING`.

## The signatures are NOT the same

The migration guide says "get/set remain the same". That is the NAMES. The
shapes differ, and the difference is silent:

    old   get(key)                    set(key, data, ttl)      invalidate(key)
    new   get({ key })                set({ key, data, ttl })  clear({ key })

Both call sites here are wrapped in `.catch(() => …)`, so a naive rename would
have thrown on every call, been swallowed, and left the cache permanently cold
with no error anywhere — a pure hit-rate loss nobody would ever see. Proven
rather than reasoned: through the real container, the new shape round-trips
`[{"carrier":"probe","amount":42}]` and the OLD positional call is REJECTED.

## The dev config needed the module, and it does not self-enable

`caching` was registered in prod only, so resolving it here would have thrown
locally. Adding it revealed a second trap: the module does NOT fall back to its
built-in memory provider. With no providers and `in_memory.enable` unset it
THROWS AT BOOT:

    [caching-module]: No providers have been configured and the built in
    memory cache has not been enabled.

Found by booting, not by reading — I had assumed the memory provider was the
default. Dev now enables it explicitly; prod keeps its Redis provider.

## What this does NOT change

The deprecated Cache module stays registered in prod (#1849). `@medusajs/auth`
still reads it for MFA challenges and OAuth state, there is no compatibility
shim, and `flow-plan-cache.ts` resolves it with `allowUnregistered`. This
commit removes our LAST hard dependency on it, so when Medusa migrates Auth the
registration can simply go.

Verified: 53 shipping-estimate unit tests green; `check:prod-build` unchanged
from baseline.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4

