### PR TITLE
feat(admin/ops): the partner spine acts on its own absences, 15 readers stop trusting link rows, and the #1857 sweep learns what a tombstone is (#1856, #1857)

### DIFF
--- a/apps/backend/src/admin/components/creates/create-partner-admin.tsx
+++ b/apps/backend/src/admin/components/creates/create-partner-admin.tsx
@@ -1,0 +1,169 @@
+import { useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { Button, Heading, Input, Select, Text, toast } from "@medusajs/ui"
+
+import { useModalChrome } from "../modal/chrome/use-modal-chrome"
+import {
+  partnersQueryKeys,
+  useAddPartnerAdmin,
+} from "../../hooks/api/partners-admin"
+
+/**
+ * Create an admin for a partner.
+ *
+ * Lifted out of the drawer inside `PartnerAdminsSection` so the partner graph
+ * can open the same form the section does — chrome and "done" come from
+ * whichever shell wraps it (#1856).
+ *
+ * 🔴 This is the form behind the partner spine's loudest absence. A partner
+ * with no admin has *nobody who can sign in*, so a dispatch to them is
+ * recorded as successful and then stops dead. Until this was registered, the
+ * absent `admins` node's only affordance was an action card pointing at
+ * `/partners/:id` — the page the graph is already on, which from inside the
+ * workspace tears the graph down to arrive where you already were.
+ */
+export const AddPartnerAdminForm = ({ partnerId }: { partnerId: string }) => {
+  const Chrome = useModalChrome()
+  const queryClient = useQueryClient()
+
+  const [email, setEmail] = useState("")
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [phone, setPhone] = useState("")
+  const [role, setRole] = useState<"admin" | "manager" | "owner">("admin")
+  const [password, setPassword] = useState("")
+
+  const { mutateAsync: addAdmin, isPending } = useAddPartnerAdmin(partnerId)
+
+  const handleAdd = async () => {
+    if (!email.trim()) {
+      toast.error("Email is required")
+      return
+    }
+    try {
+      const result = await addAdmin({
+        email: email.trim(),
+        first_name: firstName.trim() || undefined,
+        last_name: lastName.trim() || undefined,
+        phone: phone.trim() || undefined,
+        role,
+        password: password || undefined,
+      })
+      toast.success("Admin added", {
+        description: `Welcome email sent to ${email}.${
+          result.temp_password ? ` Temp password: ${result.temp_password}` : ""
+        }`,
+      })
+      await queryClient.invalidateQueries({
+        queryKey: partnersQueryKeys.details(),
+      })
+      Chrome.onDone()
+    } catch (e: any) {
+      toast.error("Failed to add admin", {
+        description: e?.message || "Could not create admin",
+      })
+    }
+  }
+
+  return (
+    <>
+      <Chrome.Header>
+        <div>
+          <Chrome.Title asChild>
+            <Heading>Add admin</Heading>
+          </Chrome.Title>
+          <Text size="small" className="text-ui-fg-subtle">
+            They receive a welcome email with login credentials.
+          </Text>
+        </div>
+      </Chrome.Header>
+
+      <Chrome.Body className="flex flex-col gap-y-4 overflow-y-auto px-6 py-6">
+        <div className="flex flex-col gap-y-1">
+          <Text size="small" className="text-ui-fg-subtle">
+            Email *
+          </Text>
+          <Input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="admin@partner.com"
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex flex-col gap-y-1">
+            <Text size="small" className="text-ui-fg-subtle">
+              First name
+            </Text>
+            <Input
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              placeholder="John"
+            />
+          </div>
+          <div className="flex flex-col gap-y-1">
+            <Text size="small" className="text-ui-fg-subtle">
+              Last name
+            </Text>
+            <Input
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              placeholder="Doe"
+            />
+          </div>
+        </div>
+        <div className="flex flex-col gap-y-1">
+          <Text size="small" className="text-ui-fg-subtle">
+            Phone
+          </Text>
+          <Input
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="+91 98765 43210"
+          />
+        </div>
+        <div className="flex flex-col gap-y-1">
+          <Text size="small" className="text-ui-fg-subtle">
+            Role
+          </Text>
+          <Select value={role} onValueChange={(v) => setRole(v as any)}>
+            <Select.Trigger>
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value="admin">Admin</Select.Item>
+              <Select.Item value="manager">Manager</Select.Item>
+              <Select.Item value="owner">Owner</Select.Item>
+            </Select.Content>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-y-1">
+          <Text size="small" className="text-ui-fg-subtle">
+            Password (leave blank to auto-generate)
+          </Text>
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Auto-generated if empty"
+            autoComplete="new-password"
+          />
+        </div>
+      </Chrome.Body>
+
+      <Chrome.Footer>
+        <div className="flex w-full items-center justify-end gap-x-2">
+          <Chrome.Close asChild>
+            <Button variant="secondary" size="small" disabled={isPending}>
+              Cancel
+            </Button>
+          </Chrome.Close>
+          <Button size="small" isLoading={isPending} onClick={handleAdd}>
+            Add admin
+          </Button>
+        </div>
+      </Chrome.Footer>
+    </>
+  )
+}

--- a/apps/backend/src/admin/components/creates/create-partner-payment-method.tsx
+++ b/apps/backend/src/admin/components/creates/create-partner-payment-method.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react"
+import { Button, Heading, Input, Label, Select, Text, Textarea, toast } from "@medusajs/ui"
+
+import { useModalChrome } from "../modal/chrome/use-modal-chrome"
+import { useCreatePartnerPaymentMethod } from "../../hooks/api/payment-methods"
+
+/**
+ * Create a payment method and link it to a partner.
+ *
+ * Lifted out of `routes/partners/[id]/@add-payment-method/page.tsx` so the
+ * partner graph can open the same form its route does — chrome and "done" come
+ * from whichever shell wraps it (#1856).
+ *
+ * 🔴 The second of the partner spine's two absence rules. "There is payable
+ * work here and no account to pay it into" was measured on eight partners
+ * locally, and the graph could state it without being able to fix it: the
+ * absent node's action pointed back at the partner page, which from inside the
+ * workspace closes the graph to reach the drawer this form now IS.
+ */
+export const AddPartnerPaymentMethodForm = ({
+  partnerId,
+}: {
+  partnerId: string
+}) => {
+  const Chrome = useModalChrome()
+  const { mutateAsync, isPending } = useCreatePartnerPaymentMethod(partnerId)
+
+  const [type, setType] = useState<string>("")
+  const [accountName, setAccountName] = useState("")
+  const [accountNumber, setAccountNumber] = useState("")
+  const [bankName, setBankName] = useState("")
+  const [ifsc, setIfsc] = useState("")
+  const [walletId, setWalletId] = useState("")
+  const [note, setNote] = useState("")
+
+  const onCreate = async () => {
+    try {
+      await mutateAsync({
+        type,
+        account_name: accountName || undefined,
+        account_number: accountNumber || undefined,
+        bank_name: bankName || undefined,
+        ifsc_code: ifsc || undefined,
+        wallet_id: walletId || undefined,
+        metadata: note ? { note } : undefined,
+      })
+      toast.success("Payment method created")
+      Chrome.onDone()
+    } catch (e: any) {
+      /*
+       * 🔴 The route this replaced navigated away on success and had no catch
+       * at all, so a rejected create left the drawer open with no message —
+       * indistinguishable from a button that did nothing.
+       */
+      toast.error("Failed to create payment method", {
+        description: e?.message || "The payment method was not created",
+      })
+    }
+  }
+
+  return (
+    <>
+      <Chrome.Header>
+        <div>
+          <Chrome.Title asChild>
+            <Heading>Add payment method</Heading>
+          </Chrome.Title>
+          <Text size="small" className="text-ui-fg-subtle">
+            Payouts for this partner are paid to a linked method.
+          </Text>
+        </div>
+      </Chrome.Header>
+
+      <Chrome.Body className="flex flex-1 flex-col gap-y-4 overflow-y-auto px-6 py-6">
+        <div className="grid gap-y-2">
+          <Label>Type</Label>
+          <Select value={type} onValueChange={setType}>
+            <Select.Trigger>
+              <Select.Value placeholder="Select a type" />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value="bank_account">Bank Account</Select.Item>
+              <Select.Item value="cash_account">Cash Account</Select.Item>
+              <Select.Item value="digital_wallet">Digital Wallet</Select.Item>
+            </Select.Content>
+          </Select>
+        </div>
+        <div className="grid gap-y-2">
+          <Label>Account Name</Label>
+          <Input value={accountName} onChange={(e) => setAccountName(e.target.value)} />
+        </div>
+        <div className="grid gap-y-2">
+          <Label>Account Number</Label>
+          <Input
+            value={accountNumber}
+            onChange={(e) => setAccountNumber(e.target.value)}
+          />
+        </div>
+        <div className="grid gap-y-2">
+          <Label>Bank Name</Label>
+          <Input value={bankName} onChange={(e) => setBankName(e.target.value)} />
+        </div>
+        <div className="grid gap-y-2">
+          <Label>IFSC</Label>
+          <Input value={ifsc} onChange={(e) => setIfsc(e.target.value)} />
+        </div>
+        <div className="grid gap-y-2">
+          <Label>Wallet ID</Label>
+          <Input value={walletId} onChange={(e) => setWalletId(e.target.value)} />
+        </div>
+        <div className="grid gap-y-2">
+          <Label>Note</Label>
+          <Textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Optional"
+          />
+        </div>
+      </Chrome.Body>
+
+      <Chrome.Footer className="bg-ui-bg-base border-t border-ui-border-base">
+        <div className="flex w-full items-center justify-end gap-x-2">
+          <Chrome.Close asChild>
+            <Button variant="secondary" size="small" disabled={isPending}>
+              Cancel
+            </Button>
+          </Chrome.Close>
+          <Button size="small" onClick={onCreate} disabled={isPending || !type}>
+            Create method
+          </Button>
+        </div>
+      </Chrome.Footer>
+    </>
+  )
+}

--- a/apps/backend/src/admin/components/forms/link-partner-people/link-partner-people-form.tsx
+++ b/apps/backend/src/admin/components/forms/link-partner-people/link-partner-people-form.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from "react"
+import { Button, Checkbox, Heading, Input, Text, toast } from "@medusajs/ui"
+
+import { useModalChrome } from "../../modal/chrome/use-modal-chrome"
+import {
+  usePartnerPeople,
+  useLinkPeopleToPartner,
+} from "../../../hooks/api/partner-people"
+import { usePersons } from "../../../hooks/api/persons"
+
+/**
+ * Link existing people to a partner.
+ *
+ * Lifted out of the `FocusModal` inside `PartnerPeopleSection` so the partner
+ * graph can open the same form the section does — chrome and "done" come from
+ * whichever shell wraps it (#1856).
+ *
+ * 🔴 It fetches the partner's CURRENT people itself rather than taking them as
+ * a prop. The section had them to hand; the graph does not — its `people` node
+ * carries a count, not the rows. Taking them as a prop would have meant the
+ * graph passing `[]`, and every already-linked person would have rendered as
+ * selectable, offering a link that silently duplicates a row.
+ *
+ * 🔴 It stays OPEN after a successful link, the same as the design's partner
+ * form. Linking people is a repeated gesture, and the count behind it updates
+ * on close.
+ */
+export const LinkPartnerPeopleForm = ({
+  partnerId,
+}: {
+  partnerId: string
+}) => {
+  const Chrome = useModalChrome()
+  const [search, setSearch] = useState("")
+  const [selected, setSelected] = useState<Record<string, boolean>>({})
+
+  const { people } = usePartnerPeople(partnerId)
+  const { persons = [], isLoading } = usePersons({
+    limit: 50,
+    ...(search ? { q: search } : {}),
+  })
+
+  const linkMutation = useLinkPeopleToPartner(partnerId)
+
+  const existingSet = useMemo(
+    () => new Set((people || []).map((p) => p.id)),
+    [people]
+  )
+
+  const selectedIds = useMemo(
+    () => Object.keys(selected).filter((k) => selected[k]),
+    [selected]
+  )
+
+  const handleLink = async () => {
+    if (!selectedIds.length) {
+      return
+    }
+    await linkMutation.mutateAsync(
+      { person_ids: selectedIds },
+      {
+        onSuccess: () => {
+          toast.success(
+            `${selectedIds.length} ${
+              selectedIds.length === 1 ? "person" : "people"
+            } linked`
+          )
+          setSelected({})
+        },
+        onError: (error) => {
+          toast.error(error.message || "The people could not be linked")
+        },
+      }
+    )
+  }
+
+  return (
+    <>
+      <Chrome.Header>
+        <div>
+          <Chrome.Title asChild>
+            <Heading>Link people</Heading>
+          </Chrome.Title>
+          <Text size="small" className="text-ui-fg-subtle">
+            Linked people can reach shared folders and upload through the
+            partner portal.
+          </Text>
+        </div>
+      </Chrome.Header>
+
+      <Chrome.Body className="flex flex-1 flex-col gap-y-4 overflow-y-auto px-6 py-6">
+        <Input
+          placeholder="Search people..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          size="small"
+        />
+
+        {isLoading ? (
+          <div className="py-8 text-center">
+            <Text size="small" className="text-ui-fg-muted">
+              Loading...
+            </Text>
+          </div>
+        ) : persons.length === 0 ? (
+          <div className="py-8 text-center">
+            <Text size="small" className="text-ui-fg-muted">
+              No people found
+            </Text>
+          </div>
+        ) : (
+          <div className="border-ui-border-base flex flex-col divide-y rounded-lg border">
+            {persons.map((person: any) => {
+              const isExisting = existingSet.has(person.id)
+              return (
+                <label
+                  key={person.id}
+                  className="hover:bg-ui-bg-base-hover flex cursor-pointer items-center gap-x-3 px-4 py-3"
+                >
+                  <Checkbox
+                    checked={!!selected[person.id]}
+                    disabled={isExisting}
+                    onCheckedChange={() =>
+                      setSelected((prev) => ({
+                        ...prev,
+                        [person.id]: !prev[person.id],
+                      }))
+                    }
+                  />
+                  <div className="flex flex-col">
+                    <Text size="small" weight="plus">
+                      {person.first_name} {person.last_name}
+                      {isExisting && (
+                        <span className="text-ui-fg-muted ml-2">
+                          (already linked)
+                        </span>
+                      )}
+                    </Text>
+                    {person.email && (
+                      <Text size="xsmall" className="text-ui-fg-muted">
+                        {person.email}
+                      </Text>
+                    )}
+                  </div>
+                </label>
+              )
+            })}
+          </div>
+        )}
+      </Chrome.Body>
+
+      <Chrome.Footer>
+        <div className="flex w-full items-center justify-end gap-x-2">
+          <Chrome.Close asChild>
+            <Button variant="secondary" size="small">
+              Cancel
+            </Button>
+          </Chrome.Close>
+          <Button
+            size="small"
+            onClick={handleLink}
+            disabled={selectedIds.length === 0}
+            isLoading={linkMutation.isPending}
+          >
+            Link {selectedIds.length > 0 ? `(${selectedIds.length})` : ""}
+          </Button>
+        </div>
+      </Chrome.Footer>
+    </>
+  )
+}

--- a/apps/backend/src/admin/components/graph/__tests__/node-forms.unit.spec.ts
+++ b/apps/backend/src/admin/components/graph/__tests__/node-forms.unit.spec.ts
@@ -1,5 +1,7 @@
 import {
+  actRail,
   actionRail,
+  canApply,
   hasAffordance,
   nodeAffordance,
   type AffordanceNode,
@@ -191,5 +193,107 @@ describe("nodeAffordance", () => {
     )
 
     expect(a).toEqual({ create: false, edit: false, action: true })
+  })
+})
+
+/**
+ * The ACT rail (#1857). Both cases below are safety properties that look
+ * identical on screen until the press lands.
+ */
+describe("actRail", () => {
+  it("previews first where a dry run exists", () => {
+    expect(actRail({ previewBody: { dry_run: true }, applyBody: { dry_run: false } })).toBe(
+      "preview-then-apply"
+    )
+  })
+
+  /*
+   * 🔴 `previewBody: null` is "there IS no dry run", never "preview with an
+   * empty body". Read the second way, the safe-looking press posts to the real
+   * endpoint — and the two acts this rule was written for send a WhatsApp
+   * message to a partner and push live DNS.
+   */
+  it("gives one confirmed press where nothing can be previewed", () => {
+    expect(actRail({ previewBody: null, applyBody: { phone: "919876543210" } })).toBe(
+      "confirm-once"
+    )
+  })
+
+  it("renders nothing for a node that runs nothing", () => {
+    expect(actRail(null)).toBe("none")
+    expect(actRail(undefined)).toBe("none")
+  })
+})
+
+describe("canApply", () => {
+  it("withholds Apply until a preview has come back", () => {
+    const act = { previewBody: { dry_run: true }, applyBody: { dry_run: false } }
+    expect(canApply(act, false)).toBe(false)
+    expect(canApply(act, true)).toBe(true)
+  })
+
+  /*
+   * A read-only job has nothing to apply. A DISABLED Apply would imply a write
+   * that is merely unavailable, when there is none to make.
+   */
+  it("never offers Apply where there is nothing to apply", () => {
+    expect(canApply({ previewBody: { dry_run: true }, applyBody: null }, true)).toBe(false)
+  })
+
+  /*
+   * 🔴 And never a SECOND button on a confirm-once act — the single button is
+   * already the action, so an Apply beside it would fire it twice.
+   */
+  it("never adds a second button to a confirm-once act", () => {
+    expect(canApply({ previewBody: null, applyBody: { phone: "9" } }, true)).toBe(false)
+  })
+})
+
+/*
+ * 🔴 Found by RENDERING the partner spine, not by any test that existed. The
+ * WhatsApp node drew "Verify the number" TWICE — the working act directly
+ * above the old `action`, whose href is null and which therefore renders as a
+ * dead disabled button with identical words. #1854, repeated by the thing
+ * meant to retire it.
+ */
+describe("the action rail does not repeat the act", () => {
+  const none = { create: false, edit: false, action: false }
+
+  it("stands down where the node runs something", () => {
+    expect(
+      actionRail(
+        none,
+        {
+          href: null,
+          action: { label: "Verify the number", href: null },
+          act: { previewBody: null, applyBody: { phone: "9" } },
+        },
+        null
+      )
+    ).toBe("none")
+  })
+
+  it("still names the step where there is no act", () => {
+    expect(
+      actionRail(none, { href: null, action: { label: "Verify the number", href: null } }, null)
+    ).toBe("action")
+  })
+
+  /*
+   * `open` is a different question — the neighbour's own page, not a job — so
+   * an act must not swallow a real drill-in.
+   */
+  it("keeps a real drill-in beside an act", () => {
+    expect(
+      actionRail(
+        none,
+        {
+          href: "/partners/p_1/tasks",
+          action: { label: "Verify the number", href: null },
+          act: { previewBody: null, applyBody: {} },
+        },
+        "/partners/p_1"
+      )
+    ).toBe("open")
   })
 })

--- a/apps/backend/src/admin/components/graph/entity-graph.tsx
+++ b/apps/backend/src/admin/components/graph/entity-graph.tsx
@@ -189,7 +189,19 @@ export const EntityGraph = ({ spine, id, title = "Graph", expandHref }: Props) =
             <>
               <NodeInspectorHeader node={active} />
               <NodeInspectorBody node={active} edge={activeEdge} />
-              <NodeInspectorActions node={active} />
+              {/*
+                🔴 The card is embedded ON the spine's own page, so it must not
+                offer to navigate there. `graph.spine.href` IS that page — an
+                action or an "Open" pointing at it is a button that does
+                nothing, and on the partner spine that is almost every node.
+                Where a workspace exists the action is redirected into it, on
+                this node, which is where the create form lives.
+              */}
+              <NodeInspectorActions
+                node={active}
+                selfHref={graph.spine.href ?? undefined}
+                workspaceHref={expandHref}
+              />
             </>
           )}
         </div>

--- a/apps/backend/src/admin/components/graph/graph-create-modal.tsx
+++ b/apps/backend/src/admin/components/graph/graph-create-modal.tsx
@@ -4,7 +4,13 @@ import { Link } from "react-router-dom"
 
 import type { GraphNode } from "../../hooks/api/graph"
 import { StackedFocusModal } from "../modal/stacked-modal/stacked-focused-modal"
-import { createFormFor, editFormFor, registryFor, withArticle } from "./graph-forms"
+import {
+  createFormFor,
+  createLabelFor,
+  editFormFor,
+  registryFor,
+  withArticle,
+} from "./graph-forms"
 import { nodeAffordance } from "./node-forms"
 
 /**
@@ -79,10 +85,19 @@ export const GraphCreateModal = ({
   // across the JSX branch.
   const action = node.action
   const modalId = `graph-create-${node.key}`
+  /*
+   * 🔴 The absent branch names what the FORM creates, not what the node is.
+   * The node's label is the aggregate — "Payment methods" — so this read
+   * "Create the missing payment methods" above a form that creates one. The
+   * registered label is singular by contract, which is exactly what this
+   * sentence needs; where there is no form there is no button either, so the
+   * fallback only ever serves the action card's own wording.
+   */
+  const createLabel = createLabelFor(spine, node.key)
   const triggerLabel = isPlaceholder
     ? `Add ${withArticle(node.label.toLowerCase())}`
     : node.state === "absent"
-      ? `Create the missing ${node.label.toLowerCase()}`
+      ? `Create the missing ${(createLabel ?? node.label).toLowerCase()}`
       : `Add to ${node.label.toLowerCase()}`
 
   return (

--- a/apps/backend/src/admin/components/graph/graph-forms.tsx
+++ b/apps/backend/src/admin/components/graph/graph-forms.tsx
@@ -3,6 +3,9 @@ import { Skeleton, Text } from "@medusajs/ui"
 import { useParams } from "react-router-dom"
 
 import ColorPaletteEditor from "../edits/edit-color-palette"
+import { AddPartnerAdminForm } from "../creates/create-partner-admin"
+import { AddPartnerPaymentMethodForm } from "../creates/create-partner-payment-method"
+import { LinkPartnerPeopleForm } from "../forms/link-partner-people/link-partner-people-form"
 import { AddDesignComponentForm } from "../creates/create-design-component"
 import { CreateDesignTaskComponent } from "../creates/create-design-task"
 import { DesignInventoryTable } from "../designs/design-inventory-table"
@@ -203,8 +206,79 @@ const DESIGN_FORMS: SpineForms = {
    */
 }
 
+/**
+ * The partner id, from the workspace's own route (`/partners/:id/graph`).
+ *
+ * The same adapter shape as the design's, and for the same reason: the forms
+ * keep taking an explicit `partnerId`, so the section on the partner page can
+ * go on rendering them without a URL shaped like the graph's.
+ */
+const usePartnerId = () => useParams().id!
+
+const PartnerAdminCreateForm = () => {
+  const partnerId = usePartnerId()
+  return <AddPartnerAdminForm partnerId={partnerId} />
+}
+
+const PartnerPaymentMethodCreateForm = () => {
+  const partnerId = usePartnerId()
+  return <AddPartnerPaymentMethodForm partnerId={partnerId} />
+}
+
+const PartnerPeopleCreateForm = () => {
+  const partnerId = usePartnerId()
+  return <LinkPartnerPeopleForm partnerId={partnerId} />
+}
+
+/**
+ * The PARTNER spine's forms (#1856).
+ *
+ * 🔴 The first two exist because this spine's two absence rules were unfixable
+ * from the graph that stated them. "No admin — nobody can sign in" and
+ * "delivered work, no account to pay it into" are the only two absences on the
+ * platform that no list can show, and until now the absent node's sole
+ * affordance was an action card pointing at `/partners/:id` — the page the
+ * graph is embedded in. From the full-page workspace that button tears the
+ * graph down to arrive where you already were.
+ *
+ * That is also why ZERO partner cards came off in #1856's first pass: the
+ * three questions ask what a card DOES that the graph cannot, and until this
+ * registry entry existed the answer for every one of them was "create".
+ */
+const PARTNER_FORMS: SpineForms = {
+  create: {
+    admins: { Form: PartnerAdminCreateForm, label: "admin" },
+    payment_methods: {
+      Form: PartnerPaymentMethodCreateForm,
+      label: "payment method",
+    },
+    people: { Form: PartnerPeopleCreateForm, label: "person" },
+  },
+  addAnother: {},
+  edit: {},
+  /*
+   * Deliberately NOT registered:
+   *
+   * - `partner` itself. The edit form is a multi-tab page (`partners/[id]`
+   *   general section) rather than a body-and-footer form, so it is not
+   *   chrome-agnostic and would render its own shell inside the stacked one.
+   * - `runs`, `designs`, `orders`, `products`, `inventory_orders`,
+   *   `submissions`. None of these is created FROM a partner: a run belongs to
+   *   the design that ordered it, an order to a customer, a submission to the
+   *   work it bills. Registering a form here would put the partner at the
+   *   start of a flow it is only ever the object of.
+   * - `stores`, `subscriptions`. Both are provisioning flows with steps of
+   *   their own; the absent `stores` node keeps its action card.
+   * - `whatsapp`, `domain`. Both are `derived` — the value is already on the
+   *   record and unverified. What is missing is a verification, not a
+   *   neighbour, and `nodeAffordance` correctly offers neither create nor the
+   *   action card on a derived node.
+   */
+}
+
 const SPINE_FORMS: Record<string, SpineForms> = {
   design: DESIGN_FORMS,
+  partner: PARTNER_FORMS,
 }
 
 const EMPTY: SpineForms = { create: {}, edit: {}, addAnother: {} }
@@ -252,6 +326,20 @@ export const creatableFor = (
     key,
     label,
   }))
+
+/**
+ * The registered, SINGULAR name of what a node's create form makes.
+ *
+ * 🔴 Not `node.label`. A node's label is the aggregate's ("Payment methods",
+ * "Tasks"), so the absent node's button rendered "Create the missing payment
+ * methodS" over a form that creates exactly one. Only rendering says so — the
+ * string is assembled from a label that is correct everywhere else on the
+ * card, and no test was ever going to spell it out.
+ */
+export const createLabelFor = (
+  spine: string,
+  key: string
+): string | undefined => formsFor(spine).create[key]?.label
 
 export const editFormFor = (spine: string, key: string): EditForm | undefined =>
   formsFor(spine).edit[key]

--- a/apps/backend/src/admin/components/graph/graph-workspace.tsx
+++ b/apps/backend/src/admin/components/graph/graph-workspace.tsx
@@ -7,6 +7,7 @@ import { RouteDrawer } from "../modal/route-drawer/route-drawer"
 import { GraphCanvas, canvasSize } from "./graph-canvas"
 import { GraphViewport } from "./graph-viewport"
 import {
+  NodeInspectorAct,
   NodeInspectorActions,
   NodeInspectorBody,
   NodeInspectorHeader,
@@ -362,6 +363,16 @@ export const GraphWorkspace = ({ spine, id, title = "Graph", selfHref }: Props) 
                 href={another.href(id)}
               />
             )}
+            {/*
+              The ACT rail sits BESIDE the action rail, not inside it (#1857).
+              They answer different questions — the action rail names a page
+              that would create the missing neighbour, the act rail runs a job
+              against the one that is wrong — and a node can legitimately have
+              both. Folding the act into `actionRail`'s three-way choice would
+              have made them exclusive, and the node that most needs the job is
+              exactly the node that also has somewhere to send you.
+            */}
+            <NodeInspectorAct node={active} spine={spine} id={id} />
             <NodeInspectorActions node={active} mode={rail} />
           </RouteDrawer.Body>
         </RouteDrawer>

--- a/apps/backend/src/admin/components/graph/node-forms.ts
+++ b/apps/backend/src/admin/components/graph/node-forms.ts
@@ -99,12 +99,28 @@ export type ActionRail = "action" | "open" | "none"
 
 export const actionRail = (
   affordance: NodeAffordance,
-  node: { href: string | null; action: { label: string; href: string | null } | null },
+  node: {
+    href: string | null
+    action: { label: string; href: string | null } | null
+    /** #1857. A node that RUNS something already answers its own question. */
+    act?: { previewBody: unknown | null; applyBody: unknown | null } | null
+  },
   spineHref: string | null
 ): ActionRail => {
   const hasForm = affordance.create || affordance.edit
 
-  if (!hasForm && node.action) {
+  /*
+   * 🔴 The rail must not repeat the ACT, for the same reason it must not
+   * repeat a form — and this one was worse, because the two are word for word
+   * identical. Rendered, the partner's WhatsApp node showed "Verify the
+   * number" twice: the act, which sends the template, directly above the old
+   * `action`, which has a null href and is therefore a DEAD DISABLED BUTTON.
+   *
+   * That is #1854 exactly — a new affordance that did not replace the old one
+   * and kept rendering beside it. `open` survives, because a drill-in to the
+   * neighbour's own page is a different question from running a job.
+   */
+  if (!hasForm && node.action && !node.act) {
     return "action"
   }
 
@@ -113,4 +129,51 @@ export const actionRail = (
   }
 
   return "none"
+}
+
+/**
+ * What the ACT rail renders (#1857).
+ *
+ *   - `preview-then-apply` — a dry run exists; the first press previews and
+ *     Apply is unreachable until one comes back.
+ *   - `confirm-once`       — there IS no dry run. One button, behind the
+ *     confirm, and pressing it does the thing.
+ *   - `none`               — this node runs nothing.
+ *
+ * 🔴 The distinction is the whole safety property, and getting it backwards is
+ * invisible on screen. The first version pressed preview unconditionally, so
+ * an act with `previewBody: null` would have POSTed to the real endpoint with
+ * no body while the button still said preview. The two acts that arrived next
+ * were "verify the WhatsApp number", which SENDS A MESSAGE to a real partner,
+ * and "verify the domain", which pushes live DNS. Neither has a dry run, and
+ * for both the safe-looking press was the entire action.
+ */
+export type ActRail = "preview-then-apply" | "confirm-once" | "none"
+
+export const actRail = (
+  act: { previewBody: unknown | null; applyBody: unknown | null } | null | undefined
+): ActRail => {
+  if (!act) {
+    return "none"
+  }
+  return act.previewBody !== null ? "preview-then-apply" : "confirm-once"
+}
+
+/**
+ * Whether the Apply button may be drawn yet.
+ *
+ * 🔴 `previewed` is required and is not the same as "a preview exists". An
+ * Apply drawn before the operator has read what would change is the guard
+ * removed — and on this board the reason for the guard is that three sweeps
+ * running were topped by a pair that turned out to be correct state.
+ */
+export const canApply = (
+  act: { previewBody: unknown | null; applyBody: unknown | null } | null | undefined,
+  previewed: boolean
+): boolean => {
+  if (!act || act.applyBody === null) {
+    return false
+  }
+  // With no dry run there is no separate Apply — the single button IS the act.
+  return actRail(act) === "preview-then-apply" && previewed
 }

--- a/apps/backend/src/admin/components/graph/node-inspector.tsx
+++ b/apps/backend/src/admin/components/graph/node-inspector.tsx
@@ -62,9 +62,18 @@ export const NodeInspectorBody = ({
 export const NodeInspectorActions = ({
   node,
   mode,
+  selfHref,
+  workspaceHref,
 }: {
   node: GraphNode
   mode?: ActionRail
+  /**
+   * The page this graph is embedded IN. Any action whose href equals it is a
+   * link back to where the reader already is.
+   */
+  selfHref?: string
+  /** The full-page workspace, where the forms live. */
+  workspaceHref?: string
 }) => {
   const resolved: ActionRail = mode ?? (node.action ? "action" : node.href ? "open" : "none")
 
@@ -72,11 +81,45 @@ export const NodeInspectorActions = ({
     return null
   }
 
+  /*
+   * 🔴 An action that points at the page you are on is a dead button.
+   *
+   * Every absent node on the PARTNER spine names `/partners/:id` as where to
+   * go — which is correct for a reader coming from a list, and useless in the
+   * card embedded on that very page: "Add a payment method" rendered as a link
+   * to the partner page, from the partner page. Nothing errors; the button
+   * simply does nothing, which is the same shape as the superseded link-out
+   * that kept rendering beside its replacement (#1854).
+   *
+   * The words are kept and the destination is corrected: the workspace, opened
+   * on this node, which is where its create form actually is. Where there is
+   * no workspace to send them to, the button is dropped rather than left dead.
+   */
+  const actionHref = node.action?.href
+  const isSelfLink = !!actionHref && !!selfHref && actionHref === selfHref
+  const redirected = isSelfLink
+    ? workspaceHref
+      ? `${workspaceHref}?node=${encodeURIComponent(node.key)}`
+      : null
+    : actionHref
+
+  if (resolved === "action" && isSelfLink && !redirected) {
+    return null
+  }
+
+  /*
+   * Nothing left to draw — return null rather than an empty bordered strip.
+   * A 12px rule under the card reads as a section that failed to load.
+   */
+  if (resolved === "open" && (!node.href || node.href === selfHref)) {
+    return null
+  }
+
   return (
     <div className="border-t px-6 py-3">
       {resolved === "action" && node.action ? (
-        node.action.href ? (
-          <Link to={node.action.href}>
+        redirected ? (
+          <Link to={redirected}>
             <Button variant="secondary" size="small">
               {node.action.label}
             </Button>
@@ -86,7 +129,12 @@ export const NodeInspectorActions = ({
             {node.action.label}
           </Button>
         )
-      ) : node.href ? (
+      ) : node.href && node.href !== selfHref ? (
+        /*
+         * 🔴 `!== selfHref` for the same reason. Most present nodes on the
+         * partner spine carry the partner's own page as their href, so "Open"
+         * offered to open the page it is rendered on.
+         */
         <Link to={node.href}>
           <Button variant="secondary" size="small">
             Open

--- a/apps/backend/src/admin/components/graph/node-inspector.tsx
+++ b/apps/backend/src/admin/components/graph/node-inspector.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom"
 
 import { useRunGraphNodeAct } from "../../hooks/api/graph"
 import type { GraphEdge, GraphNode, NodeActResult } from "../../hooks/api/graph"
+import { actRail, canApply } from "./node-forms"
 import type { ActionRail } from "./node-forms"
 
 /**
@@ -249,6 +250,24 @@ export const NodeInspectorAct = ({
     return null
   }
 
+  /*
+   * 🔴 `previewBody: null` means THERE IS NO DRY RUN — not "preview with an
+   * empty body".
+   *
+   * The first version pressed preview unconditionally, so an act with no
+   * preview would have POSTed to the real endpoint with no body while the
+   * button still said preview. For the two acts that arrived next — verify a
+   * WhatsApp number, which SENDS A MESSAGE to a real partner, and re-verify a
+   * custom domain, which pushes DNS — the safe-looking press was the whole
+   * action. Caught before either was wired, and only because writing the
+   * second kind of act forced the question.
+   *
+   * With no preview there is exactly one button and it is the act itself,
+   * behind the confirm. With a preview, the apply cannot be reached until one
+   * has come back.
+   */
+  const hasPreview = actRail(act) === "preview-then-apply"
+
   const runApply = async () => {
     /*
      * 🔴 The confirm sentence is the SERVER's. A generic "Are you sure?" would
@@ -259,7 +278,14 @@ export const NodeInspectorAct = ({
     const ok = await prompt({
       title: act.label,
       description: act.confirm,
-      confirmText: "Apply",
+      /*
+       * The act's own words where there was nothing to preview. "Apply" is
+       * right for the second half of a preview-then-apply pair and wrong for a
+       * single press that SENDS A WHATSAPP MESSAGE — the confirm's last word
+       * should be the thing about to happen, not a stage of a flow this act
+       * does not have.
+       */
+      confirmText: hasPreview ? "Apply" : act.label,
     })
     if (ok) {
       mutate({ act, apply: true })
@@ -269,18 +295,28 @@ export const NodeInspectorAct = ({
   return (
     <div className="border-t px-6 py-3">
       <div className="flex flex-wrap items-center gap-2">
-        <Button
-          variant="secondary"
-          size="small"
-          isLoading={isPending}
-          onClick={() => mutate({ act, apply: false })}
-        >
-          {preview ? "Preview again" : act.label}
-        </Button>
+        {hasPreview ? (
+          <Button
+            variant="secondary"
+            size="small"
+            isLoading={isPending}
+            onClick={() => mutate({ act, apply: false })}
+          >
+            {preview ? "Preview again" : act.label}
+          </Button>
+        ) : (
+          /*
+           * No dry run exists, so the label IS the action and it goes through
+           * the confirm. `danger`, because nothing here previews first.
+           */
+          <Button variant="danger" size="small" isLoading={isPending} onClick={runApply}>
+            {act.label}
+          </Button>
+        )}
         {/*
           Only after a preview, and only where there is something to apply.
         */}
-        {preview && act.applyBody && (
+        {canApply(act, !!preview) && (
           <Button variant="danger" size="small" disabled={isPending} onClick={runApply}>
             Apply
           </Button>

--- a/apps/backend/src/admin/components/graph/node-inspector.tsx
+++ b/apps/backend/src/admin/components/graph/node-inspector.tsx
@@ -1,7 +1,9 @@
-import { Badge, Button, Heading, Text } from "@medusajs/ui"
+import { useState } from "react"
+import { Badge, Button, Heading, Text, toast, usePrompt } from "@medusajs/ui"
 import { Link } from "react-router-dom"
 
-import type { GraphEdge, GraphNode } from "../../hooks/api/graph"
+import { useRunGraphNodeAct } from "../../hooks/api/graph"
+import type { GraphEdge, GraphNode, NodeActResult } from "../../hooks/api/graph"
 import type { ActionRail } from "./node-forms"
 
 /**
@@ -26,7 +28,17 @@ export const NodeInspectorBody = ({
           key={p.key}
           className="flex items-center justify-between gap-x-2 px-6 py-2"
         >
-          <Text size="xsmall" className="text-ui-fg-muted truncate">
+          {/*
+            🔴 `shrink-0` with a cap, not a bare `truncate`. Two truncating
+            halves of a flex row shrink in proportion to their content, so a
+            long value eats its own label: the dangling board's sweep summary
+            rendered its key as "S…" — a row with a value and no name. The cap
+            keeps a runaway key from doing the same thing in reverse.
+          */}
+          <Text
+            size="xsmall"
+            className="text-ui-fg-muted truncate shrink-0 max-w-[45%]"
+          >
             {p.key}
           </Text>
           <Text size="small" weight="plus" className="truncate">
@@ -184,3 +196,120 @@ export const NodeInspectorHeader = ({
     </Badge>
   </div>
 )
+
+/**
+ * The ACT rail: a data-ops job run from the node that states the problem.
+ *
+ * ## Why this exists (#1856 → #1857)
+ *
+ * A node could previously offer a form or a LINK. That is the right pair for
+ * an absence somebody fills in — "no payment method, here is the form" — and
+ * it is nothing at all for a node whose answer is an operation. The partner
+ * spine carries four cards drawn `derived` for exactly this reason (verify,
+ * provision, apply), and the dangling board is unbuildable without it: a board
+ * that can only report is the report it was meant to replace.
+ *
+ * ## Preview, then apply — never one press
+ *
+ * 🔴 The first press ALWAYS runs the preview, whatever the button says, and
+ * the apply button does not exist until a preview has come back. The reason is
+ * this board specifically: three sweeps running have been topped by a pair
+ * that was not a defect, and the failure mode is an operator repairing correct
+ * state because the count looked alarming. Making them read what would change
+ * before anything changes is the only guard that survives a convincing number.
+ *
+ * 🔴 `applyBody: null` renders NO apply button rather than a disabled one. The
+ * sweep writes nothing in either mode; a greyed-out "Apply" would imply a
+ * write that is merely unavailable, when there is none to make.
+ */
+export const NodeInspectorAct = ({
+  node,
+  spine,
+  id,
+}: {
+  node: GraphNode
+  spine: string
+  id: string
+}) => {
+  const act = node.act
+  const prompt = usePrompt()
+  const [preview, setPreview] = useState<NodeActResult["result"] | null>(null)
+
+  const { mutate, isPending } = useRunGraphNodeAct(spine, id, {
+    onSuccess: (data) => {
+      setPreview(data.result)
+      toast.success(
+        data.result.applied ? "Applied" : `Preview — ${data.result.changes.length} change(s)`
+      )
+    },
+    onError: (e: any) => toast.error(e?.message ?? "The job failed"),
+  })
+
+  if (!act) {
+    return null
+  }
+
+  const runApply = async () => {
+    /*
+     * 🔴 The confirm sentence is the SERVER's. A generic "Are you sure?" would
+     * drop the one thing worth reading — that these FX markers point at prices
+     * which were REPLACED, not lost, and that the rerate job already skips
+     * them. That sentence is why an operator can tell repair from destruction.
+     */
+    const ok = await prompt({
+      title: act.label,
+      description: act.confirm,
+      confirmText: "Apply",
+    })
+    if (ok) {
+      mutate({ act, apply: true })
+    }
+  }
+
+  return (
+    <div className="border-t px-6 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          variant="secondary"
+          size="small"
+          isLoading={isPending}
+          onClick={() => mutate({ act, apply: false })}
+        >
+          {preview ? "Preview again" : act.label}
+        </Button>
+        {/*
+          Only after a preview, and only where there is something to apply.
+        */}
+        {preview && act.applyBody && (
+          <Button variant="danger" size="small" disabled={isPending} onClick={runApply}>
+            Apply
+          </Button>
+        )}
+      </div>
+
+      {preview && (
+        <div className="mt-3 flex flex-col gap-y-1">
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            {preview.summary}
+          </Text>
+          {/*
+            The first few rows the job named, not just how many. A dry run that
+            lists a count cannot be argued with; one that shows its reasons can
+            be caught before it is applied.
+          */}
+          {preview.changes.slice(0, 5).map((c, i) => (
+            <Text key={`${c.id}-${i}`} size="xsmall" className="text-ui-fg-muted truncate">
+              {c.id}
+              {c.note ? ` — ${c.note}` : ""}
+            </Text>
+          ))}
+          {preview.changes.length > 5 && (
+            <Text size="xsmall" className="text-ui-fg-muted">
+              …and {preview.changes.length - 5} more.
+            </Text>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/backend/src/admin/components/modal/chrome/modal-chrome-context.tsx
+++ b/apps/backend/src/admin/components/modal/chrome/modal-chrome-context.tsx
@@ -16,7 +16,17 @@ import type { ComponentType } from "react"
  * graph". A form asks the context what to render with and what "done" means,
  * and the shell answers.
  */
-export type ModalChromeVariant = "route-focus" | "route-drawer" | "stacked"
+/**
+ * `drawer` is a PLAIN drawer opened by a section's own button, not by a route.
+ * It exists so a form does not have to be moved to a route before a second
+ * surface can reuse it — the alternative was a second copy of the form living
+ * in the section, which is how the trade price ended up with two homes.
+ */
+export type ModalChromeVariant =
+  | "route-focus"
+  | "route-drawer"
+  | "stacked"
+  | "drawer"
 
 export type ModalChromeValue = {
   variant: ModalChromeVariant

--- a/apps/backend/src/admin/components/modal/chrome/route-chrome-provider.tsx
+++ b/apps/backend/src/admin/components/modal/chrome/route-chrome-provider.tsx
@@ -58,3 +58,32 @@ export const StackedChromeProvider = ({
     <ModalChromeContext.Provider value={value}>{children}</ModalChromeContext.Provider>
   )
 }
+
+/**
+ * Publishes a PLAIN drawer's chrome — one a section opens with its own button
+ * rather than by navigating.
+ *
+ * 🔴 This is what lets a section and the graph share ONE form. Without it the
+ * only reusable shells were the route ones, so a form living inside a
+ * section's `<Drawer>` had to be duplicated to appear anywhere else. `onDone`
+ * closes that drawer; there is nothing to navigate to and nothing to unwind.
+ */
+export const DrawerChromeProvider = ({
+  parts,
+  onClose,
+  children,
+}: PropsWithChildren<{ parts: Parts; onClose: () => void }>) => {
+  const value = useMemo<ModalChromeValue>(
+    () => ({
+      variant: "drawer",
+      ...parts,
+      onDone: () => onClose(),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [onClose]
+  )
+
+  return (
+    <ModalChromeContext.Provider value={value}>{children}</ModalChromeContext.Provider>
+  )
+}

--- a/apps/backend/src/admin/components/partners/partner-admins-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-admins-section.tsx
@@ -17,10 +17,11 @@ import { Plus } from "@medusajs/icons"
 import {
   partnersQueryKeys,
   useUpdatePartner,
-  useAddPartnerAdmin,
   useUpdatePartnerAdmin,
 } from "../../hooks/api/partners-admin"
 import { Select } from "@medusajs/ui"
+import { AddPartnerAdminForm } from "../creates/create-partner-admin"
+import { DrawerChromeProvider } from "../modal/chrome/route-chrome-provider"
 import {
   PARTNER_ADMIN_LANGUAGES,
   getLanguageDisplayName,
@@ -107,15 +108,13 @@ export const PartnerAdminsSection = ({
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
 
-  // Add admin drawer state
+  /*
+   * Add admin drawer. The FORM inside it lives in
+   * `components/creates/create-partner-admin` so the partner graph opens the
+   * same one this section does (#1856) — the drawer supplies the chrome and
+   * what "done" means, and nothing else about the form is duplicated here.
+   */
   const [addDrawerOpen, setAddDrawerOpen] = useState(false)
-  const [newEmail, setNewEmail] = useState("")
-  const [newFirstName, setNewFirstName] = useState("")
-  const [newLastName, setNewLastName] = useState("")
-  const [newPhone, setNewPhone] = useState("")
-  const [newRole, setNewRole] = useState<"admin" | "manager" | "owner">("admin")
-  const [newPassword, setNewPassword] = useState("")
-  const { mutateAsync: addAdmin, isPending: isAdding } = useAddPartnerAdmin(partnerId)
 
   // Set-language drawer state
   const [languageDrawerOpen, setLanguageDrawerOpen] = useState(false)
@@ -213,15 +212,15 @@ export const PartnerAdminsSection = ({
         <Button
           variant="secondary"
           size="small"
-          onClick={() => {
-            setNewEmail("")
-            setNewFirstName("")
-            setNewLastName("")
-            setNewPhone("")
-            setNewRole("admin")
-            setNewPassword("")
-            setAddDrawerOpen(true)
-          }}
+          /*
+           * 🔴 No field resets here any more. They used to clear six pieces of
+           * state this section owned; the form owns them now, and the drawer
+           * unmounts its content when closed, so every open starts blank on
+           * its own. Left behind, the six `setNew*` calls referenced nothing —
+           * and `medusa build` compiled the admin CLEAN anyway. Only opening
+           * the drawer said "setNewEmail is not defined".
+           */
+          onClick={() => setAddDrawerOpen(true)}
         >
           <Plus className="mr-1" />
           Add Admin
@@ -399,115 +398,27 @@ export const PartnerAdminsSection = ({
           </Drawer.Footer>
         </Drawer.Content>
       </Drawer>
-      <Drawer open={addDrawerOpen} onOpenChange={(o) => (!o ? setAddDrawerOpen(false) : setAddDrawerOpen(true))}>
+      <Drawer open={addDrawerOpen} onOpenChange={setAddDrawerOpen}>
         <Drawer.Content className="max-w-md">
-          <Drawer.Header>
-            <Drawer.Title>Add Admin</Drawer.Title>
-            <Drawer.Description>
-              Create a new admin for this partner. They will receive a welcome email with login credentials.
-            </Drawer.Description>
-          </Drawer.Header>
-          <Drawer.Body className="overflow-y-auto">
-            <div className="flex flex-col gap-y-4">
-              <div>
-                <Text size="small" className="text-ui-fg-subtle mb-1">Email *</Text>
-                <Input
-                  type="email"
-                  value={newEmail}
-                  onChange={(e) => setNewEmail(e.target.value)}
-                  placeholder="admin@partner.com"
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Text size="small" className="text-ui-fg-subtle mb-1">First name</Text>
-                  <Input
-                    value={newFirstName}
-                    onChange={(e) => setNewFirstName(e.target.value)}
-                    placeholder="John"
-                  />
-                </div>
-                <div>
-                  <Text size="small" className="text-ui-fg-subtle mb-1">Last name</Text>
-                  <Input
-                    value={newLastName}
-                    onChange={(e) => setNewLastName(e.target.value)}
-                    placeholder="Doe"
-                  />
-                </div>
-              </div>
-              <div>
-                <Text size="small" className="text-ui-fg-subtle mb-1">Phone</Text>
-                <Input
-                  value={newPhone}
-                  onChange={(e) => setNewPhone(e.target.value)}
-                  placeholder="+91 98765 43210"
-                  type="tel"
-                />
-              </div>
-              <div>
-                <Text size="small" className="text-ui-fg-subtle mb-1">Role</Text>
-                <Select value={newRole} onValueChange={(v) => setNewRole(v as any)}>
-                  <Select.Trigger>
-                    <Select.Value />
-                  </Select.Trigger>
-                  <Select.Content>
-                    <Select.Item value="admin">Admin</Select.Item>
-                    <Select.Item value="manager">Manager</Select.Item>
-                    <Select.Item value="owner">Owner</Select.Item>
-                  </Select.Content>
-                </Select>
-              </div>
-              <div>
-                <Text size="small" className="text-ui-fg-subtle mb-1">Password (leave blank to auto-generate)</Text>
-                <Input
-                  type="password"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  placeholder="Auto-generated if empty"
-                  autoComplete="new-password"
-                />
-              </div>
-            </div>
-          </Drawer.Body>
-          <Drawer.Footer>
-            <div className="flex w-full items-center justify-end gap-x-2">
-              <Drawer.Close asChild>
-                <Button variant="secondary" size="small" disabled={isAdding}>Cancel</Button>
-              </Drawer.Close>
-              <Button
-                size="small"
-                isLoading={isAdding}
-                onClick={async () => {
-                  if (!newEmail.trim()) {
-                    toast.error("Email is required")
-                    return
-                  }
-                  try {
-                    const result = await addAdmin({
-                      email: newEmail.trim(),
-                      first_name: newFirstName.trim() || undefined,
-                      last_name: newLastName.trim() || undefined,
-                      phone: newPhone.trim() || undefined,
-                      role: newRole,
-                      password: newPassword || undefined,
-                    })
-                    toast.success("Admin added", {
-                      description: `Welcome email sent to ${newEmail}. ${result.temp_password ? `Temp password: ${result.temp_password}` : ""}`,
-                    })
-                    setAddDrawerOpen(false)
-                    await queryClient.invalidateQueries({ queryKey: partnersQueryKeys.details() })
-                  } catch (e: any) {
-                    toast.error("Failed to add admin", {
-                      description: e?.message || "Could not create admin",
-                    })
-                  }
-                }}
-              >
-                Add Admin
-              </Button>
-            </div>
-          </Drawer.Footer>
+          {/*
+            🔴 The chrome is published to the form rather than wrapped around a
+            copy of it. `onDone` closes THIS drawer — there is no route to
+            unwind — so the same component serves the section and the graph's
+            stacked modal without either knowing about the other.
+          */}
+          <DrawerChromeProvider
+            parts={{
+              Header: Drawer.Header,
+              Title: Drawer.Title,
+              Description: Drawer.Description,
+              Body: Drawer.Body,
+              Footer: Drawer.Footer,
+              Close: Drawer.Close,
+            }}
+            onClose={() => setAddDrawerOpen(false)}
+          >
+            <AddPartnerAdminForm partnerId={partnerId} />
+          </DrawerChromeProvider>
         </Drawer.Content>
       </Drawer>
     </Container>

--- a/apps/backend/src/admin/components/partners/partner-credits-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-credits-section.tsx
@@ -271,7 +271,12 @@ export const PartnerCreditsSection = ({ partnerId }: { partnerId: string }) => {
       })
 
   return (
-    <Container className="divide-y p-0" data-partner-id={partnerId}>
+    /* Its own name — see the note in `partner-ledger-section.tsx`. */
+    <Container
+      className="divide-y p-0"
+      data-panel="partner-credits"
+      data-partner-id={partnerId}
+    >
       <div className="flex items-center justify-between px-6 py-4">
         <div className="flex items-center gap-x-2">
           <Heading level="h2">Credits</Heading>

--- a/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
@@ -340,7 +340,19 @@ export const PartnerLedgerSection = ({ partnerId }: { partnerId: string }) => {
   const showTotals = !!totals?.currency && rows.length > 0
 
   return (
-    <Container className="divide-y p-0" data-partner-id={partnerId}>
+    /*
+     * 🔴 `data-panel` as well as the partner id. The id alone stopped being an
+     * identifier the moment a SECOND panel on this page stamped it too — the
+     * credits section (#1730) copied this line, and `[data-partner-id=...]`
+     * then matched two elements, which Playwright's strict mode refuses. The
+     * spec failed reporting that the ledger panel was not visible, when in
+     * fact it was visible twice over.
+     */
+    <Container
+      className="divide-y p-0"
+      data-panel="partner-ledger"
+      data-partner-id={partnerId}
+    >
       <div className="flex items-center justify-between px-6 py-4">
         <div className="flex items-center gap-x-2">
           <Heading level="h2">Payments</Heading>

--- a/apps/backend/src/admin/components/partners/partner-people-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-people-section.tsx
@@ -1,26 +1,24 @@
 import {
   Badge,
   Button,
-  Checkbox,
   Container,
   FocusModal,
   Heading,
-  Input,
   Text,
   toast,
   usePrompt,
 } from "@medusajs/ui"
 import { Plus, Trash, Users } from "@medusajs/icons"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { Link } from "react-router-dom"
 import { ActionMenu } from "../common/action-menu"
 import {
   usePartnerPeople,
   useUnlinkPeopleFromPartner,
-  useLinkPeopleToPartner,
   PartnerPerson,
 } from "../../hooks/api/partner-people"
-import { usePersons } from "../../hooks/api/persons"
+import { LinkPartnerPeopleForm } from "../forms/link-partner-people/link-partner-people-form"
+import { DrawerChromeProvider } from "../modal/chrome/route-chrome-provider"
 
 interface PartnerPeopleSectionProps {
   partnerId: string
@@ -170,7 +168,6 @@ export const PartnerPeopleSection = ({
         partnerId={partnerId}
         open={linkModalOpen}
         onOpenChange={setLinkModalOpen}
-        existingPersonIds={people.map((p) => p.id)}
       />
     </>
   )
@@ -178,153 +175,38 @@ export const PartnerPeopleSection = ({
 
 // ── Modal to search and link existing persons ──
 
-interface LinkPersonToPartnerModalProps {
-  partnerId: string
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  existingPersonIds: string[]
-}
-
+/**
+ * 🔴 The shell only. The form inside it lives in
+ * `components/forms/link-partner-people` so the partner graph opens the same
+ * one this section does (#1856). Before that split this modal WAS the form,
+ * which is why the graph's `people` node could list who was linked and offer
+ * no way to link anybody.
+ */
 const LinkPersonToPartnerModal = ({
   partnerId,
   open,
   onOpenChange,
-  existingPersonIds,
-}: LinkPersonToPartnerModalProps) => {
-  const [search, setSearch] = useState("")
-  const [selected, setSelected] = useState<Record<string, boolean>>({})
-
-  const { persons = [], isLoading } = usePersons(
-    { limit: 50, ...(search ? { q: search } : {}) },
-    { enabled: open }
-  )
-
-  const linkMutation = useLinkPeopleToPartner(partnerId)
-
-  const existingSet = useMemo(
-    () => new Set(existingPersonIds),
-    [existingPersonIds]
-  )
-
-  const selectedCount = useMemo(
-    () => Object.values(selected).filter(Boolean).length,
-    [selected]
-  )
-
-  const togglePerson = (id: string) => {
-    setSelected((prev) => ({ ...prev, [id]: !prev[id] }))
-  }
-
-  const handleLink = async () => {
-    const personIds = Object.entries(selected)
-      .filter(([, v]) => v)
-      .map(([k]) => k)
-
-    if (!personIds.length) return
-
-    await linkMutation.mutateAsync(
-      { person_ids: personIds },
-      {
-        onSuccess: () => {
-          toast.success(`${personIds.length} person(s) linked to partner`)
-          setSelected({})
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast.error(error.message)
-        },
-      }
-    )
-  }
-
-  const handleClose = () => {
-    setSelected({})
-    setSearch("")
-    onOpenChange(false)
-  }
-
+}: {
+  partnerId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) => {
   return (
-    <FocusModal open={open} onOpenChange={handleClose}>
+    <FocusModal open={open} onOpenChange={onOpenChange}>
       <FocusModal.Content>
-        <FocusModal.Header>
-          <Heading>Link People to Partner</Heading>
-        </FocusModal.Header>
-
-        <FocusModal.Body className="flex flex-col gap-y-4 p-6 overflow-y-auto">
-          <Text size="small" className="text-ui-fg-subtle">
-            Select existing people to link to this partner. Linked people can
-            access shared folders and upload files through the partner portal.
-          </Text>
-
-          <Input
-            placeholder="Search people..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            size="small"
-          />
-
-          {isLoading ? (
-            <div className="py-8 text-center">
-              <Text size="small" className="text-ui-fg-muted">
-                Loading...
-              </Text>
-            </div>
-          ) : persons.length === 0 ? (
-            <div className="py-8 text-center">
-              <Text size="small" className="text-ui-fg-muted">
-                No people found
-              </Text>
-            </div>
-          ) : (
-            <div className="flex flex-col divide-y border rounded-lg border-ui-border-base">
-              {persons.map((person: any) => {
-                const isExisting = existingSet.has(person.id)
-                const isChecked = !!selected[person.id]
-
-                return (
-                  <label
-                    key={person.id}
-                    className="flex items-center gap-x-3 px-4 py-3 cursor-pointer hover:bg-ui-bg-base-hover"
-                  >
-                    <Checkbox
-                      checked={isChecked}
-                      disabled={isExisting}
-                      onCheckedChange={() => togglePerson(person.id)}
-                    />
-                    <div className="flex flex-col">
-                      <Text size="small" weight="plus">
-                        {person.first_name} {person.last_name}
-                        {isExisting && (
-                          <span className="text-ui-fg-muted ml-2">
-                            (already linked)
-                          </span>
-                        )}
-                      </Text>
-                      {person.email && (
-                        <Text size="xsmall" className="text-ui-fg-muted">
-                          {person.email}
-                        </Text>
-                      )}
-                    </div>
-                  </label>
-                )
-              })}
-            </div>
-          )}
-        </FocusModal.Body>
-
-        <div className="flex items-center justify-end gap-x-2 border-t border-ui-border-base px-6 py-4">
-          <Button variant="secondary" onClick={handleClose}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleLink}
-            disabled={selectedCount === 0}
-            isLoading={linkMutation.isPending}
-          >
-            Link {selectedCount > 0 ? `(${selectedCount})` : ""}
-          </Button>
-        </div>
+        <DrawerChromeProvider
+          parts={{
+            Header: FocusModal.Header,
+            Title: FocusModal.Title,
+            Description: FocusModal.Description,
+            Body: FocusModal.Body,
+            Footer: FocusModal.Footer,
+            Close: FocusModal.Close,
+          }}
+          onClose={() => onOpenChange(false)}
+        >
+          <LinkPartnerPeopleForm partnerId={partnerId} />
+        </DrawerChromeProvider>
       </FocusModal.Content>
     </FocusModal>
   )

--- a/apps/backend/src/admin/hooks/api/graph.ts
+++ b/apps/backend/src/admin/hooks/api/graph.ts
@@ -32,6 +32,37 @@ export type GraphNode = {
   href: string | null
   props: GraphProp[]
   action: { label: string; href: string | null } | null
+  /** A job this node can RUN. Mirrors `NodeAct` in `src/lib/graph/types.ts`. */
+  act?: NodeAct | null
+}
+
+/**
+ * A two-press operation offered on a node: preview, then apply.
+ *
+ * 🔴 Both bodies come from the SERVER and are sent verbatim — the client never
+ * flips `dry_run` itself. The whole point of shipping two named bodies is that
+ * the call which writes is a different value chosen by a different press, not
+ * the same object with a mutated flag.
+ */
+export type NodeAct = {
+  method: "POST"
+  path: string
+  previewBody: Record<string, unknown> | null
+  /** Null where the act has nothing to apply — render no apply button at all. */
+  applyBody: Record<string, unknown> | null
+  label: string
+  confirm: string
+}
+
+/** What a maintenance-job run answers with. */
+export type NodeActResult = {
+  result: {
+    job_id: string
+    dry_run: boolean
+    applied: boolean
+    summary: string
+    changes: Array<{ id: string; note?: string }>
+  }
 }
 
 export type GraphEdge = {
@@ -183,6 +214,42 @@ export const useRemoveGraphNodeItem = (
       })
       queryClient.invalidateQueries({ queryKey: graphQueryKeys.detail(spine, id) })
       options?.onSuccess?.(...args)
+    },
+  })
+}
+
+/**
+ * Run the job a node offers, through the path the server named.
+ *
+ * 🔴 Invalidates the graph and the node's rows on success, and does it for the
+ * PREVIEW as well as the apply. A dry run writes nothing, but the sweep behind
+ * this board records a run — so the board's "last swept" is stale the moment a
+ * preview returns, and a board that states a time it no longer means is worse
+ * than one that states none.
+ *
+ * 🔴 `...options` BEFORE `onSuccess`. Spread after, the caller's handler
+ * silently replaces the invalidation and the screen stays stale until a hard
+ * refresh — the defect that was live in 165 admin hooks (#1800).
+ */
+export const useRunGraphNodeAct = (
+  spine: string,
+  id: string,
+  options?: UseMutationOptions<NodeActResult, FetchError, { act: NodeAct; apply: boolean }>,
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ act, apply }: { act: NodeAct; apply: boolean }) => {
+      const body = apply ? act.applyBody : act.previewBody
+      return sdk.client.fetch<NodeActResult>(act.path, {
+        method: act.method,
+        ...(body ? { body } : {}),
+      })
+    },
+    ...options,
+    onSuccess: (...args: Parameters<NonNullable<typeof options>["onSuccess"] & {}>) => {
+      queryClient.invalidateQueries({ queryKey: graphQueryKeys.detail(spine, id) })
+      queryClient.invalidateQueries({ queryKey: ["graph", spine, id, "items"] })
+      return options?.onSuccess?.(...args)
     },
   })
 }

--- a/apps/backend/src/admin/routes/desk/entities/queues.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/queues.tsx
@@ -1,3 +1,4 @@
+import DanglingPointersQueuePage from "../../queues/dangling-pointers/page"
 import ProductsAwaitingQueuePage from "../../queues/products-awaiting/page"
 import type { EntityPanelConfig } from "../EntityPanel"
 
@@ -20,6 +21,10 @@ export const queuesEntityConfig: EntityPanelConfig = {
     {
       path: "/queues/products-awaiting",
       element: <ProductsAwaitingQueuePage />,
+    },
+    {
+      path: "/queues/dangling-pointers",
+      element: <DanglingPointersQueuePage />,
     },
   ],
 }

--- a/apps/backend/src/admin/routes/partners/[id]/@add-payment-method/page.tsx
+++ b/apps/backend/src/admin/routes/partners/[id]/@add-payment-method/page.tsx
@@ -1,89 +1,18 @@
-import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer";
-import { Button, Input, Label, Select, Textarea, toast } from "@medusajs/ui";
-import { useParams, useNavigate } from "react-router-dom";
-import { useState } from "react";
-import { useCreatePartnerPaymentMethod } from "../../../../hooks/api/payment-methods";
+import { useParams } from "react-router-dom";
 
+import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer";
+import { AddPartnerPaymentMethodForm } from "../../../../components/creates/create-partner-payment-method";
+
+/**
+ * The route shell. The form itself lives in `components/creates` so the
+ * partner graph opens the same one (#1856) — this page owns only the drawer.
+ */
 const AddPaymentMethodForPartner = () => {
   const { id } = useParams();
-  const navigate = useNavigate();
-  const { mutateAsync, isPending } = useCreatePartnerPaymentMethod(id!);
-
-  const [type, setType] = useState<string>("");
-  const [accountName, setAccountName] = useState("");
-  const [accountNumber, setAccountNumber] = useState("");
-  const [bankName, setBankName] = useState("");
-  const [ifsc, setIfsc] = useState("");
-  const [walletId, setWalletId] = useState("");
-  const [note, setNote] = useState("");
-
-  const onCreate = async () => {
-    await mutateAsync({
-      type,
-      account_name: accountName || undefined,
-      account_number: accountNumber || undefined,
-      bank_name: bankName || undefined,
-      ifsc_code: ifsc || undefined,
-      wallet_id: walletId || undefined,
-      metadata: note ? { note } : undefined,
-    });
-    toast.success("Payment method created");
-    navigate("..", { replace: true });
-  };
 
   return (
     <RouteDrawer>
-      <RouteDrawer.Header>
-        <RouteDrawer.Title>Add Payment Method</RouteDrawer.Title>
-        <RouteDrawer.Description>
-          Create and link a payment method to this partner.
-        </RouteDrawer.Description>
-      </RouteDrawer.Header>
-      <RouteDrawer.Body className="flex flex-1 flex-col gap-y-4 overflow-y-auto pb-4">
-        <div className="grid gap-y-2">
-          <Label>Type</Label>
-          <Select value={type} onValueChange={setType}>
-            <Select.Trigger>
-              <Select.Value placeholder="Select a type" />
-            </Select.Trigger>
-            <Select.Content>
-              <Select.Item value="bank_account">Bank Account</Select.Item>
-              <Select.Item value="cash_account">Cash Account</Select.Item>
-              <Select.Item value="digital_wallet">Digital Wallet</Select.Item>
-            </Select.Content>
-          </Select>
-        </div>
-        <div className="grid gap-y-2">
-          <Label>Account Name</Label>
-          <Input value={accountName} onChange={(e) => setAccountName(e.target.value)} />
-        </div>
-        <div className="grid gap-y-2">
-          <Label>Account Number</Label>
-          <Input value={accountNumber} onChange={(e) => setAccountNumber(e.target.value)} />
-        </div>
-        <div className="grid gap-y-2">
-          <Label>Bank Name</Label>
-          <Input value={bankName} onChange={(e) => setBankName(e.target.value)} />
-        </div>
-        <div className="grid gap-y-2">
-          <Label>IFSC</Label>
-          <Input value={ifsc} onChange={(e) => setIfsc(e.target.value)} />
-        </div>
-        <div className="grid gap-y-2">
-          <Label>Wallet ID</Label>
-          <Input value={walletId} onChange={(e) => setWalletId(e.target.value)} />
-        </div>
-        <div className="grid gap-y-2">
-          <Label>Note</Label>
-          <Textarea value={note} onChange={(e) => setNote(e.target.value)} placeholder="Optional" />
-        </div>
-      </RouteDrawer.Body>
-      <RouteDrawer.Footer className="bg-ui-bg-base border-t border-ui-border-base">
-        <RouteDrawer.Close asChild>
-          <Button variant="secondary" size="small">Cancel</Button>
-        </RouteDrawer.Close>
-        <Button size="small" onClick={onCreate} disabled={isPending || !type}>Create Method</Button>
-      </RouteDrawer.Footer>
+      <AddPartnerPaymentMethodForm partnerId={id!} />
     </RouteDrawer>
   );
 };

--- a/apps/backend/src/admin/routes/queues/dangling-pointers/page.tsx
+++ b/apps/backend/src/admin/routes/queues/dangling-pointers/page.tsx
@@ -1,0 +1,30 @@
+import { GraphWorkspace } from "../../../components/graph/graph-workspace"
+
+/**
+ * `/queues/dangling-pointers` — the data-integrity board (#1857).
+ *
+ * Every `<x>_id` column in the database whose target the graph cannot see,
+ * drawn as one canvas: ranked by what is UNEXPLAINED, each node carrying the
+ * sweep's own sentence — count, rate, a sample of the offending value, and the
+ * written reason where one exists — and, where a fixer job has been written
+ * for it, the data-ops run that repairs it.
+ *
+ * 🔴 It renders `GraphWorkspace` unchanged, like the first cohort board. The
+ * board is a queue whose members are `table.column` PAIRS rather than records,
+ * which cost a resolver and a registry entry: no route, no hook, no new
+ * component. The one thing it did need was an affordance the graph never had —
+ * a node that RUNS something rather than linking somewhere. That is the `act`
+ * rail, and it is the gap #1856 named and left open.
+ */
+const DanglingPointersQueuePage = () => (
+  <div className="flex h-[calc(100vh-140px)] w-full flex-col overflow-hidden rounded-lg border bg-ui-bg-base">
+    <GraphWorkspace
+      spine="queue"
+      id="dangling-pointers"
+      title="Dangling pointers"
+      selfHref="/queues/dangling-pointers"
+    />
+  </div>
+)
+
+export default DanglingPointersQueuePage

--- a/apps/backend/src/api/admin/designs/[id]/cancel-partner-assignment/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/cancel-partner-assignment/route.ts
@@ -1,5 +1,6 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { presentRows } from "../../../../../lib/links/dangling"
 import { cancelPartnerAssignmentWorkflow } from "../../../../../workflows/designs/cancel-partner-assignment"
 import type { CancelPartnerAssignmentReq } from "./validators"
 
@@ -35,7 +36,14 @@ export const POST = async (
   if (!design) {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Design not found")
   }
-  if (!(design.partners || []).some((p: any) => p.id === partner_id)) {
+  /*
+   * 🔴 `presentRows`, not `design.partners`. A dangling `design_partners_link`
+   * row arrives here as a NULL in the array, and `p.id` on it throws — a 500
+   * on the one route whose whole job is undoing a link (#1857). The graph's
+   * partner drawer now calls this endpoint, so a partner with any dangling
+   * design link could not unassign ANY of them.
+   */
+  if (!presentRows(design.partners).some((p) => p.id === partner_id)) {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
       "Partner is not linked to this design"

--- a/apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
@@ -109,6 +109,7 @@ import { approveProductionRunWorkflow } from "../../../../../workflows/productio
 import { autoDispatchApprovedChildren } from "../../../production-runs/auto-dispatch-approved-children"
 
 import type { AdminCreateDesignProductionRunReq } from "./validators"
+import { presentRows } from "../../../../../lib/links/dangling"
 
 export const POST = async (
   req: MedusaRequest<AdminCreateDesignProductionRunReq>,
@@ -141,7 +142,17 @@ export const POST = async (
       filters: { id: designId },
       fields: ["partners.id", "partners.name"],
     })
-    const linkedPartners = designs?.[0]?.partners || []
+    /*
+     * 🔴 Dangling link rows must not get a share of the quantity (#1857). A
+     * null here is a `design_partners_link` row whose partner is gone or
+     * soft-deleted; unfiltered it counts toward `linkedPartners.length`, so
+     * every real partner's split shrinks and one child run is created with
+     * `partner_id: undefined`. Nothing throws — the run is simply smaller than
+     * asked for, which is the hardest kind of wrong to notice.
+     */
+    const linkedPartners = presentRows<{ id: string; name?: string }>(
+      designs?.[0]?.partners
+    )
 
     if (linkedPartners.length && body.quantity != null) {
       // Single partner: assign full quantity

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-dangling-links.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-dangling-links.unit.spec.ts
@@ -24,6 +24,7 @@ const measure = (over: Partial<PairMeasurement> = {}): PairMeasurement => ({
   target: "some",
   total: 10,
   orphans: 3,
+  sample: null,
   ...over,
 })
 
@@ -71,6 +72,37 @@ describe("describePair", () => {
 
   it("survives a pair with no rows rather than dividing by zero", () => {
     expect(describePair(measure({ total: 0, orphans: 0 }), "unexplained")).toContain("(0%)")
+  })
+
+  /*
+   * 🔴 The third false positive to top this sweep, and the first the RATE
+   * could not explain. `payment_schedule.cart_id` read 23 of 27 — partial,
+   * unclassified, ranked first — and every offending value was
+   * `cart_e2e_<stamp>`, written by `e2e/helpers/e2e-seed.ts` in a database
+   * that is not prod (prod: 4 rows, 0 orphans). The count took a session to
+   * read. The string takes a glance, so the line has to carry one.
+   */
+  it("carries a sample of the offending value, which the rate cannot supply", () => {
+    const note = describePair(
+      measure({
+        table: "payment_schedule",
+        column: "cart_id",
+        target: "cart",
+        total: 27,
+        orphans: 23,
+        sample: "cart_e2e_1787467149960",
+      }),
+      "unexplained"
+    )
+    expect(note).toContain("23 of 27")
+    // 85% — no shape hint at all, which is exactly why the value is needed.
+    expect(note).not.toContain("never pointed here")
+    expect(note).toContain("cart_e2e_1787467149960")
+  })
+
+  it("says nothing about a sample when there is none to show", () => {
+    const note = describePair(measure({ sample: null }), "unexplained")
+    expect(note).not.toContain("e.g.")
   })
 })
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-dangling-links.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-dangling-links.unit.spec.ts
@@ -1,0 +1,114 @@
+import fs from "fs"
+import path from "path"
+
+import {
+  CLASSIFIED,
+  classifyPair,
+  describePair,
+  type PairMeasurement,
+} from "../audit-dangling-links-job"
+
+/**
+ * #1857 — the re-ranked sweep.
+ *
+ * The first two sweeps ranked by row count and put two NON-defects on top. The
+ * classification table is what fixes that, and it is also the only part of
+ * this job that can rot: every entry is a claim about code that may change
+ * under it. A stale entry does not fail loudly — it makes the sweep go QUIET
+ * about a real defect, which is the one outcome an audit must never have.
+ */
+
+const measure = (over: Partial<PairMeasurement> = {}): PairMeasurement => ({
+  table: "some_table",
+  column: "some_id",
+  target: "some",
+  total: 10,
+  orphans: 3,
+  ...over,
+})
+
+describe("classifyPair", () => {
+  it("returns unexplained for anything not in the table", () => {
+    expect(classifyPair("payment_schedule", "cart_id")).toBe("unexplained")
+  })
+
+  it("recognises the two tombstones that topped the previous sweeps", () => {
+    // Neither is a defect: revoke DELETES the price list, and a variant price
+    // save replaces the whole price set.
+    expect(classifyPair("partner_quote", "price_list_id")).toBe("tombstone")
+    expect(
+      classifyPair("pricing_price_fx_rates_fx_price_meta", "price_id")
+    ).toBe("tombstone")
+  })
+
+  it("recognises the external ids that measured 100%", () => {
+    expect(classifyPair("lead", "form_id")).toBe("external_id")
+    expect(classifyPair("conversion", "analytics_session_id")).toBe("external_id")
+  })
+})
+
+describe("describePair", () => {
+  it("calls out a 100% rate as the external-id signature", () => {
+    /*
+     * 🔴 The line has to say this. Every known false positive measured 100%,
+     * and without it the next reader ranks `conversion.analytics_session_id`
+     * (1934 of 1934) first all over again.
+     */
+    const note = describePair(
+      measure({ table: "lead", column: "form_id", target: "form", total: 230, orphans: 230 }),
+      "external_id"
+    )
+    expect(note).toContain("100%")
+    expect(note).toContain("never pointed here")
+  })
+
+  it("does not claim that shape for a partial rate", () => {
+    const note = describePair(measure({ total: 10, orphans: 3 }), "unexplained")
+    expect(note).toContain("3 of 10")
+    expect(note).toContain("30%")
+    expect(note).not.toContain("never pointed here")
+  })
+
+  it("survives a pair with no rows rather than dividing by zero", () => {
+    expect(describePair(measure({ total: 0, orphans: 0 }), "unexplained")).toContain("(0%)")
+  })
+})
+
+describe("the classification table cannot rot silently", () => {
+  const repoSrc = path.resolve(__dirname, "../../../../..")
+
+  it("every entry gives a reason", () => {
+    for (const [key, value] of Object.entries(CLASSIFIED)) {
+      expect(`${key}: ${value.reason}`.length).toBeGreaterThan(key.length + 30)
+    }
+  })
+
+  it("every file a tombstone cites still exists", () => {
+    /*
+     * 🔴 An audit verdict is a claim about the PAST. A previous verdict sweep
+     * in this repo cited eleven files and four of them had been deleted. A
+     * tombstone entry whose cited file is gone is an explanation nobody can
+     * check, sitting in front of rows the sweep has stopped reporting.
+     *
+     * This does not prove the behaviour is unchanged — only a reader can do
+     * that. It catches the cheapest and commonest rot: the file moved.
+     */
+    const cited = Object.values(CLASSIFIED)
+      .flatMap((c) => c.reason.match(/[\w./-]+\.ts/g) ?? [])
+      .filter((p) => p.includes("/"))
+
+    expect(cited.length).toBeGreaterThan(0)
+    for (const rel of cited) {
+      expect({ rel, exists: fs.existsSync(path.join(repoSrc, rel)) }).toEqual({
+        rel,
+        exists: true,
+      })
+    }
+  })
+
+  it("keys are `table.column`, so a typo cannot silently match nothing", () => {
+    for (const key of Object.keys(CLASSIFIED)) {
+      expect(key).toMatch(/^[a-z0-9_-]+\.[a-z0-9_]+_id$/)
+    }
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/compact-fx-price-meta.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/compact-fx-price-meta.unit.spec.ts
@@ -1,0 +1,154 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import priceFxMetaLink from "../../../../../links/price-fx-meta"
+import { FX_RATES_MODULE } from "../../../../../modules/fx_rates"
+import {
+  compactFxPriceMetaJob,
+  isOrphanedFxMeta,
+} from "../compact-fx-price-meta-job"
+
+/**
+ * #1857 — the FX marker compaction pass.
+ *
+ * The pure predicate is one line; what is worth locking down is the SHAPE of
+ * the apply path, because every way of getting it wrong is silent:
+ *
+ *   - taking the price id from `meta.price.id` gets `undefined` on exactly the
+ *     rows this job exists for, and a dismiss with a missing side removes
+ *     nothing while the delete still succeeds — leaving a link row whose BOTH
+ *     ends are gone, which is worse than the dangle being cleaned up
+ *   - deleting before dismissing has the same end state if the dismiss throws
+ *   - a dry run that writes anything is unarguable in the wrong direction
+ */
+
+describe("isOrphanedFxMeta", () => {
+  it("is true when the price did not resolve", () => {
+    expect(isOrphanedFxMeta({ price: null })).toBe(true)
+    expect(isOrphanedFxMeta({})).toBe(true)
+  })
+
+  it("is true for a price object with no id", () => {
+    // A soft-deleted target resolves to the same absent join as a hard-deleted
+    // one. Asking "does a row exist" instead of "can the graph see it" is what
+    // took the prod count from 27 pairs to 46.
+    expect(isOrphanedFxMeta({ price: {} })).toBe(true)
+  })
+
+  it("is false for a live price", () => {
+    expect(isOrphanedFxMeta({ price: { id: "price_1" } })).toBe(false)
+  })
+})
+
+/** One live marker, one orphan — the orphan's price id exists ONLY on the link row. */
+const buildContainer = () => {
+  const graph = jest.fn(async ({ entity }: { entity: string }) => {
+    if (entity === "fx_price_meta") {
+      return {
+        data: [
+          { id: "meta_live", base_currency: "inr", base_amount: 10, fx_rate: 1, price: { id: "price_live" } },
+          { id: "meta_orphan", base_currency: "inr", base_amount: 10, fx_rate: 1, price: null },
+        ],
+      }
+    }
+    if (entity === priceFxMetaLink.entryPoint) {
+      return {
+        data: [{ fx_price_meta_id: "meta_orphan", price_id: "price_dead" }],
+      }
+    }
+    return { data: [] }
+  })
+
+  const order: string[] = []
+  /*
+   * 🔴 The parameters are DECLARED even though the bodies ignore them.
+   * `jest.fn(async () => …)` types `mock.calls` as an empty tuple, so
+   * `mock.calls[0][0]` below is `error TS2493` — and jest itself is perfectly
+   * happy, so the suite goes green and `check:prod-build` (which compiles the
+   * specs) is the thing that fails.
+   */
+  const dismiss = jest.fn(async (_defs: Record<string, any>[]) => {
+    order.push("dismiss")
+  })
+  const deleteFxPriceMetas = jest.fn(async (_id: string) => {
+    order.push("delete")
+  })
+
+  const container = {
+    resolve: (key: string) => {
+      if (key === ContainerRegistrationKeys.QUERY) return { graph }
+      if (key === ContainerRegistrationKeys.LINK) return { dismiss }
+      if (key === FX_RATES_MODULE) return { deleteFxPriceMetas }
+      return {}
+    },
+  }
+
+  return { container, graph, dismiss, deleteFxPriceMetas, order }
+}
+
+describe("compact-fx-price-meta — dry run", () => {
+  it("selects only the orphan and states why", async () => {
+    const { container, dismiss, deleteFxPriceMetas } = buildContainer()
+
+    const result = await compactFxPriceMetaJob.run(container, {
+      dry_run: true,
+      params: {},
+    })
+
+    expect(result.changes).toHaveLength(1)
+    expect(result.changes[0].id).toBe("meta_orphan")
+    expect(result.applied).toBe(false)
+    // 🔴 The reason field is `note`. Named `reason` it type-errors only without
+    // a cast — and with one, the dry run silently loses the only thing that
+    // makes it checkable.
+    expect(result.changes[0].note).toContain("price_dead")
+    expect(result.summary).toContain("Would prune 1")
+
+    // Asserted on the mocks AFTER the call, never inside them.
+    expect(dismiss).not.toHaveBeenCalled()
+    expect(deleteFxPriceMetas).not.toHaveBeenCalled()
+  })
+})
+
+describe("compact-fx-price-meta — apply", () => {
+  it("dismisses with the price id FROM THE LINK ROW, then deletes", async () => {
+    const { container, dismiss, deleteFxPriceMetas, order } = buildContainer()
+
+    const result = await compactFxPriceMetaJob.run(container, {
+      dry_run: false,
+      params: {},
+    })
+
+    expect(result.applied).toBe(true)
+
+    /*
+     * 🔴 `price_dead` comes only from the link table. `meta.price` is null on
+     * this row — that is what makes it an orphan — so a dismiss built from the
+     * meta would carry `price_id: undefined` and quietly match nothing.
+     */
+    expect(dismiss).toHaveBeenCalledTimes(1)
+    expect(dismiss.mock.calls[0][0]).toEqual([
+      {
+        [Modules.PRICING]: { price_id: "price_dead" },
+        [FX_RATES_MODULE]: { fx_price_meta_id: "meta_orphan" },
+      },
+    ])
+
+    expect(deleteFxPriceMetas).toHaveBeenCalledTimes(1)
+    expect(deleteFxPriceMetas.mock.calls[0][0]).toBe("meta_orphan")
+
+    // Order matters: reversed, a throw between them strands the link row.
+    expect(order).toEqual(["dismiss", "delete"])
+  })
+
+  it("leaves the live marker completely alone", async () => {
+    const { container, dismiss, deleteFxPriceMetas } = buildContainer()
+    await compactFxPriceMetaJob.run(container, { dry_run: false, params: {} })
+
+    const touched = [
+      ...dismiss.mock.calls.flat(),
+      ...deleteFxPriceMetas.mock.calls,
+    ]
+    expect(JSON.stringify(touched)).not.toContain("meta_live")
+    expect(JSON.stringify(touched)).not.toContain("price_live")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/audit-dangling-links-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/audit-dangling-links-job.ts
@@ -108,6 +108,18 @@ export type PairMeasurement = {
   total: number
   /** Of those, how many point at a target the graph cannot see. */
   orphans: number
+  /**
+   * One of the offending pointer values, verbatim.
+   *
+   * 🔴 This exists because three sweeps in a row put a NON-defect on top and
+   * the count could not say so. `payment_schedule.cart_id` read 23 of 27 —
+   * and every one of the 23 was `cart_e2e_<stamp>`, fabricated by
+   * `e2e/helpers/e2e-seed.ts`, which needs a text key and not a cart. Prod
+   * holds 4 rows and 0 orphans. A single sample value answers in one glance
+   * the question the count takes a session to answer: is this a pointer that
+   * broke, or a string that was never a pointer?
+   */
+  sample: string | null
 }
 
 /** PURE: how a measured pair is classified. Exported for unit tests. */
@@ -122,6 +134,14 @@ export function classifyPair(table: string, column: string): PairClass {
  * catastrophe — every one of the known false positives measured 100%. Saying
  * so on the line is what stops the next reader ranking it first all over
  * again.
+ *
+ * 🔴 And the line carries a SAMPLE VALUE, because the rate is not always the
+ * tell. `payment_schedule.cart_id` measured 23 of 27 — a partial rate, no
+ * classification, top of the sweep — and the sample would have read
+ * `cart_e2e_1787467149960`: an id the e2e seed fabricates, in a database that
+ * is not prod. Three sweeps have now been topped by something that was not a
+ * defect. Two of them were answered by reading code; this one is answered by
+ * looking at the string.
  */
 export function describePair(m: PairMeasurement, klass: PairClass): string {
   const pct = m.total ? Math.round((m.orphans / m.total) * 100) : 0
@@ -130,7 +150,10 @@ export function describePair(m: PairMeasurement, klass: PairClass): string {
       ? " — 100%, the signature of an id that never pointed here"
       : ""
   const known = CLASSIFIED[`${m.table}.${m.column}`]
-  return `${m.orphans} of ${m.total} point at a ${m.target} that is not visible (${pct}%)${shape}${
+  // The value itself, because a count cannot tell a broken pointer from a
+  // string that was never one — and the shape of the id usually can.
+  const sample = m.sample ? ` · e.g. \`${m.sample}\`` : ""
+  return `${m.orphans} of ${m.total} point at a ${m.target} that is not visible (${pct}%)${shape}${sample}${
     known ? ` · ${klass}: ${known.reason}` : ""
   }`
 }
@@ -223,7 +246,8 @@ export const auditDanglingLinksJob: MaintenanceJob = {
       const sql = `
         select
           count(*) filter (where s."${col}" is not null) as total,
-          count(*) filter (where s."${col}" is not null and t."id" is null) as orphans
+          count(*) filter (where s."${col}" is not null and t."id" is null) as orphans,
+          min(s."${col}") filter (where s."${col}" is not null and t."id" is null) as sample
         from "${src}" s
         left join "${tgt}" t on t."id" = s."${col}" ${tgtLive}
         where true ${srcLive}
@@ -251,6 +275,7 @@ export const auditDanglingLinksJob: MaintenanceJob = {
         target: tgt,
         total: Number(row?.total ?? 0),
         orphans: Number(row?.orphans ?? 0),
+        sample: row?.sample == null ? null : String(row.sample),
       }
       if (m.orphans < min_orphans) {
         continue

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/audit-dangling-links-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/audit-dangling-links-job.ts
@@ -1,0 +1,299 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * #1857 — the dangling-pointer sweep, re-run so it ranks by what is
+ * UNEXPLAINED rather than by row count.
+ *
+ * WHY THE FIRST TWO SWEEPS RANKED THE WRONG THINGS
+ * ------------------------------------------------
+ * They measured "how many rows point at a target the graph cannot see" and
+ * sorted by the number. Both clusters that came top were then investigated and
+ * neither was a defect:
+ *
+ *   pricing_price_fx_rates_fx_price_meta   215/610  a variant price save
+ *     REPLACES the whole price set, so FX markers outlive their prices. The one
+ *     reader already skips them; `compact-fx-price-meta` prunes them.
+ *   partner_quote.price_list_id             10/12   `revokeQuote` DELETES the
+ *     price list. A revoked quote pointing at a deleted list is the DESIGNED
+ *     terminal state.
+ *
+ * 🔑 A sweep asking "does the target resolve" cannot tell a DANGLING pointer
+ * from a DELIBERATELY SEVERED one — severing a pointer is how several systems
+ * here express *revoked*, *superseded*, *expired*. So this one carries a
+ * classification table with a written reason per entry, reports the classified
+ * pairs separately, and ranks only the rest.
+ *
+ * An entry in that table is a CLAIM about the code, and it is the only part of
+ * this job that can rot. Each one names the function that does the severing.
+ *
+ * 🔴 VISIBILITY, not existence. A soft-deleted target resolves to the same
+ * absent join as a hard-deleted one, and asking the other question is what
+ * made the first sweeps undercount — the corrected prod figure went from 27
+ * pairs to 46.
+ *
+ * 🔴 A pair that could not be measured is reported as UNMEASURED, never folded
+ * into the clean ones. A check that never ran reads as a pass, and on a sweep
+ * whose whole output is "these are fine" that is the worst available failure.
+ */
+
+export const MAX_PAIR_SCAN = 1000
+/** Per-pair statement timeout. A slow pair becomes `unmeasured`, not `clean`. */
+export const PAIR_TIMEOUT_MS = 15000
+
+export type PairClass = "tombstone" | "external_id" | "core" | "unexplained"
+
+export type Classification = {
+  klass: Exclude<PairClass, "unexplained">
+  /** Why, naming the code that does it. Read as a claim that can go stale. */
+  reason: string
+}
+
+/**
+ * What we already know about, keyed `table.column`.
+ *
+ * 🔴 Every `tombstone` entry names the function that severs the pointer. When
+ * one of these is wrong the sweep goes quiet about a real defect, so the
+ * citation is the only thing making it checkable.
+ */
+export const CLASSIFIED: Record<string, Classification> = {
+  "partner_quote.price_list_id": {
+    klass: "tombstone",
+    reason:
+      "revokeQuote (modules/partner-quote/lib/revoke-quote.ts) DELETES the price list and sets status='revoked'. A revoked quote pointing at a deleted list is the designed terminal state — the list is destroyed so the quote can never price again.",
+  },
+  "pricing_price_fx_rates_fx_price_meta.price_id": {
+    klass: "tombstone",
+    reason:
+      "updateProductVariantsWorkflow replaces the whole price set, so an FX marker outlives the price it marks. rerate-auto-converted-prices already skips these; compact-fx-price-meta prunes them.",
+  },
+
+  // Ids that belong to someone else's system and happen to share a name with a
+  // local table. Measured at 100% 'dangling' precisely because they never
+  // pointed here in the first place.
+  "lead.form_id": {
+    klass: "external_id",
+    reason: "Meta/ads form id — an external identifier, not a local `form` row.",
+  },
+  "lead.ad_id": {
+    klass: "external_id",
+    reason: "Meta/ads ad id — an external identifier, not a local `ad` row.",
+  },
+  "conversion.analytics_session_id": {
+    klass: "external_id",
+    reason:
+      "Analytics session id from the tracking payload — not a local `analytics_session` row.",
+  },
+
+  // Medusa's own tables. Excluded by decision in #1857: core copes with its
+  // own lifecycle, and we do not own the writers.
+  "cart.customer_id": { klass: "core", reason: "Medusa core owns this lifecycle." },
+  "product_product_option.product_id": {
+    klass: "core",
+    reason: "Medusa core owns this lifecycle.",
+  },
+  "product_product_option.product_option_id": {
+    klass: "core",
+    reason: "Medusa core owns this lifecycle.",
+  },
+}
+
+export type PairMeasurement = {
+  table: string
+  column: string
+  target: string
+  /** Rows with a non-null pointer (live source rows only). */
+  total: number
+  /** Of those, how many point at a target the graph cannot see. */
+  orphans: number
+}
+
+/** PURE: how a measured pair is classified. Exported for unit tests. */
+export function classifyPair(table: string, column: string): PairClass {
+  return CLASSIFIED[`${table}.${column}`]?.klass ?? "unexplained"
+}
+
+/**
+ * PURE: the operator-facing line for one pair.
+ *
+ * 🔴 A 100% orphan rate is the signature of an EXTERNAL id, not of a
+ * catastrophe — every one of the known false positives measured 100%. Saying
+ * so on the line is what stops the next reader ranking it first all over
+ * again.
+ */
+export function describePair(m: PairMeasurement, klass: PairClass): string {
+  const pct = m.total ? Math.round((m.orphans / m.total) * 100) : 0
+  const shape =
+    pct === 100
+      ? " — 100%, the signature of an id that never pointed here"
+      : ""
+  const known = CLASSIFIED[`${m.table}.${m.column}`]
+  return `${m.orphans} of ${m.total} point at a ${m.target} that is not visible (${pct}%)${shape}${
+    known ? ` · ${klass}: ${known.reason}` : ""
+  }`
+}
+
+const paramsSchema = z.object({
+  limit: z.number().int().positive().max(MAX_PAIR_SCAN).optional().default(MAX_PAIR_SCAN),
+  /** Report a pair only at or above this many orphans. */
+  min_orphans: z.number().int().min(1).optional().default(1),
+  /** Include the pairs we already have an answer for. Off by default. */
+  include_classified: z.boolean().optional().default(false),
+})
+
+/** Candidate `(table, column) → target` pairs, discovered from the catalog. */
+const DISCOVERY_SQL = `
+with cols as (
+  select c.table_name, c.column_name,
+         regexp_replace(c.column_name, '_id$', '') as base
+  from information_schema.columns c
+  join information_schema.tables t
+    on t.table_name = c.table_name and t.table_schema = 'public'
+   and t.table_type = 'BASE TABLE'
+  where c.table_schema = 'public'
+    and c.column_name like '%\\_id'
+    and c.data_type in ('text', 'character varying')
+),
+resolved as (
+  select distinct on (cols.table_name, cols.column_name)
+         cols.table_name, cols.column_name, tt.table_name as target
+  from cols
+  join information_schema.tables tt
+    on tt.table_schema = 'public' and tt.table_type = 'BASE TABLE'
+   and tt.table_name in (cols.base, cols.base || 's', regexp_replace(cols.base, 's$', ''))
+  join information_schema.columns tid
+    on tid.table_schema = 'public' and tid.table_name = tt.table_name
+   and tid.column_name = 'id'
+  where tt.table_name <> cols.table_name
+  order by cols.table_name, cols.column_name,
+           -- prefer the exact name over a pluralised guess
+           (tt.table_name = cols.base) desc
+)
+select table_name, column_name, target,
+       exists (select 1 from information_schema.columns d
+                where d.table_schema='public' and d.table_name = resolved.table_name
+                  and d.column_name='deleted_at') as src_soft_deletes,
+       exists (select 1 from information_schema.columns d
+                where d.table_schema='public' and d.table_name = resolved.target
+                  and d.column_name='deleted_at') as tgt_soft_deletes
+from resolved
+order by table_name, column_name
+`
+
+export const auditDanglingLinksJob: MaintenanceJob = {
+  id: "audit-dangling-links",
+  label: "Audit dangling pointers, ranked by what is unexplained",
+  description:
+    "Read-only. Walks every `<x>_id` column whose implied table exists and counts the rows pointing at a target query.graph cannot see — counting a soft-deleted target as invisible, because a reader cannot tell it from a missing one. Pairs with a written explanation (a deliberate tombstone like revokeQuote deleting its price list, an external id that merely shares a name, or a Medusa-core table) are classified and reported separately, so the ranking is by UNEXPLAINED rows rather than by rows. A pair that cannot be measured in time is reported as unmeasured, never as clean. Writes nothing in either mode.",
+  params: [
+    { name: "limit", type: "number", required: false, description: `Max pairs to measure (default & max ${MAX_PAIR_SCAN})` },
+    { name: "min_orphans", type: "number", required: false, description: "Only report pairs with at least this many orphans (default 1)" },
+    { name: "include_classified", type: "boolean", required: false, description: "Also list the pairs that already have an explanation (default false)" },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { limit, min_orphans, include_classified } = parsed.data
+
+    const pg: any = container.resolve(ContainerRegistrationKeys.PG_CONNECTION)
+
+    const discovered = (await pg.raw(DISCOVERY_SQL))?.rows ?? []
+    const pairs = discovered.slice(0, limit)
+
+    const changes: MaintenanceChange[] = []
+    const unmeasured: Array<{ id: string; message: string }> = []
+    let measured = 0
+    let unexplainedOrphans = 0
+    let classifiedOrphans = 0
+
+    for (const p of pairs) {
+      const src = String(p.table_name)
+      const col = String(p.column_name)
+      const tgt = String(p.target)
+      const srcLive = p.src_soft_deletes ? `and s."deleted_at" is null` : ""
+      const tgtLive = p.tgt_soft_deletes ? `and t."deleted_at" is null` : ""
+
+      const sql = `
+        select
+          count(*) filter (where s."${col}" is not null) as total,
+          count(*) filter (where s."${col}" is not null and t."id" is null) as orphans
+        from "${src}" s
+        left join "${tgt}" t on t."id" = s."${col}" ${tgtLive}
+        where true ${srcLive}
+      `
+
+      let row: any
+      try {
+        /*
+         * 🔴 A per-statement timeout, and a timeout is an ERROR not a zero.
+         * Some of these tables are large in prod; a pair that quietly returned
+         * 0 because it gave up would read exactly like a clean one, on a job
+         * whose entire output is a list of things that are fine.
+         */
+        await pg.raw(`set local statement_timeout = ${PAIR_TIMEOUT_MS}`)
+        row = (await pg.raw(sql))?.rows?.[0]
+      } catch (e: any) {
+        unmeasured.push({ id: `${src}.${col}`, message: e?.message ?? String(e) })
+        continue
+      }
+
+      measured += 1
+      const m: PairMeasurement = {
+        table: src,
+        column: col,
+        target: tgt,
+        total: Number(row?.total ?? 0),
+        orphans: Number(row?.orphans ?? 0),
+      }
+      if (m.orphans < min_orphans) {
+        continue
+      }
+
+      const klass = classifyPair(src, col)
+      if (klass === "unexplained") {
+        unexplainedOrphans += m.orphans
+      } else {
+        classifiedOrphans += m.orphans
+        if (!include_classified) {
+          continue
+        }
+      }
+
+      changes.push({
+        entity: klass === "unexplained" ? "dangling" : `known:${klass}`,
+        id: `${src}.${col}`,
+        field: `→ ${tgt}`,
+        before: m.orphans,
+        after: m.total,
+        note: describePair(m, klass),
+      })
+    }
+
+    // Worst first, and only among the ones nobody has explained yet.
+    changes.sort((a, b) => Number(b.before ?? 0) - Number(a.before ?? 0))
+
+    const unexplainedPairs = changes.filter((c) => c.entity === "dangling").length
+    const summary =
+      `Measured ${measured} of ${discovered.length} pointer pair(s): ` +
+      `${unexplainedPairs} unexplained pair(s) holding ${unexplainedOrphans} row(s), ` +
+      `${classifiedOrphans} row(s) in pairs that already have a written explanation` +
+      (unmeasured.length ? `, ${unmeasured.length} UNMEASURED (timed out — not clean, unknown)` : "")
+
+    return {
+      job_id: auditDanglingLinksJob.id,
+      dry_run,
+      // Read-only: there is nothing to apply, in either mode.
+      applied: false,
+      summary,
+      changes,
+      errors: unmeasured.length ? unmeasured : undefined,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/compact-fx-price-meta-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/compact-fx-price-meta-job.ts
@@ -1,0 +1,214 @@
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import priceFxMetaLink from "../../../../links/price-fx-meta"
+import { FX_RATES_MODULE } from "../../../../modules/fx_rates"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * #1857 — prune `fx_price_meta` markers whose Price no longer exists.
+ *
+ * THE MECHANISM (measured, not inferred)
+ * --------------------------------------
+ * `fx_price_meta` marks a Price as "created by FX fanout, safe to re-rate",
+ * joined to the price by a 1:1 link. Nothing was wrong with how those rows are
+ * WRITTEN — the fault is what happens to the price underneath them.
+ *
+ * `updateProductVariantsWorkflow` (every partner variant save, and the admin
+ * variant route) does not patch prices in place: it **replaces the whole price
+ * set**. Reproduced locally on `pset_01KX8REJ65…` — one `POST
+ * /admin/products/:id/variants/:id` carrying a single `inr` price:
+ *
+ *   - all 11 fanout prices were HARD-deleted (0 soft-deleted, 0 surviving)
+ *   - live link rows pointing at a missing price went 9 → 20 in that one request
+ *   - all 20 markers survived
+ *   - even the `inr` price I SENT came back with a new id
+ *
+ * So every variant price save orphans every FX marker on that variant, and the
+ * fanout that runs immediately afterwards creates a fresh set beside them. The
+ * tables grow by N rows per save, for ever. In prod this is the largest
+ * dangling-link cluster in the #1857 audit: 215 of 610.
+ *
+ * WHY THIS IS A JANITOR AND NOT A BUG FIX
+ * ---------------------------------------
+ * 🔴 The one reader that walks these rows — `rerate-auto-converted-prices` —
+ * already handles it correctly: it skips a marker whose price is gone and says
+ * in a comment that "a separate compaction pass can prune these". That pass was
+ * never written; this is it. Nothing is mispriced by the orphans. What they
+ * cost is unbounded growth and a `scanned` count that is 35% noise.
+ *
+ * Fixing it at the producer would mean intercepting Medusa's own price-set
+ * replacement, which owns those rows and gives us no event to hang off.
+ *
+ * WHAT IT DOES
+ * ------------
+ * Finds every live `fx_price_meta` whose linked Price is not visible, dismisses
+ * the link and deletes the marker — the same order, and the same two calls, the
+ * strip-on-edit route already uses when a partner overrides an auto price.
+ * Dry-run (the default) lists them with the reason. Apply is idempotent.
+ */
+
+/** Hard cap on markers scanned in one call. */
+export const MAX_META_SCAN = 20000
+
+const paramsSchema = z.object({
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_META_SCAN)
+    .optional()
+    .default(MAX_META_SCAN),
+})
+
+/**
+ * PURE: is this marker orphaned?
+ *
+ * 🔴 The test is whether `query.graph` can SEE the price, not whether a row
+ * exists somewhere. A soft-deleted price resolves to the same absent join as a
+ * hard-deleted one, and the first two sweeps of #1857 missed every soft-deleted
+ * target by asking the other question — which is what took the prod count from
+ * 27 pairs to 46. Exported for unit tests.
+ */
+export function isOrphanedFxMeta(meta: { price?: { id?: string } | null }): boolean {
+  return !meta?.price?.id
+}
+
+export const compactFxPriceMetaJob: MaintenanceJob = {
+  id: "compact-fx-price-meta",
+  label: "Compact FX price markers whose price is gone",
+  description:
+    "Prune fx_price_meta rows (and their price↔meta link) left behind when the underlying Medusa Price was deleted. Every variant price save REPLACES the whole price set, so each save orphans all of that variant's FX markers while fanout creates a fresh set beside them — measured at 11 orphans from a single variant update locally, and 215 of 610 link rows in prod. Nothing is mispriced by them: the daily re-rate already skips a marker whose price is gone. This is the compaction pass that job's own comment asks for. Dry-run lists what would be pruned and why; apply dismisses the link then deletes the marker, in that order, and is idempotent.",
+  params: [
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max fx_price_meta rows to scan in one call (default & max ${MAX_META_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+    const fxService: any = container.resolve(FX_RATES_MODULE)
+
+    /*
+     * The same read the re-rate job makes, so the two agree about what an
+     * orphan is by construction rather than by two similar-looking filters.
+     */
+    const { data: metas } = await query.graph({
+      entity: "fx_price_meta",
+      fields: [
+        "id",
+        "base_currency",
+        "base_amount",
+        "fx_rate",
+        "source_price_id",
+        "price.id",
+      ],
+      pagination: { take: limit },
+    })
+
+    const orphans = ((metas || []) as any[]).filter(isOrphanedFxMeta)
+
+    /*
+     * 🔴 The price id has to come from the LINK table, read through its
+     * `entryPoint`.
+     *
+     * The obvious source is `meta.price.id` from the query above — and on an
+     * orphan that is precisely the thing that is null. Without the link row
+     * there is nothing to dismiss WITH: `link.dismiss` needs both sides, and a
+     * dismiss with a wrong or missing price id silently removes nothing while
+     * `deleteFxPriceMetas` succeeds, which would leave the link row behind
+     * pointing at a marker that no longer exists either — a worse dangle than
+     * the one being cleaned up.
+     */
+    const orphanIds = orphans.map((m) => String(m.id))
+    const priceIdByMeta = new Map<string, string>()
+    if (orphanIds.length) {
+      const { data: linkRows } = await query.graph({
+        entity: priceFxMetaLink.entryPoint,
+        filters: { fx_price_meta_id: orphanIds },
+        fields: ["price_id", "fx_price_meta_id"],
+      })
+      for (const row of (linkRows || []) as any[]) {
+        if (row?.fx_price_meta_id && row?.price_id) {
+          priceIdByMeta.set(String(row.fx_price_meta_id), String(row.price_id))
+        }
+      }
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    for (const meta of orphans) {
+      const metaId = String(meta.id)
+      const priceId = priceIdByMeta.get(metaId)
+
+      changes.push({
+        entity: "fx_price_meta",
+        id: metaId,
+        field: "price link",
+        before: priceId ?? "(no live link row)",
+        after: null,
+        /*
+         * 🔴 `note`, and NOT behind an `as MaintenanceChange`. My first draft
+         * called this `reason` and cast the object to shut the compiler up —
+         * which type-checked, and would have dropped the one field that makes
+         * a dry-run arguable. A sweep that lists ids and nothing else can only
+         * be checked by re-deriving it by hand.
+         */
+        note: priceId
+          ? `price ${priceId} is not visible — the marker says this price was FX-created and it no longer exists (base ${meta.base_currency} ${meta.base_amount} @ ${meta.fx_rate})`
+          : `no live link row for this marker — it marks nothing at all`,
+      })
+
+      if (dry_run) {
+        continue
+      }
+
+      try {
+        /*
+         * Dismiss first, delete second — the order the strip-on-edit route
+         * uses. Reversed, a failure between the two leaves a link row whose
+         * BOTH ends are gone.
+         */
+        if (priceId) {
+          await link.dismiss([
+            {
+              [Modules.PRICING]: { price_id: priceId },
+              [FX_RATES_MODULE]: { fx_price_meta_id: metaId },
+            },
+          ])
+        }
+        await fxService.deleteFxPriceMetas(metaId)
+      } catch (e: any) {
+        errors.push({ id: metaId, message: e?.message ?? String(e) })
+      }
+    }
+
+    const scanned = ((metas || []) as any[]).length
+    const summary =
+      changes.length === 0
+        ? `No changes — scanned ${scanned} fx_price_meta row(s), every one still points at a live price`
+        : `${dry_run ? "Would prune" : "Pruned"} ${changes.length} orphaned FX marker(s) of ${scanned} scanned (${Math.round((changes.length / Math.max(scanned, 1)) * 100)}% of the table marks a price that no longer exists)`
+
+    return {
+      job_id: compactFxPriceMetaJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0 && errors.length < changes.length,
+      summary,
+      changes,
+      errors: errors.length ? errors : undefined,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -130,6 +130,7 @@ import { reconcileConsumptionVsProductionJob } from "./reconcile-consumption-vs-
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
 import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
+import { compactFxPriceMetaJob } from "./compact-fx-price-meta-job"
 import { repairShippingOptionStoreVisibilityJob } from "./repair-shipping-option-store-visibility-job"
 import { backfillOpenOrderRequiresShippingJob } from "./backfill-open-order-requires-shipping-job"
 import { cleanOrderFulfillmentDataJob } from "./clean-order-fulfillment-data-job"
@@ -5906,6 +5907,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillDesignSizeSetsJob,
   backfillPartnerShippingOptionsJob,
   repairShippingOptionStoreVisibilityJob,
+  compactFxPriceMetaJob,
   backfillOpenOrderRequiresShippingJob,
   backfillProductShippingProfilesJob,
   normalizeArtisanProductsJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -130,6 +130,7 @@ import { reconcileConsumptionVsProductionJob } from "./reconcile-consumption-vs-
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
 import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
+import { auditDanglingLinksJob } from "./audit-dangling-links-job"
 import { compactFxPriceMetaJob } from "./compact-fx-price-meta-job"
 import { repairShippingOptionStoreVisibilityJob } from "./repair-shipping-option-store-visibility-job"
 import { backfillOpenOrderRequiresShippingJob } from "./backfill-open-order-requires-shipping-job"
@@ -5908,6 +5909,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillPartnerShippingOptionsJob,
   repairShippingOptionStoreVisibilityJob,
   compactFxPriceMetaJob,
+  auditDanglingLinksJob,
   backfillOpenOrderRequiresShippingJob,
   backfillProductShippingProfilesJob,
   normalizeArtisanProductsJob,

--- a/apps/backend/src/api/partners/api-keys/[id]/revoke/route.ts
+++ b/apps/backend/src/api/partners/api-keys/[id]/revoke/route.ts
@@ -2,6 +2,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { revokeApiKeysWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerFromAuthContext } from "../../../helpers"
+import { presentRows } from "../../../../../lib/links/dangling"
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
@@ -24,7 +25,7 @@ export const POST = async (
     fields: ["id", "stores.*"],
     filters: { id: partner.id },
   })
-  const stores = partnerData?.[0]?.stores || []
+  const stores = presentRows(partnerData?.[0]?.stores)
   const salesChannelIds = stores
     .map((s: any) => s.default_sales_channel_id)
     .filter(Boolean)

--- a/apps/backend/src/api/partners/api-keys/[id]/route.ts
+++ b/apps/backend/src/api/partners/api-keys/[id]/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/frame
 import { updateApiKeysWorkflow, deleteApiKeysWorkflow, revokeApiKeysWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerFromAuthContext } from "../../helpers"
 import { PartnerUpdateApiKeyReq } from "../validators"
+import { presentRows } from "../../../../lib/links/dangling"
 
 async function validateApiKeyOwnership(partner: any, apiKeyId: string, container: any) {
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
@@ -13,7 +14,7 @@ async function validateApiKeyOwnership(partner: any, apiKeyId: string, container
     fields: ["id", "stores.*"],
     filters: { id: partner.id },
   })
-  const stores = partnerData?.[0]?.stores || []
+  const stores = presentRows(partnerData?.[0]?.stores)
   const salesChannelIds = stores
     .map((s: any) => s.default_sales_channel_id)
     .filter(Boolean)

--- a/apps/backend/src/api/partners/api-keys/[id]/sales-channels/route.ts
+++ b/apps/backend/src/api/partners/api-keys/[id]/sales-channels/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { linkSalesChannelsToApiKeyWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerFromAuthContext } from "../../../helpers"
 import { PartnerBatchSalesChannelsReq } from "../../validators"
+import { presentRows } from "../../../../../lib/links/dangling"
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
@@ -25,7 +26,7 @@ export const POST = async (
     fields: ["id", "stores.*"],
     filters: { id: partner.id },
   })
-  const stores = partnerData?.[0]?.stores || []
+  const stores = presentRows(partnerData?.[0]?.stores)
   const partnerSalesChannelIds = stores
     .map((s: any) => s.default_sales_channel_id)
     .filter(Boolean)

--- a/apps/backend/src/api/partners/api-keys/route.ts
+++ b/apps/backend/src/api/partners/api-keys/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/frame
 import { createApiKeysWorkflow, linkSalesChannelsToApiKeyWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerFromAuthContext } from "../helpers"
 import { PartnerCreateApiKeyReq } from "./validators"
+import { presentRows } from "../../../lib/links/dangling"
 
 async function getPartnerSalesChannelIds(partner: any, container: any): Promise<string[]> {
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
@@ -12,7 +13,7 @@ async function getPartnerSalesChannelIds(partner: any, container: any): Promise<
     filters: { id: partner.id },
   })
 
-  const stores = data?.[0]?.stores || []
+  const stores = presentRows(data?.[0]?.stores)
   return stores
     .map((s: any) => s.default_sales_channel_id)
     .filter(Boolean)

--- a/apps/backend/src/api/partners/helpers.ts
+++ b/apps/backend/src/api/partners/helpers.ts
@@ -2,6 +2,7 @@ import { MedusaContainer } from "@medusajs/framework"
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import partnerOrderLink from "../../links/partner-order"
 import { pickPartnerShipFromLocation } from "./lib/ship-from-location"
+import { presentRows } from "../../lib/links/dangling"
 
 export const refetchPartner = async (
     partnerId: string,
@@ -65,7 +66,13 @@ export const validatePartnerStoreAccess = async (
         filters: { id: partner.id },
     })
 
-    const stores = (data?.[0]?.stores || []) as any[]
+    /*
+     * 🔴 Only the stores that RESOLVED (#1857). A dangling
+     * `partner_partner_stores_store` row arrives as a null: `s.id` on it
+     * throws a 500 in the ownership check below, and where it lands at index 0
+     * it makes a partner who HAS a store look like one that has none.
+     */
+    const stores = presentRows(data?.[0]?.stores) as any[]
     const store = stores.find((s: any) => s.id === storeId)
 
     if (!store) {
@@ -106,7 +113,13 @@ export const getPartnerStore = async (
         filters: { id: partner.id },
     })
 
-    const stores = (data?.[0]?.stores || []) as any[]
+    /*
+     * 🔴 Only the stores that RESOLVED (#1857). A dangling
+     * `partner_partner_stores_store` row arrives as a null: `s.id` on it
+     * throws a 500 in the ownership check below, and where it lands at index 0
+     * it makes a partner who HAS a store look like one that has none.
+     */
+    const stores = presentRows(data?.[0]?.stores) as any[]
     if (!stores.length) {
         throw new MedusaError(
             MedusaError.Types.NOT_FOUND,
@@ -149,7 +162,13 @@ export const tryGetPartnerStore = async (
         filters: { id: partner.id },
     })
 
-    const stores = (data?.[0]?.stores || []) as any[]
+    /*
+     * 🔴 Only the stores that RESOLVED (#1857). A dangling
+     * `partner_partner_stores_store` row arrives as a null: `s.id` on it
+     * throws a 500 in the ownership check below, and where it lands at index 0
+     * it makes a partner who HAS a store look like one that has none.
+     */
+    const stores = presentRows(data?.[0]?.stores) as any[]
     return { partner, store: stores[0] || null }
 }
 

--- a/apps/backend/src/api/partners/reservations/[id]/route.ts
+++ b/apps/backend/src/api/partners/reservations/[id]/route.ts
@@ -1,5 +1,6 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules, MedusaError } from "@medusajs/framework/utils"
+import { presentRows } from "../../../../lib/links/dangling"
 
 /**
  * Verify reservation belongs to a partner's stock locations.
@@ -24,7 +25,7 @@ async function verifyReservationOwnership(
     filters: { id: partnerId },
   })
 
-  const salesChannelId = partners?.[0]?.stores?.[0]?.default_sales_channel_id
+  const salesChannelId = presentRows(partners?.[0]?.stores)[0]?.default_sales_channel_id
   if (!salesChannelId) {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Reservation not found")
   }

--- a/apps/backend/src/api/partners/reservations/route.ts
+++ b/apps/backend/src/api/partners/reservations/route.ts
@@ -2,6 +2,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { ContainerRegistrationKeys, Modules, MedusaError } from "@medusajs/framework/utils"
 
 import { applyReservationListFilters } from "./list-filters"
+import { presentRows } from "../../../lib/links/dangling"
 
 /**
  * GET /partners/reservations
@@ -30,7 +31,7 @@ export const GET = async (
     filters: { id: partnerId },
   })
 
-  const salesChannelId = partners?.[0]?.stores?.[0]?.default_sales_channel_id
+  const salesChannelId = presentRows(partners?.[0]?.stores)[0]?.default_sales_channel_id
   if (!salesChannelId) {
     return res.json({ reservations: [], count: 0, limit: 20, offset: 0 })
   }
@@ -126,7 +127,7 @@ export const POST = async (
     filters: { id: partnerId },
   })
 
-  const salesChannelId = partners?.[0]?.stores?.[0]?.default_sales_channel_id
+  const salesChannelId = presentRows(partners?.[0]?.stores)[0]?.default_sales_channel_id
   if (salesChannelId) {
     const { data: channels } = await query.graph({
       entity: "sales_channels",

--- a/apps/backend/src/api/partners/stores/route.ts
+++ b/apps/backend/src/api/partners/stores/route.ts
@@ -205,6 +205,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { PartnerCreateStoreReq } from "./validators"
 import { createStoreWithDefaultsWorkflow } from "../../../workflows/stores/create-store-with-defaults"
 import { getPartnerFromAuthContext } from "../helpers"
+import { presentRows } from "../../../lib/links/dangling"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -228,7 +229,7 @@ export const GET = async (
     filters: { id: partner.id },
   })
 
-  const stores = (data?.[0]?.stores || []) as any[]
+  const stores = presentRows(data?.[0]?.stores) as any[]
 
   if (!stores.length) {
     return res.status(200).json({

--- a/apps/backend/src/lib/graph/queues/__tests__/dangling-pointers.unit.spec.ts
+++ b/apps/backend/src/lib/graph/queues/__tests__/dangling-pointers.unit.spec.ts
@@ -1,0 +1,219 @@
+import {
+  FIXERS,
+  MAX_ITEMS,
+  SWEEP_JOB_ID,
+  pairFromNodeKey,
+  pairNode,
+  resolveDanglingPointers,
+} from "../dangling-pointers"
+
+/**
+ * The dangling-pointer board (#1857).
+ *
+ * Everything worth checking here is a judgement the board makes about a pair,
+ * and none of it is visible from a screenshot: which state a node draws, which
+ * nodes earn a button, and — the one that matters most — that the button which
+ * WRITES is never the button that previews.
+ */
+
+const change = (over: Record<string, unknown> = {}) => ({
+  entity: "dangling",
+  id: "payment_schedule.cart_id",
+  field: "→ cart",
+  before: 23,
+  after: 27,
+  note: "23 of 27 point at a cart that is not visible (85%) · e.g. `cart_e2e_1787467149960`",
+  ...over,
+})
+
+const scopeWith = (runs: any[]) => ({
+  resolve: () => ({
+    listOpsMaintenanceRuns: async () => runs,
+  }),
+})
+
+describe("pairNode", () => {
+  it("draws an unexplained pair as absent, which is what makes it red", () => {
+    const n = pairNode(change())
+    expect(n.state).toBe("absent")
+    expect(n.status).toBe("unexplained")
+    expect(n.count).toBe(23)
+    expect(n.props.find((p) => p.key === "Rate")?.value).toBe("85%")
+  })
+
+  /*
+   * 🔴 A classified pair must NOT draw red. Both `revokeQuote` deleting its
+   * price list and a variant price save replacing its price set are correct
+   * terminal states; ranking them beside the real defects is precisely the
+   * failure the sweep was rewritten to remove, and it would come straight back
+   * if the board coloured every non-resolving pointer the same.
+   */
+  it("does not draw an explained pair as absent", () => {
+    const n = pairNode(change({ entity: "known:tombstone", id: "partner_quote.price_list_id" }))
+    expect(n.state).toBe("derived")
+    expect(n.status).toBe("tombstone")
+  })
+
+  it("offers no act on a pair nobody has written a fixer for", () => {
+    expect(pairNode(change()).act).toBeNull()
+  })
+
+  it("offers the written fixer on the one pair that has one", () => {
+    const n = pairNode(
+      change({ id: "pricing_price_fx_rates_fx_price_meta.price_id", entity: "known:tombstone" })
+    )
+    expect(n.act?.path).toBe("/admin/ops/maintenance-jobs/compact-fx-price-meta/run")
+  })
+
+  /*
+   * 🔴 Found by RENDERING, not by any test that existed. The canvas draws
+   * `sublabel ?? count`, so a sublabel of just the target hid the number on
+   * every node — and a board that ranks by row count drew 21 identical boxes.
+   */
+  it("puts the row count where the canvas will actually draw it", () => {
+    expect(pairNode(change()).sublabel).toBe("23 of 27 → cart")
+  })
+
+  it("survives a pair with no rows rather than dividing by zero", () => {
+    const n = pairNode(change({ before: 0, after: 0 }))
+    expect(n.props.find((p) => p.key === "Rate")?.value).toBe("0%")
+  })
+})
+
+/**
+ * 🔴 The invariant the whole affordance rests on.
+ *
+ * The reason `NodeAct` carries two named bodies instead of one body plus a
+ * flag is that a client which mutates `dry_run` is one typo away from applying
+ * what the reader asked to preview — and that typo is invisible in review. If
+ * the two bodies were ever equal the type would still compile, the UI would
+ * still render two buttons, and the safe press would write.
+ */
+describe("preview is never the apply", () => {
+  it("every fixer previews with dry_run true and applies with dry_run false", () => {
+    for (const key of Object.keys(FIXERS)) {
+      const n = pairNode(change({ id: key }))
+      expect(n.act).toBeTruthy()
+      expect(n.act!.previewBody).toEqual({ dry_run: true })
+      expect(n.act!.applyBody).toEqual({ dry_run: false })
+      expect(n.act!.previewBody).not.toEqual(n.act!.applyBody)
+    }
+  })
+
+  it("every fixer says what applying does, in words the server owns", () => {
+    for (const [key, f] of Object.entries(FIXERS)) {
+      // A generic "Are you sure?" is what this field exists to prevent.
+      expect(f.confirm.length).toBeGreaterThan(40)
+      expect(key).toMatch(/^[a-z0-9_]+\.[a-z0-9_]+_id$/)
+    }
+  })
+
+  /*
+   * 🔴 The board must never grow a fixer that can act on any pair. Three
+   * sweeps running were topped by a pair that was not a defect; a job that
+   * nulls whatever ranked first would have destroyed correct state on all
+   * three and looked like tidying up. Every entry names ONE column.
+   */
+  it("has no generic fixer", () => {
+    for (const f of Object.values(FIXERS)) {
+      expect(f.job).not.toMatch(/generic|any|all/i)
+    }
+  })
+})
+
+describe("pairFromNodeKey", () => {
+  it("splits on the last dot, so a schema-ish table name survives", () => {
+    expect(pairFromNodeKey("pair:pricing_price_fx_rates_fx_price_meta.price_id")).toEqual({
+      table: "pricing_price_fx_rates_fx_price_meta",
+      column: "price_id",
+    })
+  })
+
+  it("refuses anything that is not a pair node", () => {
+    expect(pairFromNodeKey("sweep")).toBeNull()
+    expect(pairFromNodeKey("pair:no_dot")).toBeNull()
+    expect(pairFromNodeKey("pair:.leading")).toBeNull()
+    expect(pairFromNodeKey("pair:trailing.")).toBeNull()
+  })
+})
+
+describe("resolveDanglingPointers", () => {
+  /*
+   * 🔴 The single most dangerous thing this board could say is nothing. An
+   * empty canvas after a page that has never been swept is indistinguishable
+   * from a clean database, and a reader would take the reassuring reading.
+   */
+  it("says NO SWEEP rather than drawing an empty, reassuring board", async () => {
+    const g = await resolveDanglingPointers({ scope: scopeWith([]), id: "dangling-pointers" })
+    expect(g.nodes).toHaveLength(1)
+    expect(g.nodes[0].label).toBe("No sweep recorded")
+    expect(g.spine.sublabel).toBe("never swept")
+    /*
+     * 🔴 The BOARD is never `absent` — only its findings are. The drawer
+     * badges an absent node with the red word "absent", and a spine carrying
+     * it introduced the board as "Dangling pointers · absent", which is not a
+     * statement about anything. Found by rendering.
+     */
+    expect(g.spine.state).toBe("present")
+    expect(g.nodes[0].state).toBe("absent")
+    expect(g.edges[0].reason).toContain("not a statement that nothing dangles")
+  })
+
+  it("offers to run the sweep, and the sweep has nothing to apply", async () => {
+    const g = await resolveDanglingPointers({ scope: scopeWith([]), id: "dangling-pointers" })
+    expect(g.spine.act?.path).toBe(`/admin/ops/maintenance-jobs/${SWEEP_JOB_ID}/run`)
+    // Read-only in both modes — a disabled "Apply" would imply a write exists.
+    expect(g.spine.act?.applyBody).toBeNull()
+  })
+
+  it("draws one node per measured pair and keeps the sweep's own sentence", async () => {
+    const g = await resolveDanglingPointers({
+      scope: scopeWith([
+        {
+          id: "run_1",
+          actor_id: "user_1",
+          summary: "2 unexplained pair(s)",
+          created_at: "2026-09-07T02:00:00.000Z",
+          changes: [change(), change({ id: "lead.form_id", entity: "known:external_id" })],
+        },
+      ]),
+      id: "dangling-pointers",
+    })
+
+    expect(g.nodes.map((n) => n.key)).toEqual([
+      "pair:payment_schedule.cart_id",
+      "pair:lead.form_id",
+    ])
+    // Verbatim, so the sentence has one home and the sample value survives.
+    expect(g.edges[0].reason).toContain("cart_e2e_1787467149960")
+    expect(g.summary.absent).toBe(1)
+    expect(g.summary.derived).toBe(1)
+  })
+
+  /*
+   * 🔴 A count with no time attached is what let a LOCAL sweep get written
+   * into a handoff as a fact about production. The board states when, and who.
+   */
+  it("states when it was swept and by whom", async () => {
+    const g = await resolveDanglingPointers({
+      scope: scopeWith([
+        {
+          id: "run_1",
+          actor_id: "user_42",
+          summary: "clean",
+          created_at: "2026-09-07T02:00:00.000Z",
+          changes: [],
+        },
+      ]),
+      id: "dangling-pointers",
+    })
+    expect(g.spine.props.find((p) => p.key === "Last swept")?.value).toContain("2026-09-07")
+    expect(g.spine.props.find((p) => p.key === "Ran by")?.value).toBe("user_42")
+    expect(g.spine.state).toBe("present")
+    expect(g.spine.sublabel).toContain("swept 2026-09-07")
+  })
+
+  it("caps the evidence it will list", () => {
+    expect(MAX_ITEMS).toBeLessThanOrEqual(100)
+  })
+})

--- a/apps/backend/src/lib/graph/queues/dangling-pointers.ts
+++ b/apps/backend/src/lib/graph/queues/dangling-pointers.ts
@@ -1,0 +1,401 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { GraphBuilder } from "../builder"
+import type { Graph, GraphNode, NodeAct, NodeItem, SpineContext } from "../types"
+import { OPS_AUDIT_MODULE } from "../../../modules/ops_audit"
+
+/**
+ * The dangling-pointer board (#1857).
+ *
+ * Every `<x>_id` column in the database that points at something the graph
+ * cannot see, drawn as one canvas: what the sweep found, ranked, with the
+ * evidence attached and — where a written fixer exists — the data-ops job that
+ * repairs it, runnable from the node that states the problem.
+ *
+ * ## Why it reads the last RUN rather than sweeping on open
+ *
+ * `audit-dangling-links` measures 456 pointer pairs with a per-pair timeout.
+ * Re-running that on every page load would make a board somebody opens
+ * casually into the most expensive request in the admin, and it would still
+ * only ever show one moment.
+ *
+ * The sweep already persists its complete result: `ops_maintenance_run` stores
+ * the FULL `changes` JSON of every run, dry or applied (#457). So the board is
+ * a reader of the audit log, opens instantly, and — this is the part that
+ * matters — **states how old its reading is**. A number with no timestamp and
+ * no database attached is what let a local measurement get written into a
+ * handoff as a fact about production. The spine node says when, and by whom.
+ *
+ * ## Why an empty board is impossible
+ *
+ * 🔴 If no sweep has ever run, this does NOT return an empty graph. An empty
+ * graph is indistinguishable from "nothing dangles", which is the single most
+ * dangerous thing this board could say. It returns one absent node — "no sweep
+ * recorded" — carrying the act that runs one. Same rule the queue registry
+ * applies to an unknown queue name, for the same reason.
+ */
+
+/** `job_id` of the sweep whose output this board draws. */
+export const SWEEP_JOB_ID = "audit-dangling-links"
+
+/**
+ * The written fixers, keyed `table.column`.
+ *
+ * 🔴 There is deliberately NO generic "null the dangling pointer" job here,
+ * and the board must never grow one. Three sweeps running have been topped by
+ * a pair that was not a defect — a revoked quote whose price list is DELETED
+ * on purpose, an FX marker outliving a replaced price set, and a column full
+ * of ids an e2e fixture invented. A button that nulls whatever the sweep
+ * ranked first would have destroyed correct state on all three, and it would
+ * have looked like tidying up.
+ *
+ * A pair earns an act only once somebody has written down what its rows mean
+ * and shipped a job that acts on that meaning. Everything else gets evidence
+ * and no button, which is the honest offer.
+ */
+export const FIXERS: Record<string, { job: string; label: string; confirm: string }> = {
+  "pricing_price_fx_rates_fx_price_meta.price_id": {
+    job: "compact-fx-price-meta",
+    label: "Compact the stale FX markers",
+    confirm:
+      "Deletes the FX price markers whose price no longer exists. A variant price save replaces the whole price set, so these mark prices that were REPLACED, not lost — the rerate job already skips them. Preview first; the preview lists every marker it would remove.",
+  },
+}
+
+/**
+ * How a maintenance job is offered on a node.
+ *
+ * Both bodies are built here, on the server, for the same reason `remove.path`
+ * is: the client must never assemble a call to a job endpoint out of ids it
+ * half-understands. Preview is `dry_run: true` and is what the button does
+ * first; apply is a second, separately confirmed call.
+ */
+const jobAct = (jobId: string, label: string, confirm: string): NodeAct => ({
+  method: "POST",
+  path: `/admin/ops/maintenance-jobs/${jobId}/run`,
+  previewBody: { dry_run: true },
+  applyBody: { dry_run: false },
+  label,
+  confirm,
+})
+
+/** Re-running the sweep is itself an act, and a read-only one. */
+const sweepAct = (label: string): NodeAct => ({
+  ...jobAct(SWEEP_JOB_ID, label, ""),
+  /*
+   * 🔴 No apply step. The sweep writes nothing in either mode — `applied` is
+   * hard-coded false — so offering "apply" would invent a destructive-looking
+   * second press for a job that has no second behaviour.
+   */
+  applyBody: null,
+  confirm: "",
+})
+
+type SweepRun = {
+  id: string
+  actor_id: string
+  summary: string
+  created_at: string | Date
+  changes: Array<{
+    entity: string
+    id: string
+    field?: string
+    before?: unknown
+    after?: unknown
+    note?: string
+  }>
+}
+
+/** The newest recorded run of the sweep, or null if it has never been run. */
+const latestSweep = async (scope: any): Promise<SweepRun | null> => {
+  const audit: any = scope.resolve(OPS_AUDIT_MODULE)
+  /*
+   * `listOpsMaintenanceRuns`, not `listAndCount` — the latter returns a TUPLE
+   * and reading `[0]` off it yields the whole rows array, not a row. That
+   * exact confusion silently broke every weaver edit in #1864.
+   */
+  const rows = await audit.listOpsMaintenanceRuns(
+    { job_id: SWEEP_JOB_ID },
+    { order: { created_at: "DESC" }, take: 1 }
+  )
+  const row = Array.isArray(rows) ? rows[0] : null
+  return row ? ({ ...row, changes: Array.isArray(row.changes) ? row.changes : [] } as SweepRun) : null
+}
+
+const pct = (orphans: number, total: number) =>
+  total ? Math.round((orphans / total) * 100) : 0
+
+/**
+ * PURE: one measured pair → its node.
+ *
+ * Exported for tests, because every judgement the board makes about a pair is
+ * in here and none of it is visible from a screenshot.
+ */
+export const pairNode = (change: SweepRun["changes"][number]): GraphNode => {
+  const orphans = Number(change.before ?? 0)
+  const total = Number(change.after ?? 0)
+  const explained = change.entity.startsWith("known:")
+  const fixer = FIXERS[change.id]
+
+  return {
+    key: `pair:${change.id}`,
+    type: "pointer-pair",
+    label: change.id,
+    /*
+     * 🔴 The COUNT has to be in here, and this was only visible by rendering.
+     *
+     * The canvas draws `sublabel ?? count` — the sublabel WINS — so a node
+     * whose sublabel was just the target read `→ cart` and nothing else. The
+     * board's entire claim is that it ranks pairs by how many rows are
+     * unexplained, and on a radial canvas there is no order: a 23-row pair and
+     * a 1-row pair were the same box. The number was in the payload, in the
+     * drawer, and nowhere a reader would look first.
+     */
+    sublabel: `${orphans} of ${total} ${change.field ?? ""}`.trim(),
+    /*
+     * 🔴 `absent` means the model expected a neighbour and there is none —
+     * exactly what an unexplained dangling pointer is, and it draws red.
+     *
+     * An EXPLAINED pair is a compromise, and worth naming as one. Its target
+     * is just as gone, so `present` would be a lie; but the absence is the
+     * design — `revokeQuote` DELETES the price list so the quote can never
+     * price again — so drawing it red beside the real defects would restore
+     * the exact ranking this sweep was rewritten to remove. `derived` is the
+     * least-wrong of the three states the canvas can draw: not a live link,
+     * not an alarm, and the edge reason carries the actual explanation. A
+     * fourth state would be more honest and would ripple through the canvas
+     * palette, the summary counts and four other spines.
+     */
+    state: explained ? "derived" : "absent",
+    count: orphans,
+    status: explained ? change.entity.replace("known:", "") : "unexplained",
+    /* No page exists for a `table.column`. The evidence is the drawer. */
+    href: null,
+    props: [
+      { key: "Rows pointing at nothing", value: String(orphans) },
+      { key: "Rows with a pointer", value: String(total) },
+      { key: "Rate", value: `${pct(orphans, total)}%` },
+    ],
+    action: null,
+    act: fixer ? jobAct(fixer.job, fixer.label, fixer.confirm) : null,
+  }
+}
+
+export const resolveDanglingPointers = async (ctx: SpineContext): Promise<Graph> => {
+  const run = await latestSweep(ctx.scope)
+  const b = new GraphBuilder("dangling")
+
+  if (!run) {
+    /*
+     * 🔴 Never an empty graph. "No sweep has run" and "nothing dangles" are
+     * opposite facts that would render identically.
+     */
+    b.push(
+      {
+        key: "sweep",
+        type: "sweep",
+        label: "No sweep recorded",
+        sublabel: null,
+        state: "absent",
+        count: 0,
+        status: null,
+        href: null,
+        props: [{ key: "Job", value: SWEEP_JOB_ID }],
+        action: null,
+        act: sweepAct("Run the sweep"),
+      },
+      {
+        label: SWEEP_JOB_ID,
+        state: "absent",
+        reason:
+          "This board reads the last recorded run of the dangling-pointer sweep, and there has never been one. It is not a statement that nothing dangles.",
+      }
+    )
+
+    return b.build({
+      key: "dangling",
+      type: "board",
+      label: "Dangling pointers",
+      sublabel: "never swept",
+      state: "present",
+      count: 0,
+      status: null,
+      href: null,
+      props: [{ key: "Last swept", value: "never" }],
+      action: null,
+      act: sweepAct("Run the sweep"),
+    })
+  }
+
+  const sweptAt = new Date(run.created_at)
+  for (const change of run.changes) {
+    const node = pairNode(change)
+    b.push(node, {
+      label: String(change.id).split(".").slice(1).join(".") || String(change.id),
+      state: node.state,
+      /*
+       * The sweep's own sentence, verbatim — count, rate, the 100%
+       * external-id signature, a SAMPLE of the offending value, and the
+       * classification reason where there is one. Re-phrasing it here would
+       * give that sentence a second home and let the two drift.
+       */
+      reason: change.note ?? null,
+    })
+  }
+
+  const unexplained = run.changes.filter((c) => !c.entity.startsWith("known:"))
+  const unexplainedRows = unexplained.reduce((n, c) => n + Number(c.before ?? 0), 0)
+
+  return b.build({
+    key: "dangling",
+    type: "board",
+    label: "Dangling pointers",
+    sublabel: `swept ${sweptAt.toISOString().slice(0, 16).replace("T", " ")}`,
+    /*
+     * 🔴 `present`, never `absent`, and rendering is what said so. The drawer
+     * badges an absent node with the red word "absent", so a board keyed on
+     * whether it had findings introduced itself as "Dangling pointers ·
+     * absent" — which is not a fact about anything. The spine is the board; it
+     * is not a missing neighbour. Present, the badge falls back to the
+     * sublabel and reads "swept 2026-09-07 02:26", which is the one thing a
+     * reader most needs and the number the last handoff got wrong.
+     *
+     * The alarm is not lost: the header counts the EDGES, and every
+     * unexplained pair is still an absent edge drawn red.
+     */
+    state: "present",
+    count: run.changes.length,
+    status: null,
+    href: "/settings/ops-data-plumbing",
+    props: [
+      { key: "Last swept", value: sweptAt.toISOString() },
+      { key: "Ran by", value: run.actor_id },
+      { key: "Unexplained pairs", value: String(unexplained.length) },
+      { key: "Unexplained rows", value: String(unexplainedRows) },
+      /*
+       * A short key on purpose: the row is a flex of two truncating halves,
+       * and against this sentence "Sweep said" rendered as "Swe…".
+       */
+      { key: "Sweep", value: run.summary },
+    ],
+    action: null,
+    act: sweepAct("Re-run the sweep"),
+  })
+}
+
+/** The `table.column` behind a node key, or null if this is not a pair node. */
+export const pairFromNodeKey = (nodeKey: string): { table: string; column: string } | null => {
+  if (!nodeKey.startsWith("pair:")) {
+    return null
+  }
+  const rest = nodeKey.slice("pair:".length)
+  const dot = rest.lastIndexOf(".")
+  if (dot <= 0 || dot === rest.length - 1) {
+    return null
+  }
+  return { table: rest.slice(0, dot), column: rest.slice(dot + 1) }
+}
+
+/** How many offending rows the drawer will list. Evidence, not a data export. */
+export const MAX_ITEMS = 50
+
+/**
+ * The offending rows behind one pair.
+ *
+ * 🔴 Every item's `remove` is null, always. The whole lesson of this issue is
+ * that most of what a sweep ranks first is correct state; a board that offered
+ * "delete this row" beside each piece of evidence would make destroying it the
+ * easiest gesture available, one row at a time, with no written reason and no
+ * dry run. Repair happens through a named job on the node, or not at all.
+ *
+ * Queried live rather than replayed from the run, because the run stores the
+ * COUNT per pair and not the rows, and because a reader opening the drawer is
+ * asking what is true now.
+ */
+export const danglingPointersItems = async (
+  ctx: SpineContext,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const pair = pairFromNodeKey(nodeKey)
+  if (!pair) {
+    return []
+  }
+
+  const pg: any = ctx.scope.resolve(ContainerRegistrationKeys.PG_CONNECTION)
+
+  /*
+   * Re-derived here rather than trusted from the node key: `table` and
+   * `column` reach this function through a URL. Everything interpolated below
+   * is checked against the catalog first, so a crafted node key selects
+   * nothing instead of naming a table of its own choosing.
+   */
+  const meta = (
+    await pg.raw(
+      `select
+         (select tt.table_name from information_schema.tables tt
+           where tt.table_schema='public' and tt.table_type='BASE TABLE'
+             and tt.table_name = ?) as src,
+         exists (select 1 from information_schema.columns c
+                  where c.table_schema='public' and c.table_name = ? and c.column_name = ?) as has_col,
+         exists (select 1 from information_schema.columns c
+                  where c.table_schema='public' and c.table_name = ? and c.column_name = 'id') as has_id,
+         exists (select 1 from information_schema.columns c
+                  where c.table_schema='public' and c.table_name = ? and c.column_name = 'deleted_at') as soft_deletes`,
+      [pair.table, pair.table, pair.column, pair.table, pair.table]
+    )
+  )?.rows?.[0]
+
+  if (!meta?.src || !meta.has_col) {
+    return []
+  }
+
+  const target = pair.column.replace(/_id$/, "")
+  const tgt = (
+    await pg.raw(
+      `select tt.table_name, exists (select 1 from information_schema.columns c
+          where c.table_schema='public' and c.table_name = tt.table_name and c.column_name='deleted_at') as soft_deletes
+         from information_schema.tables tt
+        where tt.table_schema='public' and tt.table_type='BASE TABLE'
+          and tt.table_name in (?, ?, ?)
+        order by (tt.table_name = ?) desc
+        limit 1`,
+      [target, `${target}s`, target.replace(/s$/, ""), target]
+    )
+  )?.rows?.[0]
+
+  if (!tgt?.table_name) {
+    return []
+  }
+
+  const srcLive = meta.soft_deletes ? `and s."deleted_at" is null` : ""
+  const tgtLive = tgt.soft_deletes ? `and t."deleted_at" is null` : ""
+  const idCol = meta.has_id ? `s."id"` : `s."${pair.column}"`
+
+  const rows =
+    (
+      await pg.raw(
+        `select ${idCol} as row_id, s."${pair.column}" as pointer
+           from "${pair.table}" s
+           left join "${tgt.table_name}" t on t."id" = s."${pair.column}" ${tgtLive}
+          where s."${pair.column}" is not null and t."id" is null ${srcLive}
+          order by 1
+          limit ${MAX_ITEMS}`
+      )
+    )?.rows ?? []
+
+  return rows.map((r: any) => ({
+    id: String(r.row_id),
+    label: String(r.pointer),
+    /*
+     * The pointer VALUE is the label and the row id is the sublabel, not the
+     * other way round. What a reader needs first is the string that does not
+     * resolve — `cart_e2e_1787467149960` answered in one glance a question the
+     * counts took a session to answer.
+     */
+    sublabel: meta.has_id ? `${pair.table}.id ${r.row_id}` : null,
+    status: `${pair.column} → ${tgt.table_name}`,
+    href: null,
+    props: [],
+    remove: null,
+  }))
+}

--- a/apps/backend/src/lib/graph/queues/index.ts
+++ b/apps/backend/src/lib/graph/queues/index.ts
@@ -1,6 +1,7 @@
 import { MedusaError } from "@medusajs/framework/utils"
 
 import type { Graph, NodeItem, SpineContext, SpineDescriptor } from "../types"
+import { danglingPointersItems, resolveDanglingPointers } from "./dangling-pointers"
 import { productsAwaitingItems, resolveProductsAwaiting } from "./products-awaiting"
 
 /**
@@ -34,6 +35,18 @@ const QUEUES: Record<string, QueueDescriptor> = {
     label: "Products awaiting creation",
     resolve: resolveProductsAwaiting,
     items: productsAwaitingItems,
+  },
+  /*
+   * A queue whose members are not records at all but `table.column` PAIRS
+   * (#1857). It is here rather than in a surface of its own because the
+   * registry's claim — a board costs a resolver and an entry — holds for a
+   * population of columns exactly as it did for a cohort of designs.
+   */
+  "dangling-pointers": {
+    key: "dangling-pointers",
+    label: "Dangling pointers",
+    resolve: resolveDanglingPointers,
+    items: danglingPointersItems,
   },
 }
 

--- a/apps/backend/src/lib/graph/spines/partner/__tests__/items.unit.spec.ts
+++ b/apps/backend/src/lib/graph/spines/partner/__tests__/items.unit.spec.ts
@@ -1,0 +1,173 @@
+import designPartnersLink from "../../../../../links/design-partners-link"
+import partnerPersonLink from "../../../../../links/partner-person"
+import { PARTNER_ITEM_NODES, resolvePartnerItems } from "../items"
+
+/*
+ * 🔴 Keyed by the link's own `entryPoint`, never a hand-written table name.
+ * Medusa abbreviates a long link table name, so a stub keyed on a guess
+ * answers `[]` to a resolver that is working perfectly — which on this spine
+ * reads as "this partner has no people", the exact untruth #1857 is about.
+ */
+const DESIGN_ENTRY = designPartnersLink.entryPoint
+const PERSON_ENTRY = partnerPersonLink.entryPoint
+
+const stubQuery = (byEntity: Record<string, any[]>) => ({
+  graph: jest.fn(async ({ entity }: { entity: string }) => ({
+    data: byEntity[entity] ?? [],
+  })),
+})
+
+const ctx = (query: any) => ({
+  scope: { resolve: () => query },
+  id: "pt_1",
+})
+
+describe("the partner node registry", () => {
+  it("answers an unknown node with an empty list and asks nothing", async () => {
+    const query = stubQuery({})
+    await expect(resolvePartnerItems(ctx(query), "not_a_node")).resolves.toEqual([])
+    expect(query.graph).not.toHaveBeenCalled()
+  })
+
+  it("advertises the nodes it can resolve", () => {
+    expect(PARTNER_ITEM_NODES).toEqual(
+      expect.arrayContaining([
+        "admins",
+        "designs",
+        "runs",
+        "submissions",
+        "payment_methods",
+        "people",
+      ])
+    )
+  })
+})
+
+/**
+ * The REMOVE descriptors (#1856).
+ *
+ * Both point at an endpoint that already exists, and the two take different
+ * shapes — a POST with the partner in the body against the DESIGN's route, and
+ * a DELETE that carries a body. A wrong shape here is a well-formed request to
+ * the wrong record: nothing throws, nothing renders red, and the row vanishes
+ * from the drawer either way. So they are asserted, not eyeballed.
+ */
+describe("people — unlink", () => {
+  it("names the partner's own people route, with the id in the body", async () => {
+    const query = stubQuery({
+      [PERSON_ENTRY]: [{ person_id: "per_1" }],
+      person: [{ id: "per_1", first_name: "Asha", last_name: "R", email: "a@x.com" }],
+    })
+
+    const [item] = await resolvePartnerItems(ctx(query), "people")
+
+    expect(item.id).toBe("per_1")
+    expect(item.remove).toEqual({
+      method: "DELETE",
+      path: "/admin/partners/pt_1/people",
+      body: { person_ids: ["per_1"] },
+      label: "Unlink",
+      confirm: expect.stringContaining("Asha R"),
+    })
+  })
+
+  it("says the person record survives, because the row beside it does not", async () => {
+    /*
+     * 🔴 The two removals in this drawer are not equivalent: this dismisses a
+     * link, while "Cancel assignment" one node over cancels live production.
+     * A shared "Are you sure?" would describe the milder of them.
+     */
+    const query = stubQuery({
+      [PERSON_ENTRY]: [{ person_id: "per_1" }],
+      person: [{ id: "per_1", first_name: "Asha", last_name: "R" }],
+    })
+    const [item] = await resolvePartnerItems(ctx(query), "people")
+    expect(item.remove!.confirm).toContain("person record is untouched")
+  })
+})
+
+describe("designs — cancel assignment", () => {
+  const linked = {
+    [DESIGN_ENTRY]: [{ design_id: "des_1" }],
+    designs: [{ id: "des_1", name: "Kurta", status: "In_Development" }],
+  }
+
+  it("posts to the DESIGN's route with this partner in the body", async () => {
+    const query = stubQuery({ ...linked, production_runs: [] })
+
+    const [item] = await resolvePartnerItems(ctx(query), "designs")
+
+    // 🔴 The design's id in the path, the partner's in the body — the same
+    // endpoint the design spine uses, with the two ids the other way round.
+    expect(item.remove!.method).toBe("POST")
+    expect(item.remove!.path).toBe("/admin/designs/des_1/cancel-partner-assignment")
+    expect(item.remove!.body).toEqual({ partner_id: "pt_1", unlink: true })
+  })
+
+  it("says Unlink, and says no runs are affected, when none are live", async () => {
+    const query = stubQuery({
+      ...linked,
+      production_runs: [{ id: "pr_1", design_id: "des_1", status: "completed" }],
+    })
+    const [item] = await resolvePartnerItems(ctx(query), "designs")
+    expect(item.remove!.label).toBe("Unlink")
+    expect(item.remove!.confirm).toContain("No live runs")
+  })
+
+  it("says Cancel assignment, and the sentence agrees with the label", async () => {
+    const query = stubQuery({
+      ...linked,
+      production_runs: [
+        { id: "pr_1", design_id: "des_1", status: "in_progress" },
+        { id: "pr_2", design_id: "des_1", status: "cancelled" },
+        { id: "pr_3", design_id: "des_1", status: "accepted" },
+      ],
+    })
+    const [item] = await resolvePartnerItems(ctx(query), "designs")
+    expect(item.remove!.label).toBe("Cancel assignment")
+    /*
+     * 🔴 The sentence must not open with "Unlink" while the button says
+     * "Cancel assignment" — it did on the first pass, and the milder of the
+     * two words is the one the reader would have believed.
+     */
+    expect(item.remove!.confirm).toMatch(/^Cancel this partner's assignment/)
+    expect(item.remove!.confirm).toContain("2 live runs")
+  })
+
+  it("ignores the partner's runs on OTHER designs", async () => {
+    /*
+     * The runs are fetched by partner, not by design, so every row this
+     * partner has comes back at once. Counting them all would tell the reader
+     * that unlinking one design cancels work on another.
+     */
+    const query = stubQuery({
+      ...linked,
+      production_runs: [
+        { id: "pr_1", design_id: "des_OTHER", status: "in_progress" },
+        { id: "pr_2", design_id: "des_1", status: "in_progress" },
+      ],
+    })
+    const [item] = await resolvePartnerItems(ctx(query), "designs")
+    expect(item.remove!.confirm).toContain("1 live run of theirs")
+    expect(item.props).toContainEqual({ key: "live runs", value: "1" })
+  })
+})
+
+describe("what deliberately carries no removal", () => {
+  it.each([
+    ["runs", { production_runs: [{ id: "pr_1", status: "completed" }] }],
+    [
+      "admins",
+      { partners: [{ id: "pt_1", admins: [{ id: "pa_1", email: "a@x.com" }] }] },
+    ],
+  ])("%s offers none", async (node, data) => {
+    /*
+     * 🔴 Asserted rather than left implicit. `admins` and `payment_methods`
+     * have no delete route at all — only POST and PATCH exist — so a bin icon
+     * here would have to invent a destructive path the platform does not have.
+     */
+    const items = await resolvePartnerItems(ctx(stubQuery(data as any)), node)
+    expect(items.length).toBeGreaterThan(0)
+    expect(items.every((i) => i.remove === null)).toBe(true)
+  })
+})

--- a/apps/backend/src/lib/graph/spines/partner/index.ts
+++ b/apps/backend/src/lib/graph/spines/partner/index.ts
@@ -463,21 +463,66 @@ const resolvePartnerGraph = async ({ scope, id }: SpineContext): Promise<Graph> 
     )
   }
 
+  /*
+   * ---- people, and the link rows that resolve to nobody ------------------
+   *
+   * 🔴 `dangling` is DRAWN, not just excluded (#1857).
+   *
+   * Counting link rows was the original fault: a node read "4 linked" against
+   * four rows whose people do not exist. Filtering them out fixed the lie and
+   * introduced a quieter one — with every row dangling, `personIds` is empty
+   * and NO node is emitted at all, so the partner that provoked this whole
+   * issue draws a graph with nothing wrong on it. "Nobody was ever linked" and
+   * "four links point at nobody" are different facts and must not render the
+   * same.
+   */
+  const danglingPeople = linkedPersonIds.length - personIds.length
+
   if (personIds.length) {
     push(
       {
         key: "people",
         type: "person",
         label: "People",
-        sublabel: `${personIds.length} linked`,
+        sublabel: danglingPeople
+          ? `${personIds.length} linked, ${danglingPeople} missing`
+          : `${personIds.length} linked`,
         state: "present",
         count: personIds.length,
         status: null,
         href: `/partners/${partnerId}`,
-        props: [{ key: "people", value: String(personIds.length) }],
+        props: [
+          { key: "people", value: String(personIds.length) },
+          ...(danglingPeople
+            ? [{ key: "dangling links", value: String(danglingPeople) }]
+            : []),
+        ],
         action: null,
       },
       { label: "partner_person", state: "present", reason: null }
+    )
+  } else if (danglingPeople) {
+    push(
+      {
+        key: "people",
+        type: "person",
+        label: "People",
+        sublabel: `${danglingPeople} ${danglingPeople === 1 ? "link points" : "links point"} at nobody`,
+        state: "absent",
+        count: 0,
+        status: null,
+        href: `/partners/${partnerId}`,
+        props: [
+          { key: "link rows", value: String(linkedPersonIds.length) },
+          { key: "people that exist", value: "0" },
+        ],
+        action: { label: "Link a person", href: `/partners/${partnerId}` },
+      },
+      {
+        label: "partner_person",
+        state: "absent",
+        reason: `This partner has ${danglingPeople} ${danglingPeople === 1 ? "link row" : "link rows"} to people that no longer exist or have been deleted, and nobody it can actually reach. Anything counting the link table reports this partner as having people; nothing can open one.`,
+      }
     )
   }
 

--- a/apps/backend/src/lib/graph/spines/partner/index.ts
+++ b/apps/backend/src/lib/graph/spines/partner/index.ts
@@ -569,7 +569,34 @@ const resolvePartnerGraph = async ({ scope, id }: SpineContext): Promise<Graph> 
           { key: "number", value: String(partner.whatsapp_number) },
           { key: "verified", value: "no" },
         ],
+        /*
+         * 🔴 Kept, and now DEAD ON PURPOSE — it renders disabled because
+         * `href` is null, and the working affordance is the act below. The
+         * words stay so a reader still learns what the missing step is called
+         * where the rail is rendered without acts.
+         */
         action: { label: "Verify the number", href: null },
+        /*
+         * The act #1856 was waiting for. `POST /admin/partners/:id/
+         * whatsapp-verify` has existed all along; the graph could name the
+         * step and not take it.
+         *
+         * 🔴 NO PREVIEW, and that is not an omission. This endpoint SENDS A
+         * WHATSAPP TEMPLATE to a real partner — there is no dry run of a
+         * message that has already left. So `previewBody` is null, which the
+         * rail renders as a single confirmed press, and the confirm says what
+         * the partner will receive.
+         */
+        act: {
+          method: "POST",
+          path: `/admin/partners/${partnerId}/whatsapp-verify`,
+          previewBody: null,
+          applyBody: { phone: String(partner.whatsapp_number) },
+          label: "Verify the number",
+          confirm: `Sends a WhatsApp welcome template to ${String(
+            partner.whatsapp_number
+          )} and starts the consent flow. The partner receives a real message — there is no preview and it cannot be recalled.`,
+        },
       },
       {
         label: "whatsapp_number",
@@ -596,6 +623,24 @@ const resolvePartnerGraph = async ({ scope, id }: SpineContext): Promise<Graph> 
           { key: "verified", value: "no" },
         ],
         action: { label: "Verify the domain", href: null },
+        /*
+         * `POST /admin/partners/:id/storefront/domain/verify` — re-checks
+         * ownership with the hosting provider and, for Vercel partners inside
+         * the Cloudflare zone we control, pushes the DNS Vercel recommends so
+         * the domain self-heals.
+         *
+         * 🔴 No preview here either: it WRITES DNS. Nothing about it is a read.
+         */
+        act: {
+          method: "POST",
+          path: `/admin/partners/${partnerId}/storefront/domain/verify`,
+          previewBody: null,
+          applyBody: {},
+          label: "Verify the domain",
+          confirm: `Re-checks ${String(
+            partner.custom_domain
+          )} with the hosting provider and, on Vercel, pushes the DNS it recommends through Cloudflare. This changes live DNS records — there is no dry run.`,
+        },
       },
       {
         label: "custom_domain",

--- a/apps/backend/src/lib/graph/spines/partner/items.ts
+++ b/apps/backend/src/lib/graph/spines/partner/items.ts
@@ -10,18 +10,26 @@ import type { NodeItem, SpineContext } from "../../types"
 /**
  * The members behind a partner's aggregate nodes.
  *
- * 🔴 Nothing here offers a `remove`, and that is a decision rather than an
- * omission. Detaching a partner's work is not the mirror of detaching a
- * design's: a run belongs to the design that ordered it, a submission is a
- * financial record, a payment method may already have been paid to, and a
- * person may be linked from either side. Every one of those has a route of its
- * own with its own guards; surfacing a bin icon here would either duplicate
- * that logic or bypass it.
+ * 🔴 Only TWO of these offer a `remove`, and the split is the point (#1856).
+ * Detaching a partner's work is not the blanket mirror of detaching a design's:
+ * a run belongs to the design that ordered it, a submission is a financial
+ * record, an order is history. A bin icon on those would either duplicate the
+ * guards their own routes already run or bypass them.
+ *
+ * What DOES detach is the two relationships the partner is genuinely a party
+ * to — the people linked to it, and its design assignments — and both name an
+ * EXISTING admin endpoint rather than carrying unlink logic of their own.
+ * `admins`, `payment_methods`, `submissions` and `runs` deliberately carry
+ * none: the first two have no delete route at all (only `POST` and `PATCH`
+ * exist), and inventing one here would put a destructive path in the graph
+ * before it exists anywhere else.
  *
  * The rows are worth listing regardless — "which four designs?" is exactly the
  * question the count provokes, and answering it is most of what the drawer is
  * for.
  */
+
+const s = (n: number, word: string) => (n === 1 ? word : `${word}s`)
 
 const designItems = async (query: any, partnerId: string): Promise<NodeItem[]> => {
   const { data: links } = await query.graph({
@@ -32,27 +40,70 @@ const designItems = async (query: any, partnerId: string): Promise<NodeItem[]> =
   const ids = asArray<any>(links).map((l) => l.design_id).filter(Boolean)
   if (!ids.length) return []
 
-  const { data: designs } = await query.graph({
-    entity: "designs",
-    filters: { id: ids },
-    fields: ["id", "name", "status", "design_type", "priority"],
-  })
+  const [{ data: designs }, { data: runs }] = await Promise.all([
+    query.graph({
+      entity: "designs",
+      filters: { id: ids },
+      fields: ["id", "name", "status", "design_type", "priority"],
+    }),
+    /*
+     * The partner's runs, so the confirm text can say what unlinking costs.
+     * Filtered by partner rather than by design: this is the removal of THIS
+     * partner from the design, and the design's other partners' runs are none
+     * of its business.
+     */
+    query.graph({
+      entity: "production_runs",
+      filters: { partner_id: partnerId },
+      fields: ["id", "design_id", "status"],
+    }),
+  ])
 
-  return asArray<any>(designs).map((d) => ({
-    id: String(d.id),
-    label: String(d.name ?? d.id),
-    sublabel:
-      [d.design_type, d.priority ? `${d.priority} priority` : null]
-        .filter(Boolean)
-        .join(" · ") || null,
-    status: d.status ? String(d.status) : null,
-    href: `/designs/${d.id}`,
-    props: [
-      ...(d.design_type ? [{ key: "type", value: String(d.design_type) }] : []),
-      ...(d.priority ? [{ key: "priority", value: String(d.priority) }] : []),
-    ],
-    remove: null,
-  }))
+  const runList = asArray<any>(runs)
+
+  return asArray<any>(designs).map((d) => {
+    const live = runList.filter(
+      (r) =>
+        r.design_id === d.id &&
+        !["cancelled", "completed"].includes(String(r.status))
+    )
+    return {
+      id: String(d.id),
+      label: String(d.name ?? d.id),
+      sublabel:
+        [d.design_type, d.priority ? `${d.priority} priority` : null]
+          .filter(Boolean)
+          .join(" · ") || null,
+      status: d.status ? String(d.status) : null,
+      href: `/designs/${d.id}`,
+      props: [
+        ...(d.design_type ? [{ key: "type", value: String(d.design_type) }] : []),
+        ...(d.priority ? [{ key: "priority", value: String(d.priority) }] : []),
+        { key: "live runs", value: String(live.length) },
+      ],
+      /*
+       * 🔴 The SAME endpoint the design spine's partner row uses, with the two
+       * ids swapped round. That is the whole reason this is safe to offer from
+       * here: `cancel-partner-assignment` already verifies the partner is
+       * linked, cancels their live runs and open tasks, and compensates. A
+       * second unlink path for the same link table is exactly the fault
+       * `delete-design` was carrying — one of twenty tables handled by name.
+       *
+       * 🔴 And it is NOT called "Unlink" when runs are live. The workflow
+       * cancels production; a button whose label hides that is the worst thing
+       * that could sit in this drawer, so the count is in the sentence.
+       */
+      remove: {
+        method: "POST" as const,
+        path: `/admin/designs/${d.id}/cancel-partner-assignment`,
+        body: { partner_id: partnerId, unlink: true },
+        label: live.length ? "Cancel assignment" : "Unlink",
+        confirm: live.length
+          ? `Cancel this partner's assignment on ${d.name || "this design"}? ${live.length} live ${s(live.length, "run")} of theirs and the open tasks on ${live.length === 1 ? "it" : "them"} are cancelled, and the partner is unlinked.`
+          : `Unlink this partner from ${d.name || "this design"}? No live runs are affected.`,
+      },
+    }
+  })
 }
 
 const runItems = async (query: any, partnerId: string): Promise<NodeItem[]> => {
@@ -171,15 +222,34 @@ const peopleItems = async (query: any, partnerId: string): Promise<NodeItem[]> =
     fields: ["id", "first_name", "last_name", "email"],
   })
 
-  return asArray<any>(people).map((p) => ({
-    id: String(p.id),
-    label: [p.first_name, p.last_name].filter(Boolean).join(" ") || String(p.id),
-    sublabel: p.email ? String(p.email) : null,
-    status: null,
-    href: `/persons/${p.id}`,
-    props: p.email ? [{ key: "email", value: String(p.email) }] : [],
-    remove: null,
-  }))
+  return asArray<any>(people).map((p) => {
+    const name =
+      [p.first_name, p.last_name].filter(Boolean).join(" ") || String(p.id)
+    return {
+      id: String(p.id),
+      label: name,
+      sublabel: p.email ? String(p.email) : null,
+      status: null,
+      href: `/persons/${p.id}`,
+      props: p.email ? [{ key: "email", value: String(p.email) }] : [],
+      /*
+       * 🔴 A `DELETE` that carries a BODY. `/admin/partners/:id/people` takes
+       * `{ person_ids }` on both POST and DELETE, and the admin's own unlink
+       * hook has always sent it that way — so this is the route's real shape,
+       * not a new one. It dismisses the link and leaves the person standing,
+       * which is why the sentence says so out loud: the neighbouring row in
+       * this same drawer ("Cancel assignment") does cancel real work, and the
+       * two must not read alike.
+       */
+      remove: {
+        method: "DELETE" as const,
+        path: `/admin/partners/${partnerId}/people`,
+        body: { person_ids: [String(p.id)] },
+        label: "Unlink",
+        confirm: `Unlink ${name} from this partner? The person record is untouched — they lose access to the partner's shared folders.`,
+      },
+    }
+  })
 }
 
 const adminItems = async (query: any, partnerId: string): Promise<NodeItem[]> => {

--- a/apps/backend/src/lib/graph/types.ts
+++ b/apps/backend/src/lib/graph/types.ts
@@ -30,6 +30,58 @@ export type GraphNode = {
   props: GraphProp[]
   /** Present only on an absent node: what would bring it into existence. */
   action: { label: string; href: string | null } | null
+  /**
+   * A job this node can RUN, as opposed to a page it can send you to.
+   *
+   * 🔴 The gap this closes (#1856 → #1857). Until now a node had exactly two
+   * affordances: a registered create/edit form, or `action` — a LINK. That is
+   * enough for a spine whose absences are records somebody fills in, and it is
+   * nothing at all for a node whose answer is an operation: compact these
+   * markers, re-run this sweep, reconcile these balances. The partner spine
+   * has been carrying four cards drawn `derived` for exactly this reason —
+   * verify, provision, apply — and the dangling board cannot exist without it,
+   * because a board that can only report is the report it was meant to replace.
+   *
+   * OPTIONAL, deliberately: four spines already build `GraphNode` literals by
+   * hand and a required field would make adding an affordance a rename across
+   * all of them. Absent means "this node runs nothing", which is the truth for
+   * every node that predates this.
+   */
+  act?: NodeAct | null
+}
+
+/**
+ * A two-press operation offered on a node: preview, then apply.
+ *
+ * Modelled on `NodeItemRemoval` and for the same reason — the SERVER builds
+ * the path and both bodies, and the client sends them verbatim. A client that
+ * assembled a call to `/admin/ops/maintenance-jobs/:id/run` would be choosing,
+ * from the browser, which job runs and whether it writes.
+ *
+ * 🔴 The two bodies are separate fields rather than one body plus a flag. A
+ * single body the client mutates to flip `dry_run` is one typo away from
+ * applying what the reader asked to preview, and that typo is invisible in
+ * review. Here the destructive call is a different value, named as such,
+ * chosen by a different press.
+ */
+export type NodeAct = {
+  method: "POST"
+  path: string
+  /** The safe call. For a maintenance job this carries `dry_run: true`. */
+  previewBody: Record<string, unknown> | null
+  /**
+   * The call that writes, or NULL where the act has nothing to apply — a
+   * read-only job like the sweep itself. Null must render no apply button at
+   * all rather than a disabled one: a greyed-out "Apply" implies a write that
+   * is merely unavailable, when in fact there is none.
+   */
+  applyBody: Record<string, unknown> | null
+  label: string
+  /**
+   * What the reader is told before the apply press. Empty where `applyBody`
+   * is null and nothing is being confirmed.
+   */
+  confirm: string
 }
 
 export type GraphEdge = {

--- a/apps/backend/src/lib/graph/types.ts
+++ b/apps/backend/src/lib/graph/types.ts
@@ -85,7 +85,14 @@ export type NodeItem = {
 export type NodeItemRemoval = {
   method: "DELETE" | "POST"
   path: string
-  /** Sent as the JSON body on a POST. Null on a DELETE. */
+  /**
+   * Sent as the JSON body, or null where the route needs none.
+   *
+   * 🔴 Not "null on a DELETE". `DELETE /admin/partners/:id/people` takes
+   * `{ person_ids }` — the admin's own unlink hook has always sent it that
+   * way, and the client here forwards `body` on whatever method is named. The
+   * shape of the existing route decides this, not the verb.
+   */
   body: Record<string, unknown> | null
   /** The words on the button. "Remove", "Unlink", "Cancel assignment". */
   label: string

--- a/apps/backend/src/lib/links/__tests__/dangling.unit.spec.ts
+++ b/apps/backend/src/lib/links/__tests__/dangling.unit.spec.ts
@@ -1,0 +1,69 @@
+import { linkedRows, presentRows } from "../dangling"
+
+/**
+ * The null a dangling link row arrives as (#1857).
+ *
+ * 🔴 These cases are written from the two REAL failures, not from the shape of
+ * the helper: the partner page that died on `person.id` off a null, and the
+ * production-run split that handed a share of the quantity to a partner that
+ * does not exist.
+ */
+describe("linkedRows", () => {
+  it("drops the nulls and counts them", () => {
+    const { rows, dangling } = linkedRows([
+      { id: "per_1" },
+      null,
+      null,
+      { id: "per_2" },
+    ])
+    expect(rows).toEqual([{ id: "per_1" }, { id: "per_2" }])
+    expect(dangling).toBe(2)
+  })
+
+  it("reports a wholly dangling collection as empty AND dangling", () => {
+    // The measured case: four link rows, zero people. `rows.length === 0` alone
+    // is indistinguishable from "nobody was ever linked", which is why the
+    // count is returned rather than swallowed.
+    const { rows, dangling } = linkedRows([null, null, null, null])
+    expect(rows).toEqual([])
+    expect(dangling).toBe(4)
+  })
+
+  it("keeps rows that carry no id", () => {
+    /*
+     * 🔴 The regression this exists to prevent. Several callers request a
+     * single column — `fields: ["stores.default_sales_channel_id"]` — so a
+     * predicate of `!!r.id` would discard every RESOLVED row and report total
+     * loss. A dangling link is `null`, and that is all this looks for.
+     */
+    const { rows, dangling } = linkedRows([
+      { default_sales_channel_id: "sc_1" },
+      null,
+    ])
+    expect(rows).toEqual([{ default_sales_channel_id: "sc_1" }])
+    expect(dangling).toBe(1)
+  })
+
+  it("treats a missing field as empty rather than throwing", () => {
+    expect(linkedRows(undefined)).toEqual({ rows: [], dangling: 0 })
+    expect(linkedRows(null)).toEqual({ rows: [], dangling: 0 })
+  })
+
+  it("wraps a single object, because a to-one link is not an array", () => {
+    expect(linkedRows({ id: "st_1" }).rows).toEqual([{ id: "st_1" }])
+  })
+})
+
+describe("presentRows — the index-0 trap", () => {
+  it("picks the first store that RESOLVED, not stores[0]", () => {
+    /*
+     * The whole reason `stores?.[0]?.x` is not good enough: optional chaining
+     * turns a dangling row at index 0 into `undefined` and the caller falls
+     * through to "this partner has no store", while a real store sits at
+     * index 1.
+     */
+    const stores = [null, { id: "st_2", default_sales_channel_id: "sc_2" }]
+    expect((stores as any)[0]?.default_sales_channel_id).toBeUndefined()
+    expect(presentRows(stores)[0]?.default_sales_channel_id).toBe("sc_2")
+  })
+})

--- a/apps/backend/src/lib/links/dangling.ts
+++ b/apps/backend/src/lib/links/dangling.ts
@@ -1,0 +1,68 @@
+/**
+ * Link rows whose target is no longer visible (#1857).
+ *
+ * `query.graph` resolves a linked collection by joining the link table to the
+ * target module. Where the target is gone it returns a **null in the array** —
+ * not a shorter array, not an error. Every reader that maps, counts or
+ * dereferences that array is therefore one dangling row away from either a
+ * crash or a quiet over-count:
+ *
+ *   - `/admin/partners/:id/people` answered `{"people":[null,null,null,null],
+ *     "count":4}` and took the whole partner detail page down.
+ *   - `/admin/designs/:id/production-runs` splits a quantity across
+ *     `linkedPartners.length` — a dangling row shrinks every real partner's
+ *     share and creates a child run with `partner_id: undefined`.
+ *
+ * 🔴 "Gone" here means INVISIBLE, not absent. A soft-deleted target produces
+ * exactly the same null as a hard-deleted one, and the first two sweeps of
+ * #1857 missed that entirely: they asked whether the row EXISTS (`tgt.id IS
+ * NULL`) when the question is whether `query.graph` can see it. Correcting
+ * that took the prod count from 27 pairs to 46. Nothing downstream can tell
+ * the two apart, and nothing downstream needs to.
+ *
+ * 🔴 The count is RETURNED, never swallowed. Dropping the nulls silently
+ * trades a crash for "No people linked" rendered over four link rows, which is
+ * the quieter half of the same lie. A caller that has somewhere to say so
+ * should say so.
+ */
+
+export type LinkedRows<T> = {
+  /** The members that actually resolved. Safe to map and dereference. */
+  rows: T[]
+  /** How many link rows pointed at something `query.graph` could not see. */
+  dangling: number
+}
+
+/**
+ * Split a linked collection into what resolved and how much did not.
+ *
+ * Accepts the raw field off a `query.graph` result — which may be undefined
+ * (the entity has no such link), a single object, or an array with holes.
+ */
+export const linkedRows = <T extends Record<string, any>>(
+  value: unknown
+): LinkedRows<T> => {
+  const all: unknown[] = Array.isArray(value)
+    ? value
+    : value == null
+      ? []
+      : [value]
+
+  /*
+   * 🔴 A plain non-null test, NOT `!!r.id`.
+   *
+   * The `id` version is the obvious one and it is wrong here: several callers
+   * ask for a single column and nothing else — `fields: ["stores.
+   * default_sales_channel_id"]` — so every resolved row would have been thrown
+   * away as dangling and the count would have read as total loss. A dangling
+   * link resolves to exactly `null`, which is all this needs to look for.
+   */
+  const rows = all.filter((r): r is T => !!r && typeof r === "object")
+
+  return { rows, dangling: all.length - rows.length }
+}
+
+/** Just the rows, where the caller has nowhere to report the discrepancy. */
+export const presentRows = <T extends Record<string, any>>(
+  value: unknown
+): T[] => linkedRows<T>(value).rows

--- a/apps/backend/src/lib/resolve-store-currency.ts
+++ b/apps/backend/src/lib/resolve-store-currency.ts
@@ -1,4 +1,5 @@
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { presentRows } from "./links/dangling"
 
 /**
  * #485 — multi-store currency resolution.
@@ -77,7 +78,14 @@ export async function resolveStoreCurrency(
         fields: ["id", "stores.supported_currencies.*"],
         filters: { id: partnerId },
       })
-      const partnerStore = data?.[0]?.stores?.[0]
+      /*
+       * 🔴 The first PRESENT store (#1857). A dangling store link at index 0
+       * made this fall through to the platform store's currency — the partner
+       * would be priced in the wrong currency with nothing logged, which is
+       * the shape of the ShipRocket AUD/INR fault (#1834) arriving by a
+       * different door.
+       */
+      const partnerStore = presentRows(data?.[0]?.stores)[0]
       const code = partnerStore?.supported_currencies?.find(
         (c: any) => c?.is_default
       )?.currency_code

--- a/apps/backend/src/modules/partner-quote/lib/__tests__/price-list-usable.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/lib/__tests__/price-list-usable.unit.spec.ts
@@ -1,0 +1,133 @@
+import {
+  priceListUnusableReason,
+  quoteExpiryFrom,
+  quoteUnusableReason,
+} from "../token"
+
+/**
+ * #1857 — the half of "can this quote still price?" that lives on the price
+ * list.
+ *
+ * The audit flagged `partner_quote.price_list_id` as 10 of 12 dangling in prod.
+ * It is not debris: `revokeQuote` DELETES the price list, so a revoked quote
+ * pointing at a deleted list is the designed terminal state. What the audit
+ * could not see is that `accept-quote` guarded on the COLUMN BEING SET, never
+ * on the list still being able to price — and the gap between those two is a
+ * cart silently built at base prices, not an error.
+ */
+
+const NOW = new Date("2026-09-07T12:00:00.000Z")
+const past = new Date(NOW.getTime() - 1000).toISOString()
+const future = new Date(NOW.getTime() + 1000).toISOString()
+
+describe("priceListUnusableReason", () => {
+  it("passes a live, active, in-window list", () => {
+    expect(
+      priceListUnusableReason(
+        { id: "pl_1", status: "active", starts_at: past, ends_at: future },
+        NOW
+      )
+    ).toBeNull()
+  })
+
+  it("treats a soft-deleted list exactly like a missing one", () => {
+    /*
+     * 🔴 The whole point. `query.graph` returns NO ROW for a soft-deleted
+     * price list, identically to one that never existed — establishing that
+     * the question is VISIBILITY, not existence, is what took the #1857 prod
+     * sweep from 27 pairs to 46.
+     */
+    expect(priceListUnusableReason(undefined, NOW)).toBe("missing")
+    expect(priceListUnusableReason(null, NOW)).toBe("missing")
+    expect(priceListUnusableReason({ id: "pl_1", deleted_at: past }, NOW)).toBe(
+      "missing"
+    )
+  })
+
+  it("refuses a list that has ENDED — the revoke/supersede shape", () => {
+    // Superseding a quote dates the prior list to `now` rather than deleting
+    // it, so the row is perfectly visible and completely inert.
+    expect(
+      priceListUnusableReason(
+        { id: "pl_1", status: "active", ends_at: past },
+        NOW
+      )
+    ).toBe("ended")
+  })
+
+  it("refuses a draft list", () => {
+    expect(
+      priceListUnusableReason({ id: "pl_1", status: "draft" }, NOW)
+    ).toBe("draft")
+  })
+
+  it("refuses a list that has not started", () => {
+    expect(
+      priceListUnusableReason(
+        { id: "pl_1", status: "active", starts_at: future },
+        NOW
+      )
+    ).toBe("not_started")
+  })
+
+  it("accepts an ISO STRING clock, because a step boundary serialises Date", () => {
+    /*
+     * The trap `quoteUnusableReason` already carries a docblock about: a Date
+     * handed between workflow steps arrives as a string, and tsc cannot see it
+     * because the declared types describe the graph, not the payload.
+     */
+    expect(
+      priceListUnusableReason(
+        { id: "pl_1", status: "active", ends_at: past },
+        NOW.toISOString() as any
+      )
+    ).toBe("ended")
+  })
+})
+
+describe("the invariant this guard turns into an assertion", () => {
+  it("is not vacuous: quote and price list lapse together TODAY", () => {
+    /*
+     * `mint-quote` derives `quote.expires_at` and the list's `ends_at` from one
+     * value, so the quote expires at the instant the list goes inert — measured
+     * equal to the microsecond on every active quote in the local database.
+     * While that holds, the quote guard fires first and this one never does.
+     */
+    const mintedAt = new Date("2026-09-01T00:00:00.000Z")
+    const expiry = quoteExpiryFrom(mintedAt, 14)
+    const justAfter = new Date(expiry.getTime() + 1)
+
+    expect(
+      quoteUnusableReason({ status: "active", expires_at: expiry }, justAfter)
+    ).toBe("expired")
+    expect(
+      priceListUnusableReason(
+        { id: "pl_1", status: "active", ends_at: expiry.toISOString() },
+        justAfter
+      )
+    ).toBe("ended")
+  })
+
+  it("catches the drift the quote guard would MISS", () => {
+    /*
+     * 🔴 The case the guard exists for, and the reason a test that only
+     * exercised the aligned pair would be worthless: nothing enforces the two
+     * timestamps staying equal. Give the quote a longer life than its list —
+     * one changed TTL, one manual edit to a price list — and the quote reads
+     * as perfectly acceptable while the cart would price at base.
+     */
+    const quoteExpiry = new Date("2026-09-20T00:00:00.000Z")
+    const listEnded = new Date("2026-09-05T00:00:00.000Z")
+
+    expect(
+      quoteUnusableReason({ status: "active", expires_at: quoteExpiry }, NOW)
+    ).toBeNull() // the quote says: go ahead
+
+    expect(
+      priceListUnusableReason(
+        { id: "pl_1", status: "active", ends_at: listEnded.toISOString() },
+        NOW
+      )
+    ).toBe("ended") // the price list says: you would be charging base
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/token.ts
+++ b/apps/backend/src/modules/partner-quote/lib/token.ts
@@ -80,6 +80,68 @@ export function quoteUnusableReason(
   return null
 }
 
+/**
+ * The half of "can this quote still price?" that lives on the PRICE LIST.
+ *
+ * `quoteUnusableReason` above asks the quote. That is not the whole question,
+ * and #1857 is where the gap showed: `accept-quote` guards on
+ * `!quote.price_list_id` — that the COLUMN IS SET — while what it needs is
+ * that the list can still price. A revoked quote's price list is DELETED (see
+ * `lib/revoke-quote.ts`), and a superseded one's is dated to `now`; if either
+ * quote reached the accept path it would build a cart against a list core
+ * ignores, and the docblock there names the consequence exactly: "a silently
+ * cheaper (or dearer) cart rather than an error".
+ *
+ * 🔴 Today nothing can reach that state, and the reason is an INVARIANT NOT
+ * ENFORCED ANYWHERE: `mint-quote` sets `quote.expires_at` and the price list's
+ * `ends_at` from ONE value, so the quote expires at the same instant the list
+ * goes inert. Measured on all five active local quotes — equal to the
+ * microsecond. This function is what makes that an assertion rather than a
+ * coincidence: if the two ever drift, acceptance refuses instead of
+ * mispricing.
+ *
+ * `missing` covers "no row" and "soft-deleted" alike, because a caller reading
+ * through `query.graph` cannot tell them apart — both come back as no row at
+ * all, and the corrected #1857 sweep is what established that the question is
+ * VISIBILITY, not existence.
+ */
+export type QuotePriceListState = {
+  id?: string | null
+  deleted_at?: Date | string | null
+  status?: string | null
+  starts_at?: Date | string | null
+  ends_at?: Date | string | null
+}
+
+export function priceListUnusableReason(
+  priceList: QuotePriceListState | null | undefined,
+  now: Date | string | number
+): "missing" | "draft" | "ended" | "not_started" | null {
+  if (!priceList?.id || priceList.deleted_at) {
+    return "missing"
+  }
+
+  // `status: draft` is how a quote's list is switched off without deleting it.
+  if (priceList.status && String(priceList.status) !== "active") {
+    return "draft"
+  }
+
+  const nowMs = new Date(now as any).getTime()
+  if (!Number.isFinite(nowMs)) {
+    // Same defensive normalisation as above — a step boundary turns a Date
+    // into a string, and an unparseable clock must not silently pass a list.
+    return null
+  }
+
+  if (priceList.ends_at && new Date(priceList.ends_at).getTime() <= nowMs) {
+    return "ended"
+  }
+  if (priceList.starts_at && new Date(priceList.starts_at).getTime() > nowMs) {
+    return "not_started"
+  }
+  return null
+}
+
 export function isQuoteUsable(
   quote: QuoteLifecycle,
   now: Date | string | number

--- a/apps/backend/src/workflows/designs/cancel-partner-assignment.ts
+++ b/apps/backend/src/workflows/designs/cancel-partner-assignment.ts
@@ -10,6 +10,7 @@ import { DESIGN_MODULE } from "../../modules/designs"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { TASKS_MODULE } from "../../modules/tasks"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import { presentRows } from "../../lib/links/dangling"
 
 export type CancelPartnerAssignmentInput = {
   design_id: string
@@ -53,7 +54,14 @@ const cancelPartnerRunsStep = createStep(
         fields: ["tasks.id", "tasks.status"],
         filters: { id: run.id },
       })
-      for (const t of rd?.[0]?.tasks || []) {
+      /*
+       * 🔴 Present tasks only (#1857). A dangling `production_run_task` link
+       * resolves to a null here, and `t.status` on it throws INSIDE a step
+       * that has already cancelled runs — the compensation would then run over
+       * a partially cancelled cascade. This is reachable from the partner
+       * graph's "Cancel assignment" row.
+       */
+      for (const t of presentRows<{ id: string; status?: string }>(rd?.[0]?.tasks)) {
         if (t.status !== "completed" && t.status !== "cancelled") {
           await taskService.updateTasks({ id: t.id, status: "cancelled" })
           cancelledTasks++

--- a/apps/backend/src/workflows/partner-quote/accept-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/accept-quote.ts
@@ -28,7 +28,10 @@ import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
 import { resolveQuoteRegion } from "../../modules/partner-quote/lib/resolve-region"
 import { PARTNER_QUOTE_EVENTS } from "../../modules/partner-quote/events"
 import { PAYMENT_SCHEDULE_MODULE } from "../../modules/payment_schedule"
-import { quoteUnusableReason } from "../../modules/partner-quote/lib/token"
+import {
+  priceListUnusableReason,
+  quoteUnusableReason,
+} from "../../modules/partner-quote/lib/token"
 import { buildQuoteView } from "../../modules/partner-quote/lib/build-quote-view"
 
 /**
@@ -168,6 +171,40 @@ const loadQuoteForAcceptStep = createStep(
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
         `Quote ${quote.id} predates buyer-scoped pricing and cannot be accepted; re-mint it`
+      )
+    }
+
+    /**
+     * 🔴 The check above asks whether the COLUMN IS SET. That is not the same
+     * question as whether the list can still price, and the difference is a
+     * silent mispricing rather than an error (#1857).
+     *
+     * A revoked quote's price list is DELETED and a superseded one's is dated
+     * to `now`; either would build a cart core prices at BASE — the failure
+     * this step's own docblock names. Nothing can reach that state today only
+     * because `mint-quote` derives `quote.expires_at` and the list's `ends_at`
+     * from one value, so the two lapse together — an invariant enforced
+     * nowhere until this line. Measured: on every quote in the local database
+     * the two timestamps are equal to the microsecond, and 0 quotes are in the
+     * exposed shape.
+     *
+     * Read back rather than trusted: the id on the quote is a pointer, and
+     * `query.graph` returns NO ROW for a soft-deleted list exactly as it does
+     * for one that never existed.
+     */
+    const { data: priceLists } = await query.graph({
+      entity: "price_list",
+      filters: { id: quote.price_list_id },
+      fields: ["id", "status", "starts_at", "ends_at", "deleted_at"],
+    })
+    const priceListProblem = priceListUnusableReason(
+      (priceLists ?? [])[0],
+      input.now
+    )
+    if (priceListProblem) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Quote ${quote.id} can no longer be priced — its price list ${quote.price_list_id} is ${priceListProblem}. Accepting it would build the cart at base prices, which is not what was quoted. Re-mint the quote.`
       )
     }
 

--- a/apps/backend/src/workflows/production-runs/create-production-run-transfer.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run-transfer.ts
@@ -25,6 +25,7 @@ import {
   buildTransferShipmentInput,
   transferQuantity,
 } from "./lib/goods-transfer-shipment"
+import { presentRows } from "../../lib/links/dangling"
 
 /**
  * #891 — move a production run's output from where it was made to wherever it
@@ -151,7 +152,9 @@ export async function resolveRunGoodsLocation(
       fields: ["stores.default_sales_channel_id"],
       filters: { id: run.partner_id },
     })
-    const scId = partners?.[0]?.stores?.[0]?.default_sales_channel_id
+    // The first PRESENT store — see partner-run-steps for what a null here
+    // costs (#1857).
+    const scId = presentRows(partners?.[0]?.stores)[0]?.default_sales_channel_id
     if (!scId) return undefined
     const { data: channels } = await query.graph({
       entity: "sales_channels",

--- a/apps/backend/src/workflows/production-runs/lib/cancel-production-run-cascade.ts
+++ b/apps/backend/src/workflows/production-runs/lib/cancel-production-run-cascade.ts
@@ -6,6 +6,7 @@ import { PRODUCTION_RUNS_MODULE } from "../../../modules/production_runs"
 import type ProductionRunService from "../../../modules/production_runs/service"
 import { TASKS_MODULE } from "../../../modules/tasks"
 import { mirrorRunStatusToUnifiedOrder } from "../dual-write-unified-run-order"
+import { presentRows } from "../../../lib/links/dangling"
 
 /**
  * Cancelling a run, in ONE place.
@@ -55,7 +56,7 @@ export const cancelSingleRun = async (
       fields: ["tasks.id", "tasks.status"],
       filters: { id: runId },
     })
-    const tasks = runData?.[0]?.tasks || []
+    const tasks = presentRows(runData?.[0]?.tasks)
 
     for (const task of tasks) {
       if (task.status !== "completed" && task.status !== "cancelled") {

--- a/apps/backend/src/workflows/production-runs/partner-run-steps.ts
+++ b/apps/backend/src/workflows/production-runs/partner-run-steps.ts
@@ -18,6 +18,7 @@ import {
   isMissingLifecycleTransaction,
 } from "./lib/lifecycle-signal-errors"
 import { lifecycleWorkflowId } from "./run-production-run-lifecycle"
+import { presentRows } from "../../lib/links/dangling"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -242,7 +243,14 @@ export const resolvePartnerLocationStep = createStep(
       filters: { id: input.partner_id },
     })
 
-    const scId = partners?.[0]?.stores?.[0]?.default_sales_channel_id
+    /*
+     * 🔴 The first PRESENT store, not `stores[0]` (#1857). A dangling
+     * `partner_partner_stores_store` row resolves to a null in this array, and
+     * `null?.default_sales_channel_id` is `undefined` — so the step returns no
+     * stock location and the run is dispatched against nothing, while a real
+     * store sits at index 1. Optional chaining turns the fault into silence.
+     */
+    const scId = presentRows(partners?.[0]?.stores)[0]?.default_sales_channel_id
     if (scId) {
       const { data: channels } = await query.graph({
         entity: "sales_channels",

--- a/apps/backend/src/workflows/production-runs/reassign-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/reassign-production-run.ts
@@ -9,6 +9,7 @@ import {
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
 import { TASKS_MODULE } from "../../modules/tasks"
+import { presentRows } from "../../lib/links/dangling"
 
 /**
  * #1093 — move a run into the admin reassignment queue.
@@ -125,7 +126,7 @@ const cancelReassignedTasksStep = createStep(
       filters: { id: input.production_run_id },
     })
     let cancelled = 0
-    for (const t of data?.[0]?.tasks || []) {
+    for (const t of presentRows<{ id: string; status?: string }>(data?.[0]?.tasks)) {
       if (t.status !== "completed" && t.status !== "cancelled") {
         await taskService.updateTasks({ id: t.id, status: "cancelled" })
         cancelled++

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -2564,6 +2564,43 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating act-rail partner (unverified WhatsApp + domain)...")
   const actRail = await seedActRailPartner(container)
 
+  /**
+   * 🔴 The parked run is re-asserted LAST, because something later in this
+   * seed moves it.
+   *
+   * Measured: the fixture is created `awaiting_reassignment` and read back
+   * `approved` with its `cancelled_reason` cleared, updated 90 seconds after
+   * creation — i.e. while this seed was still running, not during the specs.
+   * The result is a fixture whose state depends on seeding order, so
+   * `production-run-reassign` passes on one seed and fails on the next looking
+   * for "awaiting reassignment" on a run that is no longer parked.
+   *
+   * A seed's contract is the state of its fixtures at the moment it writes the
+   * file. This makes that true rather than hoping nothing downstream reaches
+   * back — and it throws if the re-force does not stick, so a fixture that
+   * cannot be parked is a loud seed failure instead of a silent spec one.
+   */
+  const runsForCheck: any = container.resolve("production_runs")
+  const parkedNow = await runsForCheck.retrieveProductionRun(parkedRun.runId)
+  if (parkedNow?.status !== "awaiting_reassignment") {
+    logger.warn(
+      `E2E seed: parked run ${parkedRun.runId} drifted to "${parkedNow?.status}" during seeding — re-parking it.`
+    )
+    await runsForCheck.updateProductionRuns({
+      id: parkedRun.runId,
+      status: "awaiting_reassignment",
+      partner_id: null,
+      previous_partner_id: parkedRun.lapsedPartnerId,
+      cancelled_reason: "Declined by partner (capacity): Machine servicing",
+    })
+    const reparked = await runsForCheck.retrieveProductionRun(parkedRun.runId)
+    if (reparked?.status !== "awaiting_reassignment") {
+      throw new Error(
+        `E2E seed: could not park run ${parkedRun.runId} — it reads "${reparked?.status}". production-run-reassign.spec.ts cannot pass against this fixture.`
+      )
+    }
+  }
+
   const seedData = {
     email,
     password: SEED_PASSWORD,

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -377,6 +377,53 @@ async function seedAdminQuotes(container: any): Promise<{
   })
   const partner = Array.isArray(createdPartner) ? createdPartner[0] : createdPartner
 
+  /**
+   * 🔴 The store, without which this partner cannot be quoted AT ALL.
+   *
+   * `POST /admin/quotes/drafts` and `POST /admin/quotes` both refuse a partner
+   * with no store — "a quote is priced against a store's catalogue and shipped
+   * from its location" — and the refusal is correct. The fixture was the thing
+   * that was wrong: it created a quote partner that no quote route would
+   * accept, so the mint wizard's Save 500'd, `waitForURL` timed out 30s later,
+   * and `admin-quote-deposit-terms` failed pointing at a navigation.
+   *
+   * A seed defect wearing the costume of a broken screen, exactly like the
+   * gate partner's missing store defaults below. This took e2e red on `main`
+   * for every branch, which is why it is fixed here rather than filed.
+   */
+  const quoteQuery = container.resolve(ContainerRegistrationKeys.QUERY)
+  const quoteLink = container.resolve(ContainerRegistrationKeys.LINK)
+  const [{ data: qRegions }, { data: qChannels }, { data: qLocations }] =
+    await Promise.all([
+      quoteQuery.graph({ entity: "region", fields: ["id"] }),
+      quoteQuery.graph({ entity: "sales_channel", fields: ["id"] }),
+      quoteQuery.graph({ entity: "stock_location", fields: ["id"] }),
+    ])
+  const qRegionId = qRegions?.[0]?.id
+  const qChannelId = qChannels?.[0]?.id
+  const qLocationId = qLocations?.[0]?.id
+  if (!qRegionId || !qChannelId || !qLocationId) {
+    throw new Error(
+      `E2E seed: the quote partner's store needs a region (${qRegionId}), a sales channel (${qChannelId}) and a stock location (${qLocationId}). Run the demo seed first: \`medusa exec ./src/scripts/seed.ts\`.`
+    )
+  }
+
+  const quoteStoreModule: any = container.resolve(Modules.STORE)
+  const createdQuoteStore: any = await quoteStoreModule.createStores({
+    name: `E2E Quote Store ${stamp}`,
+    default_sales_channel_id: qChannelId,
+    default_location_id: qLocationId,
+    default_region_id: qRegionId,
+  })
+  const quoteStoreId = Array.isArray(createdQuoteStore)
+    ? createdQuoteStore[0].id
+    : createdQuoteStore.id
+
+  await quoteLink.create({
+    partner: { partner_id: partner.id },
+    store: { store_id: quoteStoreId },
+  })
+
   // Stamped company names: the spec SEARCHES for these, and the search reaches
   // the server (#1461), so a duplicate from a previous seed would make a
   // one-row assertion flap.

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -2253,6 +2253,63 @@ async function seedRateBreakdownSubmission(container: any): Promise<{
 const SEED_PASSWORD = "e2etest123!"
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 
+
+/**
+ * A partner whose two CONTROL cards are both drawable (#1856, #1857).
+ *
+ * 🔴 This fixture exists because the states cannot be found in real data.
+ * Measured on the local database while wiring the act rail: of **338 partners,
+ * exactly one had a WhatsApp number and it was verified, and ZERO had a custom
+ * domain**. Both cards were therefore unreachable, and an affordance nobody can
+ * exercise is the #1855 trap — four marketing rules shipped against tables with
+ * no rows in them.
+ *
+ * The two fields are set unverified on purpose. `whatsappUnverified` and
+ * `domainUnverified` are what put the cards on the partner spine at all, and
+ * the spec's whole subject is the button those cards now carry.
+ */
+export async function seedActRailPartner(container: any): Promise<{
+  partnerId: string
+  partnerName: string
+  whatsappNumber: string
+  customDomain: string
+}> {
+  // 🔴 The literal, like every other partner fixture in this file. The seed
+  // does not import the module constants, and a bare `PARTNER_MODULE` here is
+  // a ReferenceError that kills the seed — which means EVERY spec fails before
+  // it runs, and the failure reads like the module is unregistered.
+  const partnerModule: any = container.resolve("partner")
+  const stamp = Date.now()
+
+  /*
+   * A number that is syntactically real and belongs to nobody. The spec
+   * CANCELS the confirm rather than pressing through — the endpoint behind
+   * this card sends a live WhatsApp template — but a seed that put a real
+   * number here would be one misread assertion away from messaging a stranger.
+   */
+  const whatsappNumber = `9199${String(stamp).slice(-8)}`
+  const customDomain = `e2e-${stamp}.example.test`
+
+  const created = await partnerModule.createPartners({
+    name: `E2E Act Rail Partner ${stamp}`,
+    handle: `e2e-act-rail-${stamp}`,
+    status: "active",
+    is_verified: true,
+    whatsapp_number: whatsappNumber,
+    whatsapp_verified: false,
+    custom_domain: customDomain,
+    custom_domain_verified: false,
+  })
+  const row = Array.isArray(created) ? created[0] : created
+
+  return {
+    partnerId: row.id as string,
+    partnerName: row.name as string,
+    whatsappNumber,
+    customDomain,
+  }
+}
+
 export default async function e2eSeed({ container }: ExecArgs) {
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const userModule = container.resolve(Modules.USER)
@@ -2457,6 +2514,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating payment-methods partner + two methods (settings/payments spec)...")
   const paymentMethods = await seedPaymentMethodsPartner(container)
 
+  logger.info("E2E seed: creating act-rail partner (unverified WhatsApp + domain)...")
+  const actRail = await seedActRailPartner(container)
+
   const seedData = {
     email,
     password: SEED_PASSWORD,
@@ -2514,6 +2574,15 @@ export default async function e2eSeed({ container }: ExecArgs) {
     paymentsEditMethodName: paymentMethods.editMethodName,
     paymentsDeleteMethodId: paymentMethods.deleteMethodId,
     paymentsDeleteMethodName: paymentMethods.deleteMethodName,
+    /*
+     * #1856/#1857 act rail — consumed by admin-graph-act-rail.spec.ts (admin,
+     * CI). NOT single-use: the spec cancels every confirm, so the partner is
+     * left exactly as seeded and the fixture survives a re-run.
+     */
+    actRailPartnerId: actRail.partnerId,
+    actRailPartnerName: actRail.partnerName,
+    actRailWhatsappNumber: actRail.whatsappNumber,
+    actRailCustomDomain: actRail.customDomain,
     // #1363 per-assignment material allocation — consumed by
     // production-run-material-allocation.spec.ts (admin, CI). SINGLE-USE like
     // every other run fixture: the spec approves the run, and an approved run

--- a/e2e/specs/admin-graph-act-rail.spec.ts
+++ b/e2e/specs/admin-graph-act-rail.spec.ts
@@ -1,0 +1,206 @@
+import fs from "fs"
+import path from "path"
+import { expect, request as pwRequest, test } from "@playwright/test"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+const BASE = process.env.E2E_BACKEND_URL || "http://localhost:9000"
+
+/**
+ * The ACT rail, and the dangling-pointer board it was built for (#1856, #1857).
+ *
+ * ## Why these cases and not others
+ *
+ * Every assertion below is one that a green build, a green `tsc` and 164 green
+ * unit tests all missed on this exact code, within one session:
+ *
+ *   - The board's node COUNT was invisible, because the canvas draws
+ *     `sublabel ?? count` and the sublabel wins. A board whose whole claim is
+ *     that it ranks by row count drew identical boxes.
+ *   - The WhatsApp node rendered its button TWICE — the working act directly
+ *     above the old `action`, whose href is null and which therefore draws a
+ *     dead disabled button with the same words (#1854, again).
+ *   - An act with no dry run pressed "preview" straight into the real
+ *     endpoint. For this card that endpoint SENDS A WHATSAPP MESSAGE.
+ *
+ * 🔴 None of them throws. Each one is a button that is missing, duplicated, or
+ * does something other than what it says — which is why they belong in a spec
+ * that drives the screen rather than in another unit test.
+ */
+
+let seed: any
+let token: string
+
+const login = async (page: any) => {
+  await page.goto("/app/login")
+  // `networkidle` never settles against `medusa develop`, so wait on the form.
+  await page.locator('input[name="email"]').waitFor({ timeout: 60000 })
+  await page.locator('input[name="email"]').fill(seed.email)
+  await page.locator('input[name="password"]').fill(seed.password)
+  await page.locator('button[type="submit"]').click()
+  await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+}
+
+test.beforeAll(async () => {
+  if (!fs.existsSync(SEED_FILE)) {
+    throw new Error(
+      `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+    )
+  }
+  seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+
+  const api = await pwRequest.newContext({ baseURL: BASE })
+  const auth = await api.post("/auth/user/emailpass", {
+    data: { email: seed.email, password: seed.password },
+  })
+  expect(auth.ok()).toBeTruthy()
+  token = (await auth.json()).token
+  await api.dispose()
+})
+
+test.describe("the partner spine's control cards can be acted on", () => {
+  test.beforeAll(() => {
+    /*
+     * 🔴 Loud, not skipped. The fixture is what makes both cards drawable at
+     * all — of 338 partners on a real database, one had a WhatsApp number and
+     * it was verified, and none had a custom domain. A spec that quietly
+     * skipped here would be a check that never ran reading as a pass.
+     */
+    expect(
+      seed.actRailPartnerId,
+      "seed.actRailPartnerId is missing — re-run `pnpm e2e:seed`"
+    ).toBeTruthy()
+  })
+
+  /*
+   * 🔴 The #1854 regression, in one number. The act did not replace the old
+   * `action`; both rendered, word for word identical, one of them dead.
+   */
+  test("offers exactly ONE verify button, not the act plus a dead one", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(
+      `/app/partners/${seed.actRailPartnerId}/graph?node=whatsapp`
+    )
+
+    const drawer = page.getByRole("dialog")
+    const verify = drawer.getByRole("button", { name: "Verify the number" })
+    await expect(verify).toHaveCount(1, { timeout: 30000 })
+  })
+
+  /*
+   * 🔴 The one that matters most. This endpoint sends a live WhatsApp template
+   * — there is no dry run of a message that has already left — so the press
+   * must be intercepted, the confirm must say so in the SERVER's words, and
+   * Cancel must send nothing at all.
+   */
+  test("confirms before sending, and Cancel sends nothing", async ({ page }) => {
+    const posted: string[] = []
+    page.on("request", (r) => {
+      if (r.method() === "POST" && r.url().includes("whatsapp-verify")) {
+        posted.push(r.url())
+      }
+    })
+
+    await login(page)
+    await page.goto(
+      `/app/partners/${seed.actRailPartnerId}/graph?node=whatsapp`
+    )
+
+    const drawer = page.getByRole("dialog")
+    await drawer
+      .getByRole("button", { name: "Verify the number" })
+      .click({ timeout: 30000 })
+
+    const prompt = page.locator('[role="alertdialog"]')
+    await expect(prompt).toBeVisible({ timeout: 10000 })
+    // The server's sentence, naming the number and the irreversibility.
+    await expect(prompt).toContainText(seed.actRailWhatsappNumber)
+    await expect(prompt).toContainText("cannot be recalled")
+    /*
+     * And the confirm's last word is the ACT, not "Apply" — which is a stage
+     * of a preview-then-apply flow this card does not have.
+     */
+    await expect(
+      prompt.getByRole("button", { name: "Verify the number" })
+    ).toBeVisible()
+
+    await prompt.getByRole("button", { name: /cancel/i }).click()
+    await page.waitForTimeout(1500)
+
+    expect(
+      posted,
+      "Cancelling the confirm must not send the WhatsApp template"
+    ).toEqual([])
+  })
+
+  test("the domain card is acted on the same way", async ({ page }) => {
+    await login(page)
+    await page.goto(`/app/partners/${seed.actRailPartnerId}/graph?node=domain`)
+
+    const drawer = page.getByRole("dialog")
+    const verify = drawer.getByRole("button", { name: "Verify the domain" })
+    await expect(verify).toHaveCount(1, { timeout: 30000 })
+    await expect(drawer).toContainText(seed.actRailCustomDomain)
+  })
+})
+
+test.describe("the dangling-pointer board", () => {
+  test.beforeAll(async () => {
+    /*
+     * The board reads the LAST RECORDED RUN of the sweep rather than sweeping
+     * on open, so the fixture is a run. Dry — the job writes nothing in either
+     * mode, and its audit row is the whole point.
+     */
+    const api = await pwRequest.newContext({
+      baseURL: BASE,
+      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    })
+    const res = await api.post(
+      "/admin/ops/maintenance-jobs/audit-dangling-links/run",
+      { data: { dry_run: true, params: { min_orphans: 1 } }, timeout: 180000 }
+    )
+    expect(res.status(), await res.text()).toBe(200)
+    const body = await res.json()
+    // 🔴 Everything is under `.result`; `.summary` at the top level is null.
+    expect(body.result.dry_run).toBe(true)
+    expect(body.result.applied).toBe(false)
+    await api.dispose()
+  })
+
+  /*
+   * 🔴 The count has to be ON the node. The canvas draws `sublabel ?? count`,
+   * so a sublabel of just the target hid the number on every box — and the
+   * board's entire claim is that it ranks by how many rows are unexplained.
+   */
+  test("draws each pair with the number of rows behind it", async ({ page }) => {
+    await login(page)
+    await page.goto("/app/queues/dangling-pointers")
+
+    const board = page.locator("body")
+    await expect(board).toContainText("Dangling pointers", { timeout: 60000 })
+    // "<n> of <m> → <target>" is the shape; assert the shape, not a fixed pair,
+    // because which columns dangle is a property of the database, not the code.
+    await expect(board).toContainText(/\d+ of \d+ →/, { timeout: 30000 })
+    // And the board states WHEN it was measured — a count with no time
+    // attached is what let a local reading be written up as a fact about prod.
+    await expect(board).toContainText(/swept \d{4}-\d{2}-\d{2}/)
+  })
+
+  /*
+   * 🔴 A read-only job has nothing to apply, and a DISABLED Apply would imply
+   * a write that is merely unavailable rather than one that does not exist.
+   */
+  test("offers the sweep with no Apply, because it writes nothing", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto("/app/queues/dangling-pointers?node=dangling")
+
+    const drawer = page.getByRole("dialog")
+    await expect(
+      drawer.getByRole("button", { name: /Re-run the sweep/ })
+    ).toBeVisible({ timeout: 30000 })
+    await expect(drawer.getByRole("button", { name: "Apply" })).toHaveCount(0)
+  })
+})

--- a/e2e/specs/admin-quote-drafts.spec.ts
+++ b/e2e/specs/admin-quote-drafts.spec.ts
@@ -246,7 +246,19 @@ test.describe("Admin quote drafts (#1446)", () => {
 
     // Back on the draft, and the units are on the record — not zero.
     await page.waitForURL(/\/app\/quotes\/drafts\/[^/]+$/, { timeout: 30000 })
-    await expect(page.getByText("500")).toBeVisible({ timeout: 15000 })
+    /*
+     * 🔴 `500×`, the QUANTITY cell, not a bare "500".
+     *
+     * The row renders the units as `500×` beside a right-aligned amount, and
+     * on a database where that amount is also 500 the bare match resolved to
+     * two elements and Playwright's strict mode failed the case — reporting
+     * "500 is not visible" about a basket that had persisted perfectly.
+     *
+     * `{ exact: true }` would have silenced it and asserted the wrong thing:
+     * it selects the AMOUNT, so the case would pass with the quantity at zero,
+     * which is the single outcome this test exists to catch.
+     */
+    await expect(page.getByText("500×")).toBeVisible({ timeout: 15000 })
   })
 
   test("the buyer drawer saves without emptying the basket", async ({ page }) => {

--- a/e2e/specs/admin-quote-drafts.spec.ts
+++ b/e2e/specs/admin-quote-drafts.spec.ts
@@ -1,8 +1,13 @@
-import { test, expect } from "@playwright/test"
+import { test, expect, request as pwRequest } from "@playwright/test"
 import * as fs from "fs"
 import * as path from "path"
 
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+const BASE = "http://localhost:9000"
+
+/** Escapes a region label so it can be used as a `getByRole` name match. */
+const rx = (literal: string) =>
+  new RegExp(literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
 
 /**
  * Starting a quote, through a browser (#1439 S4 / #1446).
@@ -36,13 +41,71 @@ const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 test.describe("Admin quote drafts (#1446)", () => {
   let seed: { email: string; password: string }
 
-  test.beforeAll(() => {
+  /**
+   * 🔴 The region is DERIVED, never named.
+   *
+   * Every case below used to click `/Singapore/`. Nothing in this repo creates
+   * a Singapore region: `apps/backend/src/scripts/seed.ts`, which the e2e job
+   * runs, creates exactly ONE — "Europe" (eur; gb, de, dk, se, fr, es, it) —
+   * and `e2e/helpers/e2e-seed.ts` creates none, it only reads `regions[0]`. So
+   * five cases sat for 120s waiting for an option that could not exist, on
+   * this branch, on the other open PRs and on `main`, while passing on the one
+   * database that had a hand-made Singapore region.
+   *
+   * Hardcoding "Europe" instead only moves the problem one database over: what
+   * these cases actually need is a region that DECLARES COUNTRIES — picking
+   * one writes its first country into the form, and Save refuses a draft with
+   * no destination — and a region's country list is database state, not a
+   * name. A region with an empty list is a legitimate thing to have here (the
+   * form renders a whole warning for it), so a name is never a safe proxy.
+   *
+   * It therefore asks the API which region is usable and builds the label from
+   * the same two fields `create-draft-form.tsx` renders into the option.
+   */
+  let regionOption: RegExp
+
+  test.beforeAll(async () => {
     if (!fs.existsSync(SEED_FILE)) {
       throw new Error(
         `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
       )
     }
     seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+
+    const api = await pwRequest.newContext({ baseURL: BASE })
+    const auth = await api.post("/auth/user/emailpass", {
+      data: { email: seed.email, password: seed.password },
+    })
+    expect(auth.ok()).toBeTruthy()
+    const token = (await auth.json()).token
+
+    const res = await api.get(
+      "/admin/regions?limit=100&fields=id,name,currency_code,countries.iso_2",
+      { headers: { Authorization: `Bearer ${token}` } }
+    )
+    expect(res.ok()).toBeTruthy()
+    const regions: any[] = (await res.json()).regions ?? []
+    await api.dispose()
+
+    const usable = regions.find((r) => (r.countries ?? []).length > 0)
+    /**
+     * A loud, actionable failure instead of five 120s timeouts pointing at a
+     * Select — the exact shape of red this file just spent months in.
+     */
+    if (!usable) {
+      throw new Error(
+        `No region declares a country, so the draft modal has no destination to pick and this spec cannot run. Regions seen: ${
+          regions
+            .map((r) => `${r.name}(${(r.countries ?? []).length})`)
+            .join(", ") || "none"
+        }. Run \`pnpm run seed\` in apps/backend.`
+      )
+    }
+
+    // Exactly what the Select renders: `{name} · {CURRENCY}`.
+    regionOption = rx(
+      `${usable.name} · ${String(usable.currency_code).toUpperCase()}`
+    )
   })
 
   const login = async (page: any) => {
@@ -103,8 +166,8 @@ test.describe("Admin quote drafts (#1446)", () => {
     await expect(currency).toHaveValue("")
 
     await page.getByText("Select a region").click()
-    // A region that declares countries — at least one of ours declares none.
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    // Derived in beforeAll: a region that DECLARES COUNTRIES. Some do not.
+    await page.getByRole("option", { name: regionOption }).click()
 
     // The region wrote the currency; nobody typed it.
     await expect(currency).not.toHaveValue("")
@@ -122,7 +185,7 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
     await page.getByText("Select a region").click()
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: regionOption }).click()
 
     await page.getByRole("button", { name: "Save" }).click()
 
@@ -167,7 +230,7 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
     await page.getByText("Select a region").click()
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: regionOption }).click()
     await page.getByRole("button", { name: "Save" }).click()
     await page.waitForURL(/\/app\/quotes\/drafts\//, { timeout: 30000 })
 
@@ -231,7 +294,7 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
     await page.getByText("Select a region").click()
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: regionOption }).click()
     await page.getByRole("button", { name: "Save" }).click()
     await page.waitForURL(/\/app\/quotes\/drafts\//, { timeout: 30000 })
 
@@ -268,7 +331,7 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
     await page.getByText("Select a region").click()
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: regionOption }).click()
     await page.getByRole("button", { name: "Save" }).click()
     await page.waitForURL(/\/app\/quotes\/drafts\//, { timeout: 30000 })
 

--- a/e2e/specs/crm-contact-activity.spec.ts
+++ b/e2e/specs/crm-contact-activity.spec.ts
@@ -41,10 +41,30 @@ test.describe("CRM contact detail", () => {
       )
     }
     seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    /*
+     * 🔴 Loud on CI, skipped locally — and the difference is deliberate.
+     *
+     * The CRM is a Hyperbee node, not Postgres. Without `CRM_HYPERBEE=true`
+     * (or `CRM_NODE_URL`) the module never registers, the seed logs
+     * "[crm] disabled" and writes `crmPersonId: null`, and these screens render
+     * an empty state that would let a broken section pass — which is why this
+     * has always thrown rather than skipped.
+     *
+     * But CI sets it and a developer's machine does not, so on every local run
+     * these three specs failed for a reason nobody could act on. A red that
+     * everyone learns to ignore costs more than it protects: it is the noise a
+     * real failure has to be spotted against.
+     *
+     * So: on CI a missing fixture is still a hard failure, because there it
+     * means the CRM actually broke. Locally it is a skip that says why.
+     */
     if (!seed.crmPersonId) {
-      throw new Error(
-        "E2E seed missing crmPersonId — re-run the seed with CRM_HYPERBEE=true."
-      )
+      const why =
+        "CRM fixtures absent — the seed logged \"[crm] disabled\". Set CRM_HYPERBEE=true (or CRM_NODE_URL) and re-seed to run these."
+      if (process.env.CI) {
+        throw new Error(`E2E seed missing crmPersonId on CI. ${why}`)
+      }
+      test.skip(true, why)
     }
   })
 

--- a/e2e/specs/crm-list-ordering.spec.ts
+++ b/e2e/specs/crm-list-ordering.spec.ts
@@ -26,7 +26,7 @@ const BASE = "http://localhost:9000"
  * finds one row where it expected two passes vacuously.
  */
 test.describe("CRM list ordering (#1551)", () => {
-  let seed: { email: string; password: string }
+  let seed: { email: string; password: string; crmPersonId: string | null }
   let token: string
   const stamp = Date.now()
   /** Oldest → newest, which is the order they are created in below. */
@@ -43,6 +43,32 @@ test.describe("CRM list ordering (#1551)", () => {
       )
     }
     seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+
+    /*
+     * 🔴 Loud on CI, skipped locally — and the difference is deliberate.
+     *
+     * The CRM is a Hyperbee node, not Postgres. Without `CRM_HYPERBEE=true`
+     * (or `CRM_NODE_URL`) the module never registers, the seed logs
+     * "[crm] disabled" and writes `crmPersonId: null`, and these screens render
+     * an empty state that would let a broken section pass — which is why this
+     * has always thrown rather than skipped.
+     *
+     * But CI sets it and a developer's machine does not, so on every local run
+     * these three specs failed for a reason nobody could act on. A red that
+     * everyone learns to ignore costs more than it protects: it is the noise a
+     * real failure has to be spotted against.
+     *
+     * So: on CI a missing fixture is still a hard failure, because there it
+     * means the CRM actually broke. Locally it is a skip that says why.
+     */
+    if (!seed.crmPersonId) {
+      const why =
+        "CRM fixtures absent — the seed logged \"[crm] disabled\". Set CRM_HYPERBEE=true (or CRM_NODE_URL) and re-seed to run these."
+      if (process.env.CI) {
+        throw new Error(`E2E seed missing crmPersonId on CI. ${why}`)
+      }
+      test.skip(true, why)
+    }
 
     const api = await pwRequest.newContext({ baseURL: BASE })
     const auth = await api.post("/auth/user/emailpass", {

--- a/e2e/specs/crm-open-a-deal.spec.ts
+++ b/e2e/specs/crm-open-a-deal.spec.ts
@@ -21,7 +21,7 @@ const BASE = "http://localhost:9000"
  * about a deal THIS spec opened, never about a count.
  */
 test.describe("Open a CRM deal (#1552)", () => {
-  let seed: { email: string; password: string }
+  let seed: { email: string; password: string; crmPersonId: string | null }
   let token: string
   let contactName: string
   let contactId: string
@@ -42,6 +42,32 @@ test.describe("Open a CRM deal (#1552)", () => {
       )
     }
     seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+
+    /*
+     * 🔴 Loud on CI, skipped locally — and the difference is deliberate.
+     *
+     * The CRM is a Hyperbee node, not Postgres. Without `CRM_HYPERBEE=true`
+     * (or `CRM_NODE_URL`) the module never registers, the seed logs
+     * "[crm] disabled" and writes `crmPersonId: null`, and these screens render
+     * an empty state that would let a broken section pass — which is why this
+     * has always thrown rather than skipped.
+     *
+     * But CI sets it and a developer's machine does not, so on every local run
+     * these three specs failed for a reason nobody could act on. A red that
+     * everyone learns to ignore costs more than it protects: it is the noise a
+     * real failure has to be spotted against.
+     *
+     * So: on CI a missing fixture is still a hard failure, because there it
+     * means the CRM actually broke. Locally it is a skip that says why.
+     */
+    if (!seed.crmPersonId) {
+      const why =
+        "CRM fixtures absent — the seed logged \"[crm] disabled\". Set CRM_HYPERBEE=true (or CRM_NODE_URL) and re-seed to run these."
+      if (process.env.CI) {
+        throw new Error(`E2E seed missing crmPersonId on CI. ${why}`)
+      }
+      test.skip(true, why)
+    }
 
     const api = await pwRequest.newContext({ baseURL: BASE })
     const auth = await api.post("/auth/user/emailpass", {

--- a/e2e/specs/partner-ledger-panel.spec.ts
+++ b/e2e/specs/partner-ledger-panel.spec.ts
@@ -62,7 +62,15 @@ test.describe("Partner ledger panel (#1612)", () => {
    * accessible-name match would swallow.
    */
   const ledgerPanel = (page: any) =>
-    page.locator(`[data-partner-id="${seed.ledgerPartnerId}"]`)
+    page.locator(
+      /*
+       * 🔴 `data-panel` too. The partner id alone matched TWO containers once
+       * the credits section (#1730) started stamping it as well, and strict
+       * mode then failed the assertion with "the ledger panel is not visible"
+       * — about a panel that was on screen the whole time.
+       */
+      `[data-panel="partner-ledger"][data-partner-id="${seed.ledgerPartnerId}"]`
+    )
 
   const openPartner = async (page: any) => {
     await login(page)


### PR DESCRIPTION
Closes nothing yet — both issues stay open with a tail. Handoffs updated on each.

## #1856 — the partner spine registers create forms and removal descriptors

Session 64 removed **zero** partner cards, and the reason was the same for all fourteen: the graph could *state* this spine's two absences and fix neither. **"No admin — nobody can sign in"** and **"delivered work, no account to pay it into"** are the only absences on the platform that no list can show, and the absent node's sole affordance was an action card pointing at `/partners/:id` — the page the graph is embedded in.

Three forms are now chrome-agnostic and registered — each with **one home**, shared by its section and the graph:

| node | form | its other home |
|---|---|---|
| `admins` | `AddPartnerAdminForm` | the section's drawer |
| `payment_methods` | `AddPartnerPaymentMethodForm` | `@add-payment-method` route |
| `people` | `LinkPartnerPeopleForm` | the section's modal |

The admin form's drawer is not a *route* shell, so a `DrawerChromeProvider` was added — without it a form living inside a section's `<Drawer>` has to be duplicated to appear anywhere else, which is how the trade price ended up with two homes.

**Two removals**, from the two relationships a partner is genuinely a party to:

- `people` → `DELETE /admin/partners/:id/people` with `{ person_ids }` — a DELETE that carries a body, which is the route's real shape and always has been.
- `designs` → `POST /admin/designs/:designId/cancel-partner-assignment` — the **same endpoint the design spine uses**, ids swapped round. Labelled "Cancel assignment" and counting the live runs when there are any; "Unlink" when there are none.

`admins`, `payment_methods`, `submissions` and `runs` deliberately carry none: the first two have **no delete route at all**, and inventing one in the graph would put a destructive path here before it exists anywhere else.

## #1857 — the readers

`presentRows` / `linkedRows` (`src/lib/links/dangling.ts`) split a linked collection into what resolved and how much did not. **15 call sites**, ranked by what a null actually costs:

| reader | what a dangling row did |
|---|---|
| `cancel-partner-assignment` | `p.id` off a null **threw a 500** on the one route whose job is undoing a link — and the graph's new partner drawer calls it |
| `designs/:id/production-runs` | a dangling partner got a **share of the quantity**: every real partner's split shrank and one child run was created with `partner_id: undefined`. Nothing threw |
| `stores?.[0]` ×4 | picked index 0 blind, so a dangling store link made a partner **with** a store read as one without — including the sales channel a run is transferred against and the currency a partner is priced in |
| partner portal helpers ×7 | `s.id` off a null 500s the ownership check |
| task cascades ×3 | a null task threw **inside** a step that had already cancelled runs |

🔴 The predicate is a plain null test, **not `!!r.id`** — the obvious one, and wrong: several callers ask for a single column (`fields: ["stores.default_sales_channel_id"]`), so an id-keyed filter would have discarded every *resolved* row and reported total loss. That case has a test that fails on the wrong predicate.

And the graph now **draws** the discrepancy rather than only excluding it. A partner whose person links all dangle used to emit no `people` node at all — "nobody was ever linked" and "four links point at nobody" rendered identically. The partner that provoked #1857 now says so:

```
people: absent | "4 links point at nobody" | link rows 4, people that exist 0
```

## Verified on the local database, not only in tests

- The payment-method form **submitted from inside the graph** took the header from "8 linked · 1 absent" to **"9 linked"**, the node flipped to present with its member row, and the stacked modal closed onto the drawer without tearing the graph down. Fixture reverted (row + link deleted, node back to `absent`).
- The people unlink was **executed exactly as its descriptor describes** — `DELETE` with the body — and dismissed the link row with the person untouched. Fixture reverted.
- Both design-removal branches exercised against real runs (0 live → "Unlink"; 1 live → "Cancel assignment", and a run on *another* design correctly ignored).

## 🔴 Three defects only RENDERING found — tsc and the build were green throughout

1. **"Create the missing payment method<b>s</b>"** — the button took its words from the node's *aggregate* label instead of the registered singular. Now `createLabelFor`.
2. **The embedded card offered "Add a payment method" as a link to the partner page it was already on.** Every absent node on this spine names that page, so it was a dead button on all of them — the superseded-link-out shape from #1854 in a new disguise. The words are kept and the destination corrected to the workspace, opened on that node. Same guard on the "Open" rail.
3. **`medusa build` compiled a reference to a deleted `setNewEmail` clean.** `check:prod-build`'s frontend step **bundles; it does not type-check** — only opening the drawer said `setNewEmail is not defined`. Confirmed `tsc -p` *does* catch it (TS2304), so a scoped tsconfig is the gate for admin changes, not the build.

## Checks

- `check:prod-build` ✓ (read the verdict line)
- graph + links unit suites: **148 passed**, incl. a new `items.unit.spec.ts` for the partner spine's removal shapes and `dangling.unit.spec.ts` with a revert-the-fix case
- `brief-shaper.unit.spec.ts` fails **on a stashed clean tree too** — pre-existing, verified, not from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4

---

## Update — `c460a1264`: the `fx_rates` cluster, understood

The largest cluster in the #1857 audit (**215 of 610 in prod**) and the one I refused to guard blind. Reproduced, and it is **not a mispricing**.

**`updateProductVariantsWorkflow` replaces the whole price set.** One `POST /admin/products/:id/variants/:id` carrying a single `inr` price:

| | before | after |
|---|---|---|
| fanout prices on the set | 11 | **0 — hard-deleted** |
| live links pointing at a missing price | 9 | **20** |
| markers | 20 | 20 — all survived |

…and **the `inr` price I sent came back with a new id.** So every variant price save orphans every FX marker on that variant, and the fanout right afterwards creates a fresh set beside them. Fixture restored byte-for-byte.

🔴 **The only reader already gets it right.** `rerate-auto-converted-prices` skips a marker whose price is gone and its comment asks for "a separate compaction pass". That pass was never written; this PR adds it as the `compact-fx-price-meta` maintenance job. Verdict moves from *"money-adjacent, not understood"* → **"understood, guarded, needs a janitor"**.

🔴 **The price id comes from the LINK table via `entryPoint`, not `meta.price.id`** — null on exactly the rows the job exists for. A dismiss built from the meta carries `price_id: undefined`, matches nothing, and the delete still succeeds, leaving a link row whose *both* ends are gone. Two tests go red if that source changes.

Exercised locally, both halves: dry-run 9/20 (45%) each naming the price it lost; apply → links 20→11, metas 20→11, **0 dangling, 0 links with a dead marker**; re-run "No changes" twice.

Not yet run against prod — the job does not exist there until this ships.


---

## Update — `ae0b9396b`: `partner_quote.price_list_id` is **not debris either**

**`revokeQuote` DELETES the price list** and sets `status='revoked'`. A revoked quote pointing at a deleted list is the *designed terminal state*. Locally, both flagged rows are revoked quotes; quotes still acceptable with an unusable list = **0**.

What the audit *did* surface: `accept-quote` guarded on `!quote.price_list_id` — that the **column is set** — never that the list can still price. Its own docblock names the consequence: *"a silently cheaper (or dearer) cart rather than an error."* Nothing reaches it today only because `mint-quote` derives `quote.expires_at` and the list's `ends_at` from **one value** (equal to the microsecond on every local quote) — **an invariant enforced nowhere.** `priceListUnusableReason` makes it an assertion.

Exercised on the real accept route, both directions: list **ended** → refused with the new message; list **active** → gets *past* the guard and fails far later on an unrelated pre-existing condition. The second run is what proves this guard is the discriminator. Fixture reverted byte-for-byte. 514 existing quote tests unchanged.

---

## Update — `b560d79ab`: the sweep, re-ranked

The first two sweeps ranked by row count and put two non-defects on top. `audit-dangling-links` carries a classification table with a written reason per entry — `tombstone` / `external_id` / `core` — reports those separately, and ranks only the rest. Read-only in both modes.

**Measured locally: 456 of 456 pairs, 0 unmeasured**, 21 unexplained pairs holding 65 rows. Both previously-top clusters classify out, and the table matched (`partner_quote.price_list_id` → `known:tombstone`, with its citation).

🔴 **New #1 unexplained: `payment_schedule.cart_id`, 23 of 27** — carts genuinely hard-gone (0 soft-deleted, 0 completed). Deliberately *not* classified: I have no explanation for it. That is the sweep doing its job.

Design points that are the whole rewrite:
- **Visibility, not existence** — a soft-deleted target counts as invisible; asking the other question is what made the first sweeps undercount (27 → 46).
- **Unmeasured ≠ clean** — per-pair `statement_timeout`, timeouts surfaced as errors. A check that never ran reads as a pass, and on a job whose output is "these are fine" that is the worst failure available.
- **100% is the external-id signature**, said on the line — every known false positive measured 100%.
- **Pairs discovered from the catalog**, never by guessing names: Medusa abbreviates long link tables, and three pairs found locally have hashed names no grep would match.

🔴 The classification table is the only part that can rot, and a stale entry makes the sweep go *quiet* about a real defect. A test asserts every file a tombstone cites still exists — a previous verdict sweep here cited eleven files, four of them deleted. Verified non-vacuous by renaming a citation and watching it fail.
