### PR TITLE
feat(admin): the graph's nodes get members, a remove path, a viewport — and a second spine (#1847)

### DIFF
--- a/apps/backend/src/admin/components/graph/__tests__/viewport-math.unit.spec.ts
+++ b/apps/backend/src/admin/components/graph/__tests__/viewport-math.unit.spec.ts
@@ -1,0 +1,136 @@
+import {
+  MAX_SCALE,
+  MIN_SCALE,
+  centreOffset,
+  clampScale,
+  fitScale,
+  isPan,
+  stepScale,
+  zoomAbout,
+} from "../viewport-math"
+
+describe("fitScale", () => {
+  it("shrinks a graph wider than its viewport", () => {
+    expect(fitScale({ width: 2000, height: 400 }, { width: 1064, height: 800 })).toBeCloseTo(
+      1000 / 2000
+    )
+  })
+
+  it("never enlarges one that already fits", () => {
+    /*
+     * 🔴 Fit means "show me all of it", not "fill the space". Uncapped this
+     * returns 2.5 and renders a six-node graph at 440px per box with the same
+     * 10px edge labels.
+     */
+    expect(fitScale({ width: 400, height: 200 }, { width: 1200, height: 900 })).toBe(1)
+  })
+
+  it("returns 1 for a viewport that has not been measured yet", () => {
+    // A first render has zero height. 0 and Infinity both paint an empty
+    // canvas, which is indistinguishable from a graph with no nodes.
+    expect(fitScale({ width: 800, height: 400 }, { width: 0, height: 0 })).toBe(1)
+    expect(fitScale({ width: 0, height: 0 }, { width: 800, height: 400 })).toBe(1)
+  })
+
+  it("stays inside the scale bounds for an enormous graph", () => {
+    expect(
+      fitScale({ width: 100000, height: 100000 }, { width: 800, height: 600 })
+    ).toBe(MIN_SCALE)
+  })
+
+  it("fits the constraining dimension, not the generous one", () => {
+    /*
+     * Short and very wide: width binds even though height has room to spare.
+     * The ratio is kept above MIN_SCALE on purpose — at 4000 wide the floor
+     * clamps the result and the assertion would pass for the wrong reason,
+     * proving only that the clamp works (which the case above already does).
+     */
+    const s = fitScale({ width: 2500, height: 100 }, { width: 1064, height: 900 })
+    expect(s).toBeCloseTo(1000 / 2500)
+  })
+})
+
+describe("zoomAbout", () => {
+  it("keeps the point under the cursor fixed", () => {
+    const before = { scale: 1, x: 0, y: 0 }
+    const cursor = { x: 300, y: 200 }
+    const after = zoomAbout(cursor, before, 2)
+
+    // The content coordinate under the cursor must be the same before & after.
+    const contentBefore = {
+      x: (cursor.x - before.x) / before.scale,
+      y: (cursor.y - before.y) / before.scale,
+    }
+    const contentAfter = {
+      x: (cursor.x - after.x) / after.scale,
+      y: (cursor.y - after.y) / after.scale,
+    }
+    expect(contentAfter.x).toBeCloseTo(contentBefore.x)
+    expect(contentAfter.y).toBeCloseTo(contentBefore.y)
+  })
+
+  it("holds the anchor across a zoom out from a panned position", () => {
+    // The offset term is easiest to drop when it is already non-zero, so the
+    // case that would still pass with `x` ignored is the one worth asserting.
+    const before = { scale: 1.6, x: -240, y: 90 }
+    const cursor = { x: 512, y: 300 }
+    const after = zoomAbout(cursor, before, 0.8)
+    expect((cursor.x - after.x) / after.scale).toBeCloseTo(
+      (cursor.x - before.x) / before.scale
+    )
+    expect((cursor.y - after.y) / after.scale).toBeCloseTo(
+      (cursor.y - before.y) / before.scale
+    )
+  })
+
+  it("does not nudge the offset when already at the limit", () => {
+    const at = { scale: MAX_SCALE, x: 40, y: 12 }
+    // A wheel held down at the ceiling would otherwise walk the canvas away
+    // a pixel per event while the scale never changes.
+    expect(zoomAbout({ x: 100, y: 100 }, at, MAX_SCALE * 2)).toEqual(at)
+  })
+})
+
+describe("clampScale and stepScale", () => {
+  it("bounds both ends", () => {
+    expect(clampScale(99)).toBe(MAX_SCALE)
+    expect(clampScale(0.001)).toBe(MIN_SCALE)
+  })
+
+  it("steps in and out symmetrically", () => {
+    const start = 1
+    expect(stepScale(stepScale(start, 1), -1)).toBeCloseTo(start)
+  })
+})
+
+describe("centreOffset", () => {
+  it("centres content smaller than the viewport", () => {
+    expect(centreOffset({ width: 400, height: 200 }, { width: 1000, height: 600 }, 1)).toEqual(
+      { x: 300, y: 200 }
+    )
+  })
+
+  it("accounts for the scale, not just the raw size", () => {
+    expect(
+      centreOffset({ width: 400, height: 200 }, { width: 1000, height: 600 }, 0.5)
+    ).toEqual({ x: 400, y: 250 })
+  })
+})
+
+describe("isPan", () => {
+  it("treats a steady click as a click", () => {
+    // 🔴 Otherwise every pan that begins over a node opens that node's drawer
+    // on release, mid-drag.
+    expect(isPan({ x: 100, y: 100 }, { x: 102, y: 101 })).toBe(false)
+  })
+
+  it("treats a real drag as a pan", () => {
+    expect(isPan({ x: 100, y: 100 }, { x: 140, y: 100 })).toBe(true)
+  })
+
+  it("measures the diagonal, not either axis alone", () => {
+    // 4px on each axis is 5.6px of travel — a pan. An axis-wise check would
+    // call this a click.
+    expect(isPan({ x: 0, y: 0 }, { x: 4, y: 4 })).toBe(true)
+  })
+})

--- a/apps/backend/src/admin/components/graph/graph-canvas.tsx
+++ b/apps/backend/src/admin/components/graph/graph-canvas.tsx
@@ -82,6 +82,25 @@ export const placeBalanced = (nodes: GraphNode[]) => {
   return { placed, height: Math.max(height, 220), width, spineX }
 }
 
+/**
+ * The canvas's natural, unscaled size — without rendering it.
+ *
+ * The viewport has to know how big the content is in order to fit it, and it
+ * cannot measure a child it has not laid out yet. Both layouts already compute
+ * this internally; exposing it keeps ONE arithmetic for the size, rather than
+ * a second estimate in the viewport that drifts the moment a constant here
+ * changes.
+ */
+export const canvasSize = (
+  nodes: GraphNode[],
+  layout: "columns" | "balanced" = "columns",
+  maxRows = 4
+): { width: number; height: number } => {
+  const { width, height } =
+    layout === "balanced" ? placeBalanced(nodes) : place(nodes, maxRows)
+  return { width, height }
+}
+
 export const stateStyles = (state: string, selected: boolean) => {
   const base =
     "absolute box-border rounded-lg px-3 py-2 text-left transition-shadow cursor-pointer"

--- a/apps/backend/src/admin/components/graph/graph-forms.tsx
+++ b/apps/backend/src/admin/components/graph/graph-forms.tsx
@@ -116,9 +116,28 @@ type EditForm = {
   title: string
 }
 
+/**
+ * The "and another" action on a node that already has members.
+ *
+ * Distinct from a create FORM, which opens inside the graph, and from an
+ * absent node's action, which names a step that does not exist yet. This is
+ * the third case the workspace had no answer for: the neighbour is present and
+ * the reader wants one more of it.
+ *
+ * 🔴 It exists because of one node. `runs` is the only card the design page
+ * could not give up — the graph could send an UNSTARTED design to production,
+ * but had nowhere to start a second run beside the ones already there, so the
+ * production-runs summary stayed purely to hold that button.
+ */
+type AddAnother = {
+  label: string
+  href: (id: string) => string
+}
+
 type SpineForms = {
   create: Record<string, ComponentType>
   edit: Record<string, EditForm>
+  addAnother: Record<string, AddAnother>
 }
 
 const DESIGN_FORMS: SpineForms = {
@@ -127,6 +146,19 @@ const DESIGN_FORMS: SpineForms = {
     partners: DesignPartnerCreateForm,
     inventory: DesignInventoryCreateForm,
     components: DesignComponentCreateForm,
+  },
+  addAnother: {
+    /*
+     * A run's own flow, not a form in the drawer: starting a run picks a
+     * partner, a quantity and an execution mode across several screens, and
+     * half of that is a decision rather than a field. The graph's job here is
+     * to say the step exists and get you to it — the same judgement that keeps
+     * `runs`, `product` and `specifications` out of the form registry below.
+     */
+    runs: {
+      label: "Start another run",
+      href: (id: string) => `/designs/${id}/production-run`,
+    },
   },
   edit: {
     design: {
@@ -161,7 +193,7 @@ const SPINE_FORMS: Record<string, SpineForms> = {
   design: DESIGN_FORMS,
 }
 
-const EMPTY: SpineForms = { create: {}, edit: {} }
+const EMPTY: SpineForms = { create: {}, edit: {}, addAnother: {} }
 
 const formsFor = (spine: string): SpineForms => SPINE_FORMS[spine] ?? EMPTY
 
@@ -179,3 +211,8 @@ export const createFormFor = (spine: string, key: string): ComponentType | undef
 
 export const editFormFor = (spine: string, key: string): EditForm | undefined =>
   formsFor(spine).edit[key]
+
+export const addAnotherFor = (
+  spine: string,
+  key: string
+): AddAnother | undefined => formsFor(spine).addAnother[key]

--- a/apps/backend/src/admin/components/graph/graph-viewport.tsx
+++ b/apps/backend/src/admin/components/graph/graph-viewport.tsx
@@ -1,0 +1,232 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
+import { IconButton, Text } from "@medusajs/ui"
+import { Minus, Plus } from "@medusajs/icons"
+
+import {
+  MAX_SCALE,
+  MIN_SCALE,
+  centreOffset,
+  fitScale,
+  isPan,
+  stepScale,
+  zoomAbout,
+} from "./viewport-math"
+
+/**
+ * Pan and zoom around whatever canvas is handed to it (#1847 step 5).
+ *
+ * The canvas lays nodes out in absolute pixels and draws its edges in an SVG
+ * behind them. Scaling the WRAPPER rather than the layout is what keeps those
+ * two in step: one `transform` moves the boxes and the lines by the same
+ * amount, so an edge cannot end up pointing at where a node used to be. It also
+ * means the canvas itself stays a pure function of its nodes — it knows nothing
+ * about zoom, and the in-page card can keep rendering it unwrapped.
+ *
+ * 🔴 This is not decoration. It is what lets the graph carry more nodes than
+ * fit on a screen, which is the precondition for the partner spine (19 links)
+ * and for the design page giving up its remaining sections. A canvas that can
+ * only show what fits has a hard ceiling on how much of the page it can
+ * replace.
+ */
+
+type Props = {
+  /** Natural, unscaled size of the canvas being wrapped. */
+  content: { width: number; height: number }
+  /** Changing this refits — pass something that varies with the graph shown. */
+  fitKey?: string
+  children: React.ReactNode
+}
+
+export const GraphViewport = ({ content, fitKey, children }: Props) => {
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const [view, setView] = useState({ scale: 1, x: 0, y: 0 })
+  const [size, setSize] = useState({ width: 0, height: 0 })
+  const [panning, setPanning] = useState(false)
+
+  /*
+   * The pointer gesture in a ref, not state. A pan updates on every
+   * pointermove; through state that is a re-render per frame, and the
+   * `pointerdown` origin would be a render behind by the time it is read.
+   */
+  const gesture = useRef<{
+    origin: { x: number; y: number }
+    start: { x: number; y: number }
+    moved: boolean
+  } | null>(null)
+
+  useLayoutEffect(() => {
+    const el = viewportRef.current
+    if (!el) return
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect
+      setSize({ width, height })
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const fit = useCallback(() => {
+    const scale = fitScale(content, size)
+    setView({ scale, ...centreOffset(content, size, scale) })
+  }, [content.width, content.height, size.width, size.height])
+
+  /*
+   * Refit when the graph or the viewport changes shape.
+   *
+   * 🔴 Keyed on PRIMITIVES — the width, the height, the fit key — never on the
+   * `content` object. A `useEffect` keyed on an object or array PROP re-runs on
+   * every parent render, because the identity is new each time; here that would
+   * yank the reader's pan and zoom back to fit on any unrelated re-render, and
+   * react-query's refetch-on-focus makes the parent re-render whenever the
+   * window regains focus. That exact shape wiped a five-step wizard in #1803.
+   */
+  useEffect(() => {
+    if (size.width > 0 && size.height > 0) {
+      fit()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content.width, content.height, size.width, size.height, fitKey])
+
+  const onWheel = (e: React.WheelEvent) => {
+    /*
+     * Only with a modifier, and `ctrlKey` is how a trackpad PINCH arrives in
+     * the browser. A bare wheel is left alone so the drawer and the page behind
+     * this can still scroll — hijacking it is the thing that makes an embedded
+     * canvas impossible to scroll past.
+     */
+    if (!e.ctrlKey && !e.metaKey) return
+    e.preventDefault()
+    const rect = viewportRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const point = { x: e.clientX - rect.left, y: e.clientY - rect.top }
+    setView((v) => zoomAbout(point, v, v.scale * (e.deltaY < 0 ? 1.08 : 1 / 1.08)))
+  }
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    // Left button only: a right-click is the context menu, a middle-click is
+    // the browser's own scroll gesture.
+    if (e.button !== 0) return
+    gesture.current = {
+      origin: { x: e.clientX, y: e.clientY },
+      start: { x: view.x, y: view.y },
+      moved: false,
+    }
+  }
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const g = gesture.current
+    if (!g) return
+    const to = { x: e.clientX, y: e.clientY }
+    if (!g.moved && !isPan(g.origin, to)) return
+    if (!g.moved) {
+      g.moved = true
+      setPanning(true)
+      // Capture only once the gesture has become a pan, so a plain click on a
+      // node still reaches the node's own handler.
+      ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+    }
+    setView((v) => ({
+      ...v,
+      x: g.start.x + (to.x - g.origin.x),
+      y: g.start.y + (to.y - g.origin.y),
+    }))
+  }
+
+  const endGesture = (e: React.PointerEvent) => {
+    const g = gesture.current
+    gesture.current = null
+    if (g?.moved) {
+      setPanning(false)
+      try {
+        ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+      } catch {
+        // The capture may already have been lost — releasing twice throws.
+      }
+    }
+  }
+
+  /*
+   * 🔴 A pan that ends over a node must not select it. The pointer events above
+   * never reach the node's `onClick`; this is the click that fires afterwards,
+   * on the way up through the same element. Caught in the CAPTURE phase so it
+   * is stopped before the button below sees it.
+   */
+  const onClickCapture = (e: React.MouseEvent) => {
+    if (panning) {
+      e.stopPropagation()
+      e.preventDefault()
+    }
+  }
+
+  const zoom = (direction: 1 | -1) => {
+    const centre = { x: size.width / 2, y: size.height / 2 }
+    setView((v) => zoomAbout(centre, v, stepScale(v.scale, direction)))
+  }
+
+  return (
+    <div
+      ref={viewportRef}
+      className={`relative flex-1 overflow-hidden ${panning ? "cursor-grabbing" : "cursor-grab"}`}
+      onWheel={onWheel}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endGesture}
+      onPointerCancel={endGesture}
+      onClickCapture={onClickCapture}
+    >
+      <div
+        style={{
+          transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
+          transformOrigin: "0 0",
+          width: content.width,
+          height: content.height,
+        }}
+      >
+        {children}
+      </div>
+
+      {/*
+        Controls pinned to the viewport, outside the transformed layer — inside
+        it they would zoom along with the graph and shrink out of reach at the
+        precise moment the reader needs the "fit" button most.
+      */}
+      <div className="absolute bottom-4 right-4 flex items-center gap-x-1 rounded-lg border bg-ui-bg-base p-1 shadow-elevation-card-rest">
+        <IconButton
+          size="small"
+            variant="transparent"
+            aria-label="Zoom out"
+            disabled={view.scale <= MIN_SCALE}
+            onClick={() => zoom(-1)}
+          >
+          <Minus />
+        </IconButton>
+        <Text size="xsmall" className="text-ui-fg-muted w-10 text-center tabular-nums">
+          {Math.round(view.scale * 100)}%
+        </Text>
+        <IconButton
+          size="small"
+            variant="transparent"
+            aria-label="Zoom in"
+            disabled={view.scale >= MAX_SCALE}
+            onClick={() => zoom(1)}
+          >
+          <Plus />
+        </IconButton>
+        <div className="mx-1 h-4 w-px bg-ui-border-base" />
+        <button
+          type="button"
+          onClick={fit}
+          className="rounded px-2 py-1 text-ui-fg-subtle hover:bg-ui-bg-base-hover"
+        >
+          <Text size="xsmall">Fit</Text>
+        </button>
+      </div>
+
+      <div className="absolute bottom-4 left-4">
+        <Text size="xsmall" className="text-ui-fg-muted">
+          Drag to pan · ⌘/ctrl + scroll to zoom
+        </Text>
+      </div>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/components/graph/graph-workspace.tsx
+++ b/apps/backend/src/admin/components/graph/graph-workspace.tsx
@@ -4,14 +4,16 @@ import { Badge, Button, Heading, Skeleton, Text } from "@medusajs/ui"
 
 import { useEntityGraph, type GraphNode } from "../../hooks/api/graph"
 import { RouteDrawer } from "../modal/route-drawer/route-drawer"
-import { GraphCanvas } from "./graph-canvas"
+import { GraphCanvas, canvasSize } from "./graph-canvas"
+import { GraphViewport } from "./graph-viewport"
 import {
   NodeInspectorActions,
   NodeInspectorBody,
   NodeInspectorHeader,
 } from "./node-inspector"
 import { GraphCreateModal, GraphEditModal } from "./graph-create-modal"
-import { registryFor } from "./graph-forms"
+import { addAnotherFor, registryFor } from "./graph-forms"
+import { NodeAddAnother, NodeItemList } from "./node-items"
 import { actionRail, nodeAffordance } from "./node-forms"
 
 /**
@@ -97,6 +99,17 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
       ? actionRail(affordance, active, graph?.spine.href ?? null)
       : "none"
 
+  /*
+   * 🔴 Ask for members only where the SERVER says there are members to list.
+   * `graph.itemNodes` is the spine's own declaration. Inferring it from
+   * `count > 0` would fetch on `product` and `revision` — single records with
+   * no rows — and render "Nothing linked yet" beneath a node that is a real,
+   * present neighbour.
+   */
+  const listsItems = !!active && (graph?.itemNodes ?? []).includes(active.key)
+
+  const another = active ? addAnotherFor(spine, active.key) : undefined
+
   if (isLoading) {
     return (
       <div className="flex h-full w-full flex-col gap-y-4 p-8">
@@ -151,13 +164,18 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
       </div>
 
       {/*
-        🔴 Fewer rows here, not more. `maxRows` is the point at which a SECOND
-        COLUMN starts, so raising it stacks everything into one tall column and
-        wastes the width the modal exists to provide — which is exactly what
-        the first render of this screen did. Four keeps the neighbours spread
-        across columns; the room the workspace buys is horizontal.
+        Pan and zoom, so the canvas is no longer limited to what fits.
+
+        🔴 `fitKey` varies with the SHAPE of what is drawn — the visible node
+        count and whether absent edges are shown — not with the graph object.
+        Keyed on the object it would refit on every parent render and snatch
+        the reader's pan back; keyed on nothing, toggling absent edges would
+        leave half the graph off-screen.
       */}
-      <div className="flex flex-1 items-center justify-center overflow-auto p-6">
+      <GraphViewport
+        content={canvasSize(visible, "balanced")}
+        fitKey={`${visible.length}:${showAbsent}`}
+      >
         <GraphCanvas
           spine={graph.spine}
           spineKey={spineKey}
@@ -167,7 +185,7 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
           onSelect={select}
           layout="balanced"
         />
-      </div>
+      </GraphViewport>
 
       {/*
         READ and EDIT live in the drawer; CREATE is a StackedFocusModal opened
@@ -199,6 +217,15 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
           <RouteDrawer.Body className="p-0">
             <NodeInspectorBody node={active} edge={activeEdge} />
             {/*
+              The members, and the only place in the graph that can take one
+              off. Above the create form on purpose: the reader clicked a node
+              that already has neighbours, so "which ones" comes before "add
+              one more".
+            */}
+            {listsItems && (
+              <NodeItemList spine={spine} id={id} node={active} />
+            )}
+            {/*
               Create first, then edit: on an absent node only the first of the
               two renders, and it is the one the dashed edge is asking for.
             */}
@@ -210,6 +237,17 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
               because with the summary sections gone it is the only route to the
               full list.
             */}
+            {/*
+              Present-node-only, and never on an absent one where the create
+              form or the rail below is already asking for the same thing.
+            */}
+            {another && (
+              <NodeAddAnother
+                node={active}
+                label={another.label}
+                href={another.href(id)}
+              />
+            )}
             <NodeInspectorActions node={active} mode={rail} />
           </RouteDrawer.Body>
         </RouteDrawer>

--- a/apps/backend/src/admin/components/graph/node-items.tsx
+++ b/apps/backend/src/admin/components/graph/node-items.tsx
@@ -1,0 +1,229 @@
+import { Badge, Button, IconButton, Skeleton, Text, toast, usePrompt } from "@medusajs/ui"
+import { Link } from "react-router-dom"
+import { Trash } from "@medusajs/icons"
+
+import {
+  useGraphNodeItems,
+  useRemoveGraphNodeItem,
+  type GraphNode,
+  type NodeItem,
+  type NodeItemRemoval,
+} from "../../hooks/api/graph"
+
+/**
+ * The MEMBERS behind an aggregate node — and the only place in the graph that
+ * can take one off (#1847 step 4).
+ *
+ * Until this existed the graph could only ADD. Every removal in the admin lived
+ * on a summary card, which is why those cards could not be retired: "the graph
+ * adds; only these can REMOVE" was the standing reason the design page still
+ * stacked them. This closes that.
+ *
+ * 🔴 It renders NOTHING at all for a node with no member list. Not an empty
+ * panel, not "0 items" — those read as "this node has nothing", which on
+ * `product` or `revision` (single records, no rows) would be a lie about a
+ * present, populated neighbour. The caller decides via `graph.itemNodes`.
+ */
+
+const RemoveButton = ({
+  item,
+  removal,
+  onRemove,
+  isPending,
+}: {
+  item: NodeItem
+  removal: NodeItemRemoval
+  onRemove: (r: NodeItemRemoval) => void
+  isPending: boolean
+}) => {
+  const prompt = usePrompt()
+
+  /*
+   * 🔴 The confirm text is the SERVER's, not a generic "Are you sure?".
+   * These four endpoints are not equivalent: unlinking inventory releases
+   * nothing, but cancelling a partner assignment cancels their live runs and
+   * every open task on them. A shared dialog would describe the mildest of
+   * them and be wrong about the rest — and the reader would only find out
+   * afterwards.
+   */
+  const confirm = async () => {
+    const ok = await prompt({
+      title: removal.label,
+      description: removal.confirm,
+      confirmText: removal.label,
+      cancelText: "Keep",
+    })
+    if (!ok) return
+    onRemove(removal)
+  }
+
+  return (
+    <IconButton
+      size="small"
+      variant="transparent"
+      disabled={isPending}
+      onClick={confirm}
+      aria-label={`${removal.label} ${item.label}`}
+    >
+      <Trash />
+    </IconButton>
+  )
+}
+
+export const NodeItemList = ({
+  spine,
+  id,
+  node,
+}: {
+  spine: string
+  id: string
+  node: GraphNode
+}) => {
+  const { items, isLoading, isError, error } = useGraphNodeItems(spine, id, node.key)
+  const { mutate, isPending } = useRemoveGraphNodeItem(spine, id, node.key, {
+    onSuccess: () => toast.success("Removed"),
+    /*
+     * 🔴 The server's message, surfaced. Several of these refusals are
+     * legitimate and specific — an applied consumption log answers "correct it
+     * with a reversing entry, not an edit". Swallowing that into "Something
+     * went wrong" would turn a useful instruction into a dead button.
+     */
+    onError: (e) => toast.error(e?.message ?? "The removal failed"),
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-y-2 border-t px-6 py-4">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+      </div>
+    )
+  }
+
+  /* Never render a failure as emptiness — the same rule as the canvas itself. */
+  if (isError) {
+    return (
+      <div className="border-t px-6 py-4">
+        <Text size="small">These items could not be loaded.</Text>
+        <Text size="xsmall" className="text-ui-fg-muted mt-1 break-words">
+          {(error as Error | undefined)?.message ?? "The request returned nothing."}
+        </Text>
+      </div>
+    )
+  }
+
+  if (!items.length) {
+    return (
+      <div className="border-t px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle">
+          Nothing linked yet.
+        </Text>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border-t">
+      <div className="flex items-center justify-between px-6 py-3">
+        <Text size="xsmall" weight="plus" className="text-ui-fg-muted uppercase">
+          {node.label}
+        </Text>
+        <Badge size="2xsmall" color="grey" rounded="full">
+          {items.length}
+        </Badge>
+      </div>
+      <div className="divide-y border-t">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center justify-between gap-x-2 px-6 py-2"
+          >
+            <div className="flex min-w-0 flex-col">
+              {/*
+                A row links out only where the target is a real page. Several
+                item types (`materials`) have no admin route of their own, and
+                a link that goes nowhere reads as a broken one.
+              */}
+              {item.href ? (
+                <Link to={item.href} className="truncate">
+                  <Text size="small" weight="plus" className="truncate hover:underline">
+                    {item.label}
+                  </Text>
+                </Link>
+              ) : (
+                <Text size="small" weight="plus" className="truncate">
+                  {item.label}
+                </Text>
+              )}
+              {item.sublabel && (
+                <Text size="xsmall" className="text-ui-fg-muted truncate">
+                  {item.sublabel}
+                </Text>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-x-1">
+              {item.status && (
+                <Badge size="2xsmall" color="grey" rounded="full">
+                  {item.status}
+                </Badge>
+              )}
+              {/*
+                🔴 No button where `remove` is null, and the reasons differ:
+                a `used_in` bundle row is owned by the PARENT design, an
+                applied consumption log has already moved stock, an order is
+                history. Rendering a disabled button on all three would imply
+                one shared "not yet" — they are three different permanent
+                answers.
+              */}
+              {item.remove && (
+                <RemoveButton
+                  item={item}
+                  removal={item.remove}
+                  onRemove={mutate}
+                  isPending={isPending}
+                />
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The "and another" affordance.
+ *
+ * The graph could send an unstarted design to production but had nowhere to
+ * create a SECOND run beside the ones that exist — the one job that kept the
+ * production-runs summary card on the design page. An absent node names the
+ * step that would create the first of a thing; this names the step that
+ * creates the next one.
+ *
+ * 🔴 Only on a PRESENT node. On an absent node the create form or the action
+ * rail is already asking for exactly this, and a second button beside it
+ * saying almost the same words is how the workspace ended up offering "Create
+ * the missing inventory" directly above "Link inventory".
+ */
+export const NodeAddAnother = ({
+  node,
+  label,
+  href,
+}: {
+  node: GraphNode
+  label: string
+  href: string
+}) => {
+  if (node.state === "absent") {
+    return null
+  }
+  return (
+    <div className="border-t px-6 py-3">
+      <Link to={href}>
+        <Button variant="secondary" size="small">
+          {label}
+        </Button>
+      </Link>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/components/graph/viewport-math.ts
+++ b/apps/backend/src/admin/components/graph/viewport-math.ts
@@ -1,0 +1,106 @@
+/**
+ * The arithmetic behind pan and zoom, as pure functions (#1847 step 5).
+ *
+ * Separated from the component for the usual reason in this feature: every
+ * mistake these can make is INVISIBLE. A fit that computes 1.4 silently
+ * enlarges a graph that already fitted; a cursor-anchored zoom that drops the
+ * offset term slides the whole canvas out from under the pointer; a drag
+ * threshold of zero turns every pan into a click on whatever node the pointer
+ * happened to start over. None of those throw, and all of them look like "the
+ * canvas feels wrong" rather than a bug with a location.
+ */
+
+export const MIN_SCALE = 0.35
+export const MAX_SCALE = 2.5
+
+export const clampScale = (scale: number): number =>
+  Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale))
+
+/**
+ * The scale at which the whole graph is visible inside the viewport.
+ *
+ * 🔴 Capped at 1. Fit means "show me all of it", not "fill the space" — a
+ * six-node design graph in a wide modal would otherwise be blown up to 2×,
+ * rendering 176px node boxes at 350px with the same 10px edge labels. Fit is
+ * allowed to shrink; enlarging is the reader's decision, via the buttons.
+ */
+export const fitScale = (
+  content: { width: number; height: number },
+  viewport: { width: number; height: number },
+  pad = 32
+): number => {
+  if (
+    content.width <= 0 ||
+    content.height <= 0 ||
+    viewport.width <= 0 ||
+    viewport.height <= 0
+  ) {
+    // A viewport not yet measured must not produce a scale of 0 or Infinity —
+    // both render an empty canvas that looks exactly like "the graph is empty".
+    return 1
+  }
+  const usableW = Math.max(1, viewport.width - pad * 2)
+  const usableH = Math.max(1, viewport.height - pad * 2)
+  return clampScale(Math.min(1, usableW / content.width, usableH / content.height))
+}
+
+/** Offset that centres content of this size in this viewport at this scale. */
+export const centreOffset = (
+  content: { width: number; height: number },
+  viewport: { width: number; height: number },
+  scale: number
+): { x: number; y: number } => ({
+  x: (viewport.width - content.width * scale) / 2,
+  y: (viewport.height - content.height * scale) / 2,
+})
+
+/**
+ * Zoom about a fixed point — the pointer, or the viewport's centre.
+ *
+ * 🔴 The offset MUST move with the scale. The point under the cursor is at
+ * content coordinate `(px - offset) / scale`; for it to stay under the cursor
+ * at the new scale, the offset has to absorb the difference. Drop this and the
+ * canvas drifts away from the pointer on every wheel tick — which reads as
+ * "the zoom is broken" long before anyone works out that it is the pan.
+ */
+export const zoomAbout = (
+  point: { x: number; y: number },
+  current: { scale: number; x: number; y: number },
+  nextScaleRaw: number
+): { scale: number; x: number; y: number } => {
+  const next = clampScale(nextScaleRaw)
+  // Clamped to the same value: nothing moves. Returning early keeps a wheel
+  // spun at the limit from nudging the offset a pixel at a time.
+  if (next === current.scale) {
+    return current
+  }
+  const cx = (point.x - current.x) / current.scale
+  const cy = (point.y - current.y) / current.scale
+  return {
+    scale: next,
+    x: point.x - cx * next,
+    y: point.y - cy * next,
+  }
+}
+
+/**
+ * Did this pointer gesture move far enough to be a PAN rather than a CLICK?
+ *
+ * 🔴 Without a threshold every pan that starts on a node box selects that node
+ * on release — the drawer flies open mid-drag. With too large a threshold a
+ * deliberate click on a node registers as a pan and nothing happens at all.
+ * Four pixels is the distance a hand holding a trackpad button moves without
+ * meaning to.
+ */
+export const PAN_THRESHOLD_PX = 4
+
+export const isPan = (
+  from: { x: number; y: number },
+  to: { x: number; y: number }
+): boolean => Math.hypot(to.x - from.x, to.y - from.y) > PAN_THRESHOLD_PX
+
+/** One notch of the zoom buttons. Multiplicative, so in and out are symmetric. */
+export const ZOOM_STEP = 1.25
+
+export const stepScale = (scale: number, direction: 1 | -1): number =>
+  clampScale(direction === 1 ? scale * ZOOM_STEP : scale / ZOOM_STEP)

--- a/apps/backend/src/admin/hooks/api/graph.ts
+++ b/apps/backend/src/admin/hooks/api/graph.ts
@@ -1,4 +1,11 @@
-import { QueryKey, useQuery, UseQueryOptions } from "@tanstack/react-query"
+import {
+  QueryKey,
+  useMutation,
+  UseMutationOptions,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from "@tanstack/react-query"
 import { FetchError } from "@medusajs/js-sdk"
 
 import { sdk } from "../../lib/config"
@@ -41,6 +48,8 @@ export type AdminGraphResponse = {
     nodes: GraphNode[]
     edges: GraphEdge[]
     summary: { links: number; absent: number; derived: number }
+    /** Node keys whose members can be listed. See `Graph.itemNodes` server-side. */
+    itemNodes: string[]
   }
 }
 
@@ -65,4 +74,115 @@ export const useEntityGraph = (
     ...options,
   })
   return { ...data, ...rest }
+}
+
+/**
+ * One MEMBER of an aggregate node, and how to detach it.
+ *
+ * Mirrors `NodeItem` / `NodeItemRemoval` in `src/lib/graph/types.ts`.
+ *
+ * 🔴 `remove.path` is built by the SERVER and used verbatim. The client never
+ * assembles it: the four removal endpoints behind these rows take four
+ * different shapes (a link-row id, a record id, a body with a list, a body
+ * with a flag), and a client that guessed between them would send a
+ * well-formed request to the wrong record.
+ */
+export type NodeItemRemoval = {
+  method: "DELETE" | "POST"
+  path: string
+  body: Record<string, unknown> | null
+  label: string
+  confirm: string
+}
+
+export type NodeItem = {
+  id: string
+  label: string
+  sublabel: string | null
+  status: string | null
+  href: string | null
+  props: GraphProp[]
+  remove: NodeItemRemoval | null
+}
+
+export type AdminGraphItemsResponse = { items: NodeItem[] }
+
+export const graphItemsQueryKey = (spine: string, id: string, node: string) =>
+  ["graph", spine, id, "items", node] as const
+
+/**
+ * The rows behind one node.
+ *
+ * `enabled` is the caller's, because the drawer mounts for EVERY node and only
+ * some of them have members. Fetching unconditionally would fire a request per
+ * selection and answer `[]` for the single-record nodes — cheap, but it would
+ * also make "no members" and "not loaded yet" the same state on screen.
+ */
+export const useGraphNodeItems = (
+  spine: string,
+  id: string,
+  node: string,
+  options?: Omit<
+    UseQueryOptions<
+      AdminGraphItemsResponse,
+      FetchError,
+      AdminGraphItemsResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >,
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: graphItemsQueryKey(spine, id, node),
+    queryFn: async () =>
+      sdk.client.fetch<AdminGraphItemsResponse>(
+        `/admin/graph/${spine}/${id}/items/${node}`,
+        { method: "GET" },
+      ),
+    ...options,
+  })
+  return { items: data?.items ?? [], ...rest }
+}
+
+/**
+ * Detach one member, through the endpoint the server named.
+ *
+ * 🔴 Invalidates BOTH the item list and the graph itself. Removing the last
+ * inventory item does not just shorten a list — it can flip the node from
+ * `present` to `absent` and add a dashed edge to the canvas. Invalidating only
+ * the rows would leave the graph behind the drawer asserting a link that no
+ * longer exists, which is precisely the class of lie this whole view was built
+ * to remove.
+ *
+ * 🔴 `...options` goes BEFORE `onSuccess`, never after. Spread last, it
+ * overwrites the invalidation with the caller's handler and the screen stays
+ * stale until a hard refresh — the bug that was live in 165 admin hooks.
+ */
+export const useRemoveGraphNodeItem = (
+  spine: string,
+  id: string,
+  node: string,
+  options?: UseMutationOptions<unknown, FetchError, NodeItemRemoval>,
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (removal: NodeItemRemoval) =>
+      sdk.client.fetch(removal.path, {
+        method: removal.method,
+        ...(removal.body ? { body: removal.body } : {}),
+      }),
+    ...options,
+    /*
+     * Forwarded with a rest spread rather than the three named parameters:
+     * react-query's mutation callbacks gained a fourth argument, and naming
+     * three would quietly drop it for every caller that passes an `onSuccess`.
+     */
+    onSuccess: (...args: Parameters<NonNullable<typeof options>["onSuccess"] & {}>) => {
+      queryClient.invalidateQueries({
+        queryKey: graphItemsQueryKey(spine, id, node),
+      })
+      queryClient.invalidateQueries({ queryKey: graphQueryKeys.detail(spine, id) })
+      options?.onSuccess?.(...args)
+    },
+  })
 }

--- a/apps/backend/src/admin/routes/partners/[id]/@graph/page.tsx
+++ b/apps/backend/src/admin/routes/partners/[id]/@graph/page.tsx
@@ -1,0 +1,40 @@
+import { useParams } from "react-router-dom"
+
+import { GraphWorkspace } from "../../../../components/graph/graph-workspace"
+import { RouteFocusModal } from "../../../../components/modal/route-focus-modal"
+
+/**
+ * `/partners/:id/graph` — the partner spine as the workspace (#1847).
+ *
+ * The second spine, and the whole point of the registry: this file and the
+ * design's are the same file with one word changed. No new route on the
+ * server, no new hook, no new canvas — `GraphWorkspace` takes the spine key as
+ * a prop and everything downstream of it was already spine-agnostic.
+ */
+const PartnerGraphWorkspacePage = () => {
+  const { id } = useParams()
+
+  return (
+    <RouteFocusModal>
+      <RouteFocusModal.Title asChild>
+        <span className="sr-only">Partner graph</span>
+      </RouteFocusModal.Title>
+      <RouteFocusModal.Description asChild>
+        <span className="sr-only">
+          The partner and its neighbours, including the edges that are expected
+          and missing.
+        </span>
+      </RouteFocusModal.Description>
+      <RouteFocusModal.Body className="flex h-full w-full flex-col overflow-hidden p-0">
+        <GraphWorkspace
+          spine="partner"
+          id={id!}
+          title="Partner graph"
+          selfHref={`/partners/${id}/graph`}
+        />
+      </RouteFocusModal.Body>
+    </RouteFocusModal>
+  )
+}
+
+export default PartnerGraphWorkspacePage

--- a/apps/backend/src/admin/routes/partners/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/partners/[id]/page.tsx
@@ -17,6 +17,7 @@ import { PartnerWhatsAppSection } from "../../../components/partners/partner-wha
 import { PartnerEmailVerificationSection } from "../../../components/partners/partner-email-verification-section"
 import { PartnerTransactionFeesSection } from "../../../components/partners/partner-transaction-fees-section"
 import type { AdminPartner } from "../../../hooks/api/partners-admin"
+import { EntityGraph } from "../../../components/graph/entity-graph"
 import { partnerLoader } from "./loader"
 
 const PartnerDetailPage = () => {
@@ -44,6 +45,30 @@ const PartnerDetailPage = () => {
       <TwoColumnPage data={partner} hasOutlet={true} showJSON showMetadata>
         <TwoColumnPage.Main>
           <PartnerGeneralSection partner={partner} />
+          {/*
+            #1847 — the partner and its neighbours, including the edges that
+            are EXPECTED AND MISSING. Above the fourteen sections below it for
+            the same reason it sits above the design's: every one of them
+            renders what IS there.
+
+            Two absences on this spine that no list in the platform can show:
+            a partner with no admin (nobody can sign in, so work assigned to
+            them stops dead while the assignment reads as successful), and a
+            partner with delivered work and no payment method (the payout has
+            nowhere to land). Measured on the local database, eight partners
+            are in the second state.
+
+            🔴 NOTHING has been removed here yet. The design page's step 3
+            taught that retiring a card can strand the only route to a
+            sub-page; the sections come off this one on evidence, per card,
+            once the graph genuinely does that card's job.
+          */}
+          <EntityGraph
+            spine="partner"
+            id={partner.id}
+            title="Graph"
+            expandHref={`/partners/${partner.id}/graph`}
+          />
           <PartnerInspectionSection partnerId={partner.id} />
           <PartnerTasksSection partnerId={partner.id} />
           <PartnerStorefrontSection partnerId={partner.id} />

--- a/apps/backend/src/api/admin/graph/[spine]/[id]/items/[node]/route.ts
+++ b/apps/backend/src/api/admin/graph/[spine]/[id]/items/[node]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { resolveGraphItems } from "../../../../../../../lib/graph/registry"
+
+/**
+ * GET /admin/graph/:spine/:id/items/:node
+ *
+ * The MEMBERS behind one aggregate node — the four inventory items behind
+ * "Inventory, 4", each with the endpoint that would detach it.
+ *
+ * A second route rather than a fatter `/admin/graph/:spine/:id`, because the
+ * canvas needs counts and the drawer needs rows, and only one of those is on
+ * screen at a time. Folding the rows into the graph would make every canvas
+ * render pay for panels nobody opened.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const items = await resolveGraphItems(
+    req.scope,
+    req.params.spine,
+    req.params.id,
+    req.params.node
+  )
+  res.json({ items })
+}

--- a/apps/backend/src/lib/graph/builder.ts
+++ b/apps/backend/src/lib/graph/builder.ts
@@ -51,3 +51,43 @@ export const money = (v: unknown, currency?: string | null): string | null => {
 }
 
 export type { EdgeState }
+
+/**
+ * Which of these ids actually resolve to a record.
+ *
+ * 🔴 A LINK ROW IS NOT A RECORD, and until this existed the spines counted
+ * link rows. Measured on the local database: one partner's `people` node said
+ * "4 linked" against four link rows pointing at person ids that do not exist —
+ * 21 people in the table, none of them those. Another's `submissions` said "2
+ * raised" with both submissions gone. The node claimed `present`, which this
+ * feature DEFINES as "a declared link with something on the other end", and
+ * there was nothing on the other end.
+ *
+ * It surfaced only because the drawer's member list and the node's count
+ * disagreed — the count came from the link table, the rows from the records.
+ * A graph that contradicts itself about the one thing it exists to assert is
+ * worse than either number alone.
+ *
+ * One extra query per node, run in parallel with its siblings. Deliberately
+ * NOT done by expanding the target through the link's own fields
+ * (`fields: ["person.id"]`): a `query.graph` hop from a link to its target can
+ * come back with no key at all rather than an error, which would silently zero
+ * EVERY count instead of correcting a few.
+ */
+export const resolveExisting = async (
+  query: any,
+  entity: string,
+  ids: string[]
+): Promise<string[]> => {
+  if (!ids.length) {
+    return []
+  }
+  const { data } = await query.graph({
+    entity,
+    filters: { id: ids },
+    fields: ["id"],
+  })
+  const found = new Set(asArray<any>(data).map((r) => String(r.id)))
+  // Preserve the caller's order; it is the link table's order.
+  return ids.filter((id) => found.has(String(id)))
+}

--- a/apps/backend/src/lib/graph/builder.ts
+++ b/apps/backend/src/lib/graph/builder.ts
@@ -28,6 +28,8 @@ export class GraphBuilder {
       nodes: this.nodes,
       edges: this.edges,
       summary: summarise(this.edges),
+      // Filled in by the registry, which is where the spine's declaration is.
+      itemNodes: [],
     }
   }
 }

--- a/apps/backend/src/lib/graph/registry.ts
+++ b/apps/backend/src/lib/graph/registry.ts
@@ -1,6 +1,7 @@
 import { MedusaError } from "@medusajs/framework/utils"
 
 import { designSpine } from "./spines/design"
+import { partnerSpine } from "./spines/partner"
 import type { Graph, NodeItem, SpineDescriptor } from "./types"
 
 /**
@@ -11,10 +12,13 @@ import type { Graph, NodeItem, SpineDescriptor } from "./types"
  * That is the whole point of the registry: the surfaces consume the resolver,
  * so they cannot drift apart as spines are added.
  *
- * Next in line is Partner — the biggest node in the platform at 18 links.
+ * Partner joined as the second spine and cost exactly that: one entry here
+ * and a resolver. No route, no hook, no client change — which is the claim the
+ * registry was making all along, now tested by something other than its author.
  */
 export const SPINES: Record<string, SpineDescriptor> = {
   [designSpine.key]: designSpine,
+  [partnerSpine.key]: partnerSpine,
 }
 
 export const SPINE_KEYS = Object.keys(SPINES)

--- a/apps/backend/src/lib/graph/registry.ts
+++ b/apps/backend/src/lib/graph/registry.ts
@@ -1,7 +1,7 @@
 import { MedusaError } from "@medusajs/framework/utils"
 
 import { designSpine } from "./spines/design"
-import type { Graph, SpineDescriptor } from "./types"
+import type { Graph, NodeItem, SpineDescriptor } from "./types"
 
 /**
  * Every spine the graph can centre on.
@@ -39,5 +39,42 @@ export const resolveGraph = async (
       `Unknown graph spine "${spineKey}". Known spines: ${SPINE_KEYS.join(", ")}`
     )
   }
-  return spine.resolve({ scope, id })
+  const graph = await spine.resolve({ scope, id })
+  /*
+   * Attached HERE rather than in each spine's `build()` call, so a spine that
+   * gains an item resolver cannot forget to advertise it — a graph whose
+   * `itemNodes` disagreed with its `items()` would render drawers that fetch
+   * nothing, or nodes whose rows exist and are never asked for.
+   */
+  return { ...graph, itemNodes: spine.itemNodes ?? [] }
+}
+
+/**
+ * The members behind one aggregate node.
+ *
+ * 🔴 An unknown SPINE is a 404, exactly as above — but an unknown NODE is an
+ * empty list, not an error. The two are genuinely different questions. A bad
+ * spine key means the caller asked for something that does not exist; a node
+ * with no item resolver means "this aggregate has no rows worth listing",
+ * which is a legitimate answer for the nodes that are a single record
+ * (`product`, `revision`) or a pure count (`palette`). Raising here would turn
+ * every one of those into a red panel in the drawer.
+ */
+export const resolveGraphItems = async (
+  scope: any,
+  spineKey: string,
+  id: string,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const spine = SPINES[spineKey]
+  if (!spine) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Unknown graph spine "${spineKey}". Known spines: ${SPINE_KEYS.join(", ")}`
+    )
+  }
+  if (!spine.items) {
+    return []
+  }
+  return spine.items({ scope, id }, nodeKey)
 }

--- a/apps/backend/src/lib/graph/spines/design/__tests__/items.unit.spec.ts
+++ b/apps/backend/src/lib/graph/spines/design/__tests__/items.unit.spec.ts
@@ -201,7 +201,7 @@ describe("consumption logs", () => {
   const logQuery = (log: any) =>
     stubQuery({
       [CONSUMPTION_ENTRY]: [{ consumption_log_id: log.id }],
-      consumption_logs: [log],
+      consumption_log: [log],
     })
 
   it("offers deletion while no stock has moved", async () => {

--- a/apps/backend/src/lib/graph/spines/design/__tests__/items.unit.spec.ts
+++ b/apps/backend/src/lib/graph/spines/design/__tests__/items.unit.spec.ts
@@ -1,0 +1,324 @@
+import designConsumptionLogLink from "../../../../../links/design-consumption-log"
+import designOrderLink from "../../../../../links/design-order-link"
+import { resolveDesignItems, DESIGN_ITEM_NODES } from "../items"
+
+/*
+ * 🔴 The link tables are keyed by the LINK's own `entryPoint`, never by a
+ * hand-written string. Medusa ABBREVIATES a link table name once it grows
+ * long, so `design_consumption_log` is a guess about a name the framework
+ * derives — and a stub keyed on the wrong one answers `[]` to a resolver that
+ * is working perfectly, which reads exactly like "nothing is linked".
+ */
+const CONSUMPTION_ENTRY = designConsumptionLogLink.entryPoint
+const ORDER_ENTRY = designOrderLink.entryPoint
+
+/**
+ * The member rows, and — the part worth testing — the REMOVE descriptor each
+ * one carries.
+ *
+ * Every removal here points at an existing admin endpoint, and the four take
+ * four different shapes. Getting one wrong produces a well-formed request to
+ * the wrong record: it does not throw, it does not render red, and the row
+ * disappears from the drawer either way. So the shapes are asserted rather
+ * than eyeballed.
+ */
+
+/** A `query.graph` stub keyed by the entity each call asks for. */
+const stubQuery = (byEntity: Record<string, any[]>) => ({
+  graph: jest.fn(async ({ entity }: { entity: string }) => ({
+    data: byEntity[entity] ?? [],
+  })),
+})
+
+const ctx = (query: any) => ({
+  scope: { resolve: () => query },
+  id: "design_1",
+})
+
+describe("the node registry", () => {
+  it("advertises exactly the nodes it can resolve", async () => {
+    // The graph payload's `itemNodes` is this list; a node named here that
+    // resolves to nothing would render "Nothing linked yet" forever.
+    expect(DESIGN_ITEM_NODES).toEqual(
+      expect.arrayContaining([
+        "inventory",
+        "components",
+        "tasks",
+        "partners",
+        "runs",
+        "consumption",
+        "materials",
+      ])
+    )
+  })
+
+  it("answers an unknown node with an empty list, not an error", async () => {
+    const query = stubQuery({})
+    await expect(resolveDesignItems(ctx(query), "not_a_node")).resolves.toEqual([])
+    // 🔴 And it must not query at all — `product` and `revision` land here on
+    // every drawer open.
+    expect(query.graph).not.toHaveBeenCalled()
+  })
+})
+
+describe("inventory", () => {
+  it("delinks exactly the one row, never the batch", async () => {
+    const query = stubQuery({
+      designs: [
+        {
+          id: "design_1",
+          inventory_items: [
+            { id: "inv_1", title: "Cotton", sku: "CTN-1" },
+            { id: "inv_2", title: "Silk", sku: "SLK-1" },
+          ],
+        },
+      ],
+    })
+
+    const items = await resolveDesignItems(ctx(query), "inventory")
+
+    expect(items).toHaveLength(2)
+    expect(items[0].remove).toMatchObject({
+      method: "POST",
+      path: "/admin/designs/design_1/inventory/delink",
+      body: { inventoryIds: ["inv_1"] },
+    })
+    // The endpoint takes a LIST. One row means one id — never both.
+    expect((items[0].remove!.body as any).inventoryIds).toEqual(["inv_1"])
+    expect((items[1].remove!.body as any).inventoryIds).toEqual(["inv_2"])
+  })
+})
+
+describe("bundled designs", () => {
+  const bundleQuery = () =>
+    stubQuery({
+      designs: [
+        {
+          id: "design_1",
+          components: [
+            {
+              id: "dc_in",
+              quantity: 2,
+              role: "lining",
+              component_design: { id: "design_2", name: "Lining panel" },
+            },
+          ],
+          used_in: [
+            {
+              id: "dc_out",
+              quantity: 1,
+              parent_design: { id: "design_3", name: "Jacket" },
+            },
+          ],
+        },
+      ],
+    })
+
+  it("lists both directions", async () => {
+    const items = await resolveDesignItems(ctx(bundleQuery()), "components")
+    expect(items.map((i) => i.label)).toEqual(["Lining panel", "Jacket"])
+  })
+
+  it("offers removal on the inbound row only", async () => {
+    const items = await resolveDesignItems(ctx(bundleQuery()), "components")
+
+    expect(items[0].remove).toMatchObject({
+      method: "DELETE",
+      path: "/admin/designs/design_1/components/dc_in",
+    })
+    /*
+     * 🔴 The endpoint scopes its lookup by `parent_design_id`, so deleting a
+     * `used_in` row from this side 404s. A button that always fails is worse
+     * than no button.
+     */
+    expect(items[1].remove).toBeNull()
+  })
+})
+
+describe("partners", () => {
+  const partnerQuery = (runs: any[]) =>
+    stubQuery({
+      designs: [{ id: "design_1", partners: [{ id: "pt_1", name: "Weavers Co" }] }],
+      production_runs: runs,
+    })
+
+  it("says how many live runs the cancellation takes with it", async () => {
+    const items = await resolveDesignItems(
+      ctx(
+        partnerQuery([
+          { id: "pr_1", partner_id: "pt_1", status: "in_progress" },
+          { id: "pr_2", partner_id: "pt_1", status: "completed" },
+          { id: "pr_3", partner_id: "pt_1", status: "cancelled" },
+          { id: "pr_4", partner_id: "pt_other", status: "in_progress" },
+        ])
+      ),
+      "partners"
+    )
+
+    // Only pr_1 is live AND theirs: completed and cancelled are done, pr_4 is
+    // another partner's.
+    expect(items[0].remove!.confirm).toContain("1 live run")
+    expect(items[0].remove!.body).toEqual({ partner_id: "pt_1", unlink: true })
+  })
+
+  it("does not threaten cancellation when nothing is live", async () => {
+    const items = await resolveDesignItems(
+      ctx(partnerQuery([{ id: "pr_1", partner_id: "pt_1", status: "completed" }])),
+      "partners"
+    )
+    expect(items[0].remove!.confirm).not.toContain("cancelled")
+  })
+})
+
+describe("production runs", () => {
+  it("never offers removal — a run is cancelled, not detached", async () => {
+    const query = stubQuery({
+      production_runs: [
+        { id: "pr_1", name: "Run 1", status: "completed", approved_product_id: null },
+      ],
+    })
+    const items = await resolveDesignItems(ctx(query), "runs")
+    expect(items[0].remove).toBeNull()
+  })
+
+  it("names the run that is missing its product", async () => {
+    const query = stubQuery({
+      production_runs: [
+        { id: "pr_1", status: "completed", approved_product_id: null },
+        { id: "pr_2", status: "completed", approved_product_id: "prod_9" },
+      ],
+    })
+    const items = await resolveDesignItems(ctx(query), "runs")
+    const value = (i: any) =>
+      i.props.find((p: any) => p.key === "approved_product_id")!.value
+    // The whole motivating absence, per run rather than in aggregate.
+    expect(value(items[0])).toBe("null")
+    expect(value(items[1])).toBe("prod_9")
+  })
+})
+
+describe("consumption logs", () => {
+  const logQuery = (log: any) =>
+    stubQuery({
+      [CONSUMPTION_ENTRY]: [{ consumption_log_id: log.id }],
+      consumption_logs: [log],
+    })
+
+  it("offers deletion while no stock has moved", async () => {
+    const items = await resolveDesignItems(
+      ctx(logQuery({ id: "cl_1", quantity: 5, unit_of_measure: "m" })),
+      "consumption"
+    )
+    expect(items[0].remove).toMatchObject({
+      method: "DELETE",
+      path: "/admin/designs/design_1/consumption-logs/cl_1",
+    })
+  })
+
+  it("withholds it once the stock movement is applied", async () => {
+    /*
+     * 🔴 The endpoint refuses this with "correct it with a reversing entry,
+     * not an edit". Rendering the button anyway would put a 400 behind a
+     * confirm dialog.
+     */
+    const items = await resolveDesignItems(
+      ctx(
+        logQuery({
+          id: "cl_1",
+          quantity: 5,
+          inventory_applied_at: "2026-09-01T00:00:00Z",
+        })
+      ),
+      "consumption"
+    )
+    expect(items[0].remove).toBeNull()
+    expect(items[0].status).toBe("applied")
+  })
+
+  it("reads the applied flag off metadata too", async () => {
+    // The field is written to both homes depending on the code path that
+    // applied it; the endpoint checks both, so this must as well.
+    const items = await resolveDesignItems(
+      ctx(
+        logQuery({
+          id: "cl_1",
+          quantity: 5,
+          metadata: { inventory_applied_at: "2026-09-01T00:00:00Z" },
+        })
+      ),
+      "consumption"
+    )
+    expect(items[0].remove).toBeNull()
+  })
+
+  it("asks for nothing when no log is linked", async () => {
+    const query = stubQuery({ [CONSUMPTION_ENTRY]: [] })
+    await expect(resolveDesignItems(ctx(query), "consumption")).resolves.toEqual([])
+    // One call — it must not go on to fetch logs by an empty id list, which
+    // reads as "no filter" and returns EVERY log in the system.
+    expect(query.graph).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("orders", () => {
+  it("never offers removal — a sale is history", async () => {
+    const query = stubQuery({
+      [ORDER_ENTRY]: [{ order_id: "order_1" }],
+      order: [{ id: "order_1", display_id: 42, status: "completed" }],
+    })
+    const items = await resolveDesignItems(ctx(query), "orders")
+    expect(items[0].label).toBe("#42")
+    expect(items[0].remove).toBeNull()
+  })
+})
+
+describe("the row's two text slots", () => {
+  /*
+   * 🔴 A row prints `sublabel` under the title and `status` as a badge beside
+   * it. Setting both to the same value is the natural thing to write and it
+   * renders as the word "pending" twice, side by side — while every field is
+   * populated, correct and passing. Only looking at the screen found it, so
+   * the rule is pinned here.
+   */
+  it("never repeats the status as the sublabel", async () => {
+    const query = stubQuery({
+      designs: [
+        {
+          id: "design_1",
+          tasks: [{ id: "t1", title: "Cut", status: "pending", priority: "high" }],
+        },
+      ],
+      production_runs: [
+        { id: "pr_1", status: "sent_to_partner", execution_mode: "outsourced" },
+      ],
+    })
+
+    for (const node of ["tasks", "runs"]) {
+      const items = await resolveDesignItems(ctx(query), node)
+      expect(items.length).toBeGreaterThan(0)
+      for (const item of items) {
+        expect(item.status).toBeTruthy()
+        expect(item.sublabel).not.toBe(item.status)
+      }
+    }
+  })
+
+  it("still says something useful in the sublabel", async () => {
+    // Not merely "different from status" — an empty sublabel would also pass
+    // the rule above while leaving the row with nothing to tell it apart.
+    const query = stubQuery({
+      production_runs: [
+        {
+          id: "pr_1",
+          status: "completed",
+          quantity_produced: 40,
+          quantity_target: 50,
+          approved_product_id: null,
+        },
+      ],
+    })
+    const [run] = await resolveDesignItems(ctx(query), "runs")
+    expect(run.sublabel).toContain("40 produced")
+    expect(run.sublabel).toContain("no product")
+  })
+})

--- a/apps/backend/src/lib/graph/spines/design/index.ts
+++ b/apps/backend/src/lib/graph/spines/design/index.ts
@@ -6,11 +6,10 @@ import productDesignLink from "../../../../links/product-design-link"
 import designConsumptionLogLink from "../../../../links/design-consumption-log"
 import designPersonLink from "../../../../links/designs-person-link"
 import designRawMaterialGroupLink from "../../../../links/design-raw-material-group"
-import { GraphBuilder, asArray, money } from "../../builder"
+import { GraphBuilder, asArray, money, resolveExisting } from "../../builder"
 import { DESIGN_ITEM_NODES, resolveDesignItems } from "./items"
 import type { EdgeState, Graph, GraphNode, SpineContext, SpineDescriptor } from "../../types"
 import {
-  COMMITTED_DESIGN_STATUSES,
   daysWaiting,
   expectsInventory,
   expectsPartner,
@@ -40,6 +39,10 @@ import {
  * relation is worse than no graph: the reader stops believing the dashed
  * edges, which are the ones worth believing.
  */
+/** Is this id in the resolved set? Kept tiny so the filters above read cleanly. */
+const orNull = (resolved: string[], id: unknown): boolean =>
+  !!id && resolved.includes(String(id))
+
 const resolveDesignGraph = async ({ scope, id }: SpineContext): Promise<Graph> => {
   const designId = id
   const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
@@ -148,14 +151,53 @@ const resolveDesignGraph = async ({ scope, id }: SpineContext): Promise<Graph> =
       fields: ["raw_material_group_id", "resolved_raw_material_id"],
     }),
   ])
-  const orderIds = asArray<any>(orderLinks).map((l) => l.order_id).filter(Boolean)
+  const rawOrderIds = asArray<any>(orderLinks).map((l) => l.order_id).filter(Boolean)
   const folderIds = asArray<any>(folderLinks).map((l) => l.folder_id).filter(Boolean)
-  const linkedProductIds = asArray<any>(productLinks).map((l) => l.product_id).filter(Boolean)
-  const consumptionIds = asArray<any>(consumptionLinks)
+  const rawProductIds = asArray<any>(productLinks).map((l) => l.product_id).filter(Boolean)
+  const rawConsumptionIds = asArray<any>(consumptionLinks)
     .map((l) => l.consumption_log_id)
     .filter(Boolean)
-  const people = asArray<any>(personLinks)
-  const materialGroups = asArray<any>(materialGroupLinks)
+  const personLinkRows = asArray<any>(personLinks)
+  const materialGroupRows = asArray<any>(materialGroupLinks)
+
+  /*
+   * 🔴 Keep only the ids with a record behind them.
+   *
+   * A LINK ROW IS NOT A RECORD. Measured on the partner spine against the
+   * local database, where four `people` link rows pointed at person ids that
+   * do not exist and two `submissions` links at submissions that were gone —
+   * so the node said "4 linked" and the drawer listed none. Every node here
+   * built from a link table had the same defect, and it makes the node claim
+   * `present`, which this feature DEFINES as "a declared link with something
+   * on the other end".
+   *
+   * The `media` folder ids are left alone: that node counts FILES off the
+   * design entity, and the folder count is a secondary prop rather than the
+   * thing the edge asserts.
+   */
+  const [orderIds, linkedProductIds, consumptionIds, personIds, materialGroupIds] =
+    await Promise.all([
+      resolveExisting(query, "order", rawOrderIds),
+      resolveExisting(query, "product", rawProductIds),
+      resolveExisting(query, "consumption_log", rawConsumptionIds),
+      resolveExisting(
+        query,
+        "person",
+        personLinkRows.map((l) => l.person_id).filter(Boolean)
+      ),
+      resolveExisting(
+        query,
+        "raw_material_group",
+        materialGroupRows.map((l) => l.raw_material_group_id).filter(Boolean)
+      ),
+    ])
+
+  // Keep the link rows (they carry `role` / `resolved_raw_material_id`), but
+  // only for the ids that actually resolved.
+  const people = personLinkRows.filter((l) => orNull(personIds, l.person_id))
+  const materialGroups = materialGroupRows.filter((l) =>
+    orNull(materialGroupIds, l.raw_material_group_id)
+  )
 
   // ---- derived facts the absence rules key on -----------------------------
 
@@ -165,7 +207,6 @@ const resolveDesignGraph = async ({ scope, id }: SpineContext): Promise<Graph> =
   )
   const outstandingRuns = runsAwaitingProduct(runList)
 
-  const committed = COMMITTED_DESIGN_STATUSES.has(String(design.status))
   // The task enum is pending | in_progress | completed | cancelled | accepted |
   // assigned — "completed" is the only terminal-done value, so don't invent
   // synonyms that would silently count nothing.
@@ -213,31 +254,45 @@ const resolveDesignGraph = async ({ scope, id }: SpineContext): Promise<Graph> =
       },
       { label: "design_id", state: "present", reason: null }
     )
-  } else {
+  } else if (expectsProductionRun(design.status, runList.length)) {
+    /*
+     * 🔴 Drawn ONLY when a run is genuinely expected.
+     *
+     * This branch used to fall through to a `present` node with a count of
+     * zero, a sublabel of "not started" and a null action — on every design
+     * that has not been committed yet, which is most of them. By this
+     * feature's own definition a `present` edge is "a declared link with
+     * SOMETHING ON THE OTHER END", and there was nothing: the node asserted a
+     * neighbour that does not exist, said nothing the spine's own status did
+     * not already say, and offered no action.
+     *
+     * It is the same defect as counting link rows instead of records, in a
+     * different disguise, and it survived three steps of this feature because
+     * a node that is merely POINTLESS looks identical to one that is wrong.
+     * Nothing is lost by dropping it: `expectsProductionRun` is exactly
+     * "committed && no runs", so the case that carried the "Send to
+     * production" action is precisely the case still drawn below.
+     */
     push(
       {
         key: "runs",
         type: "production_run",
         label: "Production runs",
-        sublabel: committed ? "none yet" : "not started",
-        state: expectsProductionRun(design.status, runList.length) ? "absent" : "present",
+        sublabel: "none yet",
+        state: "absent",
         count: 0,
         status: null,
         href: `/designs/${designId}/production-runs`,
         props: [{ key: "design status", value: String(design.status) }],
-        action: committed
-          ? {
-              label: "Send to production",
-              href: `/designs/${designId}/production-run`,
-            }
-          : null,
+        action: {
+          label: "Send to production",
+          href: `/designs/${designId}/production-run`,
+        },
       },
       {
         label: "design_id",
-        state: expectsProductionRun(design.status, runList.length) ? "absent" : "present",
-        reason: committed
-          ? `Design is ${design.status} and no run has been created.`
-          : null,
+        state: "absent",
+        reason: `Design is ${design.status} and no run has been created.`,
       }
     )
   }

--- a/apps/backend/src/lib/graph/spines/design/index.ts
+++ b/apps/backend/src/lib/graph/spines/design/index.ts
@@ -7,6 +7,7 @@ import designConsumptionLogLink from "../../../../links/design-consumption-log"
 import designPersonLink from "../../../../links/designs-person-link"
 import designRawMaterialGroupLink from "../../../../links/design-raw-material-group"
 import { GraphBuilder, asArray, money } from "../../builder"
+import { DESIGN_ITEM_NODES, resolveDesignItems } from "./items"
 import type { EdgeState, Graph, GraphNode, SpineContext, SpineDescriptor } from "../../types"
 import {
   COMMITTED_DESIGN_STATUSES,
@@ -771,4 +772,12 @@ export const designSpine: SpineDescriptor = {
   key: "design",
   label: "Design",
   resolve: resolveDesignGraph,
+  /*
+   * The members behind each aggregate node, fetched only when a drawer opens
+   * (#1847 step 4). Kept in its own file: `resolve` above is already 700 lines
+   * of node construction, and the two answer different questions — which edges
+   * exist, and which records are on the far end of one of them.
+   */
+  items: resolveDesignItems,
+  itemNodes: DESIGN_ITEM_NODES,
 }

--- a/apps/backend/src/lib/graph/spines/design/items.ts
+++ b/apps/backend/src/lib/graph/spines/design/items.ts
@@ -1,0 +1,498 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import designConsumptionLogLink from "../../../../links/design-consumption-log"
+import designOrderLink from "../../../../links/design-order-link"
+import designPersonLink from "../../../../links/designs-person-link"
+import designRawMaterialGroupLink from "../../../../links/design-raw-material-group"
+import { asArray } from "../../builder"
+import type { NodeItem, SpineContext } from "../../types"
+
+/**
+ * The MEMBERS behind each aggregate node on the design spine (#1847 step 4).
+ *
+ * The canvas answers "is there an edge here?". Once the reader has clicked the
+ * node they are asking the next question — "which ones?" — and, right after
+ * that, "take that one off". Neither is answerable from a count, which is why
+ * every removal in this admin still lives on a summary card the graph was
+ * meant to replace.
+ *
+ * 🔴 Every `remove` here names an EXISTING admin endpoint. Not one line of
+ * detachment logic lives in this file. `DELETE /admin/designs/:id/tasks/:taskId`
+ * already cancels the task's dependents; `POST /admin/designs/:id/inventory/delink`
+ * already runs a compensating workflow; `POST .../cancel-partner-assignment`
+ * already cancels the partner's runs and their open tasks. Rebuilding any of
+ * that here would give it a second home — the one failure this codebase has
+ * repeated most.
+ *
+ * 🔴 A node with no entry in the switch returns an EMPTY LIST, never an error.
+ * `product` and `revision` are single records, `palette` is a count; a drawer
+ * that reddened on those would be wrong about all three.
+ */
+
+const s = (n: number, one: string, many = `${one}s`) => (n === 1 ? one : many)
+
+/**
+ * 🔴 `sublabel` must never repeat `status`.
+ *
+ * The row renders the sublabel under the title AND the status as a badge on
+ * the right. Set to the same string — the obvious thing to write, and what the
+ * first version of these resolvers did — every row said "pending" twice, side
+ * by side, and the sublabel's real job (the one fact that tells this row from
+ * the one under it) went unused. Only RENDERING it showed this: both fields
+ * were populated, correct, and tested.
+ */
+
+/** The design, with only the relations the requested node actually needs. */
+const loadDesign = async (query: any, designId: string, fields: string[]) => {
+  const { data } = await query.graph({
+    entity: "designs",
+    filters: { id: designId },
+    fields: ["id", ...fields],
+  })
+  const design = (data || [])[0]
+  if (!design) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Design ${designId} was not found`
+    )
+  }
+  return design
+}
+
+const inventoryItems = async (
+  query: any,
+  designId: string
+): Promise<NodeItem[]> => {
+  const design = await loadDesign(query, designId, ["inventory_items.*"])
+  return asArray<any>(design.inventory_items).map((i) => ({
+    id: String(i.id),
+    label: String(i.title || i.sku || i.id),
+    sublabel: i.sku ? String(i.sku) : null,
+    status: null,
+    href: `/inventory/${i.id}`,
+    props: [
+      ...(i.sku ? [{ key: "sku", value: String(i.sku) }] : []),
+      ...(i.hs_code ? [{ key: "hs code", value: String(i.hs_code) }] : []),
+    ],
+    /*
+     * 🔴 `inventoryIds` is a LIST on the endpoint, and it is sent with exactly
+     * one id. Detaching a row the reader did not point at — because a future
+     * caller found it convenient to batch — is the kind of change that reads
+     * as correct in the diff and loses stock in production.
+     */
+    remove: {
+      method: "POST" as const,
+      path: `/admin/designs/${designId}/inventory/delink`,
+      body: { inventoryIds: [String(i.id)] },
+      label: "Unlink",
+      confirm: `Unlink ${i.title || i.sku || "this item"} from the design? Consumption already logged against it stays.`,
+    },
+  }))
+}
+
+const componentItems = async (
+  query: any,
+  designId: string
+): Promise<NodeItem[]> => {
+  /*
+   * BOTH directions. `components` is what this design is built FROM;
+   * `used_in` is what it is a part OF. They are the same table read through
+   * two foreign keys, and a drawer that showed only one would say "1 in, 3
+   * out" on the node and then list one row.
+   *
+   * 🔴 Only the `components` side is removable here. A `used_in` row belongs
+   * to the PARENT design, and the endpoint scopes its lookup by
+   * `parent_design_id` — deleting it from this side would 404, and offering a
+   * button that always fails is worse than offering none.
+   */
+  const design = await loadDesign(query, designId, [
+    "components.*",
+    "components.component_design.*",
+    "used_in.*",
+    "used_in.parent_design.*",
+  ])
+
+  const inbound = asArray<any>(design.components).map((c) => ({
+    id: String(c.id),
+    label: String(c.component_design?.name ?? c.component_design?.id ?? c.id),
+    sublabel: `part of this design${c.role ? ` — ${c.role}` : ""}`,
+    status: null,
+    href: c.component_design?.id ? `/designs/${c.component_design.id}` : null,
+    props: [
+      { key: "quantity", value: String(c.quantity ?? 1) },
+      ...(c.role ? [{ key: "role", value: String(c.role) }] : []),
+      { key: "direction", value: "component of this design" },
+    ],
+    remove: {
+      method: "DELETE" as const,
+      path: `/admin/designs/${designId}/components/${c.id}`,
+      body: null,
+      label: "Remove",
+      confirm: `Remove ${c.component_design?.name ?? "this component"} from the bundle? The design itself is not deleted.`,
+    },
+  }))
+
+  const outbound = asArray<any>(design.used_in).map((c) => ({
+    id: String(c.id),
+    label: String(c.parent_design?.name ?? c.parent_design?.id ?? c.id),
+    sublabel: "this design is a part of it",
+    status: null,
+    href: c.parent_design?.id ? `/designs/${c.parent_design.id}` : null,
+    props: [
+      { key: "quantity", value: String(c.quantity ?? 1) },
+      ...(c.role ? [{ key: "role", value: String(c.role) }] : []),
+      { key: "direction", value: "this design is used in it" },
+    ],
+    // Owned by the parent — removable from there, not here. See above.
+    remove: null,
+  }))
+
+  return [...inbound, ...outbound]
+}
+
+const taskItems = async (query: any, designId: string): Promise<NodeItem[]> => {
+  const design = await loadDesign(query, designId, ["tasks.*"])
+  return asArray<any>(design.tasks).map((t) => ({
+    id: String(t.id),
+    label: String(t.title || t.id),
+    sublabel:
+      [
+        t.priority ? `${t.priority} priority` : null,
+        t.due_date ? `due ${new Date(t.due_date).toLocaleDateString()}` : null,
+      ]
+        .filter(Boolean)
+        .join(" · ") || null,
+    status: t.status ? String(t.status) : null,
+    href: `/designs/${designId}/tasks`,
+    props: [
+      ...(t.status ? [{ key: "status", value: String(t.status) }] : []),
+      ...(t.priority ? [{ key: "priority", value: String(t.priority) }] : []),
+      ...(t.due_date
+        ? [{ key: "due", value: new Date(t.due_date).toLocaleDateString() }]
+        : []),
+    ],
+    remove: {
+      method: "DELETE" as const,
+      path: `/admin/designs/${designId}/tasks/${t.id}`,
+      body: null,
+      label: "Delete",
+      confirm: `Delete "${t.title || "this task"}"? Its subtasks and dependencies go with it.`,
+    },
+  }))
+}
+
+const partnerItems = async (
+  query: any,
+  designId: string
+): Promise<NodeItem[]> => {
+  const design = await loadDesign(query, designId, ["partners.*"])
+  const { data: runs } = await query.graph({
+    entity: "production_runs",
+    filters: { design_id: designId },
+    fields: ["id", "partner_id", "status", "execution_mode"],
+  })
+  const runList = asArray<any>(runs)
+
+  return asArray<any>(design.partners).map((p) => {
+    const theirRuns = runList.filter((r) => r.partner_id === p.id)
+    const live = theirRuns.filter(
+      (r) => !["cancelled", "completed"].includes(String(r.status))
+    )
+    return {
+      id: String(p.id),
+      label: String(p.name || p.handle || p.id),
+      sublabel: theirRuns.length
+        ? `${theirRuns.length} ${s(theirRuns.length, "run")}`
+        : "no runs",
+      status: p.status ? String(p.status) : null,
+      href: `/partners/${p.id}`,
+      props: [
+        ...(p.handle ? [{ key: "handle", value: String(p.handle) }] : []),
+        { key: "runs", value: String(theirRuns.length) },
+        { key: "live runs", value: String(live.length) },
+      ],
+      /*
+       * 🔴 `unlink: true` and the confirm text says what that costs. This is
+       * NOT a symmetric undo of "link partner": the workflow cancels the
+       * partner's active runs and their open tasks first. A button labelled
+       * "Unlink" that silently cancels production would be the worst thing on
+       * this screen, so the count is in the sentence.
+       */
+      remove: {
+        method: "POST" as const,
+        path: `/admin/designs/${designId}/cancel-partner-assignment`,
+        body: { partner_id: String(p.id), unlink: true },
+        label: "Cancel assignment",
+        confirm: live.length
+          ? `Cancel ${p.name || "this partner"}'s assignment? ${live.length} live ${s(live.length, "run")} and their open tasks are cancelled too.`
+          : `Unlink ${p.name || "this partner"} from the design?`,
+      },
+    }
+  })
+}
+
+const runItems = async (query: any, designId: string): Promise<NodeItem[]> => {
+  const { data: runs } = await query.graph({
+    entity: "production_runs",
+    filters: { design_id: designId },
+    fields: ["*"],
+  })
+  return asArray<any>(runs).map((r) => ({
+    id: String(r.id),
+    label: String(r.name || r.id),
+    sublabel:
+      [
+        r.quantity_produced != null ? `${r.quantity_produced} produced` : null,
+        r.quantity_target != null ? `of ${r.quantity_target}` : null,
+        r.execution_mode ? String(r.execution_mode) : null,
+        // The motivating absence, said in words on the row it belongs to.
+        r.approved_product_id ? null : "no product",
+      ]
+        .filter(Boolean)
+        .join(" · ") || null,
+    status: r.status ? String(r.status) : null,
+    href: `/designs/${designId}/production-runs`,
+    props: [
+      { key: "status", value: String(r.status ?? "—") },
+      { key: "mode", value: String(r.execution_mode ?? "—") },
+      ...(r.quantity_target != null
+        ? [{ key: "target", value: String(r.quantity_target) }]
+        : []),
+      ...(r.quantity_produced != null
+        ? [{ key: "produced", value: String(r.quantity_produced) }]
+        : []),
+      /*
+       * The motivating absence, per run rather than in aggregate. The node
+       * says "2 runs awaiting a product"; this says WHICH two.
+       */
+      {
+        key: "approved_product_id",
+        value: String(r.approved_product_id ?? "null"),
+      },
+    ],
+    /*
+     * 🔴 No remove. A run is not detached from its design — it is CANCELLED,
+     * which is a state change with its own compensation, its own partner
+     * notification and its own payout consequences. Offering it as a row
+     * action beside "Unlink inventory" would make two very different things
+     * look like one.
+     */
+    remove: null,
+  }))
+}
+
+const consumptionItems = async (
+  query: any,
+  designId: string
+): Promise<NodeItem[]> => {
+  const { data: links } = await query.graph({
+    entity: designConsumptionLogLink.entryPoint,
+    filters: { design_id: designId },
+    fields: ["consumption_log_id"],
+  })
+  const ids = asArray<any>(links)
+    .map((l) => l.consumption_log_id)
+    .filter(Boolean)
+  if (!ids.length) return []
+
+  const { data: logs } = await query.graph({
+    entity: "consumption_logs",
+    filters: { id: ids },
+    fields: ["*"],
+  })
+
+  return asArray<any>(logs).map((l) => {
+    const applied = l.inventory_applied_at ?? l.metadata?.inventory_applied_at
+    return {
+      id: String(l.id),
+      label: `${l.quantity ?? "—"} ${l.unit_of_measure ?? ""}`.trim(),
+      sublabel: String(l.consumption_type ?? l.inventory_item_id ?? ""),
+      status: applied ? "applied" : "draft",
+      href: `/designs/${designId}`,
+      props: [
+        { key: "quantity", value: String(l.quantity ?? "—") },
+        ...(l.unit_of_measure
+          ? [{ key: "unit", value: String(l.unit_of_measure) }]
+          : []),
+        { key: "stock applied", value: applied ? "yes" : "no" },
+      ],
+      /*
+       * 🔴 An APPLIED log has already moved stock, and the endpoint refuses to
+       * delete it — "correct it with a reversing entry, not an edit". Offering
+       * the button anyway would put a 400 behind a confirm dialog. The rule is
+       * mirrored here so the drawer never renders an action the server will
+       * refuse; if the two ever disagree, the server still wins.
+       */
+      remove: applied
+        ? null
+        : {
+            method: "DELETE" as const,
+            path: `/admin/designs/${designId}/consumption-logs/${l.id}`,
+            body: null,
+            label: "Delete",
+            confirm: `Delete this log of ${l.quantity ?? ""} ${l.unit_of_measure ?? ""}? No stock has moved for it yet.`,
+          },
+    }
+  })
+}
+
+const materialGroupItems = async (
+  query: any,
+  designId: string
+): Promise<NodeItem[]> => {
+  const { data: links } = await query.graph({
+    entity: designRawMaterialGroupLink.entryPoint,
+    filters: { design_id: designId },
+    fields: ["raw_material_group_id"],
+  })
+  const ids = asArray<any>(links)
+    .map((l) => l.raw_material_group_id)
+    .filter(Boolean)
+  if (!ids.length) return []
+
+  const { data: groups } = await query.graph({
+    entity: "raw_material_groups",
+    filters: { id: ids },
+    fields: ["*"],
+  })
+
+  return asArray<any>(groups).map((g) => ({
+    id: String(g.id),
+    label: String(g.name || g.id),
+    sublabel: g.description ? String(g.description) : null,
+    status: g.status ? String(g.status) : null,
+    href: null,
+    props: [
+      ...(g.status ? [{ key: "status", value: String(g.status) }] : []),
+      ...(g.description
+        ? [{ key: "description", value: String(g.description) }]
+        : []),
+    ],
+    remove: {
+      method: "DELETE" as const,
+      path: `/admin/designs/${designId}/material-groups/${g.id}`,
+      body: null,
+      label: "Unpin",
+      confirm: `Unpin ${g.name || "this group"}? The group itself is untouched — only this design stops resolving materials through it.`,
+    },
+  }))
+}
+
+const orderItems = async (query: any, designId: string): Promise<NodeItem[]> => {
+  const { data: links } = await query.graph({
+    entity: designOrderLink.entryPoint,
+    filters: { design_id: designId },
+    fields: ["order_id"],
+  })
+  const ids = asArray<any>(links)
+    .map((l) => l.order_id)
+    .filter(Boolean)
+  if (!ids.length) return []
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    filters: { id: ids },
+    fields: ["id", "display_id", "status", "email", "created_at"],
+  })
+
+  return asArray<any>(orders).map((o) => ({
+    id: String(o.id),
+    label: o.display_id ? `#${o.display_id}` : String(o.id),
+    sublabel: o.email ? String(o.email) : null,
+    status: o.status ? String(o.status) : null,
+    href: `/orders/${o.id}`,
+    props: [
+      ...(o.status ? [{ key: "status", value: String(o.status) }] : []),
+      ...(o.created_at
+        ? [{ key: "placed", value: new Date(o.created_at).toLocaleDateString() }]
+        : []),
+    ],
+    // A design is not detached from an order it was sold on. That is history.
+    remove: null,
+  }))
+}
+
+const peopleItems = async (query: any, designId: string): Promise<NodeItem[]> => {
+  const { data: links } = await query.graph({
+    entity: designPersonLink.entryPoint,
+    filters: { design_id: designId },
+    fields: ["person_id"],
+  })
+  const ids = asArray<any>(links)
+    .map((l) => l.person_id)
+    .filter(Boolean)
+  if (!ids.length) return []
+
+  const { data: people } = await query.graph({
+    entity: "people",
+    filters: { id: ids },
+    fields: ["id", "first_name", "last_name", "email"],
+  })
+
+  return asArray<any>(people).map((p) => ({
+    id: String(p.id),
+    label: [p.first_name, p.last_name].filter(Boolean).join(" ") || String(p.id),
+    sublabel: p.email ? String(p.email) : null,
+    status: null,
+    href: `/persons/${p.id}`,
+    props: p.email ? [{ key: "email", value: String(p.email) }] : [],
+    remove: null,
+  }))
+}
+
+const specificationItems = async (
+  query: any,
+  designId: string
+): Promise<NodeItem[]> => {
+  const design = await loadDesign(query, designId, ["specifications.*"])
+  return asArray<any>(design.specifications).map((sp) => ({
+    id: String(sp.id),
+    label: String(sp.title || sp.technique || sp.id),
+    sublabel: sp.technique ? String(sp.technique) : null,
+    status: null,
+    href: `/designs/${designId}`,
+    props: [
+      ...(sp.technique ? [{ key: "technique", value: String(sp.technique) }] : []),
+      ...(sp.notes ? [{ key: "notes", value: String(sp.notes) }] : []),
+    ],
+    remove: null,
+  }))
+}
+
+/**
+ * Node key → its members.
+ *
+ * 🔴 Keyed by KEY, like every other registry in this feature. Two nodes on
+ * this spine are of type `design` and point at different records; a map keyed
+ * by type would list the wrong one's members.
+ */
+const RESOLVERS: Record<
+  string,
+  (query: any, designId: string) => Promise<NodeItem[]>
+> = {
+  inventory: inventoryItems,
+  components: componentItems,
+  tasks: taskItems,
+  partners: partnerItems,
+  runs: runItems,
+  consumption: consumptionItems,
+  materials: materialGroupItems,
+  orders: orderItems,
+  people: peopleItems,
+  specifications: specificationItems,
+}
+
+/** Which node keys can list their members — the drawer asks before fetching. */
+export const DESIGN_ITEM_NODES = Object.keys(RESOLVERS)
+
+export const resolveDesignItems = async (
+  { scope, id }: SpineContext,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const resolver = RESOLVERS[nodeKey]
+  if (!resolver) {
+    return []
+  }
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  return resolver(query, id)
+}

--- a/apps/backend/src/lib/graph/spines/design/items.ts
+++ b/apps/backend/src/lib/graph/spines/design/items.ts
@@ -296,7 +296,7 @@ const consumptionItems = async (
   if (!ids.length) return []
 
   const { data: logs } = await query.graph({
-    entity: "consumption_logs",
+    entity: "consumption_log",
     filters: { id: ids },
     fields: ["*"],
   })
@@ -351,7 +351,7 @@ const materialGroupItems = async (
   if (!ids.length) return []
 
   const { data: groups } = await query.graph({
-    entity: "raw_material_groups",
+    entity: "raw_material_group",
     filters: { id: ids },
     fields: ["*"],
   })
@@ -424,7 +424,7 @@ const peopleItems = async (query: any, designId: string): Promise<NodeItem[]> =>
   if (!ids.length) return []
 
   const { data: people } = await query.graph({
-    entity: "people",
+    entity: "person",
     filters: { id: ids },
     fields: ["id", "first_name", "last_name", "email"],
   })

--- a/apps/backend/src/lib/graph/spines/partner/__tests__/absence.unit.spec.ts
+++ b/apps/backend/src/lib/graph/spines/partner/__tests__/absence.unit.spec.ts
@@ -1,0 +1,161 @@
+import {
+  deliveredRuns,
+  domainUnverified,
+  expectsAdmin,
+  expectsPaymentMethod,
+  expectsStore,
+  whatsappUnverified,
+  type RunLike,
+} from "../absence"
+
+const run = (over: Partial<RunLike> = {}): RunLike => ({
+  id: over.id ?? "pr_1",
+  status: "completed",
+  partner_id: "pt_1",
+  ...over,
+})
+
+describe("expectsAdmin", () => {
+  it("fires whenever nobody can sign in", () => {
+    // 🔴 Unconditional. There is no state in which a partner with no admin is
+    // correct: work assigned to them stops dead and the assignment still reads
+    // as successful from the admin side.
+    expect(expectsAdmin(0)).toBe(true)
+  })
+
+  it("stays quiet with even one", () => {
+    expect(expectsAdmin(1)).toBe(false)
+  })
+})
+
+describe("expectsPaymentMethod — the partner spine's approved_product_id", () => {
+  it("fires when delivered work has no account to be paid into", () => {
+    expect(expectsPaymentMethod([run()], 0, 0)).toBe(true)
+  })
+
+  it("fires on an approved submission even with no runs", () => {
+    // The debt can exist without a run behind it in this graph.
+    expect(expectsPaymentMethod([], 2, 0)).toBe(true)
+  })
+
+  it("stays quiet on a partner who is owed nothing yet", () => {
+    /*
+     * 🔴 The case that decides whether this signal is worth anything. Most
+     * partners on the day they are created have no runs and no submissions;
+     * asserting unconditionally would dash an edge on all of them and teach
+     * the reader to ignore the dashed edges entirely.
+     */
+    expect(expectsPaymentMethod([], 0, 0)).toBe(false)
+  })
+
+  it("stays quiet on work that is not delivered yet", () => {
+    expect(expectsPaymentMethod([run({ status: "sent_to_partner" })], 0, 0)).toBe(
+      false
+    )
+    expect(expectsPaymentMethod([run({ status: "cancelled" })], 0, 0)).toBe(false)
+  })
+
+  it("stays quiet once a method exists", () => {
+    expect(expectsPaymentMethod([run()], 3, 1)).toBe(false)
+  })
+})
+
+describe("deliveredRuns", () => {
+  it("counts only work that was actually delivered", () => {
+    const runs = [
+      run({ id: "a", status: "completed" }),
+      run({ id: "b", status: "in_progress" }),
+      run({ id: "c", status: "cancelled" }),
+      run({ id: "d", status: "approved" }),
+    ]
+    expect(deliveredRuns(runs).map((r) => r.id)).toEqual(["a", "d"])
+  })
+
+  it("treats a missing status as not delivered", () => {
+    // `undefined` must not coerce into the delivered set by accident.
+    expect(deliveredRuns([run({ status: null })])).toHaveLength(0)
+    expect(deliveredRuns([{ id: "x" }])).toHaveLength(0)
+  })
+})
+
+describe("expectsStore", () => {
+  it("fires on a seller with nothing to sell through", () => {
+    expect(expectsStore("seller", 0)).toBe(true)
+  })
+
+  it("never fires on the workspace types that produce for someone else", () => {
+    /*
+     * 🔴 Manufacturers are the majority of the partner base and produce
+     * against another party's store by design. Dashing this on them would
+     * assert a defect on most partners in the platform.
+     */
+    for (const type of ["manufacturer", "individual", "designer"]) {
+      expect(expectsStore(type, 0)).toBe(false)
+    }
+  })
+
+  it("stays quiet on a seller who has one", () => {
+    expect(expectsStore("seller", 1)).toBe(false)
+  })
+
+  it("treats an unset workspace type as not a seller", () => {
+    expect(expectsStore(null, 0)).toBe(false)
+    expect(expectsStore(undefined, 0)).toBe(false)
+  })
+})
+
+describe("the configured-but-broken pair", () => {
+  it("flags a number that will never receive anything", () => {
+    // Unverified, the sender drops the message: a dispatch notification is
+    // recorded as sent and never arrives.
+    expect(whatsappUnverified("+919000000000", false)).toBe(true)
+  })
+
+  it("does not flag having no number at all", () => {
+    // 🔴 No number is a CHOICE, not a fault.
+    expect(whatsappUnverified(null, false)).toBe(false)
+    expect(whatsappUnverified("", false)).toBe(false)
+  })
+
+  it("does not flag a verified number", () => {
+    expect(whatsappUnverified("+919000000000", true)).toBe(false)
+  })
+
+  it("flags a claimed domain that does not resolve", () => {
+    expect(domainUnverified("hrhandloom.in", false)).toBe(true)
+    expect(domainUnverified("hrhandloom.in", true)).toBe(false)
+    expect(domainUnverified(null, false)).toBe(false)
+  })
+})
+
+describe("resolveExisting — a link row is not a record", () => {
+  const { resolveExisting } = require("../../../builder")
+
+  it("drops ids with nothing behind them", async () => {
+    /*
+     * 🔴 The case measured on the local database: four link rows pointing at
+     * person ids that do not exist. Counting the LINKS made the node claim
+     * `present` — "a declared link with something on the other end" — with
+     * nothing on the other end.
+     */
+    const query = { graph: async () => ({ data: [{ id: "b" }] }) }
+    await expect(resolveExisting(query, "person", ["a", "b", "c"])).resolves.toEqual(
+      ["b"]
+    )
+  })
+
+  it("keeps the link table's order", async () => {
+    const query = { graph: async () => ({ data: [{ id: "c" }, { id: "a" }] }) }
+    await expect(resolveExisting(query, "person", ["a", "b", "c"])).resolves.toEqual(
+      ["a", "c"]
+    )
+  })
+
+  it("asks nothing when there is nothing to ask about", async () => {
+    // An empty id list reads as "no filter" to query.graph and would return
+    // EVERY record of that entity.
+    const graph = jest.fn()
+    await expect(resolveExisting({ graph }, "person", [])).resolves.toEqual([])
+    expect(graph).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/lib/graph/spines/partner/absence.ts
+++ b/apps/backend/src/lib/graph/spines/partner/absence.ts
@@ -1,0 +1,105 @@
+/**
+ * When does the model genuinely EXPECT a neighbour on a partner? (#1847)
+ *
+ * 🔴 An absent edge is an assertion, and the partner spine is where crying
+ * wolf would cost most: a partner touches nineteen link files, so a resolver
+ * that dashed every empty relation would draw a dozen red edges on a perfectly
+ * healthy record and teach the reader to ignore all of them — including the two
+ * below, which are the ones worth believing.
+ *
+ * So the bar is the same one the design spine set: assert an absence only
+ * where a real code path is left with nowhere to go. Everything else is a
+ * present-only node — there, or simply not drawn.
+ *
+ * Pure functions with tests rather than inline conditions in the resolver,
+ * because both mistakes are silent on screen.
+ */
+
+export type RunLike = {
+  id: string
+  status?: string | null
+  partner_id?: string | null
+}
+
+/** Run states that mean work was actually delivered and is owed for. */
+const DELIVERED = new Set(["completed", "delivered", "approved"])
+
+export const deliveredRuns = (runs: RunLike[]): RunLike[] =>
+  runs.filter((r) => DELIVERED.has(String(r.status ?? "")))
+
+/**
+ * A partner with nobody who can sign in.
+ *
+ * 🔴 Unconditional — there is no state in which this is correct. A partner
+ * with no `partner_admin` cannot log in, cannot accept a dispatch, and cannot
+ * be notified of one; work assigned to them stops dead and the assignment
+ * still looks successful from the admin side. It is the partner spine's
+ * clearest dead end, and nothing in any list shows it.
+ */
+export const expectsAdmin = (adminCount: number): boolean => adminCount === 0
+
+/**
+ * A partner owed money with no account to send it to.
+ *
+ * This is the partner spine's `approved_product_id`: the platform records the
+ * debt perfectly and the payment has nowhere to land. A payout is paid to an
+ * `internal_payment_details` row reached through the partner's
+ * `payment_methods` link (see `submission-paid-to-method-link`), so with no
+ * method linked an approved submission cannot be paid at all.
+ *
+ * 🔴 Conditional on there BEING payable work. A partner just onboarded, with
+ * no runs and no submissions, owes nothing and expects no bank account — and
+ * that is most partners on the day they are created. Asserting it
+ * unconditionally would dash an edge on every new partner and make the
+ * signal worthless exactly where it matters.
+ */
+export const expectsPaymentMethod = (
+  runs: RunLike[],
+  submissionCount: number,
+  methodCount: number
+): boolean =>
+  methodCount === 0 && (submissionCount > 0 || deliveredRuns(runs).length > 0)
+
+/**
+ * A seller with no store.
+ *
+ * `workspace_type` is what the platform routes on: a `seller` gets the
+ * commerce surface and is expected to sell through a store of their own. With
+ * none linked there is nothing for that surface to act on.
+ *
+ * 🔴 Only for `seller`. A `manufacturer`, an `individual` and a `designer`
+ * produce against someone else's store by design — dashing this on them would
+ * assert a defect on the majority of the partner base.
+ */
+export const expectsStore = (
+  workspaceType: string | null | undefined,
+  storeCount: number
+): boolean => workspaceType === "seller" && storeCount === 0
+
+/**
+ * WhatsApp configured but never verified.
+ *
+ * Not an absent NEIGHBOUR — it is a broken one, and the distinction is the
+ * point: the number is there, the notifications are not. Unverified, the
+ * WhatsApp sender drops the message, so a dispatch notification is recorded as
+ * sent and never arrives. A count of "notifications sent" cannot show it.
+ *
+ * 🔴 Only when a number is actually set. No number at all is a choice, not a
+ * fault.
+ */
+export const whatsappUnverified = (
+  number: string | null | undefined,
+  verified: boolean | null | undefined
+): boolean => !!number && !verified
+
+/**
+ * A custom domain claimed but not verified.
+ *
+ * Same shape as WhatsApp: the storefront is provisioned, the domain is
+ * recorded, and the site does not resolve. It reads as "set up" everywhere the
+ * field is displayed.
+ */
+export const domainUnverified = (
+  domain: string | null | undefined,
+  verified: boolean | null | undefined
+): boolean => !!domain && !verified

--- a/apps/backend/src/lib/graph/spines/partner/index.ts
+++ b/apps/backend/src/lib/graph/spines/partner/index.ts
@@ -1,0 +1,596 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import designPartnersLink from "../../../../links/design-partners-link"
+import partnerInventoryOrderLink from "../../../../links/partner-inventory-order"
+import partnerOrderLink from "../../../../links/partner-order"
+import partnerPaymentMethodsLink from "../../../../links/partner-payment-methods-link"
+import partnerPersonLink from "../../../../links/partner-person"
+import partnerProductLink from "../../../../links/partner-product"
+import partnerStoresLink from "../../../../links/partner-stores-link"
+import partnerSubscriptionLink from "../../../../links/partner-subscription"
+import partnerTaskLink from "../../../../links/partner-task"
+import submissionPartnerLink from "../../../../links/submission-partner-link"
+import { GraphBuilder, asArray, resolveExisting } from "../../builder"
+import type { Graph, GraphNode, SpineContext, SpineDescriptor } from "../../types"
+import {
+  deliveredRuns,
+  domainUnverified,
+  expectsAdmin,
+  expectsPaymentMethod,
+  expectsStore,
+  whatsappUnverified,
+} from "./absence"
+import { PARTNER_ITEM_NODES, resolvePartnerItems } from "./items"
+
+/**
+ * The PARTNER spine (#1847).
+ *
+ * The biggest node in the platform: nineteen link files converge on a partner,
+ * against the design's six. It is also the one where the registry earns its
+ * keep — this file plus one line in `registry.ts` is the whole change. No new
+ * route, no new admin hook, no new client code, and the MCP surface picks it up
+ * for free.
+ *
+ * 🔴 Every link is read through its `entryPoint`, never as a field hop off
+ * `partners`. A `query.graph` hop from an entity to a linked field can come
+ * back with NO KEY AT ALL rather than an error, and on this spine an empty
+ * result would silently claim a partner has no work, no people and no bank
+ * account — which is the exact shape of the two absences that matter.
+ */
+const resolvePartnerGraph = async ({ scope, id }: SpineContext): Promise<Graph> => {
+  const partnerId = id
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  /*
+   * `admins` is an intra-module `hasMany` on the partner model itself, so it
+   * resolves straight off the entity. It is the ONLY neighbour here that does.
+   */
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    filters: { id: partnerId },
+    fields: ["*", "admins.*"],
+  })
+
+  const partner = (partners || [])[0]
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Partner ${partnerId} was not found`
+    )
+  }
+
+  const admins = asArray<any>(partner.admins)
+
+  const [
+    { data: runs },
+    { data: designLinks },
+    { data: personLinks },
+    { data: taskLinks },
+    { data: productLinks },
+    { data: orderLinks },
+    { data: inventoryOrderLinks },
+    { data: submissionLinks },
+    { data: methodLinks },
+    { data: storeLinks },
+    { data: subscriptionLinks },
+  ] = await Promise.all([
+    query.graph({
+      entity: "production_runs",
+      filters: { partner_id: partnerId },
+      fields: ["id", "status", "partner_id", "design_id", "execution_mode"],
+    }),
+    query.graph({
+      entity: designPartnersLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["design_id"],
+    }),
+    query.graph({
+      entity: partnerPersonLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["person_id"],
+    }),
+    query.graph({
+      entity: partnerTaskLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["task_id"],
+    }),
+    query.graph({
+      entity: partnerProductLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["product_id"],
+    }),
+    query.graph({
+      entity: partnerOrderLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["order_id"],
+    }),
+    query.graph({
+      entity: partnerInventoryOrderLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["inventory_orders_id"],
+    }),
+    query.graph({
+      entity: submissionPartnerLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["payment_submission_id"],
+    }),
+    query.graph({
+      entity: partnerPaymentMethodsLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["internal_payment_details_id"],
+    }),
+    query.graph({
+      entity: partnerStoresLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["store_id"],
+    }),
+    query.graph({
+      entity: partnerSubscriptionLink.entryPoint,
+      filters: { partner_id: partnerId },
+      fields: ["partner_subscription_id"],
+    }),
+  ])
+
+  const runList = asArray<any>(runs)
+  const linkedDesignIds = asArray<any>(designLinks).map((l) => l.design_id).filter(Boolean)
+  const linkedPersonIds = asArray<any>(personLinks).map((l) => l.person_id).filter(Boolean)
+  const linkedTaskIds = asArray<any>(taskLinks).map((l) => l.task_id).filter(Boolean)
+  const linkedProductIds = asArray<any>(productLinks).map((l) => l.product_id).filter(Boolean)
+  const linkedOrderIds = asArray<any>(orderLinks).map((l) => l.order_id).filter(Boolean)
+  const linkedInventoryOrderIds = asArray<any>(inventoryOrderLinks)
+    .map((l) => l.inventory_orders_id)
+    .filter(Boolean)
+  const linkedSubmissionIds = asArray<any>(submissionLinks)
+    .map((l) => l.payment_submission_id)
+    .filter(Boolean)
+  const linkedMethodIds = asArray<any>(methodLinks)
+    .map((l) => l.internal_payment_details_id)
+    .filter(Boolean)
+  const linkedStoreIds = asArray<any>(storeLinks).map((l) => l.store_id).filter(Boolean)
+  const linkedSubscriptionIds = asArray<any>(subscriptionLinks)
+    .map((l) => l.partner_subscription_id)
+    .filter(Boolean)
+
+  /*
+   * 🔴 Second pass: keep only the ids that resolve to a real record.
+   *
+   * A link row is not a record. Both of these were measured on the local
+   * database — a `people` node reading "4 linked" against four link rows whose
+   * person ids do not exist, and a `submissions` node reading "2 raised" with
+   * both submissions gone. Counting link rows made the node claim `present`,
+   * which this feature defines as "a declared link with SOMETHING ON THE OTHER
+   * END".
+   *
+   * It only came to light because the drawer lists records while the node
+   * counted links, and the two disagreed. Absent that, the graph would have
+   * gone on asserting neighbours that are not there — the exact failure it was
+   * built to expose, committed by the thing exposing it.
+   *
+   * Independent, so one round trip for all of them.
+   */
+  const [
+    designIds,
+    personIds,
+    taskIds,
+    productIds,
+    orderIds,
+    inventoryOrderIds,
+    submissionIds,
+    methodIds,
+    storeIds,
+    subscriptionIds,
+  ] = await Promise.all([
+    resolveExisting(query, "design", linkedDesignIds),
+    resolveExisting(query, "person", linkedPersonIds),
+    resolveExisting(query, "task", linkedTaskIds),
+    resolveExisting(query, "product", linkedProductIds),
+    resolveExisting(query, "order", linkedOrderIds),
+    resolveExisting(query, "inventory_orders", linkedInventoryOrderIds),
+    resolveExisting(query, "payment_submission", linkedSubmissionIds),
+    resolveExisting(query, "internal_payment_details", linkedMethodIds),
+    resolveExisting(query, "store", linkedStoreIds),
+    resolveExisting(query, "partner_subscription", linkedSubscriptionIds),
+  ])
+
+  const builder = new GraphBuilder("partner")
+  const push = builder.push.bind(builder)
+
+  // ---- admins -------------------------------------------------------------
+
+  if (admins.length) {
+    push(
+      {
+        key: "admins",
+        type: "partner_admin",
+        label: "Admins",
+        sublabel: `${admins.length} ${admins.length === 1 ? "admin" : "admins"}`,
+        state: "present",
+        count: admins.length,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: admins.slice(0, 4).map((a) => ({
+          key: a.email || a.id,
+          value: String(a.role ?? "admin"),
+        })),
+        action: null,
+      },
+      { label: "partner_admin", state: "present", reason: null }
+    )
+  } else if (expectsAdmin(admins.length)) {
+    push(
+      {
+        key: "admins",
+        type: "partner_admin",
+        label: "Admins",
+        sublabel: "nobody can sign in",
+        state: "absent",
+        count: 0,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [{ key: "admins", value: "0" }],
+        action: { label: "Add an admin", href: `/partners/${partnerId}` },
+      },
+      {
+        label: "partner_admin",
+        state: "absent",
+        reason:
+          "This partner has no admin, so nobody can sign in, accept a dispatch or be notified of one. Work assigned to them stops dead while the assignment still reads as successful.",
+      }
+    )
+  }
+
+  // ---- payment methods ----------------------------------------------------
+
+  const delivered = deliveredRuns(runList)
+
+  if (methodIds.length) {
+    push(
+      {
+        key: "payment_methods",
+        type: "internal_payment_details",
+        label: "Payment methods",
+        sublabel: `${methodIds.length} on file`,
+        state: "present",
+        count: methodIds.length,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [{ key: "methods", value: String(methodIds.length) }],
+        action: null,
+      },
+      { label: "payment_methods", state: "present", reason: null }
+    )
+  } else if (expectsPaymentMethod(runList, submissionIds.length, methodIds.length)) {
+    push(
+      {
+        key: "payment_methods",
+        type: "internal_payment_details",
+        label: "Payment methods",
+        sublabel: "nowhere to pay",
+        state: "absent",
+        count: 0,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [
+          { key: "delivered runs", value: String(delivered.length) },
+          { key: "submissions", value: String(submissionIds.length) },
+          { key: "methods", value: "0" },
+        ],
+        action: { label: "Add a payment method", href: `/partners/${partnerId}` },
+      },
+      {
+        label: "payment_methods",
+        state: "absent",
+        reason:
+          "There is payable work here and no account to pay it into. A payout is paid to a linked payment method, so an approved submission for this partner cannot be paid at all.",
+      }
+    )
+  }
+
+  // ---- stores -------------------------------------------------------------
+
+  if (storeIds.length) {
+    push(
+      {
+        key: "stores",
+        type: "store",
+        label: "Stores",
+        sublabel: `${storeIds.length} ${storeIds.length === 1 ? "store" : "stores"}`,
+        state: "present",
+        count: storeIds.length,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [{ key: "stores", value: String(storeIds.length) }],
+        action: null,
+      },
+      { label: "stores", state: "present", reason: null }
+    )
+  } else if (expectsStore(partner.workspace_type, storeIds.length)) {
+    push(
+      {
+        key: "stores",
+        type: "store",
+        label: "Stores",
+        sublabel: "nothing to sell through",
+        state: "absent",
+        count: 0,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [{ key: "workspace", value: String(partner.workspace_type) }],
+        action: { label: "Link a store", href: `/partners/${partnerId}` },
+      },
+      {
+        label: "stores",
+        state: "absent",
+        reason:
+          "This partner is a seller and has no store linked, so the commerce surface they are routed to has nothing to act on.",
+      }
+    )
+  }
+
+  // ---- work ---------------------------------------------------------------
+
+  if (runList.length) {
+    const byStatus = runList.reduce<Record<string, number>>((acc, r) => {
+      const k = String(r.status ?? "unknown")
+      acc[k] = (acc[k] ?? 0) + 1
+      return acc
+    }, {})
+    push(
+      {
+        key: "runs",
+        type: "production_run",
+        label: "Production runs",
+        sublabel: `${runList.length} ${runList.length === 1 ? "run" : "runs"}`,
+        state: "present",
+        count: runList.length,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [
+          ...Object.entries(byStatus).map(([k, v]) => ({ key: k, value: String(v) })),
+          { key: "delivered", value: String(delivered.length) },
+        ],
+        action: null,
+      },
+      { label: "partner_id", state: "present", reason: null }
+    )
+  }
+
+  if (designIds.length) {
+    push(
+      {
+        key: "designs",
+        type: "design",
+        label: "Designs",
+        sublabel: `${designIds.length} linked`,
+        state: "present",
+        count: designIds.length,
+        status: null,
+        href: designIds.length === 1 ? `/designs/${designIds[0]}` : null,
+        props: [{ key: "designs", value: String(designIds.length) }],
+        action: null,
+      },
+      { label: "design_partner", state: "present", reason: null }
+    )
+  }
+
+  if (taskIds.length) {
+    push(
+      {
+        key: "tasks",
+        type: "task",
+        label: "Tasks",
+        sublabel: `${taskIds.length} assigned`,
+        state: "present",
+        count: taskIds.length,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [{ key: "tasks", value: String(taskIds.length) }],
+        action: null,
+      },
+      { label: "partner_task", state: "present", reason: null }
+    )
+  }
+
+  if (productIds.length) {
+    push(
+      {
+        key: "products",
+        type: "product",
+        label: "Products",
+        sublabel: `${productIds.length} listed`,
+        state: "present",
+        count: productIds.length,
+        status: null,
+        href: productIds.length === 1 ? `/products/${productIds[0]}` : null,
+        props: [{ key: "products", value: String(productIds.length) }],
+        action: null,
+      },
+      { label: "partner_product", state: "present", reason: null }
+    )
+  }
+
+  if (orderIds.length) {
+    push(
+      {
+        key: "orders",
+        type: "order",
+        label: "Work orders",
+        sublabel: `${orderIds.length} ${orderIds.length === 1 ? "order" : "orders"}`,
+        state: "present",
+        count: orderIds.length,
+        status: null,
+        href: orderIds.length === 1 ? `/orders/${orderIds[0]}` : null,
+        props: [{ key: "orders", value: String(orderIds.length) }],
+        action: null,
+      },
+      { label: "partner_order", state: "present", reason: null }
+    )
+  }
+
+  if (inventoryOrderIds.length) {
+    push(
+      {
+        key: "inventory_orders",
+        type: "inventory_order",
+        label: "Inventory orders",
+        sublabel: `${inventoryOrderIds.length} raised`,
+        state: "present",
+        count: inventoryOrderIds.length,
+        status: null,
+        href: `/inventory-orders`,
+        props: [{ key: "orders", value: String(inventoryOrderIds.length) }],
+        action: null,
+      },
+      { label: "partner_inventory_order", state: "present", reason: null }
+    )
+  }
+
+  if (submissionIds.length) {
+    push(
+      {
+        key: "submissions",
+        type: "payment_submission",
+        label: "Payment submissions",
+        sublabel: `${submissionIds.length} raised`,
+        state: "present",
+        count: submissionIds.length,
+        status: null,
+        href: `/payment-submissions`,
+        props: [{ key: "submissions", value: String(submissionIds.length) }],
+        action: null,
+      },
+      { label: "payment_submission", state: "present", reason: null }
+    )
+  }
+
+  if (personIds.length) {
+    push(
+      {
+        key: "people",
+        type: "person",
+        label: "People",
+        sublabel: `${personIds.length} linked`,
+        state: "present",
+        count: personIds.length,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [{ key: "people", value: String(personIds.length) }],
+        action: null,
+      },
+      { label: "partner_person", state: "present", reason: null }
+    )
+  }
+
+  if (subscriptionIds.length) {
+    push(
+      {
+        key: "subscriptions",
+        type: "partner_subscription",
+        label: "Subscription",
+        sublabel: `${subscriptionIds.length} on file`,
+        state: "present",
+        count: subscriptionIds.length,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [{ key: "subscriptions", value: String(subscriptionIds.length) }],
+        action: null,
+      },
+      { label: "partner_subscription", state: "present", reason: null }
+    )
+  }
+
+  /*
+   * ---- configured but broken ----------------------------------------------
+   *
+   * 🔴 These two are `derived`, not `absent`, and the distinction is the whole
+   * reason they are drawn. The neighbour is not missing — it is there and it
+   * does not work. WhatsApp unverified means the sender drops the message, so a
+   * dispatch notification is recorded as sent and never arrives; a claimed but
+   * unverified domain means the storefront does not resolve. Both read as
+   * "set up" everywhere the field itself is displayed.
+   */
+  if (whatsappUnverified(partner.whatsapp_number, partner.whatsapp_verified)) {
+    push(
+      {
+        key: "whatsapp",
+        type: "channel",
+        label: "WhatsApp",
+        sublabel: "number set, never verified",
+        state: "derived",
+        count: 0,
+        status: "unverified",
+        href: `/partners/${partnerId}`,
+        props: [
+          { key: "number", value: String(partner.whatsapp_number) },
+          { key: "verified", value: "no" },
+        ],
+        action: { label: "Verify the number", href: null },
+      },
+      {
+        label: "whatsapp_number",
+        state: "derived",
+        reason:
+          "A number is on file but was never verified, so notifications to it are dropped by the sender — a dispatch is recorded as notified and never arrives.",
+      }
+    )
+  }
+
+  if (domainUnverified(partner.custom_domain, partner.custom_domain_verified)) {
+    push(
+      {
+        key: "domain",
+        type: "domain",
+        label: "Custom domain",
+        sublabel: "claimed, not resolving",
+        state: "derived",
+        count: 0,
+        status: "unverified",
+        href: `/partners/${partnerId}`,
+        props: [
+          { key: "domain", value: String(partner.custom_domain) },
+          { key: "verified", value: "no" },
+        ],
+        action: { label: "Verify the domain", href: null },
+      },
+      {
+        label: "custom_domain",
+        state: "derived",
+        reason:
+          "The domain is recorded against this partner but not verified, so their storefront does not resolve on it.",
+      }
+    )
+  }
+
+  const spine: GraphNode = {
+    key: "partner",
+    type: "partner",
+    label: String(partner.name ?? partnerId),
+    sublabel: String(partner.handle ?? partner.workspace_type ?? ""),
+    state: "present",
+    count: 1,
+    status: String(partner.status ?? ""),
+    href: `/partners/${partnerId}`,
+    props: [
+      { key: "status", value: String(partner.status ?? "—") },
+      { key: "workspace", value: String(partner.workspace_type ?? "—") },
+      { key: "verified", value: partner.is_verified ? "yes" : "no" },
+      ...(partner.country_code
+        ? [{ key: "country", value: String(partner.country_code).toUpperCase() }]
+        : []),
+      ...(partner.currency_code
+        ? [{ key: "currency", value: String(partner.currency_code).toUpperCase() }]
+        : []),
+    ],
+    action: null,
+  }
+
+  return builder.build(spine)
+}
+
+export const partnerSpine: SpineDescriptor = {
+  key: "partner",
+  label: "Partner",
+  resolve: resolvePartnerGraph,
+  items: resolvePartnerItems,
+  itemNodes: PARTNER_ITEM_NODES,
+}

--- a/apps/backend/src/lib/graph/spines/partner/items.ts
+++ b/apps/backend/src/lib/graph/spines/partner/items.ts
@@ -1,0 +1,230 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import designPartnersLink from "../../../../links/design-partners-link"
+import partnerPaymentMethodsLink from "../../../../links/partner-payment-methods-link"
+import partnerPersonLink from "../../../../links/partner-person"
+import submissionPartnerLink from "../../../../links/submission-partner-link"
+import { asArray } from "../../builder"
+import type { NodeItem, SpineContext } from "../../types"
+
+/**
+ * The members behind a partner's aggregate nodes.
+ *
+ * 🔴 Nothing here offers a `remove`, and that is a decision rather than an
+ * omission. Detaching a partner's work is not the mirror of detaching a
+ * design's: a run belongs to the design that ordered it, a submission is a
+ * financial record, a payment method may already have been paid to, and a
+ * person may be linked from either side. Every one of those has a route of its
+ * own with its own guards; surfacing a bin icon here would either duplicate
+ * that logic or bypass it.
+ *
+ * The rows are worth listing regardless — "which four designs?" is exactly the
+ * question the count provokes, and answering it is most of what the drawer is
+ * for.
+ */
+
+const designItems = async (query: any, partnerId: string): Promise<NodeItem[]> => {
+  const { data: links } = await query.graph({
+    entity: designPartnersLink.entryPoint,
+    filters: { partner_id: partnerId },
+    fields: ["design_id"],
+  })
+  const ids = asArray<any>(links).map((l) => l.design_id).filter(Boolean)
+  if (!ids.length) return []
+
+  const { data: designs } = await query.graph({
+    entity: "designs",
+    filters: { id: ids },
+    fields: ["id", "name", "status", "design_type", "priority"],
+  })
+
+  return asArray<any>(designs).map((d) => ({
+    id: String(d.id),
+    label: String(d.name ?? d.id),
+    sublabel:
+      [d.design_type, d.priority ? `${d.priority} priority` : null]
+        .filter(Boolean)
+        .join(" · ") || null,
+    status: d.status ? String(d.status) : null,
+    href: `/designs/${d.id}`,
+    props: [
+      ...(d.design_type ? [{ key: "type", value: String(d.design_type) }] : []),
+      ...(d.priority ? [{ key: "priority", value: String(d.priority) }] : []),
+    ],
+    remove: null,
+  }))
+}
+
+const runItems = async (query: any, partnerId: string): Promise<NodeItem[]> => {
+  const { data: runs } = await query.graph({
+    entity: "production_runs",
+    filters: { partner_id: partnerId },
+    fields: ["*"],
+  })
+  return asArray<any>(runs).map((r) => ({
+    id: String(r.id),
+    label: String(r.name || r.id),
+    sublabel:
+      [
+        r.quantity_produced != null ? `${r.quantity_produced} produced` : null,
+        r.execution_mode ? String(r.execution_mode) : null,
+      ]
+        .filter(Boolean)
+        .join(" · ") || null,
+    status: r.status ? String(r.status) : null,
+    href: r.design_id ? `/designs/${r.design_id}/production-runs` : null,
+    props: [
+      { key: "status", value: String(r.status ?? "—") },
+      ...(r.design_id ? [{ key: "design", value: String(r.design_id) }] : []),
+    ],
+    remove: null,
+  }))
+}
+
+const submissionItems = async (
+  query: any,
+  partnerId: string
+): Promise<NodeItem[]> => {
+  const { data: links } = await query.graph({
+    entity: submissionPartnerLink.entryPoint,
+    filters: { partner_id: partnerId },
+    fields: ["payment_submission_id"],
+  })
+  const ids = asArray<any>(links)
+    .map((l) => l.payment_submission_id)
+    .filter(Boolean)
+  if (!ids.length) return []
+
+  const { data: submissions } = await query.graph({
+    entity: "payment_submission",
+    filters: { id: ids },
+    fields: ["*"],
+  })
+
+  return asArray<any>(submissions).map((sub) => ({
+    id: String(sub.id),
+    label: String(sub.reference ?? sub.id),
+    sublabel:
+      sub.amount != null
+        ? `${String(sub.currency_code ?? "").toUpperCase()} ${sub.amount}`.trim()
+        : null,
+    status: sub.status ? String(sub.status) : null,
+    href: `/payment-submissions`,
+    props: [
+      { key: "status", value: String(sub.status ?? "—") },
+      ...(sub.amount != null ? [{ key: "amount", value: String(sub.amount) }] : []),
+    ],
+    remove: null,
+  }))
+}
+
+const paymentMethodItems = async (
+  query: any,
+  partnerId: string
+): Promise<NodeItem[]> => {
+  const { data: links } = await query.graph({
+    entity: partnerPaymentMethodsLink.entryPoint,
+    filters: { partner_id: partnerId },
+    fields: ["internal_payment_details_id"],
+  })
+  const ids = asArray<any>(links)
+    .map((l) => l.internal_payment_details_id)
+    .filter(Boolean)
+  if (!ids.length) return []
+
+  const { data: methods } = await query.graph({
+    entity: "internal_payment_details",
+    filters: { id: ids },
+    fields: ["*"],
+  })
+
+  return asArray<any>(methods).map((m) => ({
+    id: String(m.id),
+    label: String(m.account_name || m.type || m.id),
+    /*
+     * 🔴 Never the account number. This drawer is a read of a relationship, not
+     * a banking screen — the last four is enough to tell two accounts apart,
+     * and it is all this view has any business rendering.
+     */
+    sublabel: m.account_number
+      ? `•••• ${String(m.account_number).slice(-4)}`
+      : (m.type ?? null),
+    status: null,
+    href: null,
+    props: [...(m.type ? [{ key: "type", value: String(m.type) }] : [])],
+    remove: null,
+  }))
+}
+
+const peopleItems = async (query: any, partnerId: string): Promise<NodeItem[]> => {
+  const { data: links } = await query.graph({
+    entity: partnerPersonLink.entryPoint,
+    filters: { partner_id: partnerId },
+    fields: ["person_id"],
+  })
+  const ids = asArray<any>(links).map((l) => l.person_id).filter(Boolean)
+  if (!ids.length) return []
+
+  const { data: people } = await query.graph({
+    entity: "person",
+    filters: { id: ids },
+    fields: ["id", "first_name", "last_name", "email"],
+  })
+
+  return asArray<any>(people).map((p) => ({
+    id: String(p.id),
+    label: [p.first_name, p.last_name].filter(Boolean).join(" ") || String(p.id),
+    sublabel: p.email ? String(p.email) : null,
+    status: null,
+    href: `/persons/${p.id}`,
+    props: p.email ? [{ key: "email", value: String(p.email) }] : [],
+    remove: null,
+  }))
+}
+
+const adminItems = async (query: any, partnerId: string): Promise<NodeItem[]> => {
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    filters: { id: partnerId },
+    fields: ["id", "admins.*"],
+  })
+  const partner = (partners || [])[0]
+  return asArray<any>(partner?.admins).map((a) => ({
+    id: String(a.id),
+    label: [a.first_name, a.last_name].filter(Boolean).join(" ") || String(a.email ?? a.id),
+    sublabel: a.email ? String(a.email) : null,
+    status: a.role ? String(a.role) : null,
+    href: null,
+    props: [
+      ...(a.role ? [{ key: "role", value: String(a.role) }] : []),
+      ...(a.email ? [{ key: "email", value: String(a.email) }] : []),
+    ],
+    remove: null,
+  }))
+}
+
+const RESOLVERS: Record<
+  string,
+  (query: any, partnerId: string) => Promise<NodeItem[]>
+> = {
+  admins: adminItems,
+  designs: designItems,
+  runs: runItems,
+  submissions: submissionItems,
+  payment_methods: paymentMethodItems,
+  people: peopleItems,
+}
+
+export const PARTNER_ITEM_NODES = Object.keys(RESOLVERS)
+
+export const resolvePartnerItems = async (
+  { scope, id }: SpineContext,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const resolver = RESOLVERS[nodeKey]
+  if (!resolver) {
+    return []
+  }
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  return resolver(query, id)
+}

--- a/apps/backend/src/lib/graph/types.ts
+++ b/apps/backend/src/lib/graph/types.ts
@@ -42,6 +42,61 @@ export type GraphEdge = {
   reason: string | null
 }
 
+/**
+ * One MEMBER of a node.
+ *
+ * A node is an aggregate — "Inventory, 4 items". That is the right thing on the
+ * canvas, where the subject is which edges exist. But it is the wrong thing in
+ * the drawer, which is where the reader has already asked "which four?", and it
+ * makes REMOVAL impossible: you cannot unlink an aggregate.
+ *
+ * 🔴 Members are fetched LAZILY, per node, not folded into the graph payload.
+ * The design spine already makes seven round trips to build a dozen aggregate
+ * nodes; expanding every one of them into its rows would multiply that by the
+ * row count for a drawer the reader may never open. The canvas stays cheap and
+ * the drawer pays for what it shows.
+ */
+export type NodeItem = {
+  /** The RECORD's id — never the link row's, unless `remove` says otherwise. */
+  id: string
+  label: string
+  sublabel: string | null
+  status: string | null
+  href: string | null
+  props: GraphProp[]
+  /** How to detach this member, or null where the model forbids it. */
+  remove: NodeItemRemoval | null
+}
+
+/**
+ * How to remove one member.
+ *
+ * 🔴 This names an EXISTING admin endpoint rather than carrying its own
+ * unlink logic. Every one of these routes already exists, is already tested,
+ * and already runs the compensating workflow — `DELETE
+ * /admin/designs/:id/components/:componentId`, `POST
+ * /admin/designs/:id/inventory/delink`, and so on. Re-implementing detachment
+ * inside the graph would give each of them a SECOND HOME, which is the failure
+ * this codebase has hit every time the same logic acquired one.
+ *
+ * `path` is absolute and server-built, so the client never assembles a URL out
+ * of ids it half-understands.
+ */
+export type NodeItemRemoval = {
+  method: "DELETE" | "POST"
+  path: string
+  /** Sent as the JSON body on a POST. Null on a DELETE. */
+  body: Record<string, unknown> | null
+  /** The words on the button. "Remove", "Unlink", "Cancel assignment". */
+  label: string
+  /**
+   * What the reader is told before it happens. 🔴 Required: several of these
+   * are not symmetric with the create form beside them — delinking inventory
+   * releases reserved stock, cancelling a partner assignment notifies them.
+   */
+  confirm: string
+}
+
 export type GraphSummary = {
   links: number
   absent: number
@@ -53,6 +108,20 @@ export type Graph = {
   nodes: GraphNode[]
   edges: GraphEdge[]
   summary: GraphSummary
+  /**
+   * The node keys whose members can be listed.
+   *
+   * 🔴 The client must be TOLD this rather than inferring it. The obvious
+   * inference — "fetch members whenever `count > 0`" — is wrong on exactly the
+   * nodes that are a single record: `product` has a count of 1 and no member
+   * list, so it would fetch, get `[]` back, and render "no items" under a node
+   * that is a real, present product. Declared here, the drawer asks only where
+   * asking means something.
+   *
+   * Attached by the registry from the spine's own declaration, so no spine has
+   * to remember to put it on the graph it builds.
+   */
+  itemNodes: string[]
 }
 
 /** What a spine resolver is handed. `scope` is the request container. */
@@ -67,4 +136,16 @@ export type SpineDescriptor = {
   /** Human name, used in the not-found error. */
   label: string
   resolve: (ctx: SpineContext) => Promise<Graph>
+  /**
+   * The members behind one aggregate node, if this spine can list them.
+   *
+   * Optional on purpose: a spine is useful the moment it can draw its edges,
+   * and demanding an item resolver up front would make every new spine a
+   * bigger change than the registry is trying to make it. A spine without one
+   * — or a node the resolver does not know — yields an EMPTY LIST, and the
+   * drawer says so rather than rendering a bare panel.
+   */
+  items?: (ctx: SpineContext, nodeKey: string) => Promise<NodeItem[]>
+  /** Node keys `items` can answer for. Surfaced to the client as `itemNodes`. */
+  itemNodes?: string[]
 }

--- a/apps/backend/src/links/partner-stores-link.ts
+++ b/apps/backend/src/links/partner-stores-link.ts
@@ -2,8 +2,17 @@ import { defineLink } from "@medusajs/framework/utils"
 import PartnerModule from "../modules/partner"
 import StoreModule from "@medusajs/medusa/store"
 
-// Link a Partner to one Store (one-to-one)
-defineLink(
+/**
+ * Link a Partner to its Store(s).
+ *
+ * 🔴 EXPORTED, and that matters. `defineLink` registers the link as an import
+ * side effect, so this file worked without an export — but nothing could reach
+ * its `entryPoint`, which is the only safe way to READ a link. A `query.graph`
+ * hop from an entity to a linked field can come back with no key at all rather
+ * than an error, and an empty result is indistinguishable from "this partner
+ * has no store". Every other link file here exports; this one was the outlier.
+ */
+export default defineLink(
   PartnerModule.linkable.partner,
   { linkable: StoreModule.linkable.store, isList: true , field: 'stores'}
 )


### PR DESCRIPTION
Continues #1847. Two commits: the members layer + interaction, then the partner spine (which is where a real defect turned up).

## What was in the way

A node was a **count**. Right on the canvas, where the subject is which edges exist — wrong everywhere the reader goes next. "Which four?" is unanswerable from an aggregate, and removal is impossible: you cannot unlink a number. That is why the design page still stacked the cards this feature was meant to replace. *"The graph adds; only these can REMOVE"* was the standing reason in the code.

## What landed

**A members layer.** `NodeItem` + an optional `items` resolver per spine + `GET /admin/graph/:spine/:id/items/:node`. Lazy, per node — the canvas stays cheap and only an opened drawer pays.

**Per-item rows with a remove path**, and "Start another run" on the `runs` node — the one affordance the production-runs card was still holding.

**Pan, zoom and fit.** The canvas was capped at what fits on a screen, and that cap is what limits how much of a page the graph can replace. The partner spine does not fit without it.

**The partner spine.** One entry in `registry.ts` plus a resolver — no new route, no new hook, no client change. The workspace page is the design's with one word altered.

Every `remove` **names an existing admin endpoint**. No detachment logic is reimplemented: those four routes already run their compensating workflows, and giving any of them a second home is the failure this codebase has repeated most.

## Two absences on the partner spine that no list can show

- **No admin** — nobody can sign in, accept a dispatch or be notified of one. Work assigned to them stops dead while the assignment reads as successful.
- **Delivered work, no payment method** — the partner spine's `approved_product_id`. The debt is recorded perfectly and the money has nowhere to land. **Eight partners are in this state on the local database.**

## 🔴 A link row is not a record

Found because the drawer lists *records* while the node counted *links*, and the two disagreed:

| link | rows | records that exist |
|---|---|---|
| `partner_partner_person_person` | 4 | **0** (21 people in the table, none of them these) |
| `…payment_submissions_payment_submission` | 2 | **0** |

Counting link rows made those nodes claim `present` — which this feature *defines* as "a declared link with something on the other end". **The graph was committing the exact fault it was built to expose.** Both spines now resolve ids to records before counting; every count was checked against SQL. Filed the data question separately as #1857.

Same defect in a second disguise: the design spine drew a `present` runs node with **count 0** on every uncommitted design. It survived three shipped steps because a node that is merely *pointless* looks identical to one that is wrong.

## Things that only rendering or probing found

- Every drawer row printed its status **twice** — as the sublabel and again as the badge — while both fields were populated, correct and tested.
- Three of five `query.graph` entity names were wrong and **returned empty rather than erroring**. Both singular and plural forms appear in this repo, so usage counts settle nothing.
- `partner-stores-link.ts` had **no export** — the link registered as an import side effect, so nothing could reach its `entryPoint`, the only safe way to read a link.

## Verification

- 108 unit tests green. Mutation-checked: `used_in`'s null remove, the applied-log guard, and the single-id delink each go red when reverted.
- Item resolvers probed against the local DB for runs, partners, tasks, orders, inventory, designs, payment methods.
- **A removal executed through the descriptor verbatim returned 200 and made the `tasks` node disappear from the graph** — which is why the mutation invalidates the graph, not merely the row list.
- Both partner absences fire on real records; the two `derived` rules were exercised by forcing the condition on a fixture partner and reverting it.
- Workspace, drawers and the partner detail card rendered in a browser — no console errors.
- `✓ Prod-config build passed` (backend and frontend), read off the verdict line.

## Not in this PR

Nothing was removed from any page. #1856 covers collapsing the sections, gated per card — step 3's lesson was that retiring a card can strand the only route to a sub-page. #1855 covers the marketing and content spines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4