### PR TITLE
feat(admin): the design page collapses behind its graph (#1856)

### DIFF
--- a/apps/backend/src/admin/components/graph/entity-graph.tsx
+++ b/apps/backend/src/admin/components/graph/entity-graph.tsx
@@ -3,7 +3,8 @@ import { Badge, Button, Container, Heading, Skeleton, Text } from "@medusajs/ui"
 import { Link } from "react-router-dom"
 
 import { useEntityGraph, type GraphNode } from "../../hooks/api/graph"
-import { GraphCanvas } from "./graph-canvas"
+import { GraphCanvas, canvasSize } from "./graph-canvas"
+import { GraphViewport } from "./graph-viewport"
 import {
   NodeInspectorActions,
   NodeInspectorBody,
@@ -144,18 +145,46 @@ export const EntityGraph = ({ spine, id, title = "Graph", expandHref }: Props) =
       </div>
 
       <div className="flex flex-col lg:flex-row">
-        <div className="flex-1 overflow-x-auto">
-          <GraphCanvas
-            spine={graph.spine}
-            spineKey={spineKey}
-            nodes={visible}
-            edges={edges}
-            selectedKey={activeKey}
-            onSelect={setSelected}
-          />
+        {/*
+          🔴 The card gets the viewport too, now that it is the PRIMARY view of
+          a design rather than a preview above the sections.
+          `overflow-x-auto` was survivable while the summary cards below still
+          said everything — the reader could ignore a cramped canvas. With
+          those cards gone it is the only thing on the page that says it, and a
+          graph you cannot pan is a graph that hides its own far column behind
+          the inspector.
+
+          A fixed height, because a `TwoColumnPage` slot has no height of its
+          own to fill: without one the viewport measures zero, `fitScale`
+          returns its unmeasured fallback, and nothing is drawn.
+        */}
+        {/*
+          🔴 `min-w-0` is load-bearing. A flex child's default `min-width:auto`
+          refuses to shrink below its content, and the balanced layout is ~760px
+          wide — so the canvas pushed the inspector down to about 110px. The
+          badge clipped to "ab", and the sentence explaining WHY an edge is
+          dashed wrapped to two words a line. That sentence is the single most
+          valuable thing in the card, and it was the first casualty.
+        */}
+        <div className="flex h-[420px] min-w-0 flex-1 flex-col">
+          <GraphViewport
+            content={canvasSize(visible, "balanced")}
+            fitKey={`${visible.length}:${showAbsent}`}
+          >
+            <GraphCanvas
+              spine={graph.spine}
+              spineKey={spineKey}
+              nodes={visible}
+              edges={edges}
+              selectedKey={activeKey}
+              onSelect={setSelected}
+              layout="balanced"
+            />
+          </GraphViewport>
         </div>
 
-        <div className="w-full border-t lg:w-[280px] lg:border-l lg:border-t-0">
+        {/* `shrink-0`, for the same reason: 280px is a floor, not a wish. */}
+        <div className="w-full shrink-0 border-t lg:w-[280px] lg:border-l lg:border-t-0">
           {active && (
             <>
               <NodeInspectorHeader node={active} />

--- a/apps/backend/src/admin/components/graph/graph-create-modal.tsx
+++ b/apps/backend/src/admin/components/graph/graph-create-modal.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom"
 
 import type { GraphNode } from "../../hooks/api/graph"
 import { StackedFocusModal } from "../modal/stacked-modal/stacked-focused-modal"
-import { createFormFor, editFormFor, registryFor } from "./graph-forms"
+import { createFormFor, editFormFor, registryFor, withArticle } from "./graph-forms"
 import { nodeAffordance } from "./node-forms"
 
 /**
@@ -50,9 +50,21 @@ const useGraphRefetchOnClose = () => {
 export const GraphCreateModal = ({
   node,
   spine,
+  isPlaceholder = false,
 }: {
   node: GraphNode
   spine: string
+  /**
+   * This node is not on the canvas at all — the spine can hold this neighbour
+   * and has none, so it was synthesised to offer the create form.
+   *
+   * 🔴 It changes the WORDS, and the words matter. A placeholder is modelled
+   * as `absent` so the affordance rules treat it correctly, but "Create the
+   * MISSING bundled design" would tell the reader something is wrong when
+   * nothing is: a real absent edge means the model expected a neighbour and
+   * there is none, while this only means you opened the menu.
+   */
+  isPlaceholder?: boolean
 }) => {
   const onOpenChange = useGraphRefetchOnClose()
   const affordance = nodeAffordance(node, registryFor(spine))
@@ -67,8 +79,9 @@ export const GraphCreateModal = ({
   // across the JSX branch.
   const action = node.action
   const modalId = `graph-create-${node.key}`
-  const triggerLabel =
-    node.state === "absent"
+  const triggerLabel = isPlaceholder
+    ? `Add ${withArticle(node.label.toLowerCase())}`
+    : node.state === "absent"
       ? `Create the missing ${node.label.toLowerCase()}`
       : `Add to ${node.label.toLowerCase()}`
 

--- a/apps/backend/src/admin/components/graph/graph-forms.tsx
+++ b/apps/backend/src/admin/components/graph/graph-forms.tsx
@@ -134,18 +134,32 @@ type AddAnother = {
   href: (id: string) => string
 }
 
+/**
+ * A create form plus the words that name the thing it creates.
+ *
+ * 🔴 The label is REGISTERED, not derived from a node — because the node may
+ * not exist. A neighbour with no rows yet is drawn nowhere on the canvas, so
+ * the only way to offer "add one" is to know its name without one. That is the
+ * whole reason this stopped being a bare `ComponentType`.
+ */
+type CreateForm = {
+  Form: ComponentType
+  /** Singular, lower case: "task", "partner", "inventory item". */
+  label: string
+}
+
 type SpineForms = {
-  create: Record<string, ComponentType>
+  create: Record<string, CreateForm>
   edit: Record<string, EditForm>
   addAnother: Record<string, AddAnother>
 }
 
 const DESIGN_FORMS: SpineForms = {
   create: {
-    tasks: CreateDesignTaskComponent,
-    partners: DesignPartnerCreateForm,
-    inventory: DesignInventoryCreateForm,
-    components: DesignComponentCreateForm,
+    tasks: { Form: CreateDesignTaskComponent, label: "task" },
+    partners: { Form: DesignPartnerCreateForm, label: "partner" },
+    inventory: { Form: DesignInventoryCreateForm, label: "inventory item" },
+    components: { Form: DesignComponentCreateForm, label: "bundled design" },
   },
   addAnother: {
     /*
@@ -206,8 +220,38 @@ export const registryFor = (spine: string): FormRegistry => {
   }
 }
 
-export const createFormFor = (spine: string, key: string): ComponentType | undefined =>
-  formsFor(spine).create[key]
+export const createFormFor = (
+  spine: string,
+  key: string
+): ComponentType | undefined => formsFor(spine).create[key]?.Form
+
+/**
+ * Everything this spine can create, whether or not a node for it is drawn.
+ *
+ * 🔴 This exists because the canvas can only act on nodes it DRAWS, and a
+ * neighbour with nothing in it is drawn nowhere: no components on a design
+ * means no `components` node, which would leave no route at all to adding the
+ * first one once the summary card comes off. That is exactly how step 3
+ * stranded `/designs/:id/tasks` — a card removed while the only remaining
+ * route to it was removed alongside.
+ */
+/**
+ * "a task", "an inventory item".
+ *
+ * Trivial, and it earns its place: the labels are registered per spine and
+ * some of them begin with a vowel, so a hardcoded "a" reads as a typo on
+ * exactly the entries nobody remembers to check.
+ */
+export const withArticle = (label: string): string =>
+  `${/^[aeiou]/i.test(label) ? "an" : "a"} ${label}`
+
+export const creatableFor = (
+  spine: string
+): { key: string; label: string }[] =>
+  Object.entries(formsFor(spine).create).map(([key, { label }]) => ({
+    key,
+    label,
+  }))
 
 export const editFormFor = (spine: string, key: string): EditForm | undefined =>
   formsFor(spine).edit[key]

--- a/apps/backend/src/admin/components/graph/graph-workspace.tsx
+++ b/apps/backend/src/admin/components/graph/graph-workspace.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 import { useSearchParams } from "react-router-dom"
-import { Badge, Button, Heading, Skeleton, Text } from "@medusajs/ui"
+import { Badge, Button, DropdownMenu, Heading, Skeleton, Text } from "@medusajs/ui"
 
 import { useEntityGraph, type GraphNode } from "../../hooks/api/graph"
 import { RouteDrawer } from "../modal/route-drawer/route-drawer"
@@ -12,7 +12,7 @@ import {
   NodeInspectorHeader,
 } from "./node-inspector"
 import { GraphCreateModal, GraphEditModal } from "./graph-create-modal"
-import { addAnotherFor, registryFor } from "./graph-forms"
+import { addAnotherFor, creatableFor, registryFor, withArticle } from "./graph-forms"
 import { NodeAddAnother, NodeItemList } from "./node-items"
 import { actionRail, nodeAffordance } from "./node-forms"
 
@@ -78,11 +78,52 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
     setParams(next, { replace: true })
   }
 
+  /**
+   * A neighbour this spine can create but has none of yet.
+   *
+   * 🔴 The canvas can only act on nodes it DRAWS, and a neighbour with nothing
+   * in it is drawn nowhere — a design with no components emits no `components`
+   * node. Without this, removing the summary card that held "add a component"
+   * would leave NO route to creating the first one. That is precisely how step
+   * 3 stranded two sub-pages: a card retired while the only remaining route to
+   * its job went with it.
+   *
+   * Modelled as `absent`, which is honest — the model can hold this neighbour
+   * and there is none — so `nodeAffordance` offers the create form and refuses
+   * the edit form without needing to know the node is synthetic.
+   */
+  const placeholderNode = (key: string): GraphNode | undefined => {
+    const entry = creatableFor(spine).find((c) => c.key === key)
+    if (!entry) {
+      return undefined
+    }
+    return {
+      key,
+      type: key,
+      label: entry.label.replace(/^./, (c) => c.toUpperCase()),
+      sublabel: "none yet",
+      state: "absent",
+      count: 0,
+      status: null,
+      href: null,
+      props: [],
+      action: null,
+    }
+  }
+
   const active: GraphNode | undefined = !selectedKey
     ? undefined
     : selectedKey === spineKey
       ? graph?.spine
-      : nodes.find((n) => n.key === selectedKey)
+      : (nodes.find((n) => n.key === selectedKey) ?? placeholderNode(selectedKey))
+
+  /*
+   * True only for a neighbour the graph did not draw. Its member list is
+   * skipped: there is nothing to list, and "Nothing linked yet" under a node
+   * that exists only to offer a create form is noise.
+   */
+  const isPlaceholder =
+    !!active && active.key !== spineKey && !nodes.some((n) => n.key === active.key)
 
   const activeEdge =
     active && active.key !== spineKey
@@ -106,9 +147,24 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
    * no rows — and render "Nothing linked yet" beneath a node that is a real,
    * present neighbour.
    */
-  const listsItems = !!active && (graph?.itemNodes ?? []).includes(active.key)
+  /*
+   * 🔴 `count > 0`, not merely "this node can list members".
+   *
+   * An absent node has none by definition, so the list rendered "Nothing
+   * linked yet." directly beneath the sentence already explaining that a run
+   * exists and no inventory item is linked — the same fact twice, the second
+   * time less usefully. `0` is not `null`: the node is real, it simply has
+   * nothing to enumerate.
+   */
+  const listsItems =
+    !!active &&
+    !isPlaceholder &&
+    active.count > 0 &&
+    (graph?.itemNodes ?? []).includes(active.key)
 
   const another = active ? addAnotherFor(spine, active.key) : undefined
+
+  const creatable = creatableFor(spine)
 
   if (isLoading) {
     return (
@@ -158,9 +214,54 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
             </Badge>
           )}
         </div>
-        <Button variant="secondary" size="small" onClick={toggleAbsent}>
-          {showAbsent ? "Hide absent edges" : "Show absent edges"}
-        </Button>
+        <div className="flex items-center gap-x-2">
+          <Button variant="secondary" size="small" onClick={toggleAbsent}>
+            {showAbsent ? "Hide absent edges" : "Show absent edges"}
+          </Button>
+          {/*
+            Everything this spine can create, listed whether or not a node for
+            it is on the canvas. Selecting one opens the real node if it exists
+            and a placeholder if it does not, so "add the first" and "add
+            another" are the same gesture.
+          */}
+          {creatable.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenu.Trigger asChild>
+                <Button variant="primary" size="small">
+                  Add
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                {creatable.map((c) => {
+                  const existing = nodes.find((n) => n.key === c.key)
+                  /*
+                   * 🔴 `count > 0`, not merely "a node exists". An ABSENT node
+                   * is drawn and empty — the inventory node on a design that
+                   * expects inventory and has none — so keying on existence
+                   * rendered "Add to inventory items  0", which asks the reader
+                   * to add to a collection the same row says is empty. What
+                   * decides the wording is whether there is anything to add TO.
+                   */
+                  const hasSome = !!existing && existing.count > 0
+                  return (
+                    <DropdownMenu.Item key={c.key} onClick={() => select(c.key)}>
+                      <span className="flex w-full items-center justify-between gap-x-4">
+                        <span>
+                          {hasSome ? `Add to ${c.label}s` : `Add ${withArticle(c.label)}`}
+                        </span>
+                        {hasSome && (
+                          <Text size="xsmall" className="text-ui-fg-muted">
+                            {existing!.count}
+                          </Text>
+                        )}
+                      </span>
+                    </DropdownMenu.Item>
+                  )
+                })}
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          )}
+        </div>
       </div>
 
       {/*
@@ -212,7 +313,7 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
                   `${active.label} on ${graph.spine.label}, ${active.state}.`}
               </span>
             </RouteDrawer.Description>
-            <NodeInspectorHeader node={active} />
+            <NodeInspectorHeader node={active} isPlaceholder={isPlaceholder} />
           </RouteDrawer.Header>
           <RouteDrawer.Body className="p-0">
             <NodeInspectorBody node={active} edge={activeEdge} />
@@ -222,6 +323,15 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
               that already has neighbours, so "which ones" comes before "add
               one more".
             */}
+            {isPlaceholder && (
+              <div className="border-t px-6 py-3">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {/* Spine-agnostic: this component serves every spine. */}
+                  There are none yet. Nothing is wrong — the graph draws a node
+                  only once there is something on the other end of the edge.
+                </Text>
+              </div>
+            )}
             {listsItems && (
               <NodeItemList spine={spine} id={id} node={active} />
             )}
@@ -229,7 +339,11 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
               Create first, then edit: on an absent node only the first of the
               two renders, and it is the one the dashed edge is asking for.
             */}
-            <GraphCreateModal node={active} spine={spine} />
+            <GraphCreateModal
+              node={active}
+              spine={spine}
+              isPlaceholder={isPlaceholder}
+            />
             <GraphEditModal node={active} spine={spine} />
             {/*
               The rail never repeats a form, and never offers an "Open" that

--- a/apps/backend/src/admin/components/graph/node-inspector.tsx
+++ b/apps/backend/src/admin/components/graph/node-inspector.tsx
@@ -97,7 +97,23 @@ export const NodeInspectorActions = ({
   )
 }
 
-export const NodeInspectorHeader = ({ node }: { node: GraphNode }) => (
+export const NodeInspectorHeader = ({
+  node,
+  isPlaceholder = false,
+}: {
+  node: GraphNode
+  /**
+   * 🔴 A placeholder is `absent` for the AFFORDANCE rules — the model can hold
+   * this neighbour and there is none, which is exactly what unlocks the create
+   * form and blocks the edit form. But it must not be `absent` in the WORDS.
+   *
+   * Rendered, the red "absent" badge sat directly above the sentence saying
+   * "Nothing is wrong", which is a contradiction the reader has to resolve.
+   * A real absent edge means the model EXPECTED a neighbour and it is not
+   * there; a placeholder only means someone opened the Add menu.
+   */
+  isPlaceholder?: boolean
+}) => (
   <div className="flex items-start justify-between gap-x-2 px-6 py-4">
     <div className="flex flex-col">
       <Text size="xsmall" className="text-ui-fg-muted uppercase">
@@ -110,9 +126,13 @@ export const NodeInspectorHeader = ({ node }: { node: GraphNode }) => (
     <Badge
       size="2xsmall"
       rounded="full"
-      color={node.state === "absent" ? "red" : "grey"}
+      color={!isPlaceholder && node.state === "absent" ? "red" : "grey"}
     >
-      {node.state === "absent" ? "absent" : (node.sublabel ?? "linked")}
+      {isPlaceholder
+        ? "none yet"
+        : node.state === "absent"
+          ? "absent"
+          : (node.sublabel ?? "linked")}
     </Badge>
   </div>
 )

--- a/apps/backend/src/admin/routes/designs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/page.tsx
@@ -5,11 +5,8 @@ import { DesignGraphSection } from "../../../components/designs/design-graph-sec
 import { DesignDesignerInvitesSection } from "../../../components/designs/design-designer-invites-section";
 import { DesignMediaSection } from "../../../components/designs/design-media-section";
 import { DesignMediaFolderSection } from "../../../components/designs/design-media-folder-section";
-import { DesignInventorySection } from "../../../components/designs/design-inventory-section";
 import { DesignConsumptionLogsSection } from "../../../components/designs/design-consumption-logs-section";
 import { DesignAttributesSection } from "../../../components/designs/design-attributes-section";
-import { DesignProductionRunsSummary } from "../../../components/designs/design-production-runs-summary";
-import { DesignComponentsSection } from "../../../components/designs/design-components-section";
 import { DesignConstructionSection } from "../../../components/designs/design-construction-section";
 import { TwoColumnPageSkeleton } from "../../../components/table/skeleton";
 import { TwoColumnPage } from "../../../components/pages/two-column-pages";
@@ -72,39 +69,49 @@ const DesignDetailPage = () => {
           <DesignGeneralSection design={design} />
           {/*
             #1847 — the spine and its neighbours, including the edges that are
-            EXPECTED AND MISSING. Sits at the top because every section below it
-            renders what IS there, and an absent edge is the one thing none of
-            them can show.
+            EXPECTED AND MISSING. Sits at the top because every section below
+            it renders what IS there, and an absent edge is the one thing none
+            of them can show.
 
-            🔴 STEP 3: the Tasks and Partners summary cards are GONE. Both were
-            a count, a preview and a link — all of which the graph now says
-            better, and both of their actions (create a task, link a partner)
-            open inside the workspace. What is still here stays for a reason,
-            not by inertia:
+            🔴 STEP 6: production runs, inventory and bundled designs are GONE.
+            Each came off only once the graph did its whole job, and the test
+            was the same three questions each time — what does the card SHOW
+            that the graph does not, what does it DO that the graph cannot, and
+            what is it the only route to?
 
-              - production runs — the graph can send an unstarted design to
-                production, but it has nowhere to create ANOTHER run beside the
-                ones that exist. This card is the only route to that.
-              - inventory, bundled designs — the graph adds; only these can
-                REMOVE, and inventory's per-item drawer (planned quantity,
-                stock location) has no representation on an aggregate node.
+              - production runs — was kept purely to hold "create another run".
+                The graph's `runs` node now offers "Start another run", and its
+                href still reaches the full list.
+              - inventory — the graph lists the items, unlinks them, and its
+                rows now open `/designs/:id/inventory/:id`, the same drawer the
+                card opened for planned quantity and stock location.
+              - bundled designs — listed both directions, with removal on the
+                inbound side (the outbound row belongs to the PARENT design and
+                its endpoint would 404 from here).
+
+            🔴 And the trap that made this safe: the canvas can only act on
+            nodes it DRAWS, so a design with no components emits no `components`
+            node and removing the card would have left NO route to adding the
+            first one. The workspace's "Add" menu lists everything the spine can
+            create whether or not a node for it is drawn. Step 3 stranded two
+            sub-pages exactly this way.
+
+            What stays, still for a reason and not by inertia:
+
               - consumption logs, construction — whole editors, not summaries.
-              - media — deliberately unregistered in the graph: a design holds
-                one folder and linking repoints it, so "add" would silently
-                replace.
-              - designer invites — not on the graph at all.
+              - media, media folder — deliberately unregistered in the graph: a
+                design holds ONE folder and linking REPOINTS it, so "add" would
+                silently replace what is already there.
+              - designer invites — not on the graph at all yet.
           */}
           <DesignGraphSection design={design} />
-          <DesignProductionRunsSummary design={design} />
           <DesignDesignerInvitesSection design={design} />
-          <DesignInventorySection design={design} />
           <DesignConsumptionLogsSection design={design} />
         </TwoColumnPage.Main>
         <TwoColumnPage.Sidebar>
           <DesignAttributesSection design={design} />
           <DesignMediaFolderSection design={design} />
           <DesignMediaSection design={design} />
-          <DesignComponentsSection design={design} />
           <DesignConstructionSection design={design} />
         </TwoColumnPage.Sidebar>  
         </TwoColumnPage>

--- a/apps/backend/src/lib/graph/spines/design/items.ts
+++ b/apps/backend/src/lib/graph/spines/design/items.ts
@@ -69,7 +69,17 @@ const inventoryItems = async (
     label: String(i.title || i.sku || i.id),
     sublabel: i.sku ? String(i.sku) : null,
     status: null,
-    href: `/inventory/${i.id}`,
+    /*
+     * 🔴 The DESIGN-scoped drawer, not `/inventory/:id`.
+     *
+     * What is worth editing from here is the LINK — planned quantity, stock
+     * location, consumed-at — which is a fact about this design's use of the
+     * item, not about the item. Sending the reader to the global inventory
+     * page would open the right record and show none of the fields the design
+     * page's own inventory card exists to edit, which is the card this row is
+     * meant to replace.
+     */
+    href: `/designs/${designId}/inventory/${i.id}`,
     props: [
       ...(i.sku ? [{ key: "sku", value: String(i.sku) }] : []),
       ...(i.hs_code ? [{ key: "hs code", value: String(i.hs_code) }] : []),


### PR DESCRIPTION
Three summary cards come off the design page — **production runs, inventory, bundled designs**. Each only after the graph did its whole job.

The test for every card was the same three questions: what does it **show** that the graph does not, what does it **do** that the graph cannot, and what is it the **only route to**?

- **production runs** — kept purely to hold "create another run". The `runs` node offers "Start another run" now, and its href still reaches the full list.
- **inventory** — the graph lists items and unlinks them, and its rows now open `/designs/:id/inventory/:id`: the *design-scoped* drawer, not `/inventory/:id`. What's worth editing from here is the **link** — planned quantity, stock location, consumed-at — which is a fact about this design's use of the item. The global page would open the right record and show none of those fields.
- **bundled designs** — both directions listed, removal on the inbound side only (an outbound row belongs to the *parent* design and its endpoint scopes by `parent_design_id`, so it would 404 from here).

## 🔴 The trap that had to be closed first

**The canvas can only act on nodes it draws.** A design with no components emits no `components` node — so removing that card would have left **no route at all** to adding the first one. Nothing would error; the capability would simply cease to exist. That is exactly how step 3 stranded `/designs/:id/tasks` and `/designs/:id/partners`.

So the workspace gained an **"Add" menu** listing everything the spine can create, drawn or not. Selecting one opens the real node if it exists and a synthesised placeholder if it does not, so "add the first" and "add another" are one gesture.

A placeholder is modelled as `absent` because that is what unlocks the create form and blocks the edit form — but it must not *say* absent: the red badge sat directly above the sentence "Nothing is wrong". It reads "none yet" now.

## What only rendering found

- **`min-w-0` on the canvas column.** A flex child's default `min-width:auto` refuses to shrink below its content, and the balanced layout is ~760px wide — so the canvas crushed the inspector to about **110px**. The badge clipped to "ab" and the sentence explaining *why* an edge is dashed wrapped to two words a line. That sentence is the most valuable thing in the card, and it was the first casualty.
- **"Add to inventory items · 0"** — keyed on a node *existing* rather than on `count > 0`. An absent node is drawn and empty, so it invited the reader to add to a collection the same row called empty.
- **"Add a inventory item."** Labels are registered per spine and some begin with a vowel.
- **"Nothing linked yet."** rendered directly beneath the reason already saying a run exists and no inventory item is linked — the same fact twice, the second time less usefully.

The card also gets the viewport, since it is the primary view of a design now rather than a preview above the sections.

## Deliberately not touched

**The partner page keeps all fourteen sections.** The partner spine registers no create forms and none of its item rows offer removal — so by the rule above, not one of its cards has earned removal yet.

On the design page: consumption logs and construction stay (whole editors), media and media folder stay (deliberately unregistered — a design holds **one** folder and linking *repoints* it, so "add" would silently replace), designer invites stay (not on the graph at all).

## Verification

- 281 admin unit tests green; `✓ Prod-config build passed` (read off the verdict line).
- Rendered in a browser at every step — the collapsed page, the workspace, the Add menu, a placeholder node, a real absent node, and a populated node's rows. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4