### PR TITLE
fix(census): weaver edits could never be saved — listAndCount returns a tuple (#1864)

### DIFF
--- a/apps/backend/integration-tests/http/weaver-census-property.spec.ts
+++ b/apps/backend/integration-tests/http/weaver-census-property.spec.ts
@@ -1,0 +1,128 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(120000)
+
+/**
+ * The weaver "edit / changes" routes, addressed by census_id (#1864).
+ *
+ * 🔴 These exist because #1864 shipped completely broken and nothing caught it.
+ * It had five unit tests, all of them on `applyWeaverCorrections` — the one
+ * layer that was correct. Nothing exercised a route, and the defect was in the
+ * wiring: `listAndCount*` returns `[rows, count]`, and all three call sites read
+ * the first element as if it were a record.
+ *
+ * On the POST that is not a mis-shaped response but a dead feature: `existing`
+ * was the row LIST, an empty array is TRUTHY, so the create branch could never
+ * run and the first save of every weaver answered
+ *
+ *   {"message":"PersonProperty with id \"\" not found"}   HTTP 404
+ *
+ * So the assertions below are deliberately about the SHAPE and the SEQUENCE
+ * rather than about correction semantics: that the first POST creates, that a
+ * second POST updates the same record rather than making another, and that GET
+ * answers with an object or null and never with an array. Each one of those
+ * fails on the code as merged.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  let auth: { headers: Record<string, string> }
+  /** Unique per test: the routes upsert on this natural key. */
+  let censusId: string
+
+  /*
+   * 🔴 Per TEST, not per file. The shared runner restores a database snapshot
+   * before every test, so an admin user created in `beforeAll` no longer exists
+   * by the time the second test runs and its perfectly well-formed bearer token
+   * answers 401 on every admin route — including ones that have nothing to do
+   * with this feature, which is how I established it was the user and not the
+   * route.
+   */
+  beforeEach(async () => {
+    await createAdminUser(getContainer())
+    auth = await getAuthHeaders(api)
+    censusId = `census-${Date.now()}-${Math.floor(Math.random() * 100000)}`
+  })
+
+  const url = (id: string) => `/admin/person-properties/by-census/${id}`
+
+  it("answers null — not an empty array — when no record exists", async () => {
+    const res = await api.get(url(censusId), auth)
+
+    expect(res.status).toEqual(200)
+    /*
+     * `toBeNull` alone would pass on `undefined`, and the bug produced `[]`,
+     * which is neither. Assert the absence AND that nothing array-shaped got
+     * through, because `[]` is exactly what a reader would treat as a record.
+     */
+    expect(res.data.person_property).toBeNull()
+    expect(Array.isArray(res.data.person_property)).toBe(false)
+  })
+
+  it("CREATES on the first save, and returns the record itself", async () => {
+    const res = await api.post(
+      url(censusId),
+      {
+        social_media: [{ platform: "instagram", handle: "@weaver" }],
+        corrections: [
+          { field: "district", corrected_value: "Bhilwara", note: "verified by phone" },
+        ],
+      },
+      auth
+    )
+
+    // 404 here is the merged behaviour: the create branch was unreachable.
+    expect(res.status).toEqual(201)
+    const prop = res.data.person_property
+    expect(Array.isArray(prop)).toBe(false)
+    expect(prop?.id).toBeTruthy()
+    expect(prop?.census_id).toEqual(censusId)
+    expect(prop?.social_media?.[0]?.platform).toEqual("instagram")
+    expect(prop?.corrections?.[0]?.corrected_value).toEqual("Bhilwara")
+  })
+
+  it("reads the created record back as an object", async () => {
+    await api.post(
+      url(censusId),
+      { custom_fields: { loom_type: "pit" } },
+      auth
+    )
+
+    const res = await api.get(url(censusId), auth)
+
+    expect(res.status).toEqual(200)
+    expect(Array.isArray(res.data.person_property)).toBe(false)
+    expect(res.data.person_property?.census_id).toEqual(censusId)
+    expect(res.data.person_property?.custom_fields?.loom_type).toEqual("pit")
+  })
+
+  it("UPDATES the same record on a second save rather than creating another", async () => {
+    const created = await api.post(
+      url(censusId),
+      { custom_fields: { loom_type: "pit" } },
+      auth
+    )
+    expect(created.status).toEqual(201)
+    const firstId = created.data.person_property?.id
+
+    const updated = await api.post(
+      url(censusId),
+      { custom_fields: { loom_type: "frame" } },
+      auth
+    )
+
+    /*
+     * 200, not 201: the route distinguishes them, and that distinction was
+     * meaningless while `existing` was always truthy. Same id is the real
+     * assertion — a second row under one census_id would break the 1:1
+     * upsert the whole surface is built on.
+     */
+    expect(updated.status).toEqual(200)
+    expect(updated.data.person_property?.id).toEqual(firstId)
+
+    const read = await api.get(url(censusId), auth)
+    expect(read.data.person_property?.id).toEqual(firstId)
+    expect(read.data.person_property?.custom_fields?.loom_type).toEqual("frame")
+  })
+})

--- a/apps/backend/src/admin/hooks/api/person-properties.ts
+++ b/apps/backend/src/admin/hooks/api/person-properties.ts
@@ -101,10 +101,23 @@ export const useUpdateWeaverProperty = (
         `/admin/person-properties/by-census/${censusId}`,
         { method: "POST", body: payload }
       ),
+    /*
+     * 🔴 `...options` goes BEFORE `onSuccess`, never after. Spread last it
+     * overwrites this handler with the caller's, the invalidation never runs,
+     * and the save works while the screen stays stale until a hard refresh —
+     * the defect that was live in 165 admin hooks (#1800).
+     */
+    ...options,
     onSuccess: (data, variables, _mutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: [...PROPERTY_QUERY_KEY, censusId] })
+      /*
+       * 🔴 And the census weaver too. `GET /admin/census/weavers/:id` overlays
+       * these corrections at read time, so it — not this query — is what shows
+       * the corrected value. Invalidating only the property left the very view
+       * the correction was written for displaying the old figure.
+       */
+      queryClient.invalidateQueries({ queryKey: ["census", "weaver", censusId] })
       options?.onSuccess?.(data, variables, _mutateResult, context)
     },
-    ...options,
   })
 }

--- a/apps/backend/src/api/admin/census/weavers/[census_id]/route.ts
+++ b/apps/backend/src/api/admin/census/weavers/[census_id]/route.ts
@@ -40,11 +40,18 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   let corrections: WeaverCorrection[] = []
   try {
     const propertyService: any = req.scope.resolve(PERSON_PROPERTY_MODULE)
-    const [property] = await propertyService.listAndCountPersonProperties(
+    /*
+     * 🔴 `listAndCount*` returns `[rows, count]`. Read as `[property]` this was
+     * an ARRAY, `property?.corrections` was undefined, and the overlay below
+     * silently applied nothing — the read-time correction, which is the whole
+     * point of this route, never once fired. The `catch` made it quieter still:
+     * there was no error to see, just a weaver that ignored its corrections.
+     */
+    const [rows] = await propertyService.listAndCountPersonProperties(
       { census_id: req.params.census_id },
       { take: 1 }
     )
-    corrections = (property?.corrections ?? []) as WeaverCorrection[]
+    corrections = (rows?.[0]?.corrections ?? []) as WeaverCorrection[]
   } catch {
     // no corrections — fall through with the raw record
   }

--- a/apps/backend/src/api/admin/person-properties/by-census/[census_id]/route.ts
+++ b/apps/backend/src/api/admin/person-properties/by-census/[census_id]/route.ts
@@ -15,11 +15,20 @@ import { PERSON_PROPERTY_MODULE } from "../../../../../modules/personproperty"
 // GET /admin/person-properties/by-census/:census_id — retrieve (or null)
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE)
-  const [person_property] = await service.listAndCountPersonProperties(
+  /*
+   * 🔴 `listAndCount*` returns a TUPLE — `[rows, count]` — so the first element
+   * is the ROW LIST, not a row. Destructured as one record this answered
+   * `{"person_property":[]}`: an array where the client's type says
+   * `WeaverProperty | null`, never null even when nothing exists, and never the
+   * object when something does. `WeaverEditsSection` then read
+   * `prop?.social_media` and `prop?.id` off an array — both undefined — so the
+   * form stayed empty and its seeding effect never re-ran.
+   */
+  const [rows] = await service.listAndCountPersonProperties(
     { census_id: req.params.census_id },
     { take: 1 }
   )
-  res.json({ person_property: person_property ?? null })
+  res.json({ person_property: rows?.[0] ?? null })
 }
 
 // POST /admin/person-properties/by-census/:census_id — upsert by census_id
@@ -27,10 +36,22 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE)
   const body = (req.validatedBody || {}) as Record<string, unknown>
 
-  const [existing] = await service.listAndCountPersonProperties(
+  /*
+   * 🔴 The same tuple, and here it did not merely mis-shape a response — it
+   * made the feature impossible to use. `existing` was the row list, and an
+   * EMPTY ARRAY IS TRUTHY, so the create branch was unreachable and every
+   * first save went to update with `id: undefined`:
+   *
+   *   POST /admin/person-properties/by-census/VERIFY-1864-A
+   *   {"message":"PersonProperty with id \"\" not found"}   HTTP 404
+   *
+   * Measured against a running server. No weaver edit could ever be saved.
+   */
+  const [rows] = await service.listAndCountPersonProperties(
     { census_id: req.params.census_id },
     { take: 1 }
   )
+  const existing = rows?.[0]
 
   const result = existing
     ? await service.updatePersonProperties({ id: existing.id, ...body })


### PR DESCRIPTION
Follow-up to **#1864**, which merged and **does not work at all**. One root cause in three places, plus two latent issues in the hook.

`listAndCount*` returns `[rows, count]`. Each call site read the first element as if it were a record.

## 1. The POST could never create anything

`existing` was the row LIST, and **an empty array is truthy** — so the create branch was unreachable and every first save went to update with `id: undefined`. Measured against a running server:

```
POST /admin/person-properties/by-census/VERIFY-1864-A
{"message":"PersonProperty with id \"\" not found"}   HTTP 404
```

No weaver edit — social media, correction, or custom field — could be saved. Ever.

## 2. The GET answered with an array

```
GET /admin/person-properties/by-census/VERIFY-1864-A  ->  {"person_property":[]}
```

Never `null` when absent, never the object when present. The hook types it `WeaverProperty | null`; `WeaverEditsSection` reads `prop?.social_media` and keys its seeding effect on `prop?.id` — both `undefined` on an array — so the form could not have populated even once a record existed.

## 3. The read-time overlay never fired

`property?.corrections` off an array is `undefined`, so `applyWeaverCorrections` always returned the record unchanged and `corrected_fields` was always `[]`. That projection is the headline of #1864 and it had **never once run**. The `catch` around it completed the silence: no error, just a weaver ignoring its corrections.

## 4 & 5. Two more in the hook

`...options` was spread **after** `onSuccess`, overwriting the invalidation with the caller's handler — the defect that was live in 165 admin hooks (#1800). Latent only because today's single caller passes none.

And the save invalidated the property query but **not** `["census","weaver",id]` — the query that carries the corrected view. Fixing the destructures alone would have given you a save that works and a corrected value that doesn't appear until a refresh.

## The test that would have caught it

#1864 shipped with five unit tests, all on `applyWeaverCorrections` — the one layer that was correct. **Nothing exercised a route.**

The new HTTP spec asserts shape and sequence, which is where the defect lived: GET answers `null` and never an array; the first POST **creates** (201) and returns the record; a second POST **updates the same id** (200); the record reads back as an object.

```
against the merged code:  4 failed   (Received: [])
against this branch:      4 passed
```

## Gate

`✓ Prod-config build passed.`, 0 TS errors.

## Untouched

`applyWeaverCorrections` itself is genuinely pure and correctly tested; the migration is careful (hand-written, `add column if not exists`, unique name, `down` drops only its own three columns); the middleware is registered with `wrapSchema` and correctly ordered before the `:id` matcher. One cosmetic thing left alone: two corrections naming the same field push that field into `corrected_fields` twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4