### PR TITLE
feat(admin): the graph opens in Desk, gets its first cohort board, and stops leaving dangling links behind

### DIFF
--- a/apps/backend/src/admin/components/partners/partner-people-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-people-section.tsx
@@ -30,7 +30,7 @@ export const PartnerPeopleSection = ({
   partnerId,
 }: PartnerPeopleSectionProps) => {
   const [linkModalOpen, setLinkModalOpen] = useState(false)
-  const { people, isLoading } = usePartnerPeople(partnerId)
+  const { people, isLoading, dangling } = usePartnerPeople(partnerId)
   const unlinkMutation = useUnlinkPeopleFromPartner(partnerId)
   const prompt = usePrompt()
 
@@ -98,6 +98,21 @@ export const PartnerPeopleSection = ({
             >
               No people linked
             </Text>
+            {/*
+              🔴 Say it, rather than let "none" stand for two different facts.
+              This partner HAS link rows — they point at people that no longer
+              exist (#1857). Before the null filter went in, those rows took
+              the whole page down; silently rendering "No people linked" over
+              them would trade a crash for a quieter untruth, which is the
+              exact failure this graph work exists to remove.
+            */}
+            {dangling > 0 && (
+              <Text size="xsmall" className="text-ui-fg-muted text-center">
+                {dangling} link {dangling === 1 ? "row points" : "rows point"} at
+                a person that no longer exists, and {dangling === 1 ? "was" : "were"}{" "}
+                left out.
+              </Text>
+            )}
             <Text size="small" className="text-ui-fg-muted text-center">
               Link people to this partner so they can access shared folders and
               upload files through the partner portal.

--- a/apps/backend/src/admin/hooks/api/partner-people.ts
+++ b/apps/backend/src/admin/hooks/api/partner-people.ts
@@ -24,6 +24,8 @@ export interface PartnerPerson {
 export interface PartnerPeopleResponse {
   people: PartnerPerson[]
   count: number
+  /** Link rows pointing at a person that no longer exists (#1857). */
+  dangling?: number
 }
 
 const PARTNER_PEOPLE_QUERY_KEY = "partner_people" as const
@@ -46,9 +48,20 @@ export const usePartnerPeople = (
     ...options,
   })
 
+  /*
+   * 🔴 Filtered here as well as on the server. The route is fixed, but this
+   * hook is the last thing between a null row and `person.id` in a `.map`,
+   * and that deref did not blank the section — it blanked the entire partner
+   * page. Two layers, because the cost of the guard is a `filter` and the
+   * cost of missing it is every partner with a stale link becoming
+   * unreachable.
+   */
+  const people = (data?.people || []).filter((p): p is PartnerPerson => !!p?.id)
+
   return {
-    people: data?.people || [],
-    count: data?.count || 0,
+    people,
+    count: people.length,
+    dangling: data?.dangling ?? 0,
     ...rest,
   }
 }

--- a/apps/backend/src/admin/routes/desk/EntityPicker.tsx
+++ b/apps/backend/src/admin/routes/desk/EntityPicker.tsx
@@ -4,6 +4,7 @@ import {
   ArrowUpRightOnBox,
   Buildings,
   ChatBubbleLeftRight,
+  ExclamationCircle,
   Globe,
   Photo,
   Plus,
@@ -22,6 +23,7 @@ import { mediasEntityConfig } from "./entities/medias"
 import { websitesEntityConfig } from "./entities/websites"
 import { personsEntityConfig } from "./entities/persons"
 import { messagingEntityConfig } from "./entities/messaging"
+import { queuesEntityConfig } from "./entities/queues"
 import type { EntityPanelConfig } from "./EntityPanel"
 
 export type EntityKey =
@@ -32,6 +34,7 @@ export type EntityKey =
   | "websites"
   | "persons"
   | "messaging"
+  | "queues"
 
 type IconType = ComponentType<{ className?: string }>
 
@@ -84,6 +87,12 @@ export const ENTITY_REGISTRY: Record<EntityKey, EntityRegistryEntry> = {
     description: "Conversations and messaging.",
     icon: ChatBubbleLeftRight,
     config: messagingEntityConfig,
+  },
+  queues: {
+    label: "Queues",
+    description: "Finished work with nothing to sell it.",
+    icon: ExclamationCircle,
+    config: queuesEntityConfig,
   },
 }
 

--- a/apps/backend/src/admin/routes/desk/entities/designs.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/designs.tsx
@@ -21,6 +21,10 @@ import DesignTasksNew from "../../designs/[id]/@tasks/new/page"
 import DesignTasksTemplates from "../../designs/[id]/@tasks/templates/page"
 import DesignTaskDetail from "../../designs/[id]/@tasks/[taskId]/page"
 import DesignInventoryDetail from "../../designs/[id]/@inventory/[inventoryId]/page"
+import DesignGraph from "../../designs/[id]/@graph/page"
+import DesignPartnersList from "../../designs/[id]/partners/page"
+import DesignProductionRunsList from "../../designs/[id]/production-runs/page"
+import DesignTasksList from "../../designs/[id]/tasks/page"
 import type { EntityPanelConfig } from "../EntityPanel"
 
 /**
@@ -62,7 +66,22 @@ export const designsEntityConfig: EntityPanelConfig = {
         { path: "tasks/templates", element: <DesignTasksTemplates /> },
         { path: "tasks/:taskId", element: <DesignTaskDetail /> },
         { path: "inventory/:inventoryId", element: <DesignInventoryDetail /> },
+        /*
+         * 🔴 The graph, and the three lists it is now the only route to.
+         *
+         * #1859 retired the production-runs, inventory and bundled-design
+         * cards because the graph does their job — but the graph route was
+         * never registered here, so inside a Desk panel "Open workspace" hit
+         * the recovery card and those capabilities left the workspace with the
+         * cards. Registering the graph without its drill-ins would only move
+         * the dead end one click later: the run and task nodes link out to
+         * these lists.
+         */
+        { path: "graph", element: <DesignGraph /> },
       ],
     },
+    { path: "/designs/:id/partners", element: <DesignPartnersList /> },
+    { path: "/designs/:id/production-runs", element: <DesignProductionRunsList /> },
+    { path: "/designs/:id/tasks", element: <DesignTasksList /> },
   ],
 }

--- a/apps/backend/src/admin/routes/desk/entities/partners.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/partners.tsx
@@ -8,6 +8,7 @@ import PartnerTasksViewCanvas from "../../partners/[id]/@tasks/view-canvas/page"
 import PartnerTasksNew from "../../partners/[id]/@tasks/new/page"
 import PartnerFeedbacksEdit from "../../partners/[id]/@feedbacks/edit/page"
 import PartnerMetadataEdit from "../../partners/[id]/@metadata/edit/page"
+import PartnerGraph from "../../partners/[id]/@graph/page"
 import type { EntityPanelConfig } from "../EntityPanel"
 
 export const partnersEntityConfig: EntityPanelConfig = {
@@ -31,6 +32,7 @@ export const partnersEntityConfig: EntityPanelConfig = {
         { path: "tasks/new", element: <PartnerTasksNew /> },
         { path: "feedbacks/edit", element: <PartnerFeedbacksEdit /> },
         { path: "metadata/edit", element: <PartnerMetadataEdit /> },
+        { path: "graph", element: <PartnerGraph /> },
       ],
     },
   ],

--- a/apps/backend/src/admin/routes/desk/entities/queues.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/queues.tsx
@@ -1,0 +1,25 @@
+import ProductsAwaitingQueuePage from "../../queues/products-awaiting/page"
+import type { EntityPanelConfig } from "../EntityPanel"
+
+/**
+ * Queues: cohort boards, as a Desk panel.
+ *
+ * The point of it being a panel rather than only a page is the workflow it
+ * serves — the board says which designs are waiting on a listing, and the
+ * answer to each is a design or a product, in another tab, side by side. A
+ * board you have to navigate away from to act on is a report.
+ *
+ * Registered here from the start, unlike the graph itself: the per-record
+ * graph shipped as an admin route and reached Desk three PRs later, by which
+ * time the design page had already retired the sections it replaced and the
+ * capability was missing from the workspace entirely.
+ */
+export const queuesEntityConfig: EntityPanelConfig = {
+  initialPath: "/queues/products-awaiting",
+  routes: [
+    {
+      path: "/queues/products-awaiting",
+      element: <ProductsAwaitingQueuePage />,
+    },
+  ],
+}

--- a/apps/backend/src/admin/routes/desk/entities/websites.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/websites.tsx
@@ -17,6 +17,7 @@ import WebsitePageMetadataEdit from "../../websites/[id]/pages/[pageId]/@metadat
 import WebsitePagePublicMetadataEdit from "../../websites/[id]/pages/[pageId]/@public-metadata/edit/page"
 import WebsitePageBlockNew from "../../websites/[id]/pages/[pageId]/@blocks/new/page"
 import WebsitePageBlockEdit from "../../websites/[id]/pages/[pageId]/@blocks/[blockId]/page"
+import WebsiteGraph from "../../websites/[id]/@graph/page"
 import type { EntityPanelConfig } from "../EntityPanel"
 
 /**
@@ -43,6 +44,7 @@ export const websitesEntityConfig: EntityPanelConfig = {
         { path: "blog", element: <WebsiteBlog /> },
         { path: "metadata", element: <WebsiteMetadata /> },
         { path: "metadata/edit", element: <WebsiteMetadataEdit /> },
+        { path: "graph", element: <WebsiteGraph /> },
       ],
     },
     { path: "/websites/:id/analytics", element: <WebsiteAnalytics /> },

--- a/apps/backend/src/admin/routes/desk/page.tsx
+++ b/apps/backend/src/admin/routes/desk/page.tsx
@@ -117,6 +117,7 @@ const Desk = () => {
     websites: 0,
     persons: 0,
     messaging: 0,
+    queues: 0,
   })
   /**
    * Frozen at mount and consumed by the factory on each panel mount.

--- a/apps/backend/src/admin/routes/queues/products-awaiting/page.tsx
+++ b/apps/backend/src/admin/routes/queues/products-awaiting/page.tsx
@@ -1,0 +1,30 @@
+import { GraphWorkspace } from "../../../components/graph/graph-workspace"
+
+/**
+ * `/queues/products-awaiting` — the first cohort board (#1856).
+ *
+ * A full page rather than a `RouteFocusModal`, unlike the per-record graph
+ * workspaces: those are opened FROM a record and close back onto it, while this
+ * is not about any one record and has nowhere to close back to. It is a place
+ * you go and stay.
+ *
+ * 🔴 It renders `GraphWorkspace` unchanged. The queue is registered as a spine
+ * whose `id` is the queue's NAME, so `useEntityGraph("queue", "products-
+ * awaiting")` hits the route that already exists and the canvas, viewport,
+ * inspector and member drawer all work as they are. The cohort board cost a
+ * resolver and a registry entry — no route, no hook, no new component — which
+ * is the claim the spine registry has been making since #1847, now tested from
+ * a direction it was not designed for.
+ */
+const ProductsAwaitingQueuePage = () => (
+  <div className="flex h-[calc(100vh-140px)] w-full flex-col overflow-hidden rounded-lg border bg-ui-bg-base">
+    <GraphWorkspace
+      spine="queue"
+      id="products-awaiting"
+      title="Products awaiting creation"
+      selfHref="/queues/products-awaiting"
+    />
+  </div>
+)
+
+export default ProductsAwaitingQueuePage

--- a/apps/backend/src/api/admin/designs/[id]/consumption-logs/[logId]/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/consumption-logs/[logId]/route.ts
@@ -38,6 +38,7 @@ import {
   ContainerRegistrationKeys,
   MedusaError,
 } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/framework/modules-sdk"
 
 import { CONSUMPTION_LOG_MODULE } from "../../../../../../modules/consumption_log"
 import { OPS_AUDIT_MODULE } from "../../../../../../modules/ops_audit"
@@ -145,6 +146,22 @@ export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id: designId, logId } = req.params
   const { service, log } = await loadOwnedLog(req, designId, logId)
   assertNotApplied(log)
+
+  /*
+   * 🔴 Dismiss the links BEFORE the row goes (#1857).
+   *
+   * A consumption log sits in three link tables — design, inventory item and
+   * production run — and this is a HARD delete, so once the row is gone every
+   * one of those links points at nothing. `query.graph` then hands each reader
+   * a NULL where a log should be, and prod carries exactly one such row in each
+   * of the three: one deletion, three lying tables.
+   *
+   * Before rather than after, for the reason the partner deletion documents at
+   * length: unlinking first means the dangling state never exists, not even
+   * between two awaits, and not at all if the delete then fails.
+   */
+  const link: Link = req.scope.resolve(ContainerRegistrationKeys.LINK)
+  await link.delete({ [CONSUMPTION_LOG_MODULE]: { consumption_log_id: logId } })
 
   await service.deleteConsumptionLogs(logId)
 

--- a/apps/backend/src/api/admin/partners/[id]/people/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/people/route.ts
@@ -32,9 +32,28 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
   }
 
+  /*
+   * 🔴 `query.graph` returns a NULL in place of every link row whose target
+   * no longer exists, so a partner carrying four dangling `people` links
+   * answered `{"people":[null,null,null,null],"count":4}`. The admin's
+   * PartnerPeopleSection mapped over that and read `.id` off a null, which
+   * took the WHOLE partner detail page down — not the section, the page:
+   * "An unexpected error occurred while rendering this page". Measured on
+   * `01M1RHS2347F5D9MYBPF3AB5SS` locally. This is #1857's dangling link rows
+   * arriving at a reader that trusted the link table.
+   *
+   * The nulls are dropped rather than forwarded, and counted separately.
+   * `count` now means "people you can actually open", which is what every
+   * caller already assumed it meant. A link row is not a record — and
+   * `dangling` says so out loud instead of quietly shrinking the list.
+   */
+  const rows = (partner.people || []) as (Record<string, any> | null)[]
+  const people = rows.filter((p): p is Record<string, any> => !!p?.id)
+
   return res.json({
-    people: partner.people || [],
-    count: (partner.people || []).length,
+    people,
+    count: people.length,
+    dangling: rows.length - people.length,
   })
 }
 

--- a/apps/backend/src/api/admin/partners/[id]/person-types/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/person-types/route.ts
@@ -28,9 +28,25 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
   }
 
+  /*
+   * The same null-forwarding shape the `people` route carried, guarded before
+   * it can bite: `query.graph` answers with a null per link row whose target is
+   * gone, and any reader that maps over one and reads `.id` takes its page down
+   * rather than its section.
+   *
+   * ⚠️ Unlike the people route, this one is NOT verified against real data —
+   * `partner_partner_person_type_person_type` holds 0 rows locally, dangling or
+   * otherwise, so the guard could not be exercised. It is here because the
+   * shape is identical and the cost is a filter, not because it was seen to
+   * fire.
+   */
+  const rows = (partner.person_types || []) as (Record<string, any> | null)[]
+  const person_types = rows.filter((p): p is Record<string, any> => !!p?.id)
+
   return res.json({
-    person_types: partner.person_types || [],
-    count: (partner.person_types || []).length,
+    person_types,
+    count: person_types.length,
+    dangling: rows.length - person_types.length,
   })
 }
 

--- a/apps/backend/src/lib/graph/queues/index.ts
+++ b/apps/backend/src/lib/graph/queues/index.ts
@@ -1,0 +1,77 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+import type { Graph, NodeItem, SpineContext, SpineDescriptor } from "../types"
+import { productsAwaitingItems, resolveProductsAwaiting } from "./products-awaiting"
+
+/**
+ * QUEUES: graphs centred on a population rather than on one record (#1856).
+ *
+ * A queue is a spine whose `id` is the queue's NAME instead of a record id.
+ * That is the whole trick, and it is deliberate: `/admin/graph/queue/:key`
+ * already exists, `useEntityGraph("queue", key)` already exists, and the
+ * canvas, viewport, inspector, member drawer and node forms are all
+ * spine-agnostic and already take the spine key as a prop. A cohort board
+ * therefore costs a resolver and a registry entry — no route, no hook, no
+ * client change — which is the same claim the spine registry made and this is
+ * the test of it from a direction its author did not anticipate.
+ *
+ * 🔴 An unknown queue is a 404 naming the known ones, never an empty graph. An
+ * empty graph would be indistinguishable from "the queue is clear", and telling
+ * a reader their backlog is empty when they have merely mistyped it is the
+ * precise failure this whole feature exists to remove.
+ */
+type QueueDescriptor = {
+  key: string
+  label: string
+  resolve: (ctx: SpineContext) => Promise<Graph>
+  items?: (ctx: SpineContext, nodeKey: string) => Promise<NodeItem[]>
+  itemNodes?: string[]
+}
+
+const QUEUES: Record<string, QueueDescriptor> = {
+  "products-awaiting": {
+    key: "products-awaiting",
+    label: "Products awaiting creation",
+    resolve: resolveProductsAwaiting,
+    items: productsAwaitingItems,
+  },
+}
+
+export const QUEUE_KEYS = Object.keys(QUEUES)
+
+const queueOrThrow = (id: string): QueueDescriptor => {
+  const q = QUEUES[id]
+  if (!q) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Unknown queue "${id}". Known queues: ${QUEUE_KEYS.join(", ")}`
+    )
+  }
+  return q
+}
+
+/**
+ * The queue spine.
+ *
+ * `itemNodes` cannot be a fixed list here the way it is for a record spine: the
+ * nodes are `design:<id>`, one per member of the cohort, and their keys are not
+ * known until the graph is resolved. The route fills it from the resolved
+ * graph instead — see `SPINES.queue.resolve` below.
+ */
+export const queueSpine: SpineDescriptor = {
+  key: "queue",
+  label: "Queue",
+  resolve: async (ctx) => {
+    const graph = await queueOrThrow(ctx.id).resolve(ctx)
+    /*
+     * Every drawn node can list its members, so the drawer asks for all of
+     * them. Declared from the resolved graph rather than hard-coded, because
+     * the node keys are the cohort and the cohort changes with the data.
+     */
+    return { ...graph, itemNodes: graph.nodes.map((n) => n.key) }
+  },
+  items: async (ctx, nodeKey) => {
+    const q = queueOrThrow(ctx.id)
+    return q.items ? q.items(ctx, nodeKey) : []
+  },
+}

--- a/apps/backend/src/lib/graph/queues/products-awaiting.ts
+++ b/apps/backend/src/lib/graph/queues/products-awaiting.ts
@@ -1,0 +1,438 @@
+import { GraphBuilder, asArray, resolveExisting } from "../builder"
+import { runsAwaitingProduct, type RunLike } from "../spines/design/absence"
+import type { Graph, GraphNode, NodeItem, SpineContext } from "../types"
+import productDesignLink from "../../../links/product-design-link"
+
+/**
+ * "Products awaiting creation" — the first COHORT graph (#1856).
+ *
+ * Every spine so far centres on one record and asks which of its neighbours are
+ * missing. This asks the same question of a whole population: which finished
+ * work has no listing to sell it. That is the motivating absence of the entire
+ * feature — `production_run.approved_product_id` is written on approval and
+ * read by nothing, so a run that was never listed looks exactly like one that
+ * was — except that until now you could only see it one design at a time, which
+ * is no use for the thing it is actually for: working through the backlog.
+ *
+ * 🔴 IT SHARES THE DESIGN SPINE'S RULE, it does not restate it.
+ * `runsAwaitingProduct` is imported, not reimplemented. A board that disagreed
+ * with the design page about whether a run is owed a product would be the exact
+ * fault this whole feature exists to remove, and a second copy of a predicate is
+ * how that happens. Note the shared rule counts a run when it is FINISHED **or**
+ * explicitly approved — the two states `approve-run-output` writes the product
+ * id from. That is a small superset of "finished", and agreeing with the design
+ * page is worth more than the narrower reading.
+ *
+ * ## Why a node is a DESIGN and not a run
+ *
+ * The decision is per design, not per run: three finished runs of one design
+ * want one listing between them, and a node per run would ask the reader to
+ * make the same decision three times. The runs are a count on the node and one
+ * click away on its href.
+ *
+ * ## The state of a node is the whole point
+ *
+ *   absent  — nothing anywhere resembles a product for this design. The listing
+ *             has to be created.
+ *   derived — a product EXISTS and no run points at it: already linked to the
+ *             design, or sitting on a revision of it, or approved out of a
+ *             sibling run. `derived` is this codebase's word for "true only
+ *             through another record", which is exactly the case.
+ *
+ * That second state is why this is worth building rather than filtering a list.
+ * A list can say a run has no product. Only the neighbourhood can say that a
+ * product for it is already sitting on its parent revision — which is the
+ * difference between linking the listing that exists and minting a duplicate.
+ */
+
+/** How a candidate was reached. On the row, because it decides the action. */
+type Provenance =
+  | "linked to this design"
+  | "on a revision of this design"
+  | "approved from another run of this design"
+
+type Candidate = {
+  product_id: string
+  provenance: Provenance
+  /** The design it was reached through, when that is not this one. */
+  via_design_id: string | null
+}
+
+/**
+ * Nodes drawn at once.
+ *
+ * 🔴 Was 60, and 60 was WRONG — not marginally, uselessly. Rendered against the
+ * real cohort it produced two dense columns of thirty at 35% zoom, where no
+ * label could be read and the reader's only move was to zoom into one node at
+ * a time. The API was correct and the board was worthless, which is a
+ * distinction only a screenshot makes.
+ *
+ * A queue is a worklist, not an inventory. Eighteen fills the canvas at a
+ * legible size, and the spine says how many are behind it.
+ */
+const CAP = 18
+
+export const resolveProductsAwaiting = async ({
+  scope,
+}: SpineContext): Promise<Graph> => {
+  const query = scope.resolve("query")
+
+  /*
+   * Every run, then the shared predicate. Filtering in the query would mean
+   * encoding the rule in a `filters` object here as well as in `absence.ts` —
+   * a second copy of the very thing this file exists not to copy.
+   */
+  const { data: runRows } = await query.graph({
+    entity: "production_runs",
+    fields: [
+      "id",
+      "status",
+      "approval_decision",
+      "approved_product_id",
+      "design_id",
+      "finished_at",
+      "completed_at",
+      "updated_at",
+      "created_at",
+    ],
+  })
+
+  const allRuns = asArray<any>(runRows)
+  const awaiting = runsAwaitingProduct(allRuns as RunLike[]) as any[]
+
+  const byDesign = new Map<string, any[]>()
+  for (const r of awaiting) {
+    if (!r.design_id) continue
+    byDesign.set(r.design_id, [...(byDesign.get(r.design_id) ?? []), r])
+  }
+  const designIds = [...byDesign.keys()]
+
+  /*
+   * 🔴 A run's `design_id` is a plain column, not a link, so it can outlive the
+   * design it names. Resolve before drawing: a node for a design that does not
+   * exist is a queue item nobody can ever action, and this feature has already
+   * been bitten once by counting references instead of records (#1857).
+   */
+  const liveDesignIds = await resolveExisting(query, "design", designIds)
+  if (!liveDesignIds.length) {
+    return emptyGraph(awaiting.length, designIds.length)
+  }
+
+  const { data: designRows } = await query.graph({
+    entity: "design",
+    fields: ["id", "name", "status", "revised_from_id"],
+    filters: { id: liveDesignIds },
+  })
+  const designs = new Map(asArray<any>(designRows).map((d) => [d.id, d]))
+
+  /*
+   * The revision neighbourhood: the design each was revised FROM, and the
+   * designs revised from it. One hop each way — a product two revisions removed
+   * is a much weaker claim than "link this one", and walking an unbounded chain
+   * is a query per generation.
+   */
+  const { data: childRows } = await query.graph({
+    entity: "design",
+    fields: ["id", "name", "revised_from_id"],
+    filters: { revised_from_id: liveDesignIds },
+  })
+  const children = asArray<any>(childRows)
+
+  const lineage = new Map<string, string[]>()
+  for (const id of liveDesignIds) {
+    const rel = new Set<string>()
+    const parent = designs.get(id)?.revised_from_id
+    if (parent) rel.add(parent)
+    for (const c of children) {
+      if (c.revised_from_id === id && c.id) rel.add(c.id)
+    }
+    lineage.set(id, [...rel])
+  }
+
+  const lookupIds = [
+    ...new Set([...liveDesignIds, ...[...lineage.values()].flat()]),
+  ].filter(Boolean)
+
+  const { data: productLinks } = await query.graph({
+    entity: productDesignLink.entryPoint,
+    fields: ["product_id", "design_id"],
+    filters: { design_id: lookupIds },
+  })
+  const links = asArray<any>(productLinks)
+
+  // Products already approved out of OTHER runs of the same design.
+  const siblingProducts = new Map<string, Set<string>>()
+  const liveSet = new Set(liveDesignIds)
+  for (const r of allRuns) {
+    if (!r.approved_product_id || !r.design_id || !liveSet.has(r.design_id)) continue
+    siblingProducts.set(
+      r.design_id,
+      (siblingProducts.get(r.design_id) ?? new Set<string>()).add(r.approved_product_id)
+    )
+  }
+
+  // A link row is not a record, and neither is an `approved_product_id`.
+  const liveProductIds = new Set(
+    await resolveExisting(query, "product", [
+      ...new Set([
+        ...links.map((l) => l.product_id),
+        ...[...siblingProducts.values()].flatMap((s) => [...s]),
+      ]),
+    ].filter(Boolean))
+  )
+
+  const candidatesFor = (designId: string): Candidate[] => {
+    const out: Candidate[] = []
+    const seen = new Set<string>()
+    const add = (id: string, provenance: Provenance, via: string | null) => {
+      if (!id || !liveProductIds.has(id) || seen.has(id)) return
+      seen.add(id)
+      out.push({ product_id: id, provenance, via_design_id: via })
+    }
+    for (const l of links) {
+      if (l.design_id === designId) add(l.product_id, "linked to this design", null)
+    }
+    for (const pid of siblingProducts.get(designId) ?? []) {
+      add(pid, "approved from another run of this design", null)
+    }
+    for (const relId of lineage.get(designId) ?? []) {
+      for (const l of links) {
+        if (l.design_id === relId) add(l.product_id, "on a revision of this design", relId)
+      }
+    }
+    return out
+  }
+
+  /*
+   * Longest-waiting first, and the cap applies AFTER the sort — capping an
+   * arbitrary order would draw eighteen designs chosen by nothing, and quietly
+   * hide the one that has been finished and unsellable for a year behind
+   * seventeen from last week.
+   */
+  const ordered = [...liveDesignIds].sort((a, b) => {
+    const wa = daysSince(byDesign.get(a) ?? []) ?? -1
+    const wb = daysSince(byDesign.get(b) ?? []) ?? -1
+    if (wa !== wb) return wb - wa
+    return (byDesign.get(b)?.length ?? 0) - (byDesign.get(a)?.length ?? 0)
+  })
+
+  const builder = new GraphBuilder("queue")
+
+  for (const designId of ordered.slice(0, CAP)) {
+    const design = designs.get(designId)
+    const runs = byDesign.get(designId) ?? []
+    const candidates = candidatesFor(designId)
+    const waited = daysSince(runs)
+    const n = candidates.length
+
+    const node: GraphNode = {
+      key: `design:${designId}`,
+      type: "design_awaiting_product",
+      label: design?.name || designId,
+      sublabel: n
+        ? `${n} product${n === 1 ? "" : "s"} already exist${n === 1 ? "s" : ""}`
+        : `${runs.length} run${runs.length === 1 ? "" : "s"}, nothing to sell`,
+      state: n ? "derived" : "absent",
+      count: runs.length,
+      status: design?.status ?? null,
+      href: `/designs/${designId}/production-runs`,
+      props: [
+        { key: "runs awaiting", value: String(runs.length) },
+        ...(waited != null
+          ? [{ key: "waiting", value: `${waited} day${waited === 1 ? "" : "s"}` }]
+          : []),
+        ...(design?.status
+          ? [{ key: "design status", value: String(design.status) }]
+          : []),
+        ...(n ? [{ key: "candidate products", value: String(n) }] : []),
+      ],
+      action: {
+        label: n ? "Review the product that exists" : "Create the product",
+        href: `/designs/${designId}/graph`,
+      },
+    }
+
+    builder.push(node, {
+      label: "approved_product_id",
+      state: node.state,
+      reason: n
+        ? `Finished, and no run points at a product — but ${n === 1 ? "one exists" : "products exist"} already. Link rather than mint a second listing.`
+        : "Finished work with no listing anywhere. Nothing can be sold from it.",
+    })
+  }
+
+  return builder.build({
+    key: "queue",
+    type: "queue",
+    label: "Products awaiting creation",
+    sublabel: `${awaiting.length} finished run${awaiting.length === 1 ? "" : "s"} across ${liveDesignIds.length} design${liveDesignIds.length === 1 ? "" : "s"}`,
+    state: "present",
+    count: awaiting.length,
+    status: null,
+    href: null,
+    props: [
+      { key: "runs awaiting", value: String(awaiting.length) },
+      { key: "designs", value: String(liveDesignIds.length) },
+      ...(liveDesignIds.length > CAP
+        ? [
+            {
+              key: "shown",
+              value: `${CAP} of ${liveDesignIds.length}, longest waiting first`,
+            },
+          ]
+        : []),
+      /*
+       * Said out loud rather than quietly dropped. A run naming a design that
+       * no longer exists is itself worth knowing, and a queue whose total does
+       * not match the nodes it draws is the kind of small lie that costs a
+       * later session an afternoon.
+       */
+      ...(designIds.length !== liveDesignIds.length
+        ? [
+            {
+              key: "skipped",
+              value: `${designIds.length - liveDesignIds.length} design(s) named by a run no longer exist`,
+            },
+          ]
+        : []),
+    ],
+    action: null,
+  })
+}
+
+const emptyGraph = (runCount: number, namedDesigns: number): Graph =>
+  new GraphBuilder("queue").build({
+    key: "queue",
+    type: "queue",
+    label: "Products awaiting creation",
+    sublabel: runCount
+      ? "every finished run names a design that no longer exists"
+      : "nothing is waiting",
+    state: "present",
+    count: runCount,
+    status: null,
+    href: null,
+    props: [
+      { key: "runs awaiting", value: String(runCount) },
+      { key: "designs named", value: String(namedDesigns) },
+    ],
+    action: null,
+  })
+
+/** Whole days since the most recent of these runs last moved. */
+const daysSince = (runs: any[]): number | null => {
+  const stamps = runs
+    .map((r) => r.finished_at || r.completed_at || r.updated_at || r.created_at)
+    .map((v) => (v ? new Date(v).getTime() : NaN))
+    .filter((n) => Number.isFinite(n))
+  return stamps.length ? Math.floor((Date.now() - Math.max(...stamps)) / 86_400_000) : null
+}
+
+/**
+ * The candidate products behind one design node — the answer to "what already
+ * exists", which is what decides whether this is a create or a link. Every row
+ * says HOW it was reached, because a product on a parent revision and a product
+ * already linked to this very design call for different actions.
+ */
+export const productsAwaitingItems = async (
+  ctx: SpineContext,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const designId = nodeKey.startsWith("design:") ? nodeKey.slice("design:".length) : null
+  if (!designId) return []
+
+  const query = ctx.scope.resolve("query")
+
+  const [{ data: ownLinks }, { data: designRows }, { data: runRows }, { data: childRows }] =
+    await Promise.all([
+      query.graph({
+        entity: productDesignLink.entryPoint,
+        fields: ["product_id", "design_id"],
+        filters: { design_id: [designId] },
+      }),
+      query.graph({
+        entity: "design",
+        fields: ["id", "revised_from_id"],
+        filters: { id: [designId] },
+      }),
+      query.graph({
+        entity: "production_runs",
+        fields: ["id", "approved_product_id"],
+        filters: { design_id: [designId] },
+      }),
+      query.graph({
+        entity: "design",
+        fields: ["id", "name"],
+        filters: { revised_from_id: [designId] },
+      }),
+    ])
+
+  const parentId = asArray<any>(designRows)[0]?.revised_from_id ?? null
+  const relatedIds = [parentId, ...asArray<any>(childRows).map((c) => c.id)].filter(
+    Boolean
+  ) as string[]
+
+  const { data: relatedLinks } = relatedIds.length
+    ? await query.graph({
+        entity: productDesignLink.entryPoint,
+        fields: ["product_id", "design_id"],
+        filters: { design_id: relatedIds },
+      })
+    : { data: [] }
+
+  const entries: Array<{ id: string; provenance: Provenance; via: string | null }> = []
+  const seen = new Set<string>()
+  const add = (id: string, provenance: Provenance, via: string | null) => {
+    if (!id || seen.has(id)) return
+    seen.add(id)
+    entries.push({ id, provenance, via })
+  }
+  for (const l of asArray<any>(ownLinks)) add(l.product_id, "linked to this design", null)
+  for (const r of asArray<any>(runRows)) {
+    if (r.approved_product_id) {
+      add(r.approved_product_id, "approved from another run of this design", null)
+    }
+  }
+  for (const l of asArray<any>(relatedLinks)) {
+    add(l.product_id, "on a revision of this design", l.design_id)
+  }
+  if (!entries.length) return []
+
+  const live = new Set(
+    await resolveExisting(
+      query,
+      "product",
+      entries.map((e) => e.id)
+    )
+  )
+  const { data: products } = await query.graph({
+    entity: "product",
+    fields: ["id", "title", "status", "handle"],
+    filters: { id: [...live] },
+  })
+  const byId = new Map(asArray<any>(products).map((p) => [p.id, p]))
+
+  return entries
+    .filter((e) => live.has(e.id))
+    .map((e) => {
+      const p = byId.get(e.id)
+      return {
+        id: e.id,
+        label: p?.title || e.id,
+        sublabel: e.provenance,
+        status: p?.status ?? null,
+        href: `/products/${e.id}`,
+        props: [
+          ...(p?.handle ? [{ key: "handle", value: String(p.handle) }] : []),
+          ...(e.via ? [{ key: "via design", value: String(e.via) }] : []),
+        ],
+        /*
+         * 🔴 No removal. These are CANDIDATES for this node, not members of it —
+         * reached from a revision or a sibling run — and a "remove" here would
+         * offer to unlink somebody else's listing from a design the reader is
+         * not looking at.
+         */
+        remove: null,
+      }
+    })
+}

--- a/apps/backend/src/lib/graph/registry.ts
+++ b/apps/backend/src/lib/graph/registry.ts
@@ -1,5 +1,6 @@
 import { MedusaError } from "@medusajs/framework/utils"
 
+import { queueSpine } from "./queues"
 import { designSpine } from "./spines/design"
 import { partnerSpine } from "./spines/partner"
 import { socialPlatformSpine } from "./spines/social-platform"
@@ -23,6 +24,13 @@ export const SPINES: Record<string, SpineDescriptor> = {
   [partnerSpine.key]: partnerSpine,
   [websiteSpine.key]: websiteSpine,
   [socialPlatformSpine.key]: socialPlatformSpine,
+  /*
+   * The queue spine is centred on a POPULATION, not a record: its `id` is the
+   * queue's name. It sits in this same registry on purpose — every surface
+   * downstream (route, hook, canvas, drawer) is spine-agnostic, so a cohort
+   * board needs no route and no client change of its own.
+   */
+  [queueSpine.key]: queueSpine,
 }
 
 export const SPINE_KEYS = Object.keys(SPINES)
@@ -54,7 +62,18 @@ export const resolveGraph = async (
    * `itemNodes` disagreed with its `items()` would render drawers that fetch
    * nothing, or nodes whose rows exist and are never asked for.
    */
-  return { ...graph, itemNodes: spine.itemNodes ?? [] }
+  /*
+   * 🔴 The spine's declaration wins, and the RESOLVER's is the fallback — it
+   * used to be `?? []`, which silently discarded anything a resolver set.
+   * A record spine knows its listable nodes up front and declares them here.
+   * A QUEUE cannot: its nodes are `design:<id>`, one per member of a cohort
+   * that does not exist until the graph is built, so it fills `itemNodes` from
+   * the graph it just resolved. Overwriting that with `[]` left every node in
+   * the queue with a drawer that would never ask for its rows — and, because
+   * "no members" and "not loaded" look identical on screen, it would have
+   * looked like a queue whose designs simply had no candidate products.
+   */
+  return { ...graph, itemNodes: spine.itemNodes ?? graph.itemNodes ?? [] }
 }
 
 /**

--- a/apps/backend/src/workflows/ai/approve-id-extraction-batch.ts
+++ b/apps/backend/src/workflows/ai/approve-id-extraction-batch.ts
@@ -227,11 +227,44 @@ const approveItemsStep = createStep(
 
     return new StepResponse(
       { batch_id: input.batch_id, approved, skipped, results },
-      { created_person_ids }
+      { created_person_ids, partner_id: batch.partner_id ?? null }
     );
   },
-  async (undo: { created_person_ids: string[] } | undefined, { container }) => {
+  /*
+   * 🔴 DISMISS THE LINKS BEFORE DELETING THE PEOPLE.
+   *
+   * This compensation used to call `deletePeople` alone — a HARD delete — on
+   * people this step had already linked to the partner above. The person rows
+   * went; the link rows stayed. That is a machine for producing exactly the
+   * shape #1857 describes: a link table pointing at records that do not exist.
+   *
+   * It is not a bookkeeping detail. Four such rows on one partner made
+   * `GET /admin/partners/:id/people` answer `[null,null,null,null]` and took
+   * the entire partner detail page down in the admin. The reader is guarded
+   * now, but a reader-side guard does not stop the rows appearing — this does.
+   *
+   * Dismissal is best-effort and per-person: a link that was never created
+   * (the `link_error` path above) must not abort the rollback of the ones that
+   * were, and a failed dismissal must not leave the people behind either.
+   */
+  async (
+    undo: { created_person_ids: string[]; partner_id: string | null } | undefined,
+    { container }
+  ) => {
     if (!undo?.created_person_ids?.length) return;
+
+    if (undo.partner_id) {
+      const link: Link = container.resolve(ContainerRegistrationKeys.LINK);
+      for (const personId of undo.created_person_ids) {
+        await link
+          .dismiss({
+            [PARTNER_MODULE]: { partner_id: undo.partner_id },
+            [PERSON_MODULE]: { person_id: personId },
+          })
+          .catch(() => {});
+      }
+    }
+
     const service: any = container.resolve(PERSON_MODULE);
     await service.deletePeople(undo.created_person_ids).catch(() => {});
   }

--- a/apps/backend/src/workflows/delete-person.ts
+++ b/apps/backend/src/workflows/delete-person.ts
@@ -5,6 +5,8 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import type { Link } from "@medusajs/framework/modules-sdk";
 import PersonService from "../modules/person/service";
 import { PERSON_MODULE } from "../modules/person";
 import { InferTypeOf } from "@medusajs/framework/types";
@@ -60,10 +62,55 @@ export const deletePersonStep = createStep(
   },
 );
 
+/**
+ * Dismiss the links a deleted person still sits in.
+ *
+ * 🔴 SOFT DELETE IS THE DANGEROUS ONE, because it is the ordinary one.
+ *
+ * `softDeletePeople` sets `deleted_at` and leaves every link row live. That is
+ * not a cosmetic leftover: soft-deleted records are excluded from query results
+ * unless `withDeleted: true` is passed, so `query.graph` answers with a NULL in
+ * the person's place while the link row goes on asserting that somebody is
+ * there. A reader that maps over that list and reads `.id` off the null takes
+ * its whole page down — measured on the partner detail page, which died
+ * outright rather than losing a section (#1857).
+ *
+ * Demonstrated end to end before this step existed: link a person to a partner,
+ * DELETE /admin/persons/:id, and GET /admin/partners/:id/people came back with
+ * a null in the list and a count of one. One ordinary deletion was enough.
+ *
+ * `Link.delete` is the cascade form — it soft-deletes every link row pointing at
+ * these persons across every module, so this does not need to know which
+ * modules link to a person. Its inverse, `Link.restore`, is the compensation:
+ * the step above puts the person back, and a restored person with its links
+ * still dismissed would be a quieter version of the same lie.
+ */
+const dismissPersonLinksStep = createStep(
+  "dismiss-person-links-step",
+  async (input: DeletePersonStepInput, { container }) => {
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK);
+    await link.delete({ [PERSON_MODULE]: { person_id: input.id } });
+    return new StepResponse({ person_id: input.id }, { person_id: input.id });
+  },
+  async (undo: { person_id: string } | undefined, { container }) => {
+    if (!undo?.person_id) return;
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK);
+    await link
+      .restore({ [PERSON_MODULE]: { person_id: undo.person_id } })
+      .catch(() => {});
+  },
+);
+
 const deletePersonWorkflow = createWorkflow(
   "delete-person",
   (input: DeletePersonStepInput) => {
     const deleted = deletePersonStep(input);
+    /*
+     * After the person, not before: a failure here compensates by restoring the
+     * links AND recreating the person, whereas dismissing first would leave a
+     * window where the roster is short and the person is still there.
+     */
+    dismissPersonLinksStep(input);
     return new WorkflowResponse(deleted);
   },
 );

--- a/apps/backend/src/workflows/designs/delete-design.ts
+++ b/apps/backend/src/workflows/designs/delete-design.ts
@@ -9,6 +9,7 @@ import {
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { dismissRemoteLinkStep } from "@medusajs/medusa/core-flows";
 import type { LinkDefinition } from "@medusajs/framework/types";
+import type { Link } from "@medusajs/framework/modules-sdk";
 import DesignService from "../../modules/designs/service";
 import { DESIGN_MODULE } from "../../modules/designs";
 import { PARTNER_MODULE } from "../../modules/partner";
@@ -59,6 +60,33 @@ type DeleteDesignWorkFlowInput = {
   id: string;
 };
 
+
+/**
+ * Dismiss every link this design sits in (#1857).
+ *
+ * A soft-deleted design is excluded from query results, so every surviving link
+ * row expands to a NULL for its readers rather than to a design.
+ *
+ * `Link.delete` is the CASCADE form: it dismisses link rows across every module
+ * that links to this one, so nothing here has to enumerate them — the failure
+ * mode of naming links one at a time is that the file then LOOKS handled while
+ * the unnamed ones keep leaking. `Link.restore` is the inverse, and runs as the
+ * compensation so a restored record does not come back stripped of its links.
+ */
+const dismissDesignLinksStep = createStep(
+  "dismissDesignLinksStep",
+  async (input: { id: string }, { container }) => {
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK);
+    await link.delete({ [DESIGN_MODULE]: { design_id: input.id } });
+    return new StepResponse({ id: input.id }, { id: input.id });
+  },
+  async (undo: { id: string } | undefined, { container }) => {
+    if (!undo?.id) return;
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK);
+    await link.restore({ [DESIGN_MODULE]: { design_id: undo.id } }).catch(() => {});
+  },
+);
+
 export const deleteDesignWorkflow = createWorkflow(
   "delete-design",
   (input: DeleteDesignWorkFlowInput) => {
@@ -82,6 +110,16 @@ export const deleteDesignWorkflow = createWorkflow(
     });
 
     const result = deleteDesignStep(input);
+
+    /*
+     * 🔴 The partner link above was dismissed BY NAME, and a design sits in
+     * twenty link tables. Naming one is what made this look solved: prod
+     * carries designs whose task, inventory and customer links outlived them —
+     * 8 rows across three tables — plus one in the very table the step above
+     * handles. This sweeps the rest by cascade.
+     */
+    dismissDesignLinksStep({ id: input.id });
+
     return new WorkflowResponse(result);
   },
 );

--- a/apps/backend/src/workflows/internal_payments/delete-payment.ts
+++ b/apps/backend/src/workflows/internal_payments/delete-payment.ts
@@ -4,6 +4,8 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import type { Link } from "@medusajs/framework/modules-sdk";
 import { INTERNAL_PAYMENTS_MODULE } from "../../modules/internal_payments";
 import PaymentService from "../../modules/internal_payments/service";
 
@@ -29,10 +31,38 @@ export const deletePaymentStep = createStep(
 
 export type DeletePaymentWorkflowInput = DeletePaymentStepInput;
 
+
+/**
+ * Dismiss every link this payment sits in (#1857).
+ *
+ * This one is a HARD delete, so the row is gone outright and every link to it points
+ * at nothing at all. Prod carries one such row on the partner ledger link — a
+ * partner's payment history counting an entry that cannot be opened.
+ *
+ * `Link.delete` is the CASCADE form — it dismisses link rows across every
+ * module that links to this one, so nothing here enumerates them. Naming links
+ * one at a time is what let the design workflow look solved while nineteen of
+ * its twenty link tables kept leaking. `Link.restore` is the compensation.
+ */
+const dismissPaymentLinksStep = createStep(
+  "dismissPaymentLinksStep",
+  async (input: { id: string }, { container }) => {
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK)
+    await link.delete({ [INTERNAL_PAYMENTS_MODULE]: { internal_payments_id: input.id } })
+    return new StepResponse({ id: input.id }, { id: input.id })
+  },
+  async (undo: { id: string } | undefined, { container }) => {
+    if (!undo?.id) return
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK)
+    await link.restore({ [INTERNAL_PAYMENTS_MODULE]: { internal_payments_id: undo.id } }).catch(() => {})
+  },
+)
+
 export const deletePaymentWorkflow = createWorkflow(
   "delete-payment",
   (input: DeletePaymentWorkflowInput) => {
     const result = deletePaymentStep(input);
+    dismissPaymentLinksStep({ id: input.id });
     return new WorkflowResponse(result);
   }
 );

--- a/apps/backend/src/workflows/partners/delete-partner.ts
+++ b/apps/backend/src/workflows/partners/delete-partner.ts
@@ -6,6 +6,7 @@ import {
 } from "@medusajs/framework/workflows-sdk"
 import { linkSalesChannelsToApiKeyWorkflow } from "@medusajs/medusa/core-flows"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/framework/modules-sdk"
 import { PARTNER_MODULE } from "../../modules/partner"
 import PartnerService from "../../modules/partner/service"
 import {
@@ -256,6 +257,40 @@ const softDeletePartnerStep = createStep(
   }
 )
 
+
+/**
+ * Dismiss every link this partner sits in (#1857).
+ *
+ * This workflow already unlinks publishable keys from sales channels, for exactly
+ * this reason — the 2026-08-21 orphan where a surviving key expanded to
+ * `sales_channels: [null]` and 404'd every storefront. The partner's OWN links got
+ * no such treatment: prod carries five live partner-region rows and a partner-store
+ * pair whose partner is soft-deleted.
+ *
+ * 🔴 Scoped to `partner_id` deliberately. The stores, channels and products this
+ * workflow also soft-deletes have their own links, many of them core-managed, and
+ * cascading those is a wider blast radius than the evidence asks for.
+ *
+ * `Link.delete` is the CASCADE form: it dismisses link rows across every module
+ * that links to this one, so nothing here has to enumerate them — the failure
+ * mode of naming links one at a time is that the file then LOOKS handled while
+ * the unnamed ones keep leaking. `Link.restore` is the inverse, and runs as the
+ * compensation so a restored record does not come back stripped of its links.
+ */
+const dismissPartnerLinksStep = createStep(
+  "dismissPartnerLinksStep",
+  async (input: { id: string }, { container }) => {
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK);
+    await link.delete({ [PARTNER_MODULE]: { partner_id: input.id } });
+    return new StepResponse({ id: input.id }, { id: input.id });
+  },
+  async (undo: { id: string } | undefined, { container }) => {
+    if (!undo?.id) return;
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK);
+    await link.restore({ [PARTNER_MODULE]: { partner_id: undo.id } }).catch(() => {});
+  },
+);
+
 /**
  * Soft-delete a partner and everything that is meaningless without it.
  *
@@ -276,6 +311,7 @@ export const deletePartnerWorkflow = createWorkflow(
 
     deletePartnerAdminsStep(input)
     softDeletePartnerStep(input)
+    dismissPartnerLinksStep({ id: input.id })
 
     // The plan is what the caller wants back: not just "deleted: true", but
     // exactly what travelled with the partner and what was deliberately left

--- a/apps/backend/src/workflows/payment_submissions/delete-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/delete-payment-submission.ts
@@ -4,7 +4,8 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/framework/modules-sdk"
 
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../modules/payment_submissions"
 import PaymentSubmissionsService from "../../modules/payment_submissions/service"
@@ -117,12 +118,41 @@ const softDeleteSubmissionStep = createStep(
   }
 )
 
+
+/**
+ * Dismiss every link this submission sits in (#1857).
+ *
+ * A Draft is soft-deleted here, on purpose — the run ids it claimed are evidence.
+ * But a soft-deleted submission is invisible to `query.graph`, so its links to the
+ * partner and to the designs it billed keep pointing at a NULL. Prod carries one
+ * such row in each of those two tables.
+ *
+ * `Link.delete` is the CASCADE form — it dismisses link rows across every
+ * module that links to this one, so nothing here enumerates them. Naming links
+ * one at a time is what let the design workflow look solved while nineteen of
+ * its twenty link tables kept leaking. `Link.restore` is the compensation.
+ */
+const dismissSubmissionLinksStep = createStep(
+  "dismissSubmissionLinksStep",
+  async (input: { id: string }, { container }) => {
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK)
+    await link.delete({ [PAYMENT_SUBMISSIONS_MODULE]: { payment_submission_id: input.id } })
+    return new StepResponse({ id: input.id }, { id: input.id })
+  },
+  async (undo: { id: string } | undefined, { container }) => {
+    if (!undo?.id) return
+    const link: Link = container.resolve(ContainerRegistrationKeys.LINK)
+    await link.restore({ [PAYMENT_SUBMISSIONS_MODULE]: { payment_submission_id: undo.id } }).catch(() => {})
+  },
+)
+
 export const deletePaymentSubmissionWorkflow = createWorkflow(
   "delete-payment-submission",
   (input: DeletePaymentSubmissionInput) => {
     const submission = validateSubmissionForDeleteStep(input)
 
     softDeleteSubmissionStep({ submission_id: input.submission_id })
+    dismissSubmissionLinksStep({ id: input.submission_id })
 
     return new WorkflowResponse({
       id: input.submission_id,


### PR DESCRIPTION
Six commits across **#1856** and **#1857**. Every claim below was measured, and the two that a screenshot disproved are called out as such.

---

## 1. The graph never opened in Desk — `4fd953bad`

The graph route was registered in **none** of the Desk entity configs. Inside a Desk panel, "Open workspace" landed on the recovery card:

> **Not available in Desk** — The Designs tab can't open `/designs/…/graph`.

Captured on the unmodified code first, so the check measures the fix and not the fixture.

Worse than a missing link: **#1859 retired the production-runs, inventory and bundled-design cards on the grounds that the graph does their job.** With the route absent from Desk, those capabilities left the workspace along with the cards — the step-3 stranding bug in a new disguise.

Designs, partners and websites now register the graph; designs also registers the three sub-pages the graph is the only route to (`/partners`, `/production-runs`, `/tasks`), because the run and task nodes drill into them and registering the graph alone would have moved the dead end one click later.

## 2. A dangling link killed the whole partner page — `0e457aaac`

```
GET /admin/partners/01M1RHS2347F5D9MYBPF3AB5SS/people
{"people":[null,null,null,null],"count":4}
```

`query.graph` returns a null per link row whose target is not visible, and `PartnerPeopleSection` read `.id` off it. Not the section — **the page**, in the full admin, not only in Desk. Found while trying to verify the partner graph in Desk: the card could never appear, because its page had already crashed.

Route drops the nulls and reports `dangling`; the hook filters again; the empty state **names** the discrepancy instead of rendering "No people linked" over four link rows.

## 3 & 4. Both producers of that null — `fcb081605`, `342b55322`

**Hard delete:** `approveIdExtractionBatchWorkflow` creates a person, links it to a partner, and its compensation called `deletePeople` alone. Rows go, links stay.

**Soft delete — the dangerous one, because it is the ordinary one:** soft-deleted records are excluded from query results unless `withDeleted: true`, so `softDeletePeople` leaves every link expanding to a null. Demonstrated end to end:

```
POST   /admin/partners/:id/people  -> {"count":1,"dangling":0}
DELETE /admin/persons/:id          -> {"deleted":true}     link row: STILL LIVE
GET    /admin/partners/:id/people  -> {"count":0,"dangling":1}   <- the null
after the fix                      -> link dismissed, dangling:0
```

Prod measures clean on this table (0 of 20, absent and soft-deleted alike). That is not reassurance — it means nobody has yet deleted a person who happens to be linked to a partner.

## 5. Five more delete paths — `c41609e4f`

The sweep's finding was not the workflows that ignore links. It was the one that **handles** them: `delete-design` dismisses links carefully, with a comment explaining why, and dismisses exactly **one of the twenty** link tables a design sits in, by name. It reads as solved, and prod carries 9 rows across four design link tables — including one in the very table that step handles.

`Link.delete` (cascade) replaces naming links one at a time, `Link.restore` compensates, ranked by prod evidence:

| path | links | prod rows |
|---|---|---|
| `delete-partner.ts` | 30 | 5 region, 2 store |
| `delete-design.ts` | 20 (1 handled) | 9 across 4 tables |
| consumption-logs `DELETE` | 3 | 1 in each of 3 |
| `delete-payment-submission.ts` | 5 | 1 in each of 2 |
| `delete-payment.ts` | 3 | 1 |

Verified red **and** green on scratch designs: with the step the task link is dismissed, without it the link stays live — reproducing the prod rows exactly.

## 6. The first cohort graph — `81e37f7ef`

**214 finished runs across 84 designs, none of them sellable.** `production_run.approved_product_id` is written on approval and read by nothing; until now that was visible one design at a time, which is no use for working through a backlog.

A queue is a spine whose `id` is the queue's **name**, so the route, hook, canvas, viewport, inspector and drawer needed no change — the claim the registry has made since #1847, tested from a direction it was not designed for.

`absent` = nothing anywhere resembles a product. `derived` = a product exists and no run points at it. The drawer names how each candidate was reached — *linked to this design*, *on a revision of this design*, *approved from another run of this design* — which is the difference between linking the listing that exists and minting a duplicate.

🔴 It **imports** `runsAwaitingProduct` from the design spine rather than restating it. A board that disagreed with the design page would be the exact fault this feature exists to remove.

**Two faults only rendering caught:** the first draft drew 60 nodes — two dense columns at 35% zoom, no label readable, API correct and board worthless (now 18, longest-waiting first, "18 of 84" on the spine). And `resolveGraph` overwrote `itemNodes` with `[]` after every resolve, which would have left every drawer silently never asking for its candidates.

Local data has **zero** cohort designs with a parent or child revision, so that branch could not fire at all. Forced `revised_from_id` on one design (snapshot taken first), confirmed `derived` + the provenance row, reverted to NULL, confirmed it returned to `absent`.

---

## Gate

`✓ Prod-config build passed.` — re-run after the final edit, 0 TS errors. Verified against a running server; note `medusa start` serves a prebuilt admin and needs a rebuild to show admin changes.

## Still open, deliberately

- 46 link table/column pairs in prod carry unresolvable references, largest `pricing_price_fx_rates_fx_price_meta` at 215 of 610. Readers are guarded in two routes only.
- `delete-partner` is scoped to `partner_id`; the stores, channels and products it also soft-deletes have core-managed links and a wider blast radius than the evidence asks for.
- `/websites/:id/pages` is emitted by the website spine and has no route anywhere in the admin (#1855).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4