### PR TITLE
feat(admin): the content and marketing spines (#1855)

### DIFF
--- a/apps/backend/src/admin/routes/websites/[id]/@graph/page.tsx
+++ b/apps/backend/src/admin/routes/websites/[id]/@graph/page.tsx
@@ -1,0 +1,37 @@
+import { useParams } from "react-router-dom"
+
+import { GraphWorkspace } from "../../../../components/graph/graph-workspace"
+import { RouteFocusModal } from "../../../../components/modal/route-focus-modal"
+
+/**
+ * `/websites/:id/graph` — the website spine as the workspace (#1855).
+ *
+ * Third spine, same file as the other two with one word changed.
+ */
+const WebsiteGraphWorkspacePage = () => {
+  const { id } = useParams()
+
+  return (
+    <RouteFocusModal>
+      <RouteFocusModal.Title asChild>
+        <span className="sr-only">Website graph</span>
+      </RouteFocusModal.Title>
+      <RouteFocusModal.Description asChild>
+        <span className="sr-only">
+          The website and its neighbours, including the edges that are expected
+          and missing.
+        </span>
+      </RouteFocusModal.Description>
+      <RouteFocusModal.Body className="flex h-full w-full flex-col overflow-hidden p-0">
+        <GraphWorkspace
+          spine="website"
+          id={id!}
+          title="Website graph"
+          selfHref={`/websites/${id}/graph`}
+        />
+      </RouteFocusModal.Body>
+    </RouteFocusModal>
+  )
+}
+
+export default WebsiteGraphWorkspacePage

--- a/apps/backend/src/admin/routes/websites/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/websites/[id]/page.tsx
@@ -5,6 +5,7 @@ import { SingleColumnPage } from "../../../components/pages/single-column-pages"
 import { WebsiteGeneralSection } from "../../../components/websites/website-general-section";
 import { WebsitePagesSection } from "../../../components/websites/website-pages-section";
 import { WebsiteBlogSection } from "../../../components/websites/website-blog-section";
+import { EntityGraph } from "../../../components/graph/entity-graph";
 import { websiteLoader } from "./loader";
 
 const WebsiteDetailPage = () => {
@@ -37,6 +38,26 @@ const WebsiteDetailPage = () => {
   return (
     <SingleColumnPage data={website} hasOutlet={true} showJSON showMetadata={true}>
       <WebsiteGeneralSection website={website} />
+      {/*
+        #1855 — the content spine. Above the sections for the same reason it is
+        on the design and partner pages: both of them render what IS there.
+
+        The absence that earns this graph its place is a NEWSLETTER PUBLISHED
+        AND NEVER SENT. The page is written, marked Published, and appears in
+        every list of published pages exactly like one that went out — while
+        `sent_to_subscribers` is false and not a single subscriber received it.
+        The work is finished; only the send is missing, and nothing else in the
+        admin distinguishes the two.
+
+        🔴 Nothing removed here. The website page has three sections and the
+        graph has to earn each one, the way it did on the design page.
+      */}
+      <EntityGraph
+        spine="website"
+        id={website.id}
+        title="Graph"
+        expandHref={`/websites/${website.id}/graph`}
+      />
       <WebsitePagesSection website={website} />
       <WebsiteBlogSection website={website} />
     </SingleColumnPage>

--- a/apps/backend/src/lib/graph/registry.ts
+++ b/apps/backend/src/lib/graph/registry.ts
@@ -2,6 +2,8 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 import { designSpine } from "./spines/design"
 import { partnerSpine } from "./spines/partner"
+import { socialPlatformSpine } from "./spines/social-platform"
+import { websiteSpine } from "./spines/website"
 import type { Graph, NodeItem, SpineDescriptor } from "./types"
 
 /**
@@ -19,6 +21,8 @@ import type { Graph, NodeItem, SpineDescriptor } from "./types"
 export const SPINES: Record<string, SpineDescriptor> = {
   [designSpine.key]: designSpine,
   [partnerSpine.key]: partnerSpine,
+  [websiteSpine.key]: websiteSpine,
+  [socialPlatformSpine.key]: socialPlatformSpine,
 }
 
 export const SPINE_KEYS = Object.keys(SPINES)

--- a/apps/backend/src/lib/graph/spines/social-platform/__tests__/absence.unit.spec.ts
+++ b/apps/backend/src/lib/graph/spines/social-platform/__tests__/absence.unit.spec.ts
@@ -1,0 +1,62 @@
+import { erroredBindings, neverSynced, type BindingLike } from "../absence"
+
+const binding = (over: Partial<BindingLike> = {}): BindingLike => ({
+  id: over.id ?? "b1",
+  status: "active",
+  last_synced_at: "2026-09-01T00:00:00Z",
+  last_error: null,
+  ...over,
+})
+
+describe("neverSynced", () => {
+  it("finds an active binding that has never brought anything back", () => {
+    /*
+     * The measured case: 49 `search-console` bindings, all `active`, all with
+     * `last_synced_at` null. `status` is set at creation, so a binding that
+     * never worked looks exactly like one syncing every hour.
+     */
+    expect(
+      neverSynced([binding({ id: "b1", last_synced_at: null })]).map((b) => b.id)
+    ).toEqual(["b1"])
+  })
+
+  it("treats an undefined timestamp the same as null", () => {
+    // A field the query did not select comes back undefined, not null.
+    expect(neverSynced([binding({ last_synced_at: undefined })])).toHaveLength(1)
+  })
+
+  it("ignores one that has synced", () => {
+    expect(neverSynced([binding()])).toHaveLength(0)
+  })
+
+  it("ignores a binding that is not active", () => {
+    // 🔴 A paused or pending binding is not expected to have synced. Only
+    // `active` makes the claim that this rule contradicts.
+    for (const status of ["paused", "pending", "error"]) {
+      expect(neverSynced([binding({ status, last_synced_at: null })])).toHaveLength(0)
+    }
+  })
+})
+
+describe("erroredBindings", () => {
+  it("finds one whose status says error", () => {
+    expect(erroredBindings([binding({ id: "b1", status: "error" })])).toHaveLength(1)
+  })
+
+  it("finds one still marked active but carrying an error", () => {
+    // The status and the error disagree; the error is the one that happened.
+    expect(
+      erroredBindings([binding({ id: "b1", last_error: "quota exceeded" })])
+    ).toHaveLength(1)
+  })
+
+  it("is not fooled by an empty or whitespace error string", () => {
+    // 🔴 `''` passes a plain `is not null` check — and so does `'  '`.
+    expect(erroredBindings([binding({ last_error: "" })])).toHaveLength(0)
+    expect(erroredBindings([binding({ last_error: "   " })])).toHaveLength(0)
+  })
+
+  it("stays quiet on a healthy binding", () => {
+    expect(erroredBindings([binding()])).toHaveLength(0)
+  })
+})

--- a/apps/backend/src/lib/graph/spines/social-platform/absence.ts
+++ b/apps/backend/src/lib/graph/spines/social-platform/absence.ts
@@ -1,0 +1,58 @@
+/**
+ * When does the model genuinely EXPECT a neighbour on a social platform? (#1855)
+ *
+ * 🔴 This spine asserts ONE fault, and the restraint is deliberate.
+ *
+ * The obvious marketing rules — a scheduled post whose time has passed, a post
+ * marked `posted` with no `post_url`, a stalled campaign — are all plausible
+ * and NONE of them could be exercised: the local database holds zero social
+ * posts, zero publishing campaigns, zero leads and zero ad campaigns. A rule
+ * that has never run against a real row is a guess with a test around it, and
+ * shipping four of them onto a surface nobody can check is how a graph starts
+ * crying wolf. They are deferred, with what was learned, rather than shipped
+ * unverified.
+ *
+ * What IS here fires on 49 real rows.
+ */
+
+export type BindingLike = {
+  id: string
+  status?: string | null
+  last_synced_at?: string | Date | null
+  last_error?: string | null
+}
+
+/**
+ * A binding that is switched on and has never brought anything back.
+ *
+ * `status = "active"` is what every screen reads to decide whether an
+ * integration is connected, and it is set at creation — before a single sync
+ * has run. So a binding that never worked at all is indistinguishable from one
+ * syncing happily every hour.
+ *
+ * Measured: all 49 `search-console` bindings on the local database are
+ * `active` with `last_synced_at` null and no `last_error` — connected by every
+ * indication, and no data has ever come back from any of them.
+ *
+ * 🔴 `last_synced_at` null, NOT falsy. A date is an object; the guard has to
+ * ask whether the field is set, and a `0`-like coercion trap here would silently
+ * clear the whole rule.
+ */
+export const neverSynced = (bindings: BindingLike[]): BindingLike[] =>
+  bindings.filter(
+    (b) =>
+      String(b.status) === "active" &&
+      (b.last_synced_at === null || b.last_synced_at === undefined)
+  )
+
+/**
+ * A binding carrying an error from its last attempt.
+ *
+ * Distinct from never-synced: this one HAS worked, and then stopped. Both are
+ * `derived` — the neighbour exists and does not do its job — but they need
+ * different sentences, because the fix differs.
+ */
+export const erroredBindings = (bindings: BindingLike[]): BindingLike[] =>
+  bindings.filter(
+    (b) => String(b.status) === "error" || !!String(b.last_error ?? "").trim()
+  )

--- a/apps/backend/src/lib/graph/spines/social-platform/index.ts
+++ b/apps/backend/src/lib/graph/spines/social-platform/index.ts
@@ -1,0 +1,231 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { GraphBuilder, asArray } from "../../builder"
+import type { Graph, GraphNode, SpineContext, SpineDescriptor } from "../../types"
+import { erroredBindings, neverSynced, type BindingLike } from "./absence"
+import { SOCIAL_PLATFORM_ITEM_NODES, resolveSocialPlatformItems } from "./items"
+
+/**
+ * The SOCIAL PLATFORM spine (#1855) — the marketing surface.
+ *
+ * A platform is the marketing side's biggest node: posts, campaigns, ad
+ * accounts, leads and integration bindings all hang off it, the way work hangs
+ * off a partner.
+ *
+ * 🔴 It asserts exactly ONE fault, and everything else is a present-only node.
+ * The local database has zero social posts, zero publishing campaigns, zero
+ * leads and zero ad campaigns — so the obvious rules (a scheduled post whose
+ * time has passed; a post marked `posted` with no `post_url`) could not be run
+ * against a single real row. See `absence.ts` for why they were deferred
+ * rather than shipped on a test fixture's word.
+ *
+ * The one that IS here fires on 49 real bindings.
+ */
+const resolveSocialPlatformGraph = async ({
+  scope,
+  id,
+}: SpineContext): Promise<Graph> => {
+  const platformId = id
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  /*
+   * Every neighbour here is an intra-module `hasMany` on the platform model,
+   * so they resolve straight off the entity — no link tables, and therefore
+   * none of the `entryPoint` / `resolveExisting` treatment the design and
+   * partner spines need.
+   */
+  const { data: platforms } = await query.graph({
+    entity: "social_platforms",
+    filters: { id: platformId },
+    fields: ["*", "posts.*", "bindings.*", "ad_accounts.*", "leads.*"],
+  })
+
+  const platform = (platforms || [])[0]
+  if (!platform) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Social platform ${platformId} was not found`
+    )
+  }
+
+  const posts = asArray<any>(platform.posts)
+  const bindings = asArray<any>(platform.bindings)
+  const adAccounts = asArray<any>(platform.ad_accounts)
+  const leads = asArray<any>(platform.leads)
+
+  const { data: campaigns } = await query.graph({
+    entity: "publishing_campaigns",
+    filters: { platform_id: platformId },
+    fields: ["*"],
+  })
+  const campaignList = asArray<any>(campaigns)
+
+  const bindingLikes: BindingLike[] = bindings.map((b) => ({
+    id: String(b.id),
+    status: b.status,
+    last_synced_at: b.last_synced_at,
+    last_error: b.last_error,
+  }))
+  const dormant = neverSynced(bindingLikes)
+  const errored = erroredBindings(bindingLikes)
+
+  const builder = new GraphBuilder("social_platform")
+  const push = builder.push.bind(builder)
+
+  // ---- bindings: the one asserted fault -----------------------------------
+
+  if (bindings.length) {
+    /*
+     * 🔴 `derived`, not `absent`. The neighbour is not missing — it is there,
+     * switched on, and inert. `status = "active"` is set at CREATION and is
+     * what every screen reads to decide an integration is connected, so a
+     * binding that has never synced once is indistinguishable from one syncing
+     * every hour. Measured: all 49 on the local database are in that state.
+     */
+    const broken = dormant.length + errored.length
+    push(
+      {
+        key: "bindings",
+        type: "social_platform_binding",
+        label: "Integrations",
+        sublabel: broken
+          ? `${dormant.length} never synced${errored.length ? `, ${errored.length} errored` : ""}`
+          : `${bindings.length} connected`,
+        state: broken ? "derived" : "present",
+        count: bindings.length,
+        status: broken ? "inert" : null,
+        href: null,
+        props: [
+          { key: "bindings", value: String(bindings.length) },
+          { key: "never synced", value: String(dormant.length) },
+          { key: "errored", value: String(errored.length) },
+        ],
+        action: null,
+      },
+      {
+        label: "platform_id",
+        state: broken ? "derived" : "present",
+        reason: broken
+          ? `${dormant.length} of ${bindings.length} integration${bindings.length === 1 ? "" : "s"} ${dormant.length === 1 ? "is" : "are"} marked active and ${dormant.length === 1 ? "has" : "have"} never synced. ${dormant.length === 1 ? "It reads" : "They read"} as connected everywhere the status is shown, and no data has ever come back from ${dormant.length === 1 ? "it" : "them"}.`
+          : null,
+      }
+    )
+  }
+
+  // ---- the rest: present only ---------------------------------------------
+
+  if (posts.length) {
+    const byStatus = posts.reduce<Record<string, number>>((acc, p) => {
+      const k = String(p.status ?? "unknown")
+      acc[k] = (acc[k] ?? 0) + 1
+      return acc
+    }, {})
+    push(
+      {
+        key: "posts",
+        type: "social_post",
+        label: "Posts",
+        sublabel: `${posts.length} post${posts.length === 1 ? "" : "s"}`,
+        state: "present",
+        count: posts.length,
+        status: null,
+        href: `/social-posts`,
+        props: Object.entries(byStatus).map(([k, v]) => ({
+          key: k,
+          value: String(v),
+        })),
+        action: null,
+      },
+      { label: "platform_id", state: "present", reason: null }
+    )
+  }
+
+  if (campaignList.length) {
+    const byStatus = campaignList.reduce<Record<string, number>>((acc, c) => {
+      const k = String(c.status ?? "unknown")
+      acc[k] = (acc[k] ?? 0) + 1
+      return acc
+    }, {})
+    push(
+      {
+        key: "campaigns",
+        type: "publishing_campaign",
+        label: "Campaigns",
+        sublabel: `${campaignList.length} campaign${campaignList.length === 1 ? "" : "s"}`,
+        state: "present",
+        count: campaignList.length,
+        status: null,
+        href: `/publishing-campaigns`,
+        props: Object.entries(byStatus).map(([k, v]) => ({
+          key: k,
+          value: String(v),
+        })),
+        action: null,
+      },
+      { label: "platform_id", state: "present", reason: null }
+    )
+  }
+
+  if (adAccounts.length) {
+    push(
+      {
+        key: "ad_accounts",
+        type: "ad_account",
+        label: "Ad accounts",
+        sublabel: `${adAccounts.length} account${adAccounts.length === 1 ? "" : "s"}`,
+        state: "present",
+        count: adAccounts.length,
+        status: null,
+        href: null,
+        props: [{ key: "accounts", value: String(adAccounts.length) }],
+        action: null,
+      },
+      { label: "platform_id", state: "present", reason: null }
+    )
+  }
+
+  if (leads.length) {
+    push(
+      {
+        key: "leads",
+        type: "lead",
+        label: "Leads",
+        sublabel: `${leads.length} lead${leads.length === 1 ? "" : "s"}`,
+        state: "present",
+        count: leads.length,
+        status: null,
+        href: null,
+        props: [{ key: "leads", value: String(leads.length) }],
+        action: null,
+      },
+      { label: "platform_id", state: "present", reason: null }
+    )
+  }
+
+  const spine: GraphNode = {
+    key: "social_platform",
+    type: "social_platform",
+    label: String(platform.name ?? platformId),
+    sublabel: String(platform.category ?? ""),
+    state: "present",
+    count: 1,
+    status: String(platform.status ?? ""),
+    href: null,
+    props: [
+      { key: "status", value: String(platform.status ?? "—") },
+      { key: "category", value: String(platform.category ?? "—") },
+      { key: "auth", value: String(platform.auth_type ?? "—") },
+    ],
+    action: null,
+  }
+
+  return builder.build(spine)
+}
+
+export const socialPlatformSpine: SpineDescriptor = {
+  key: "social_platform",
+  label: "Social platform",
+  resolve: resolveSocialPlatformGraph,
+  items: resolveSocialPlatformItems,
+  itemNodes: SOCIAL_PLATFORM_ITEM_NODES,
+}

--- a/apps/backend/src/lib/graph/spines/social-platform/items.ts
+++ b/apps/backend/src/lib/graph/spines/social-platform/items.ts
@@ -1,0 +1,208 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { asArray } from "../../builder"
+import type { NodeItem, SpineContext } from "../../types"
+import { erroredBindings, neverSynced, type BindingLike } from "./absence"
+
+/**
+ * The members behind a social platform's nodes (#1855).
+ *
+ * No `remove` anywhere: a post, a campaign and an ad account each have their
+ * own lifecycle route, and a binding is an OAuth connection whose removal is a
+ * disconnection, not an unlink.
+ */
+
+const loadPlatform = async (query: any, platformId: string) => {
+  const { data } = await query.graph({
+    entity: "social_platforms",
+    filters: { id: platformId },
+    fields: ["id", "posts.*", "bindings.*", "ad_accounts.*", "leads.*"],
+  })
+  return (data || [])[0]
+}
+
+const bindingItems = async (
+  query: any,
+  platformId: string
+): Promise<NodeItem[]> => {
+  const platform = await loadPlatform(query, platformId)
+  const raw = asArray<any>(platform?.bindings)
+  const likes: BindingLike[] = raw.map((b) => ({
+    id: String(b.id),
+    status: b.status,
+    last_synced_at: b.last_synced_at,
+    last_error: b.last_error,
+  }))
+  const dormantIds = new Set(neverSynced(likes).map((b) => b.id))
+  const erroredIds = new Set(erroredBindings(likes).map((b) => b.id))
+
+  /*
+   * 🔴 The broken ones first. This node is only ever opened because it says
+   * some integrations never synced, and on a platform with 49 bindings an
+   * insertion-ordered list buries them among the healthy ones — the reader
+   * would scroll past the answer looking for it.
+   */
+  const rank = (id: string) =>
+    erroredIds.has(id) ? 0 : dormantIds.has(id) ? 1 : 2
+
+  return [...raw]
+    .sort((a, b) => rank(String(a.id)) - rank(String(b.id)))
+    .map((b) => {
+      const id = String(b.id)
+      const dormant = dormantIds.has(id)
+      const errored = erroredIds.has(id)
+      return {
+        id,
+        label: String(b.resource_label ?? b.resource_id ?? id),
+        sublabel:
+          [
+            b.service ? String(b.service) : null,
+            errored
+              ? String(b.last_error ?? "errored").slice(0, 80)
+              : dormant
+                ? "never synced"
+                : b.last_synced_at
+                  ? `synced ${new Date(b.last_synced_at).toLocaleDateString()}`
+                  : null,
+          ]
+            .filter(Boolean)
+            .join(" · ") || null,
+        status: b.status ? String(b.status) : null,
+        href: null,
+        props: [
+          ...(b.service ? [{ key: "service", value: String(b.service) }] : []),
+          ...(b.resource_id
+            ? [{ key: "resource", value: String(b.resource_id) }]
+            : []),
+          {
+            key: "last synced",
+            value: b.last_synced_at
+              ? new Date(b.last_synced_at).toLocaleString()
+              : "never",
+          },
+          ...(b.last_error ? [{ key: "error", value: String(b.last_error) }] : []),
+        ],
+        remove: null,
+      }
+    })
+}
+
+const postItems = async (query: any, platformId: string): Promise<NodeItem[]> => {
+  const platform = await loadPlatform(query, platformId)
+  return asArray<any>(platform?.posts).map((p) => ({
+    id: String(p.id),
+    label: String(p.name ?? p.id),
+    sublabel:
+      [
+        p.scheduled_at
+          ? `scheduled ${new Date(p.scheduled_at).toLocaleDateString()}`
+          : null,
+        p.posted_at ? `posted ${new Date(p.posted_at).toLocaleDateString()}` : null,
+        p.error_message ? String(p.error_message).slice(0, 60) : null,
+      ]
+        .filter(Boolean)
+        .join(" · ") || null,
+    status: p.status ? String(p.status) : null,
+    href: `/social-posts/${p.id}`,
+    props: [
+      { key: "status", value: String(p.status ?? "—") },
+      ...(p.post_url ? [{ key: "url", value: String(p.post_url) }] : []),
+      ...(p.error_message
+        ? [{ key: "error", value: String(p.error_message) }]
+        : []),
+    ],
+    remove: null,
+  }))
+}
+
+const campaignItems = async (
+  query: any,
+  platformId: string
+): Promise<NodeItem[]> => {
+  const { data } = await query.graph({
+    entity: "publishing_campaigns",
+    filters: { platform_id: platformId },
+    fields: ["*"],
+  })
+  return asArray<any>(data).map((c) => {
+    const items = Array.isArray(c.items) ? c.items.length : 0
+    return {
+      id: String(c.id),
+      label: String(c.name ?? c.id),
+      sublabel:
+        [
+          items ? `${c.current_index ?? 0} of ${items}` : null,
+          c.error_message ? String(c.error_message).slice(0, 60) : null,
+        ]
+          .filter(Boolean)
+          .join(" · ") || null,
+      status: c.status ? String(c.status) : null,
+      href: `/publishing-campaigns/${c.id}`,
+      props: [
+        { key: "status", value: String(c.status ?? "—") },
+        { key: "progress", value: `${c.current_index ?? 0} of ${items}` },
+        { key: "interval", value: `${c.interval_hours ?? "—"}h` },
+        ...(c.error_message
+          ? [{ key: "error", value: String(c.error_message) }]
+          : []),
+      ],
+      remove: null,
+    }
+  })
+}
+
+const adAccountItems = async (
+  query: any,
+  platformId: string
+): Promise<NodeItem[]> => {
+  const platform = await loadPlatform(query, platformId)
+  return asArray<any>(platform?.ad_accounts).map((a) => ({
+    id: String(a.id),
+    label: String(a.name ?? a.account_id ?? a.id),
+    sublabel: a.currency ? String(a.currency).toUpperCase() : null,
+    status: a.status ? String(a.status) : null,
+    href: null,
+    props: [
+      ...(a.account_id ? [{ key: "account", value: String(a.account_id) }] : []),
+    ],
+    remove: null,
+  }))
+}
+
+const leadItems = async (query: any, platformId: string): Promise<NodeItem[]> => {
+  const platform = await loadPlatform(query, platformId)
+  return asArray<any>(platform?.leads).map((l) => ({
+    id: String(l.id),
+    label: String(l.full_name ?? l.email ?? l.id),
+    sublabel: l.email ? String(l.email) : null,
+    status: l.status ? String(l.status) : null,
+    href: null,
+    props: [...(l.email ? [{ key: "email", value: String(l.email) }] : [])],
+    remove: null,
+  }))
+}
+
+const RESOLVERS: Record<
+  string,
+  (query: any, platformId: string) => Promise<NodeItem[]>
+> = {
+  bindings: bindingItems,
+  posts: postItems,
+  campaigns: campaignItems,
+  ad_accounts: adAccountItems,
+  leads: leadItems,
+}
+
+export const SOCIAL_PLATFORM_ITEM_NODES = Object.keys(RESOLVERS)
+
+export const resolveSocialPlatformItems = async (
+  { scope, id }: SpineContext,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const resolver = RESOLVERS[nodeKey]
+  if (!resolver) {
+    return []
+  }
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  return resolver(query, id)
+}

--- a/apps/backend/src/lib/graph/spines/website/__tests__/absence.unit.spec.ts
+++ b/apps/backend/src/lib/graph/spines/website/__tests__/absence.unit.spec.ts
@@ -1,0 +1,152 @@
+import {
+  emptyPublishedPages,
+  expectsPublishedPage,
+  failedSends,
+  isLive,
+  newslettersAwaitingSend,
+  publishedPages,
+  type PageLike,
+} from "../absence"
+
+const page = (over: Partial<PageLike> = {}): PageLike => ({
+  id: over.id ?? "page_1",
+  status: "Published",
+  page_type: "Custom",
+  content: "some body",
+  sent_to_subscribers: false,
+  block_count: 1,
+  ...over,
+})
+
+describe("isLive", () => {
+  it("counts the statuses that serve traffic", () => {
+    expect(isLive("Active")).toBe(true)
+    // Maintenance still resolves — it serves a page, just not the real one.
+    expect(isLive("Maintenance")).toBe(true)
+  })
+
+  it("excludes the ones still being built", () => {
+    expect(isLive("Development")).toBe(false)
+    expect(isLive("Inactive")).toBe(false)
+    expect(isLive(null)).toBe(false)
+  })
+})
+
+describe("expectsPublishedPage", () => {
+  it("fires on a live website serving nothing", () => {
+    expect(expectsPublishedPage("Active", [page({ status: "Draft" })])).toBe(true)
+  })
+
+  it("stays quiet on a website still being built", () => {
+    /*
+     * 🔴 The case that decides whether this rule is worth having. Every website
+     * is `Development` with no published page for its whole early life;
+     * asserting there would put a red edge on all of them.
+     */
+    expect(expectsPublishedPage("Development", [])).toBe(false)
+    expect(expectsPublishedPage("Inactive", [])).toBe(false)
+  })
+
+  it("stays quiet once one page is live", () => {
+    expect(expectsPublishedPage("Active", [page()])).toBe(false)
+  })
+})
+
+describe("newslettersAwaitingSend — the content spine's approved_product_id", () => {
+  it("finds a published newsletter nobody received", () => {
+    const found = newslettersAwaitingSend([
+      page({ id: "n1", page_type: "Newsletter", sent_to_subscribers: false }),
+    ])
+    expect(found.map((p) => p.id)).toEqual(["n1"])
+  })
+
+  it("ignores one that was sent", () => {
+    expect(
+      newslettersAwaitingSend([
+        page({ id: "n1", page_type: "Newsletter", sent_to_subscribers: true }),
+      ])
+    ).toHaveLength(0)
+  })
+
+  it("ignores a DRAFT newsletter", () => {
+    /*
+     * 🔴 Unfinished work owes nothing. Every newsletter is a draft before it is
+     * anything else, and the local database's newsletters are all drafts — a
+     * rule that fired on them would be wrong about every one.
+     */
+    expect(
+      newslettersAwaitingSend([
+        page({ id: "n1", page_type: "Newsletter", status: "Draft" }),
+      ])
+    ).toHaveLength(0)
+  })
+
+  it("ignores an ordinary published page", () => {
+    // Only a Newsletter is expected to reach subscribers.
+    expect(
+      newslettersAwaitingSend([page({ id: "p1", page_type: "Blog" })])
+    ).toHaveLength(0)
+  })
+})
+
+describe("emptyPublishedPages", () => {
+  it("finds a live page with neither blocks nor body", () => {
+    expect(
+      emptyPublishedPages([page({ id: "p1", block_count: 0, content: "" })]).map(
+        (p) => p.id
+      )
+    ).toEqual(["p1"])
+  })
+
+  it("does not flag a page whose body is in blocks", () => {
+    expect(
+      emptyPublishedPages([page({ block_count: 3, content: "" })])
+    ).toHaveLength(0)
+  })
+
+  it("does not flag a page whose body is in the content field", () => {
+    /*
+     * 🔴 Both shapes are in real use — the local database has published pages
+     * with one block and published pages with seven, plus pages carrying a
+     * content string. Checking blocks alone would dash an edge on every page
+     * written the other way.
+     */
+    expect(
+      emptyPublishedPages([page({ block_count: 0, content: "<p>hello</p>" })])
+    ).toHaveLength(0)
+  })
+
+  it("treats whitespace-only content as empty", () => {
+    // `''` is not the only empty string this will meet.
+    expect(
+      emptyPublishedPages([page({ block_count: 0, content: "   \n  " })])
+    ).toHaveLength(1)
+  })
+
+  it("ignores drafts entirely", () => {
+    expect(
+      emptyPublishedPages([page({ status: "Draft", block_count: 0, content: "" })])
+    ).toHaveLength(0)
+  })
+})
+
+describe("publishedPages and failedSends", () => {
+  it("counts only Published", () => {
+    expect(
+      publishedPages([page({ id: "a" }), page({ id: "b", status: "Archived" })]).map(
+        (p) => p.id
+      )
+    ).toEqual(["a"])
+  })
+
+  it("counts only the sends that failed", () => {
+    expect(
+      failedSends([
+        { id: "l1", status: "sent" },
+        { id: "l2", status: "failed" },
+        { id: "l3", status: "queued" },
+        { id: "l4", status: "retried" },
+      ]).map((l) => l.id)
+    ).toEqual(["l2"])
+  })
+})

--- a/apps/backend/src/lib/graph/spines/website/absence.ts
+++ b/apps/backend/src/lib/graph/spines/website/absence.ts
@@ -1,0 +1,94 @@
+/**
+ * When does the model genuinely EXPECT a neighbour on a website? (#1855)
+ *
+ * The content surface is the third spine, and the discipline is the one the
+ * first two set: assert an absence ONLY where a real code path is left with
+ * nowhere to go. A rule that fires on every empty relation trains the reader
+ * to ignore the dashed edges, which costs more than drawing none.
+ *
+ * Pure functions with tests, because every mistake they can make is silent on
+ * screen — a rule that never fires looks exactly like a healthy record.
+ */
+
+export type PageLike = {
+  id: string
+  status?: string | null
+  page_type?: string | null
+  content?: string | null
+  sent_to_subscribers?: boolean | null
+  sent_to_subscribers_at?: string | Date | null
+  /** Count of blocks on the page, resolved by the caller. */
+  block_count?: number
+}
+
+export const PUBLISHED = "Published"
+
+/** A website that is meant to be serving traffic right now. */
+export const LIVE_WEBSITE_STATUSES = new Set(["Active", "Maintenance"])
+
+export const isLive = (status: string | null | undefined): boolean =>
+  LIVE_WEBSITE_STATUSES.has(String(status))
+
+export const publishedPages = (pages: PageLike[]): PageLike[] =>
+  pages.filter((p) => String(p.status) === PUBLISHED)
+
+/**
+ * A live website serving nothing.
+ *
+ * 🔴 Conditional on the website being LIVE. A `Development` or `Inactive`
+ * website with no published pages is a website being built, which is the
+ * normal state of most of them for most of their life — dashing it there
+ * would put a red edge on every new site from the moment it is created.
+ */
+export const expectsPublishedPage = (
+  websiteStatus: string | null | undefined,
+  pages: PageLike[]
+): boolean => isLive(websiteStatus) && publishedPages(pages).length === 0
+
+/**
+ * A newsletter that was published and never sent.
+ *
+ * 🔴 THIS is the content spine's `approved_product_id`. The page is written,
+ * marked Published, and appears in every list of published pages exactly like
+ * one that went out — while `sent_to_subscribers` is false and not a single
+ * subscriber ever received it. Nothing in the admin distinguishes the two, and
+ * the work is already done; only the send is missing.
+ *
+ * A Draft newsletter is excluded: it is unfinished, and nobody expects an
+ * unfinished newsletter to have been sent.
+ */
+export const newslettersAwaitingSend = (pages: PageLike[]): PageLike[] =>
+  pages.filter(
+    (p) =>
+      String(p.page_type) === "Newsletter" &&
+      String(p.status) === PUBLISHED &&
+      !p.sent_to_subscribers
+  )
+
+/**
+ * A published page that renders nothing.
+ *
+ * A page holds its body in EITHER `blocks` or the `content` text field, so
+ * neither alone proves emptiness.
+ *
+ * 🔴 Both must be empty. Checking blocks alone would dash an edge on every
+ * page written the other way — and the local database has published pages with
+ * one block and published pages with seven, so both shapes are in real use.
+ */
+export const emptyPublishedPages = (pages: PageLike[]): PageLike[] =>
+  publishedPages(pages).filter(
+    (p) => (p.block_count ?? 0) === 0 && !String(p.content ?? "").trim()
+  )
+
+export type SendLogLike = { id: string; status?: string | null }
+
+/**
+ * Subscribers a send never reached.
+ *
+ * Not an absent NEIGHBOUR — a broken one, like the partner spine's unverified
+ * WhatsApp number. The page says it was sent, the send log says some of it
+ * failed, and the page's own `subscriber_count` counts the attempt rather than
+ * the arrival.
+ */
+export const failedSends = (logs: SendLogLike[]): SendLogLike[] =>
+  logs.filter((l) => String(l.status) === "failed")

--- a/apps/backend/src/lib/graph/spines/website/index.ts
+++ b/apps/backend/src/lib/graph/spines/website/index.ts
@@ -1,0 +1,330 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { GraphBuilder, asArray } from "../../builder"
+import type { Graph, GraphNode, SpineContext, SpineDescriptor } from "../../types"
+import {
+  emptyPublishedPages,
+  expectsPublishedPage,
+  failedSends,
+  isLive,
+  newslettersAwaitingSend,
+  publishedPages,
+  type PageLike,
+} from "./absence"
+import { WEBSITE_ITEM_NODES, resolveWebsiteItems } from "./items"
+
+/**
+ * The WEBSITE spine (#1855) — the content surface.
+ *
+ * The third spine, and the first that is not about production. It is here
+ * because content has the same shape of failure the design spine was built
+ * for: a newsletter written, marked Published, and never sent sits in every
+ * list of published pages looking exactly like one that went out. The work is
+ * finished and the send is missing, and no count anywhere says so.
+ *
+ * 🔴 Pages, blocks and domains are intra-module relations on the website and
+ * page models, NOT module links — so they resolve straight off the entity and
+ * the `entryPoint` treatment the other spines need does not apply here. The
+ * link-derived nodes are the ones that need `resolveExisting`; this spine has
+ * none, which is why it does not use it.
+ */
+const resolveWebsiteGraph = async ({ scope, id }: SpineContext): Promise<Graph> => {
+  const websiteId = id
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  const { data: websites } = await query.graph({
+    entity: "websites",
+    filters: { id: websiteId },
+    fields: [
+      "*",
+      "pages.*",
+      "pages.blocks.*",
+      "pages.subscription_send_logs.*",
+      "domains.*",
+    ],
+  })
+
+  const website = (websites || [])[0]
+  if (!website) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Website ${websiteId} was not found`
+    )
+  }
+
+  const rawPages = asArray<any>(website.pages)
+  const domains = asArray<any>(website.domains)
+
+  /*
+   * Blocks and send logs come back nested under each page. Flattened here so
+   * the absence rules take a plain shape — and `block_count` is resolved onto
+   * the page, because "is this page empty?" is a question about the page.
+   */
+  const pages: PageLike[] = rawPages.map((p) => ({
+    id: String(p.id),
+    status: p.status,
+    page_type: p.page_type,
+    content: p.content,
+    sent_to_subscribers: p.sent_to_subscribers,
+    sent_to_subscribers_at: p.sent_to_subscribers_at,
+    block_count: asArray<any>(p.blocks).length,
+  }))
+
+  const sendLogs = rawPages.flatMap((p) =>
+    asArray<any>(p.subscription_send_logs).map((l) => ({
+      id: String(l.id),
+      status: l.status,
+    }))
+  )
+
+  const live = publishedPages(pages)
+  const unsentNewsletters = newslettersAwaitingSend(pages)
+  const emptyPages = emptyPublishedPages(pages)
+  const failed = failedSends(sendLogs)
+  const totalBlocks = pages.reduce((n, p) => n + (p.block_count ?? 0), 0)
+
+  const builder = new GraphBuilder("website")
+  const push = builder.push.bind(builder)
+
+  // ---- pages --------------------------------------------------------------
+
+  if (pages.length) {
+    push(
+      {
+        key: "pages",
+        type: "page",
+        label: "Pages",
+        sublabel: `${live.length} of ${pages.length} published`,
+        state: "present",
+        count: pages.length,
+        status: null,
+        href: `/websites/${websiteId}/pages`,
+        props: [
+          { key: "published", value: String(live.length) },
+          { key: "draft", value: String(pages.length - live.length) },
+        ],
+        action: null,
+      },
+      { label: "website_id", state: "present", reason: null }
+    )
+  } else if (expectsPublishedPage(website.status, pages)) {
+    push(
+      {
+        key: "pages",
+        type: "page",
+        label: "Pages",
+        sublabel: "nothing to serve",
+        state: "absent",
+        count: 0,
+        status: null,
+        href: `/websites/${websiteId}/pages`,
+        props: [{ key: "website status", value: String(website.status) }],
+        action: { label: "Add a page", href: `/websites/${websiteId}/pages` },
+      },
+      {
+        label: "website_id",
+        state: "absent",
+        reason: `This website is ${website.status} and has no page at all, so every request to it resolves to nothing.`,
+      }
+    )
+  }
+
+  /*
+   * 🔴 A SEPARATE node from `pages`, deliberately.
+   *
+   * A live website with fifty drafts and nothing published has a perfectly
+   * healthy-looking `pages` node — fifty of them, present. Folding this into
+   * that node's state would hide it behind a count, which is precisely the
+   * failure mode this whole view exists to remove.
+   */
+  if (pages.length && expectsPublishedPage(website.status, pages)) {
+    push(
+      {
+        key: "published",
+        type: "page",
+        label: "Published pages",
+        sublabel: "none live",
+        state: "absent",
+        count: 0,
+        status: null,
+        href: `/websites/${websiteId}/pages`,
+        props: [
+          { key: "website status", value: String(website.status) },
+          { key: "drafts", value: String(pages.length) },
+        ],
+        action: { label: "Publish a page", href: `/websites/${websiteId}/pages` },
+      },
+      {
+        label: "status = Published",
+        state: "absent",
+        reason: `This website is ${website.status} but not one of its ${pages.length} page${pages.length === 1 ? "" : "s"} is published, so visitors are served nothing.`,
+      }
+    )
+  }
+
+  // ---- newsletters: the motivating absent edge -----------------------------
+
+  if (unsentNewsletters.length) {
+    push(
+      {
+        key: "newsletters",
+        type: "page",
+        label: "Newsletters",
+        sublabel: `${unsentNewsletters.length} never sent`,
+        state: "absent",
+        count: unsentNewsletters.length,
+        status: null,
+        href: `/websites/${websiteId}/pages`,
+        props: [
+          { key: "published, unsent", value: String(unsentNewsletters.length) },
+          {
+            key: "first",
+            value: String(unsentNewsletters[0]?.id ?? "").slice(0, 18),
+          },
+        ],
+        action: { label: "Send to subscribers", href: `/websites/${websiteId}/pages` },
+      },
+      {
+        label: "sent_to_subscribers",
+        state: "absent",
+        reason: `${unsentNewsletters.length} newsletter${unsentNewsletters.length === 1 ? " is" : "s are"} published and ${unsentNewsletters.length === 1 ? "was" : "were"} never sent. ${unsentNewsletters.length === 1 ? "It appears" : "They appear"} in every list of published pages exactly like one that went out, and no subscriber received it.`,
+      }
+    )
+  }
+
+  // ---- empty published pages ----------------------------------------------
+
+  if (emptyPages.length) {
+    push(
+      {
+        key: "empty_pages",
+        type: "page",
+        label: "Empty pages",
+        sublabel: `${emptyPages.length} render nothing`,
+        state: "absent",
+        count: emptyPages.length,
+        status: null,
+        href: `/websites/${websiteId}/pages`,
+        props: [{ key: "published, empty", value: String(emptyPages.length) }],
+        action: { label: "Add content", href: `/websites/${websiteId}/pages` },
+      },
+      {
+        label: "blocks / content",
+        state: "absent",
+        reason: `${emptyPages.length} published page${emptyPages.length === 1 ? " has" : "s have"} neither blocks nor body text, so ${emptyPages.length === 1 ? "it serves" : "they serve"} an empty document to anyone who reaches ${emptyPages.length === 1 ? "it" : "them"}.`,
+      }
+    )
+  }
+
+  // ---- blocks -------------------------------------------------------------
+
+  if (totalBlocks) {
+    push(
+      {
+        key: "blocks",
+        type: "block",
+        label: "Blocks",
+        sublabel: `${totalBlocks} across ${pages.length} page${pages.length === 1 ? "" : "s"}`,
+        state: "present",
+        count: totalBlocks,
+        status: null,
+        href: `/websites/${websiteId}/pages`,
+        props: [{ key: "blocks", value: String(totalBlocks) }],
+        action: null,
+      },
+      { label: "page_id", state: "present", reason: null }
+    )
+  }
+
+  // ---- domains ------------------------------------------------------------
+
+  if (domains.length) {
+    const primary = domains.filter((d) => d.is_primary)
+    push(
+      {
+        key: "domains",
+        type: "website_domain",
+        label: "Domains",
+        sublabel: `${domains.length} alias${domains.length === 1 ? "" : "es"}`,
+        state: "present",
+        count: domains.length,
+        status: null,
+        href: `/websites/${websiteId}`,
+        props: [
+          { key: "aliases", value: String(domains.length) },
+          { key: "primary", value: String(primary.length) },
+        ],
+        action: null,
+      },
+      { label: "website_id", state: "present", reason: null }
+    )
+  }
+
+  // ---- sends --------------------------------------------------------------
+
+  if (sendLogs.length) {
+    push(
+      {
+        key: "sends",
+        type: "subscription_send_log",
+        label: "Subscriber sends",
+        sublabel: failed.length
+          ? `${failed.length} of ${sendLogs.length} failed`
+          : `${sendLogs.length} delivered`,
+        /*
+         * 🔴 `derived` when sends failed, not `absent`. The neighbour is not
+         * missing — it is there and part of it did not work. The page records
+         * that it was sent and counts the ATTEMPT; the failures are only in the
+         * log, which nothing on the page reads.
+         */
+        state: failed.length ? "derived" : "present",
+        count: sendLogs.length,
+        status: failed.length ? "partial" : null,
+        href: `/websites/${websiteId}/pages`,
+        props: [
+          { key: "sent", value: String(sendLogs.length - failed.length) },
+          { key: "failed", value: String(failed.length) },
+        ],
+        action: null,
+      },
+      {
+        label: "subscription_send_log",
+        state: failed.length ? "derived" : "present",
+        reason: failed.length
+          ? `${failed.length} send${failed.length === 1 ? "" : "s"} failed. The page still reports that it was sent, and its subscriber count counts the attempt rather than the arrival.`
+          : null,
+      }
+    )
+  }
+
+  const spine: GraphNode = {
+    key: "website",
+    type: "website",
+    label: String(website.name ?? websiteId),
+    sublabel: String(website.domain ?? ""),
+    state: "present",
+    count: 1,
+    status: String(website.status ?? ""),
+    href: `/websites/${websiteId}`,
+    props: [
+      { key: "status", value: String(website.status ?? "—") },
+      { key: "live", value: isLive(website.status) ? "yes" : "no" },
+      { key: "domain", value: String(website.domain ?? "—") },
+      { key: "language", value: String(website.primary_language ?? "—") },
+      ...(website.analytics_provider
+        ? [{ key: "analytics", value: String(website.analytics_provider) }]
+        : []),
+    ],
+    action: null,
+  }
+
+  return builder.build(spine)
+}
+
+export const websiteSpine: SpineDescriptor = {
+  key: "website",
+  label: "Website",
+  resolve: resolveWebsiteGraph,
+  items: resolveWebsiteItems,
+  itemNodes: WEBSITE_ITEM_NODES,
+}

--- a/apps/backend/src/lib/graph/spines/website/items.ts
+++ b/apps/backend/src/lib/graph/spines/website/items.ts
@@ -1,0 +1,220 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { asArray } from "../../builder"
+import type { NodeItem, SpineContext } from "../../types"
+import {
+  emptyPublishedPages,
+  failedSends,
+  newslettersAwaitingSend,
+  type PageLike,
+} from "./absence"
+
+/**
+ * The members behind a website's aggregate nodes (#1855).
+ *
+ * 🔴 The three ABSENT nodes list rows too, and that is the point of them here.
+ * "3 newsletters never sent" provokes exactly one question — WHICH three — and
+ * on this spine the answer is the whole value: each row is a piece of finished
+ * work that needs one action. The design spine's absent nodes had nothing to
+ * enumerate; these do.
+ *
+ * No `remove` anywhere. Deleting a page is a content decision with its own
+ * route and its own cascade (`delete: ['blocks', 'subscription_send_logs']` on
+ * the model), and a bin icon beside a row that reads "published, never sent"
+ * would sit one pixel from the action the reader actually wants.
+ */
+
+/** Everything the item resolvers need, in one read. */
+const loadPages = async (query: any, websiteId: string) => {
+  const { data } = await query.graph({
+    entity: "websites",
+    filters: { id: websiteId },
+    fields: [
+      "id",
+      "pages.*",
+      "pages.blocks.*",
+      "pages.subscription_send_logs.*",
+      "domains.*",
+    ],
+  })
+  return (data || [])[0]
+}
+
+const toPageLike = (p: any): PageLike => ({
+  id: String(p.id),
+  status: p.status,
+  page_type: p.page_type,
+  content: p.content,
+  sent_to_subscribers: p.sent_to_subscribers,
+  block_count: asArray<any>(p.blocks).length,
+})
+
+const pageRow = (p: any, websiteId: string, sublabel: string | null): NodeItem => ({
+  id: String(p.id),
+  label: String(p.title ?? p.slug ?? p.id),
+  sublabel,
+  status: p.status ? String(p.status) : null,
+  href: `/websites/${websiteId}/pages/${p.id}`,
+  props: [
+    ...(p.page_type ? [{ key: "type", value: String(p.page_type) }] : []),
+    ...(p.slug ? [{ key: "slug", value: String(p.slug) }] : []),
+    { key: "blocks", value: String(asArray<any>(p.blocks).length) },
+  ],
+  remove: null,
+})
+
+const pageItems = async (query: any, websiteId: string): Promise<NodeItem[]> => {
+  const website = await loadPages(query, websiteId)
+  return asArray<any>(website?.pages).map((p) =>
+    pageRow(
+      p,
+      websiteId,
+      /*
+       * 🔴 Never the status — the row renders that as a badge already, and
+       * printing it twice was the fault the design spine's rows shipped with
+       * until they were looked at.
+       */
+      [p.page_type, p.slug ? `/${p.slug}` : null].filter(Boolean).join(" · ") || null
+    )
+  )
+}
+
+const publishedItems = async (
+  query: any,
+  websiteId: string
+): Promise<NodeItem[]> => {
+  // The `published` node fires only when NONE are published, so its rows are
+  // the drafts — the things one action away from fixing it.
+  const website = await loadPages(query, websiteId)
+  return asArray<any>(website?.pages)
+    .filter((p) => String(p.status) !== "Published")
+    .map((p) => pageRow(p, websiteId, "not published"))
+}
+
+const newsletterItems = async (
+  query: any,
+  websiteId: string
+): Promise<NodeItem[]> => {
+  const website = await loadPages(query, websiteId)
+  const raw = asArray<any>(website?.pages)
+  const unsent = new Set(
+    newslettersAwaitingSend(raw.map(toPageLike)).map((p) => p.id)
+  )
+  return raw
+    .filter((p) => unsent.has(String(p.id)))
+    .map((p) => pageRow(p, websiteId, "published, never sent"))
+}
+
+const emptyPageItems = async (
+  query: any,
+  websiteId: string
+): Promise<NodeItem[]> => {
+  const website = await loadPages(query, websiteId)
+  const raw = asArray<any>(website?.pages)
+  const empty = new Set(emptyPublishedPages(raw.map(toPageLike)).map((p) => p.id))
+  return raw
+    .filter((p) => empty.has(String(p.id)))
+    .map((p) => pageRow(p, websiteId, "no blocks, no body"))
+}
+
+const blockItems = async (query: any, websiteId: string): Promise<NodeItem[]> => {
+  const website = await loadPages(query, websiteId)
+  return asArray<any>(website?.pages).flatMap((p) =>
+    asArray<any>(p.blocks).map((b) => ({
+      id: String(b.id),
+      label: String(b.name ?? b.type ?? b.id),
+      // Which PAGE it is on — the one fact that tells two blocks of the same
+      // type apart when they are listed together across a whole website.
+      sublabel: `${p.title ?? p.slug ?? "page"}${b.type ? ` · ${b.type}` : ""}`,
+      status: b.status ? String(b.status) : null,
+      href: `/websites/${websiteId}/pages/${p.id}`,
+      props: [
+        ...(b.type ? [{ key: "type", value: String(b.type) }] : []),
+        { key: "order", value: String(b.order ?? 0) },
+      ],
+      remove: null,
+    }))
+  )
+}
+
+const domainItems = async (query: any, websiteId: string): Promise<NodeItem[]> => {
+  const website = await loadPages(query, websiteId)
+  return asArray<any>(website?.domains).map((d) => ({
+    id: String(d.id),
+    label: String(d.domain ?? d.id),
+    sublabel: d.is_primary ? "primary" : "alias",
+    status: null,
+    href: null,
+    props: [{ key: "primary", value: d.is_primary ? "yes" : "no" }],
+    remove: null,
+  }))
+}
+
+const sendItems = async (query: any, websiteId: string): Promise<NodeItem[]> => {
+  const website = await loadPages(query, websiteId)
+  const logs = asArray<any>(website?.pages).flatMap((p) =>
+    asArray<any>(p.subscription_send_logs).map((l) => ({ ...l, page: p }))
+  )
+
+  /*
+   * 🔴 Failures FIRST. This node is only ever opened because it says some
+   * sends failed, and a list ordered by insertion buries those under every
+   * successful one — on a send to five hundred subscribers the reader would
+   * scroll past four hundred and ninety successes to find the thing they came
+   * for.
+   */
+  const failedIds = new Set(failedSends(logs).map((l) => l.id))
+  const ordered = [
+    ...logs.filter((l) => failedIds.has(String(l.id))),
+    ...logs.filter((l) => !failedIds.has(String(l.id))),
+  ]
+
+  return ordered.map((l) => ({
+    id: String(l.id),
+    label: String(l.subscriber_email ?? l.subscriber_id ?? l.id),
+    sublabel:
+      [
+        l.page?.title ? String(l.page.title) : null,
+        l.provider ? String(l.provider) : null,
+        // The reason, where there is one — it is why the row is at the top.
+        l.error ? String(l.error).slice(0, 80) : null,
+      ]
+        .filter(Boolean)
+        .join(" · ") || null,
+    status: l.status ? String(l.status) : null,
+    href: l.page?.id ? `/websites/${websiteId}/pages/${l.page.id}` : null,
+    props: [
+      { key: "status", value: String(l.status ?? "—") },
+      ...(l.provider ? [{ key: "provider", value: String(l.provider) }] : []),
+      ...(l.error ? [{ key: "error", value: String(l.error) }] : []),
+    ],
+    remove: null,
+  }))
+}
+
+const RESOLVERS: Record<
+  string,
+  (query: any, websiteId: string) => Promise<NodeItem[]>
+> = {
+  pages: pageItems,
+  published: publishedItems,
+  newsletters: newsletterItems,
+  empty_pages: emptyPageItems,
+  blocks: blockItems,
+  domains: domainItems,
+  sends: sendItems,
+}
+
+export const WEBSITE_ITEM_NODES = Object.keys(RESOLVERS)
+
+export const resolveWebsiteItems = async (
+  { scope, id }: SpineContext,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const resolver = RESOLVERS[nodeKey]
+  if (!resolver) {
+    return []
+  }
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  return resolver(query, id)
+}


### PR DESCRIPTION
Two more spines — the third and fourth. Neither needed a route, a hook, or a line of client code; the registry entry and the resolver are the whole change.

## Website — the content spine

**The absence that earns it: a newsletter published and never sent.** The page is written, marked Published, and appears in every list of published pages *exactly like one that went out* — while `sent_to_subscribers` is false and no subscriber received it. The work is finished; only the send is missing. This is the content surface's `approved_product_id`.

Three more, each conditional on the model genuinely expecting something:

- **A live website with no page at all** — every request resolves to nothing. Only for `Active`/`Maintenance`: a `Development` website with no pages is a website being built, which is the normal state of most of them for most of their life.
- **A live website whose pages exist but none are published.** Its own node, deliberately — a site with fifty drafts has a perfectly healthy `pages` node, *fifty of them, present*. Folding this into that node's state would hide it behind a count, which is the failure this whole view exists to remove.
- **A published page with neither blocks nor body text** — it serves an empty document. Both must be empty: the local database has published pages written each way, so checking blocks alone would dash an edge on every page written the other.

Send logs go `derived` when any failed — the page still reports it was sent, and its subscriber count counts the *attempt*, not the arrival.

## Social platform — the marketing spine

🔴 **It asserts exactly one fault, and the restraint is the point.**

**An active integration that has never synced.** `status = "active"` is set at creation and is what every screen reads to decide an integration is connected — so a binding that never worked once is indistinguishable from one syncing hourly. Measured: **all 49 `search-console` bindings on the local database are in exactly that state.** One of them is `sc-domain:jaalyantra.com` — active, never synced.

The obvious marketing rules — a scheduled post whose time has passed, a post marked `posted` with no `post_url`, a stalled campaign — are all plausible and **none could be exercised**: zero social posts, zero publishing campaigns, zero leads, zero ad campaigns exist locally. A rule that has never run against a real row is a guess with a test around it, and shipping four of them onto a surface nobody can check is how a graph starts crying wolf. They're deferred with the reason rather than shipped unverified.

Also learned, and worth not repeating: **`SocialPlatformBinding` is not a posting destination.** Its `service` enum is merchant / ads / search-console / business-profile — Google integrations. "An active platform with no binding cannot publish" is a rule I nearly wrote, and it would have been false.

## Verification

Every rule that shipped was run against real rows. The two no local data reached — a published-unsent newsletter, an empty published page — were exercised by **forcing the condition on a fixture and reverting it**, because a check that never ran reads as a pass.

- Website spine probed across three real websites: an `Active` site with 2 pages and 0 published (fires), a `Development` site with 6/7 published (correctly silent), an `Active` site with no pages at all (fires).
- 132 graph tests green; `✓ Prod-config build passed`.
- Rendered in a browser — the card defaults to the absent node, states the consequence, and offers the action.

## Scope

The website graph card and workspace route are added; **nothing removed** from the website page — it has three sections and the graph has to earn each one, the way it did on the design page.

There is no `social-platforms` admin route, so that spine is API and MCP only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4