### PR TITLE
feat(admin-mcp): disable partners and stores from the admin assistant

### DIFF
--- a/apps/backend/integration-tests/http/admin-store-disable.spec.ts
+++ b/apps/backend/integration-tests/http/admin-store-disable.spec.ts
@@ -1,0 +1,121 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * Create a partner with a fully-provisioned store (sales channel + region +
+ * location) so the store has a `default_sales_channel_id` to disable.
+ */
+async function createPartnerWithStore(api: any, adminHeaders: Record<string, any>) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `partner-ds-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const login1 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const headers1: Record<string, string> = { Authorization: `Bearer ${login1.data.token}` }
+
+  await api.post(
+    "/partners",
+    {
+      name: `DS Partner ${unique}`,
+      handle: `dspartner-${unique}`,
+      admin: { email, first_name: "Admin", last_name: "DS" },
+    },
+    { headers: headers1 }
+  )
+
+  const login2 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const headers: Record<string, string> = { Authorization: `Bearer ${login2.data.token}` }
+
+  const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+  const currencies = currenciesRes.data.currencies || []
+  const usd = currencies.find((c: any) => c.code?.toLowerCase() === "usd")
+  const currencyCode = String((usd || currencies[0]).code).toLowerCase()
+
+  const storeRes = await api.post(
+    "/partners/stores",
+    {
+      store: {
+        name: `DS Store ${unique}`,
+        supported_currencies: [{ currency_code: currencyCode, is_default: true }],
+      },
+      sales_channel: { name: `DS Channel ${unique}`, description: "Default" },
+      region: { name: "Default Region", currency_code: currencyCode, countries: ["us"] },
+      location: {
+        name: "Warehouse",
+        address: { address_1: "1 Main St", city: "NY", postal_code: "10001", country_code: "US" },
+      },
+    },
+    { headers }
+  )
+
+  const store = storeRes.data.store
+  const salesChannelId = store.default_sales_channel_id || storeRes.data.sales_channel?.id
+
+  return { storeId: store.id, salesChannelId, headers }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Admin API - Store disable/enable (default sales channel)", () => {
+    let adminHeaders: Record<string, any>
+    let store: Awaited<ReturnType<typeof createPartnerWithStore>>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      store = await createPartnerWithStore(api, adminHeaders)
+    })
+
+    const readChannel = async (channelId: string) => {
+      const res = await api.get(`/admin/sales-channels/${channelId}`, adminHeaders)
+      return res.data.sales_channel
+    }
+
+    it("POST /admin/stores/:id/disable disables the store's default sales channel", async () => {
+      const res = await api.post(`/admin/stores/${store.storeId}/disable`, {}, adminHeaders)
+      expect(res.status).toBe(200)
+      expect(res.data.disabled).toBe(true)
+      expect(res.data.sales_channel_id).toBe(store.salesChannelId)
+
+      // Read the channel back — the assertion is on the persisted row, not the
+      // echoed response, so a route that reports success without writing fails.
+      const channel = await readChannel(store.salesChannelId)
+      expect(channel.is_disabled).toBe(true)
+    })
+
+    it("POST /admin/stores/:id/enable re-enables a disabled store", async () => {
+      await api.post(`/admin/stores/${store.storeId}/disable`, {}, adminHeaders)
+
+      const res = await api.post(`/admin/stores/${store.storeId}/enable`, {}, adminHeaders)
+      expect(res.status).toBe(200)
+      expect(res.data.disabled).toBe(false)
+
+      const channel = await readChannel(store.salesChannelId)
+      expect(channel.is_disabled).toBe(false)
+    })
+
+    it("returns 404 for a store that does not exist", async () => {
+      const res = await api.post(
+        `/admin/stores/store_nonexistent/disable`,
+        {},
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(res.status).toBe(404)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -386,6 +386,41 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     queryParams: ["limit", "offset"],
     inputSchema: obj({ ...PAGINATION }),
   },
+  {
+    name: "disable_store",
+    description:
+      "Disable a store's storefront by disabling its default sales channel (is_disabled=true), so its products stop being purchasable. Reversible — use enable_store to switch it back on. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/stores/:id/disable",
+    pathParams: ["id"],
+    previewPath: "/admin/stores/:id",
+    write: true,
+    sensitive: true,
+    inputSchema: obj(
+      { id: STR("Store id to disable, e.g. 'store_...'. Get it from list_stores.") },
+      ["id"]
+    ),
+    sideEffects:
+      "Sets is_disabled=true on the store's default sales channel. Does NOT delete the store, its products or the channel.",
+    nextSteps: ["enable_store", "list_stores"],
+  },
+  {
+    name: "enable_store",
+    description:
+      "Re-enable a store's storefront by enabling its default sales channel (is_disabled=false). The reverse of disable_store. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/stores/:id/enable",
+    pathParams: ["id"],
+    previewPath: "/admin/stores/:id",
+    write: true,
+    sensitive: true,
+    inputSchema: obj(
+      { id: STR("Store id to enable, e.g. 'store_...'.") },
+      ["id"]
+    ),
+    sideEffects: "Sets is_disabled=false on the store's default sales channel.",
+    nextSteps: ["disable_store", "list_stores"],
+  },
 
   // ===== Designs & production ==============================================
   {
@@ -1922,6 +1957,21 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       },
       ["id"]
     ),
+  },
+  {
+    name: "disable_partner",
+    description:
+      "Disable a partner WITHOUT deleting them: detach their storefront domain(s) (provider domain + our DNS) and set status to 'inactive', so the storefront goes dark. Reversible — products, orders, admins and the hosting project all survive, and the partner can be re-enabled by setting status back to 'active' via update_partner. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/partners/:id/disable",
+    pathParams: ["id"],
+    previewPath: "/admin/partners/:id",
+    write: true,
+    sensitive: true,
+    inputSchema: obj({ id: STR("Partner id to disable, e.g. 'partner_...'.") }, ["id"]),
+    sideEffects:
+      "Detaches the partner's storefront subdomain and custom domain from the hosting provider, removes our DNS record, clears the storefront domain columns, and sets status='inactive'. Does NOT delete products, orders, admins or the hosting project.",
+    nextSteps: ["get_partner", "update_partner"],
   },
   {
     name: "delete_partner",

--- a/apps/backend/src/api/admin/partners/[id]/disable/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/disable/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { disablePartnerWorkflow } from "../../../../../workflows/partners/disable-partner"
+
+/**
+ * POST /admin/partners/:id/disable
+ *
+ * Disable a partner without deleting them: take their storefront domain(s) down
+ * and flip `status` to `inactive`. Products, orders, admins and the hosting
+ * project all survive, so the partner can be re-enabled later (via
+ * `PUT /admin/partners/:id` with `status: "active"`).
+ *
+ * This is the admin-side counterpart to the storefront teardown in
+ * `DELETE /partners/storefront`, but scoped to "off, not gone": it detaches the
+ * domains and leaves the project standing.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const id = req.params.id
+
+  const { result } = await disablePartnerWorkflow(req.scope).run({
+    input: { id },
+  })
+
+  res.status(200).json({ partner: result.partner, storefront: result.storefront })
+}

--- a/apps/backend/src/api/admin/stores/[id]/disable/route.ts
+++ b/apps/backend/src/api/admin/stores/[id]/disable/route.ts
@@ -1,0 +1,13 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { setStoreDisabled } from "../lib/set-disabled"
+
+/**
+ * POST /admin/stores/:id/disable
+ *
+ * Disable a store's storefront by disabling its default sales channel
+ * (`is_disabled=true`). Reversible — see `POST /admin/stores/:id/enable`.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const result = await setStoreDisabled(req.scope, req.params.id, true)
+  res.status(200).json(result)
+}

--- a/apps/backend/src/api/admin/stores/[id]/enable/route.ts
+++ b/apps/backend/src/api/admin/stores/[id]/enable/route.ts
@@ -1,0 +1,13 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { setStoreDisabled } from "../lib/set-disabled"
+
+/**
+ * POST /admin/stores/:id/enable
+ *
+ * Re-enable a store's storefront by enabling its default sales channel
+ * (`is_disabled=false`). The reverse of `POST /admin/stores/:id/disable`.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const result = await setStoreDisabled(req.scope, req.params.id, false)
+  res.status(200).json(result)
+}

--- a/apps/backend/src/api/admin/stores/[id]/lib/set-disabled.ts
+++ b/apps/backend/src/api/admin/stores/[id]/lib/set-disabled.ts
@@ -1,0 +1,55 @@
+import { MedusaError, Modules } from "@medusajs/framework/utils"
+import { updateSalesChannelsWorkflow } from "@medusajs/medusa/core-flows"
+
+export type SetStoreDisabledResult = {
+  store_id: string
+  sales_channel_id: string
+  disabled: boolean
+  sales_channel: unknown
+}
+
+/**
+ * Disable or re-enable a store's storefront.
+ *
+ * A store has no "disabled" flag of its own — its storefront is its
+ * `default_sales_channel_id` → publishable key → products. Disabling the store
+ * means disabling that sales channel (`is_disabled`), which is Medusa's native
+ * "this channel is off" switch. Deleting the store/channel is the partner-delete
+ * cascade's job; this is the reversible "off, not gone".
+ */
+export async function setStoreDisabled(
+  scope: any,
+  storeId: string,
+  disabled: boolean
+): Promise<SetStoreDisabledResult> {
+  const storeService: any = scope.resolve(Modules.STORE)
+  const [store] = await storeService.listStores({ id: storeId })
+  if (!store) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Store ${storeId} not found`
+    )
+  }
+
+  const channelId = store.default_sales_channel_id
+  if (!channelId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Store ${storeId} has no default sales channel to disable`
+    )
+  }
+
+  const { result } = await updateSalesChannelsWorkflow(scope).run({
+    input: {
+      selector: { id: channelId },
+      update: { is_disabled: disabled },
+    },
+  })
+
+  return {
+    store_id: storeId,
+    sales_channel_id: channelId,
+    disabled,
+    sales_channel: result,
+  }
+}

--- a/apps/backend/src/api/admin/stores/[id]/products/route.ts
+++ b/apps/backend/src/api/admin/stores/[id]/products/route.ts
@@ -67,7 +67,7 @@ export const POST = async (
   // than create an unattributable product in someone's shop.
   const { data: partnerRows } = await query.graph({
     entity: "partner",
-    fields: ["id", "name"],
+    fields: ["id", "name", "status"],
     filters: { stores: { id: storeId } },
   })
   const ownerPartner = partnerRows?.[0]
@@ -75,6 +75,14 @@ export const POST = async (
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
       `Store ${storeId} is not linked to a partner, so a product created in it could not be attributed to an owner`
+    )
+  }
+  // A disabled partner must not have products added on their behalf — the same
+  // gate that keeps a disabled partner from doing business anywhere else.
+  if (ownerPartner.status === "inactive") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Partner ${ownerPartner.id} is inactive — re-enable the partner before adding products to their store`
     )
   }
 

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -4590,6 +4590,13 @@ export default defineMiddlewares({
       method: "POST",
       middlewares: [],
     },
+    // Admin Partner Disable — take the storefront domains down and set status
+    // inactive, without deleting the partner or its products/orders.
+    {
+      matcher: "/admin/partners/:id/disable",
+      method: "POST",
+      middlewares: [],
+    },
     // Admin Partner Admins routes
     {
       matcher: "/admin/partners/:id/admins",
@@ -5592,6 +5599,17 @@ export default defineMiddlewares({
       matcher: "/admin/stores",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(createStoreSchema))],
+    },
+    // Store disable/enable — flip the store's default sales channel `is_disabled`.
+    {
+      matcher: "/admin/stores/:id/disable",
+      method: "POST",
+      middlewares: [],
+    },
+    {
+      matcher: "/admin/stores/:id/enable",
+      method: "POST",
+      middlewares: [],
     },
     // Email Templates 
     {

--- a/apps/backend/src/workflows/partners/disable-partner.ts
+++ b/apps/backend/src/workflows/partners/disable-partner.ts
@@ -1,0 +1,231 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { PARTNER_MODULE } from "../../modules/partner"
+import type PartnerService from "../../modules/partner/service"
+import { DEPLOYMENT_MODULE } from "../../modules/deployment"
+import type DeploymentService from "../../modules/deployment/service"
+import { WEBSITE_MODULE } from "../../modules/website"
+import type WebsiteService from "../../modules/website/service"
+import { getStorefrontRefs } from "../../api/partners/storefront/helpers"
+import {
+  partnerIsOnSharedProject,
+  resolveHostingProviderForPartner,
+} from "../../modules/deployment/providers/resolve-partner-provider"
+import {
+  deriveDomainPair,
+  partnerCustomDomain,
+} from "./attach-storefront-domain"
+
+export type DisablePartnerInput = {
+  id: string
+}
+
+/**
+ * The storefront keys that live in `metadata`. The empty string is
+ * mergeMetadata's delete sentinel, so each is tombstoned explicitly rather than
+ * left in place (a key simply omitted from the patch keeps its old value).
+ */
+const STOREFRONT_META_KEYS = [
+  "vercel_project_id",
+  "vercel_project_name",
+  "storefront_domain",
+  "storefront_provisioned_at",
+  "custom_domain",
+  "custom_domain_verified",
+]
+
+function stripStorefrontKeys(metadata: any): Record<string, any> {
+  const current = (metadata || {}) as Record<string, any>
+  const patch: Record<string, any> = {}
+  for (const key of STOREFRONT_META_KEYS) {
+    if (key in current) patch[key] = ""
+  }
+  return patch
+}
+
+/**
+ * Read-only: load the partner (full record) or refuse before anything writes.
+ */
+export const resolveDisablePartnerStep = createStep(
+  "resolve-disable-partner-step",
+  async (input: DisablePartnerInput, { container }) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "partners",
+      fields: ["*"],
+      filters: { id: input.id },
+    })
+    const partner = (data ?? [])[0]
+    if (!partner) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Partner with id ${input.id} was not found`
+      )
+    }
+    return new StepResponse(partner)
+  }
+)
+
+/**
+ * Take the partner's storefront domains down at the provider + our DNS, WITHOUT
+ * deleting the hosting project. A disabled partner is meant to be re-enableable,
+ * so the project (and its refs) survive; only the domains are detached and the
+ * public host resolution goes dark.
+ */
+export const removePartnerStorefrontDomainsStep = createStep(
+  "remove-partner-storefront-domains-step",
+  async (partner: any, { container }) => {
+    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+    const refs = getStorefrontRefs(partner)
+    const storefrontDomain = refs.storefrontDomain
+    const customDomain = partnerCustomDomain(partner)
+    const projectRef = refs.projectRef
+
+    const results: Record<string, any> = {}
+
+    // Provider-side domain detach. A partner with no project ref has nothing to
+    // detach from a provider — that is the dev/never-provisioned case, where the
+    // domain only exists as a column we clear below.
+    if (projectRef) {
+      try {
+        const { provider } = await resolveHostingProviderForPartner(
+          partner,
+          container
+        )
+        const isShared = await partnerIsOnSharedProject(partner, container)
+
+        if (storefrontDomain) {
+          try {
+            await provider.removeDomain(projectRef, storefrontDomain)
+            results.subdomain = { action: "removed" }
+          } catch (e: any) {
+            results.subdomain = { action: "failed", error: e?.message || String(e) }
+          }
+        }
+
+        if (customDomain) {
+          const pair = deriveDomainPair(customDomain)
+          const hosts = [pair.primary, pair.counterpart].filter(
+            (h): h is string => !!h
+          )
+          const warnings: string[] = []
+          for (const host of hosts) {
+            try {
+              await provider.removeDomain(projectRef, host)
+            } catch (e: any) {
+              warnings.push(`${host}: ${e?.message || String(e)}`)
+            }
+          }
+          results.custom_domain = {
+            action: warnings.length ? "partial" : "removed",
+            ...(warnings.length ? { warnings } : {}),
+          }
+        }
+
+        // Shared multi-tenant project: the domain detach above is the whole job —
+        // never tear down the project that serves every tenant.
+        results.project = isShared
+          ? { action: "skipped", reason: "shared multi-tenant project" }
+          : { action: "kept", reason: "disable keeps the project for re-enable" }
+      } catch (e: any) {
+        results.domain = { action: "failed", error: e?.message || String(e) }
+      }
+    } else {
+      results.domain = {
+        action: "skipped",
+        reason: "no hosting project reference to detach from",
+      }
+    }
+
+    // Remove our Cloudflare DNS record for the provisioned subdomain.
+    if (storefrontDomain) {
+      results.dns = await deployment.removeStorefrontDns(storefrontDomain)
+    }
+
+    // Soft-delete the custom-domain alias rows so host lookups stop resolving it.
+    if (customDomain) {
+      try {
+        const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE)
+        const pair = deriveDomainPair(customDomain)
+        const hosts = [pair.primary, pair.counterpart].filter(
+          (h): h is string => !!h
+        )
+        for (const host of hosts) {
+          const [rows] = await (websiteService as any).listAndCountWebsiteDomains(
+            { domain: host },
+            { take: 1 }
+          )
+          const row = rows?.[0]
+          if (row && !row.is_primary) {
+            await (websiteService as any).softDeleteWebsiteDomains(row.id)
+          }
+        }
+      } catch {
+        // best-effort — the column clear below is what matters for resolution
+      }
+    }
+
+    return new StepResponse(results)
+  }
+)
+
+/**
+ * Flip the partner inactive and clear the storefront domain columns in one
+ * write, so the record no longer advertises a domain it no longer serves.
+ */
+export const deactivatePartnerStep = createStep(
+  "deactivate-partner-step",
+  async (partner: any, { container }) => {
+    const partnerService: PartnerService = container.resolve(PARTNER_MODULE)
+
+    const updated = await partnerService.updatePartners({
+      id: partner.id,
+      status: "inactive",
+      storefront_domain: null,
+      custom_domain: null,
+      custom_domain_verified: false,
+      metadata: stripStorefrontKeys(partner.metadata),
+    } as any)
+
+    return new StepResponse(updated as any, partner)
+  },
+  // Restore the prior status + domain fields on rollback.
+  async (previous: any, { container }) => {
+    if (!previous) return
+    const partnerService: PartnerService = container.resolve(PARTNER_MODULE)
+    await partnerService.updatePartners({
+      id: previous.id,
+      status: previous.status,
+      storefront_domain: previous.storefront_domain ?? null,
+      custom_domain: previous.custom_domain ?? null,
+      custom_domain_verified: previous.custom_domain_verified ?? false,
+      metadata: previous.metadata ?? null,
+    } as any)
+  }
+)
+
+/**
+ * Disable a partner: take the storefront domains down and set `status` to
+ * `inactive`. Deliberately NOT a delete — products, orders, admins and the
+ * hosting project all survive so the partner can be re-enabled.
+ */
+export const disablePartnerWorkflow = createWorkflow(
+  "disable-partner",
+  (input: DisablePartnerInput) => {
+    const partner = resolveDisablePartnerStep(input)
+    const removed = removePartnerStorefrontDomainsStep(partner)
+    const deactivated = deactivatePartnerStep(partner)
+
+    return new WorkflowResponse({
+      partner: deactivated,
+      storefront: removed,
+    })
+  }
+)
+
+export default disablePartnerWorkflow


### PR DESCRIPTION
## What

Adds reversible "off, not gone" admin MCP tools for disabling partners and stores, following the existing MCP registry pattern (each tool maps 1:1 to a real `/admin/*` route).

### `disable_partner` — `POST /admin/partners/:id/disable`
- New workflow `workflows/partners/disable-partner.ts` + route.
- Detaches the partner's storefront subdomain + custom domain from the hosting provider, removes our Cloudflare DNS record, soft-deletes custom-domain alias rows, clears the domain columns, and sets `status=inactive`.
- Keeps products/orders/admins and the hosting project intact so the partner can be re-enabled.

### `disable_store` / `enable_store` — `POST /admin/stores/:id/{disable,enable}`
- A store has no "disabled" flag; its storefront is its `default_sales_channel_id`. These flip that channel's `is_disabled` via `updateSalesChannelsWorkflow`.

### Guard
- `create_product_for_partner` now refuses an `inactive` partner (NOT_ALLOWED).

## Verification
- Unit: 268 admin-MCP / mcp-core tests pass (scope-invariants, tool-slice, route-validator-field-coverage, dispatch, tool-tiers).
- Integration: new `admin-store-disable.spec.ts` (3 tests) passes.
- `tsc --noEmit`: no errors in touched files.