### PR TITLE
feat(census): weaver edits/changes in Hyperbee + read-time correction merge

### DIFF
--- a/apps/backend/src/admin/components/persons/weaver-edits-section.tsx
+++ b/apps/backend/src/admin/components/persons/weaver-edits-section.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from "react"
+import { XMark } from "@medusajs/icons"
+import { Button, Container, Heading, Input, Label, Text, toast } from "@medusajs/ui"
+
+import {
+  CorrectionEntry,
+  SocialMediaEntry,
+  useUpdateWeaverProperty,
+  useWeaverProperty,
+} from "../../hooks/api/person-properties"
+
+/**
+ * Admin "edit / changes" surface for a census weaver.
+ *
+ * Persists to the person_property record keyed by census_id (MikroHyperbee KV,
+ * append-only) — NOT the read-only census core. Three editable bags:
+ * social media, correction flags ("this census value is wrong"), and arbitrary
+ * custom fields.
+ */
+export const WeaverEditsSection = ({ censusId }: { censusId: string | number }) => {
+  const { data, isLoading } = useWeaverProperty(censusId)
+  const update = useUpdateWeaverProperty(censusId)
+
+  const prop = data?.person_property
+
+  const [socialMedia, setSocialMedia] = useState<SocialMediaEntry[]>([])
+  const [corrections, setCorrections] = useState<CorrectionEntry[]>([])
+  const [customFields, setCustomFields] = useState<Record<string, unknown>>({})
+
+  // Seed the drafts once the record loads (or is created). Keyed on the record
+  // id so a refetch after save does not clobber in-flight local edits.
+  useEffect(() => {
+    setSocialMedia(prop?.social_media ?? [])
+    setCorrections(prop?.corrections ?? [])
+    setCustomFields(prop?.custom_fields ?? {})
+  }, [prop?.id])
+
+  // ── social media draft ────────────────────────────────────────────────────
+  const [smPlatform, setSmPlatform] = useState("")
+  const [smHandle, setSmHandle] = useState("")
+  const [smUrl, setSmUrl] = useState("")
+  const addSocial = () => {
+    if (!smPlatform.trim()) return
+    setSocialMedia((prev) => [
+      ...prev,
+      { platform: smPlatform.trim(), handle: smHandle.trim() || undefined, url: smUrl.trim() || undefined },
+    ])
+    setSmPlatform(""); setSmHandle(""); setSmUrl("")
+  }
+
+  // ── correction draft ──────────────────────────────────────────────────────
+  const [corrField, setCorrField] = useState("")
+  const [corrNote, setCorrNote] = useState("")
+  const [corrValue, setCorrValue] = useState("")
+  const addCorrection = () => {
+    if (!corrField.trim()) return
+    setCorrections((prev) => [
+      ...prev,
+      {
+        field: corrField.trim(),
+        note: corrNote.trim() || undefined,
+        corrected_value: corrValue.trim() === "" ? undefined : corrValue.trim(),
+        corrected_at: new Date().toISOString(),
+      },
+    ])
+    setCorrField(""); setCorrNote(""); setCorrValue("")
+  }
+
+  // ── custom field draft ────────────────────────────────────────────────────
+  const [cfKey, setCfKey] = useState("")
+  const [cfValue, setCfValue] = useState("")
+  const addCustomField = () => {
+    if (!cfKey.trim()) return
+    setCustomFields((prev) => ({ ...prev, [cfKey.trim()]: cfValue.trim() }))
+    setCfKey(""); setCfValue("")
+  }
+
+  const save = async () => {
+    try {
+      await update.mutateAsync({
+        social_media: socialMedia,
+        corrections,
+        custom_fields: customFields,
+      })
+      toast.success("Weaver edits saved")
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to save edits")
+    }
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col px-6 py-4">
+        <Heading level="h2">Edits &amp; changes</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Your additions to this census record — stored with the census data, not the database
+        </Text>
+      </div>
+
+      {/* Social media */}
+      <div className="flex flex-col gap-y-3 px-6 py-4">
+        <Text size="small" weight="plus">Social media</Text>
+        {socialMedia.map((e, i) => (
+          <div key={i} className="flex items-center gap-x-2 text-sm">
+            <span className="font-medium">{e.platform}</span>
+            <span className="text-ui-fg-subtle">{e.handle || e.url || ""}</span>
+            <button
+              type="button"
+              className="text-ui-fg-muted hover:text-ui-fg-subtle"
+              onClick={() => setSocialMedia((prev) => prev.filter((_, j) => j !== i))}
+            >
+              <XMark />
+            </button>
+          </div>
+        ))}
+        <div className="grid grid-cols-[1fr_1fr_1fr_auto] gap-x-2">
+          <Input placeholder="Platform" value={smPlatform} onChange={(e) => setSmPlatform(e.target.value)} />
+          <Input placeholder="Handle" value={smHandle} onChange={(e) => setSmHandle(e.target.value)} />
+          <Input placeholder="URL" value={smUrl} onChange={(e) => setSmUrl(e.target.value)} />
+          <Button size="small" variant="secondary" type="button" onClick={addSocial}>Add</Button>
+        </div>
+      </div>
+
+      {/* Corrections */}
+      <div className="flex flex-col gap-y-3 px-6 py-4">
+        <Text size="small" weight="plus">Incorrect values</Text>
+        {corrections.map((c, i) => (
+          <div key={i} className="flex items-center gap-x-2 text-sm">
+            <span className="font-medium">{c.field}</span>
+            {c.corrected_value !== undefined ? (
+              <span className="text-ui-fg-subtle">→ {String(c.corrected_value)}</span>
+            ) : null}
+            {c.note ? <span className="text-ui-fg-subtle">({c.note})</span> : null}
+            <button
+              type="button"
+              className="text-ui-fg-muted hover:text-ui-fg-subtle"
+              onClick={() => setCorrections((prev) => prev.filter((_, j) => j !== i))}
+            >
+              <XMark />
+            </button>
+          </div>
+        ))}
+        <div className="grid grid-cols-[1fr_1fr_1fr_auto] gap-x-2">
+          <Input placeholder="Field" value={corrField} onChange={(e) => setCorrField(e.target.value)} />
+          <Input placeholder="Corrected value" value={corrValue} onChange={(e) => setCorrValue(e.target.value)} />
+          <Input placeholder="Note" value={corrNote} onChange={(e) => setCorrNote(e.target.value)} />
+          <Button size="small" variant="secondary" type="button" onClick={addCorrection}>Add</Button>
+        </div>
+      </div>
+
+      {/* Custom fields */}
+      <div className="flex flex-col gap-y-3 px-6 py-4">
+        <Text size="small" weight="plus">Custom fields</Text>
+        {Object.entries(customFields).map(([k, v]) => (
+          <div key={k} className="flex items-center gap-x-2 text-sm">
+            <span className="font-medium">{k}</span>
+            <span className="text-ui-fg-subtle">{String(v)}</span>
+            <button
+              type="button"
+              className="text-ui-fg-muted hover:text-ui-fg-subtle"
+              onClick={() =>
+                setCustomFields((prev) => {
+                  const next = { ...prev }
+                  delete next[k]
+                  return next
+                })
+              }
+            >
+              <XMark />
+            </button>
+          </div>
+        ))}
+        <div className="grid grid-cols-[1fr_1fr_auto] gap-x-2">
+          <Input placeholder="Key" value={cfKey} onChange={(e) => setCfKey(e.target.value)} />
+          <Input placeholder="Value" value={cfValue} onChange={(e) => setCfValue(e.target.value)} />
+          <Button size="small" variant="secondary" type="button" onClick={addCustomField}>Add</Button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-x-2 px-6 py-4">
+        {isLoading ? <Text size="small" className="text-ui-fg-subtle">Loading…</Text> : null}
+        <Button
+          size="small"
+          variant="primary"
+          type="button"
+          onClick={save}
+          isLoading={update.isPending}
+        >
+          Save changes
+        </Button>
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/person-properties.ts
+++ b/apps/backend/src/admin/hooks/api/person-properties.ts
@@ -1,0 +1,110 @@
+import { FetchError } from "@medusajs/js-sdk"
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+
+export type SocialMediaEntry = {
+  platform: string
+  handle?: string
+  url?: string
+}
+
+export type CorrectionEntry = {
+  field: string
+  note?: string
+  corrected_value?: unknown
+  corrected_at?: string
+  corrected_by?: string
+}
+
+export type WeaverProperty = {
+  id: string
+  profile_type?: string
+  census_id?: string | null
+  relation_to_head?: string | null
+  gender?: string | null
+  social_group?: string | null
+  religion?: string | null
+  region_state?: string | null
+  district?: string | null
+  own_looms?: boolean | null
+  total_looms_owned?: number | null
+  natural_dye_used?: boolean | null
+  sells_local_market?: boolean | null
+  sells_master_weaver?: boolean | null
+  sells_cooperative?: boolean | null
+  sells_ecommerce?: boolean | null
+  support_requirements?: string[] | null
+  social_media?: SocialMediaEntry[] | null
+  corrections?: CorrectionEntry[] | null
+  custom_fields?: Record<string, unknown> | null
+  metadata?: Record<string, unknown> | null
+}
+
+export type WeaverPropertyUpsert = Partial<
+  Pick<
+    WeaverProperty,
+    | "social_media"
+    | "corrections"
+    | "custom_fields"
+    | "support_requirements"
+    | "own_looms"
+    | "total_looms_owned"
+    | "natural_dye_used"
+    | "sells_local_market"
+    | "sells_master_weaver"
+    | "sells_cooperative"
+    | "sells_ecommerce"
+    | "gender"
+    | "social_group"
+    | "religion"
+    | "district"
+    | "region_state"
+  >
+>
+
+const PROPERTY_QUERY_KEY = ["person_properties", "by_census"] as const
+
+export const useWeaverProperty = (
+  censusId: string | number | undefined,
+  options?: Omit<
+    UseQueryOptions<{ person_property: WeaverProperty | null }, FetchError, { person_property: WeaverProperty | null }, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  return useQuery({
+    queryKey: [...PROPERTY_QUERY_KEY, censusId],
+    queryFn: async () =>
+      sdk.client.fetch<{ person_property: WeaverProperty | null }>(
+        `/admin/person-properties/by-census/${censusId}`
+      ),
+    enabled: censusId !== undefined && censusId !== null && censusId !== "",
+    ...options,
+  })
+}
+
+export const useUpdateWeaverProperty = (
+  censusId: string | number | undefined,
+  options?: UseMutationOptions<{ person_property: WeaverProperty }, FetchError, WeaverPropertyUpsert>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: WeaverPropertyUpsert) =>
+      sdk.client.fetch<{ person_property: WeaverProperty }>(
+        `/admin/person-properties/by-census/${censusId}`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: [...PROPERTY_QUERY_KEY, censusId] })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}

--- a/apps/backend/src/admin/routes/persons/weavers/[census_id]/page.tsx
+++ b/apps/backend/src/admin/routes/persons/weavers/[census_id]/page.tsx
@@ -6,6 +6,7 @@ import { TwoColumnPageSkeleton } from "../../../../components/table/skeleton"
 import { WeaverGeneralSection } from "../../../../components/persons/weaver-general-section"
 import { WeaverCensusSection } from "../../../../components/persons/weaver-census-section"
 import { WeaverRevealSection } from "../../../../components/persons/weaver-reveal-section"
+import { WeaverEditsSection } from "../../../../components/persons/weaver-edits-section"
 import { weaverLoader } from "./loader"
 
 const WeaverDetailPage = () => {
@@ -29,6 +30,7 @@ const WeaverDetailPage = () => {
       <TwoColumnPage.Main>
         <WeaverGeneralSection weaver={weaver} />
         <WeaverCensusSection weaver={weaver} />
+        <WeaverEditsSection censusId={census_id!} />
       </TwoColumnPage.Main>
       <TwoColumnPage.Sidebar>
         <WeaverRevealSection censusId={census_id!} />

--- a/apps/backend/src/api/admin/census/weavers/[census_id]/route.ts
+++ b/apps/backend/src/api/admin/census/weavers/[census_id]/route.ts
@@ -3,13 +3,19 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 import { CENSUS_MODULE } from "../../../../../modules/census"
 import type CensusModuleService from "../../../../../modules/census/service"
+import { PERSON_PROPERTY_MODULE } from "../../../../../modules/personproperty"
+import {
+  applyWeaverCorrections,
+  WeaverCorrection,
+} from "../../../../../modules/personproperty/lib/apply-weaver-corrections"
 
 /**
  * GET /admin/census/weavers/:census_id
  *
- * A single weaver's MASKED census record (PII-free — name/mobile/coords/religion
- * live only in the sensitive core, surfaced separately via …/unmask). Used by the
- * weaver detail view in the admin persons section.
+ * A single weaver's MASKED census record (PII-free), with any admin corrections
+ * overlayed at read time. The census core is never written to — corrections live
+ * as an appended list on the person_property record (keyed by census_id) and are
+ * applied here as a pure projection so the detail view shows corrected values.
  */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const census = req.scope.resolve(CENSUS_MODULE) as CensusModuleService
@@ -29,5 +35,21 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     )
   }
 
-  res.json({ weaver })
+  // Corrections are best-effort: a weaver with no person_property record (or a
+  // reader-mode where the property module is unavailable) simply has none.
+  let corrections: WeaverCorrection[] = []
+  try {
+    const propertyService: any = req.scope.resolve(PERSON_PROPERTY_MODULE)
+    const [property] = await propertyService.listAndCountPersonProperties(
+      { census_id: req.params.census_id },
+      { take: 1 }
+    )
+    corrections = (property?.corrections ?? []) as WeaverCorrection[]
+  } catch {
+    // no corrections — fall through with the raw record
+  }
+
+  const { weaver: effective, corrected_fields } = applyWeaverCorrections(weaver, corrections)
+
+  res.json({ weaver: effective, corrections, corrected_fields })
 }

--- a/apps/backend/src/api/admin/person-properties/by-census/[census_id]/route.ts
+++ b/apps/backend/src/api/admin/person-properties/by-census/[census_id]/route.ts
@@ -1,0 +1,41 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { PERSON_PROPERTY_MODULE } from "../../../../../modules/personproperty"
+
+/**
+ * Weaver "edit / changes" surface, addressed by census_id (the natural key).
+ *
+ * The weaver detail page is keyed by census_id (not a person id), so these
+ * routes resolve the person_property record the same way — a 1:1 upsert on
+ * `census_id`. The record lives in the MikroHyperbee KV store (append-only,
+ * keyed by census_id) when PERSON_PROPERTY_HYPERBEE=true; otherwise the Postgres
+ * fallback. Either way the wire contract is identical.
+ */
+
+// GET /admin/person-properties/by-census/:census_id — retrieve (or null)
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE)
+  const [person_property] = await service.listAndCountPersonProperties(
+    { census_id: req.params.census_id },
+    { take: 1 }
+  )
+  res.json({ person_property: person_property ?? null })
+}
+
+// POST /admin/person-properties/by-census/:census_id — upsert by census_id
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE)
+  const body = (req.validatedBody || {}) as Record<string, unknown>
+
+  const [existing] = await service.listAndCountPersonProperties(
+    { census_id: req.params.census_id },
+    { take: 1 }
+  )
+
+  const result = existing
+    ? await service.updatePersonProperties({ id: existing.id, ...body })
+    : await service.createPersonProperties({ census_id: req.params.census_id, ...body })
+
+  const person_property = Array.isArray(result) ? result[0] : result
+  res.status(existing ? 200 : 201).json({ person_property })
+}

--- a/apps/backend/src/api/admin/person-properties/validators.ts
+++ b/apps/backend/src/api/admin/person-properties/validators.ts
@@ -22,6 +22,27 @@ export const CreatePersonPropertySchema = z.object({
   sells_cooperative: z.boolean().nullish(),
   sells_ecommerce: z.boolean().nullish(),
   support_requirements: z.array(z.string()).nullish(),
+  social_media: z
+    .array(
+      z.object({
+        platform: z.string().min(1),
+        handle: z.string().optional(),
+        url: z.string().optional(),
+      })
+    )
+    .nullish(),
+  corrections: z
+    .array(
+      z.object({
+        field: z.string().min(1),
+        note: z.string().optional(),
+        corrected_value: z.unknown().optional(),
+        corrected_at: z.string().optional(),
+        corrected_by: z.string().optional(),
+      })
+    )
+    .nullish(),
+  custom_fields: z.record(z.string(), z.unknown()).nullish(),
   metadata: z.record(z.string(), z.unknown()).nullish(),
 });
 

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -4013,6 +4013,14 @@ export default defineMiddlewares({
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(CreatePersonPropertySchema))],
     },
+    // Weaver edits upsert, addressed by census_id. Registered BEFORE the `:id`
+    // matcher below: matching is prefix-based, so `:id` would otherwise claim
+    // this two-segment path.
+    {
+      matcher: "/admin/person-properties/by-census/:census_id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdatePersonPropertySchema))],
+    },
     {
       matcher: "/admin/person-properties/:id",
       method: "POST",

--- a/apps/backend/src/modules/personproperty/dal/hyperbee-person-property-service.ts
+++ b/apps/backend/src/modules/personproperty/dal/hyperbee-person-property-service.ts
@@ -43,6 +43,9 @@ export const personPropertyContract = defineContract("person_property", {
     sells_cooperative: { type: "boolean", nullable: true },
     sells_ecommerce: { type: "boolean", nullable: true },
     support_requirements: { type: "json", nullable: true },
+    social_media: { type: "json", nullable: true },
+    corrections: { type: "json", nullable: true },
+    custom_fields: { type: "json", nullable: true },
     metadata: { type: "json", nullable: true },
   },
   // The fields weavers are segmented by (equality secondary index).

--- a/apps/backend/src/modules/personproperty/lib/__tests__/apply-weaver-corrections.unit.spec.ts
+++ b/apps/backend/src/modules/personproperty/lib/__tests__/apply-weaver-corrections.unit.spec.ts
@@ -1,0 +1,48 @@
+import { applyWeaverCorrections } from "../apply-weaver-corrections"
+
+describe("applyWeaverCorrections", () => {
+  const weaver = {
+    census_id: 42,
+    name: "Mohd Shahid",
+    district: "SITAPUR",
+    own_looms: true,
+  }
+
+  it("overlays a correction onto an existing field", () => {
+    const { weaver: out, corrected_fields } = applyWeaverCorrections(weaver, [
+      { field: "own_looms", corrected_value: false },
+    ])
+    expect(out.own_looms).toBe(false)
+    expect(out.district).toBe("SITAPUR") // untouched
+    expect(corrected_fields).toEqual(["own_looms"])
+  })
+
+  it("adds a correction for a field not on the record", () => {
+    const { weaver: out, corrected_fields } = applyWeaverCorrections(weaver, [
+      { field: "yarn_source", corrected_value: "Bhilwara" },
+    ])
+    expect(out.yarn_source).toBe("Bhilwara")
+    expect(corrected_fields).toEqual(["yarn_source"])
+  })
+
+  it("skips corrections with no field or no value", () => {
+    const { weaver: out, corrected_fields } = applyWeaverCorrections(weaver, [
+      { field: "", corrected_value: "x" },
+      { field: "own_looms" },
+    ])
+    expect(out.own_looms).toBe(true)
+    expect(corrected_fields).toEqual([])
+  })
+
+  it("handles null/undefined corrections and a null weaver", () => {
+    expect(applyWeaverCorrections(weaver, null).corrected_fields).toEqual([])
+    expect(applyWeaverCorrections(weaver, undefined).corrected_fields).toEqual([])
+    expect(applyWeaverCorrections(null as any, []).weaver).toEqual({})
+  })
+
+  it("does not mutate the input record", () => {
+    const before = { ...weaver }
+    applyWeaverCorrections(weaver, [{ field: "district", corrected_value: "AMBALA" }])
+    expect(weaver.district).toBe(before.district)
+  })
+})

--- a/apps/backend/src/modules/personproperty/lib/apply-weaver-corrections.ts
+++ b/apps/backend/src/modules/personproperty/lib/apply-weaver-corrections.ts
@@ -1,0 +1,41 @@
+/**
+ * Read-time projection: overlay admin corrections onto a masked census weaver.
+ *
+ * The census record is never mutated — the correction list stays an appended
+ * list on the person_property record. This pure function produces the "effective
+ * weaver" for one render by spreading `corrected_value` over the record for each
+ * correction that names a field and carries a value.
+ *
+ * Same idea as partner-quote's `effectiveQuoteLines`: derived, never stored.
+ */
+
+export type WeaverCorrection = {
+  field: string
+  note?: string
+  corrected_value?: unknown
+  corrected_at?: string
+  corrected_by?: string
+}
+
+export type AppliedWeaverCorrections = {
+  /** The weaver record with corrections overlayed. */
+  weaver: Record<string, any>
+  /** Field names a correction actually overrode. */
+  corrected_fields: string[]
+}
+
+export function applyWeaverCorrections(
+  weaver: Record<string, any>,
+  corrections: WeaverCorrection[] | null | undefined
+): AppliedWeaverCorrections {
+  const merged = { ...(weaver ?? {}) }
+  const corrected_fields: string[] = []
+
+  for (const c of corrections ?? []) {
+    if (!c?.field || c.corrected_value === undefined) continue
+    merged[c.field] = c.corrected_value
+    corrected_fields.push(c.field)
+  }
+
+  return { weaver: merged, corrected_fields }
+}

--- a/apps/backend/src/modules/personproperty/migrations/Migration20260906140000.ts
+++ b/apps/backend/src/modules/personproperty/migrations/Migration20260906140000.ts
@@ -1,0 +1,36 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Add the admin "edit / changes" surface to person_property:
+ * `social_media`, `corrections`, `custom_fields` (all JSON).
+ *
+ * Hand-written, `add column if not exists` per the repo migration hazard note.
+ * The primary persistence is the MikroHyperbee KV store (append-only, keyed by
+ * census_id); these columns exist only so the flag-off Postgres fallback keeps
+ * parity with the contract and never drops the fields.
+ */
+export class Migration20260906140000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "person_property" add column if not exists "social_media" jsonb null;`
+    );
+    this.addSql(
+      `alter table if exists "person_property" add column if not exists "corrections" jsonb null;`
+    );
+    this.addSql(
+      `alter table if exists "person_property" add column if not exists "custom_fields" jsonb null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "person_property" drop column if exists "social_media";`
+    );
+    this.addSql(
+      `alter table if exists "person_property" drop column if exists "corrections";`
+    );
+    this.addSql(
+      `alter table if exists "person_property" drop column if exists "custom_fields";`
+    );
+  }
+}

--- a/apps/backend/src/modules/personproperty/models/person_property.ts
+++ b/apps/backend/src/modules/personproperty/models/person_property.ts
@@ -38,6 +38,16 @@ const PersonProperty = model.define("person_property", {
   // Support needs (array of labels)
   support_requirements: model.json().nullable(),
 
+  // ── Admin "edit / changes" surface (stored here, NOT in the read-only census
+  // core) ────────────────────────────────────────────────────────────────────
+  // Social handles, e.g. [{ platform: "instagram", handle: "@xyz", url: "…" }].
+  social_media: model.json().nullable(),
+  // Correction flags — append-only list of "this census field is wrong", e.g.
+  // [{ field: "own_looms", note: "…", corrected_value: false, corrected_at, corrected_by }].
+  corrections: model.json().nullable(),
+  // Arbitrary admin additions, e.g. { "yarn_source": "Bhilwara" }.
+  custom_fields: model.json().nullable(),
+
   metadata: model.json().nullable(),
 });
 


### PR DESCRIPTION
## What

Adds an admin `edit / changes` surface for census weavers, stored append-only in the **MikroHyperbee KV store** (keyed by `census_id`) rather than Postgres or the read-only shared census core.

## Backend

- `person_property` gains three JSON fields: `social_media`, `corrections`, `custom_fields` (DML model + MikroHyperbee contract + validators + migration).
- `GET`/`POST /admin/person-properties/by-census/:census_id` — 1:1 upsert on the natural `census_id` key (creates if absent, updates if present).
- `GET /admin/census/weavers/:census_id` now overlays corrections at **read time** via the pure `applyWeaverCorrections` projection — the append-only record is never mutated; the corrected view is derived per request and returned as `{ weaver, corrections, corrected_fields }`.

## Frontend

- `WeaverEditsSection` on the weaver detail page: social media, incorrect-value flags (field + corrected value + note), and custom key/value fields, with a Save action.
- `useWeaverProperty` / `useUpdateWeaverProperty` hooks.

## Notes

- Storage honors "not in the DB" only when `PERSON_PROPERTY_HYPERBEE=true` (the module currently defaults to Postgres when that flag is off).
- The UI section is currently inline (`Container`); a follow-up will move it to the idiomatic metadata-style `RouteDrawer`.

## Verification

- `tsc --noEmit`: clean on all touched files.
- Unit: `apply-weaver-corrections` (5 cases) pass; census reader (13) pass.