### PR TITLE
fix(admin): restore persons select filters broken by sticky-URL change

### DIFF
--- a/apps/backend/src/admin/routes/persons/page.tsx
+++ b/apps/backend/src/admin/routes/persons/page.tsx
@@ -95,7 +95,11 @@ const PersonsPage = () => {
   const filtering: DataTableFilteringState = {};
   for (const f of ALL_FILTER_FIELDS) {
     const v = searchParams.get(f);
-    if (v) filtering[f] = v;
+    // `null` = filter absent. An empty-string value is a select filter that
+    // was added but has no value yet — it must stay visible (as `[]`) so the
+    // DataTable renders its chip and auto-opens the picker.
+    if (v === null) continue;
+    filtering[f] = v === "" ? [] : [v];
   }
 
   const sorting: SortingState = (() => {
@@ -135,8 +139,14 @@ const PersonsPage = () => {
       updateParams((p) => {
         for (const f of ALL_FILTER_FIELDS) p.delete(f);
         for (const [k, v] of Object.entries(newFilters)) {
-          const val = Array.isArray(v) ? v[0] : v;
-          if (typeof val === "string" && val !== "") p.set(k, val);
+          if (Array.isArray(v)) {
+            // Select filters arrive as string[]; an empty array is a just-added
+            // filter with no value, serialised as an empty param so the read
+            // side can reconstruct `[]` and keep the picker chip alive.
+            p.set(k, v[0] ?? "");
+          } else if (typeof v === "string" && v !== "") {
+            p.set(k, v);
+          }
         }
         resetPage(p);
       });


### PR DESCRIPTION
## What

Fixes a regression from #1852 (sticky URL filters) that broke the **select** filters on the Persons page while the boolean toggles kept working.

## Root cause

The #1852 refactor serialised the DataTable filter state through the URL query string, which broke two things the Medusa DataTable select filters rely on:

1. **Adding a filter** — Medusa's FilterMenu adds a select filter with an empty-array default (`onFilteringChange({ email: [] })`, i.e. "added but no value yet"). The write side did `v[0]` → `undefined` → dropped it from the URL, so the filter chip (and its auto-opening picker) never rendered.
2. **Selecting a value** — the read side reconstructed values as plain strings, but `DataTableFilterSelectContent` expects `string[]` (it does `filter.includes(...)` and `[...filter, value]`, which corrupt a string via substring matching / character-spreading).

## Fix

- Read side: reconstruct arrays — absent `null` → no filter, empty param → `[]`, set param → `[value]`.
- Write side: serialise arrays — `[]` → empty param, `["x"]` → `x`.

The backend `filterQuery` builder already handled arrays, so it was left unchanged.

## Verification

- `tsc --noEmit`: no errors in `persons/page.tsx`.