### PR TITLE
fix(admin): move useRouteModal into drawer body to fix weaver edits crash

### DIFF
--- a/apps/backend/src/admin/components/persons/weaver-edits-form.tsx
+++ b/apps/backend/src/admin/components/persons/weaver-edits-form.tsx
@@ -17,6 +17,28 @@ import { useRouteModal } from "../modal/use-route-modal"
  * (MikroHyperbee KV, append-only) — never the read-only census core.
  */
 export const WeaverEditsForm = ({ censusId }: { censusId: string | number }) => {
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <RouteDrawer.Title asChild>
+          <Heading>Edits &amp; changes</Heading>
+        </RouteDrawer.Title>
+        <RouteDrawer.Description className="sr-only">
+          Additions to this census record
+        </RouteDrawer.Description>
+      </RouteDrawer.Header>
+      <WeaverEditsFormBody censusId={censusId} />
+    </RouteDrawer>
+  )
+}
+
+/**
+ * Rendered INSIDE <RouteDrawer> so it sits within the RouteModalProvider that
+ * RouteDrawer mounts. Calling useRouteModal() in the parent component (which
+ * renders <RouteDrawer>) threw "useRouteModal must be used within a
+ * RouteModalProvider" and crashed the whole edits drawer.
+ */
+const WeaverEditsFormBody = ({ censusId }: { censusId: string | number }) => {
   const { handleSuccess } = useRouteModal()
   const { data, isLoading } = useWeaverProperty(censusId)
   const update = useUpdateWeaverProperty(censusId)
@@ -88,16 +110,7 @@ export const WeaverEditsForm = ({ censusId }: { censusId: string | number }) => 
   }
 
   return (
-    <RouteDrawer>
-      <RouteDrawer.Header>
-        <RouteDrawer.Title asChild>
-          <Heading>Edits &amp; changes</Heading>
-        </RouteDrawer.Title>
-        <RouteDrawer.Description className="sr-only">
-          Additions to this census record
-        </RouteDrawer.Description>
-      </RouteDrawer.Header>
-
+    <>
       <RouteDrawer.Body className="flex flex-1 flex-col gap-y-6 overflow-y-auto">
         {isLoading ? <Text size="small" className="text-ui-fg-subtle">Loading…</Text> : null}
 
@@ -194,6 +207,6 @@ export const WeaverEditsForm = ({ censusId }: { censusId: string | number }) => 
           </Button>
         </div>
       </RouteDrawer.Footer>
-    </RouteDrawer>
+    </>
   )
 }


### PR DESCRIPTION
## Problem

The `/weavers/:census_id/edits` drawer crashed with:

```
useRouteModal must be used within a RouteModalProvider
```

`WeaverEditsForm` called `useRouteModal()` in the same component that rendered `<RouteDrawer>`. `RouteDrawer` only mounts the `RouteModalProvider` around its *children*, so the hook ran before the provider existed and threw — and the error boundary swallowed the whole route.

## Fix

Split `weaver-edits-form.tsx` into two components:

- `WeaverEditsForm` — renders `<RouteDrawer>` + `<Header>`, and renders `<WeaverEditsFormBody>` inside it.
- `WeaverEditsFormBody` — a child of `RouteDrawer`, calls `useRouteModal()`, and renders the `Body`/`Footer`.

This matches the established pattern in `ad-planning/goals/[id]/@edit` and `raw-material-groups/[id]/@edit`.

## Test

- `pnpm exec tsc --noEmit -p tsconfig.json` — no errors in `weaver-edits-form.tsx`.