### PR TITLE
feat(census): index name + equality facets so weaver filters stop full-corpus scans

### DIFF
--- a/apps/backend/src/modules/census/__tests__/reader-name-index.unit.spec.ts
+++ b/apps/backend/src/modules/census/__tests__/reader-name-index.unit.spec.ts
@@ -1,6 +1,22 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { brotliCompressSync } from "node:zlib"
 
 import { censusReader, normalizeName } from "../reader"
+
+// The seeder half of this contract is a plain .mjs script outside the backend's
+// tsconfig, so it can't be imported here — but its lists MUST match the reader's
+// or the index and the reader address different keys and silently never match.
+// Read the source and compare the literals.
+const INDEX_MJS = readFileSync(
+  join(__dirname, "../../../../../../scripts/handloom-scrape/hyperbee-slice/census_index.mjs"),
+  "utf8"
+)
+const listFromMjs = (name: string): string[] => {
+  const m = INDEX_MJS.match(new RegExp(`export const ${name} = \\[([^\\]]*)\\]`))
+  if (!m) throw new Error(`${name} not found in census_index.mjs`)
+  return [...m[1].matchAll(/"([^"]+)"/g)].map((x) => x[1])
+}
 
 // Minimal in-memory stand-in for the narrow Bee/Sub surface reader.ts consumes
 // (sub → { get, createReadStream }). Keys are plain strings; the reader passes
@@ -45,6 +61,7 @@ describe("CensusReader.listAndCountWeavers — indexed facets", () => {
     { census_id: 9000001, name: "MUSTAQ AHMED", state: "BIHAR", district: "GAYA", gender: "Male", education: "Middle", own_looms: true },
     { census_id: 9000002, name: "Mustaq Ali", state: "UTTAR PRADESH", district: "LUCKNOW", gender: "Male", education: "Middle", own_looms: false },
     { census_id: 9000003, name: "Abdul Mustaq", state: "BIHAR", district: "GAYA", gender: "Male", education: "High", own_looms: true },
+    { census_id: 9000005, name: "Ravi Ravindra Ravi", state: "BIHAR", district: "GAYA", gender: "Male", education: "High", own_looms: true },
     { census_id: 9000004, name: "Ramesh Kumar", state: "BIHAR", district: "GAYA", gender: "Male", education: "High", own_looms: false },
   ]
 
@@ -60,14 +77,22 @@ describe("CensusReader.listAndCountWeavers — indexed facets", () => {
     meta.set("idx-geo-version", Buffer.from("geo-v1"))
 
     const idx = bee.subs.get("idx")!
+    const agg = bee.subs.get("agg")!
+    const counts = new Map<string, number>()
     for (const r of records) {
       const payload = compress(r)
       const p = padId(r.census_id)
       idx.set(`all/${p}`, payload)
-      idx.set(`name/${normalizeName(r.name)}/${p}`, payload)
+      // exactly what idxRelKeys emits: the full normalized name AND each token.
+      const n = normalizeName(r.name)
+      for (const t of new Set([n, ...n.split("_")])) idx.set(`name/${t}/${p}`, payload)
       idx.set(`education/${r.education}/${p}`, payload)
       idx.set(`own_looms/${String(r.own_looms)}/${p}`, payload)
+      for (const k of [`eq/education/${r.education}`, `eq/own_looms/${String(r.own_looms)}`]) {
+        counts.set(k, (counts.get(k) ?? 0) + 1)
+      }
     }
+    for (const [k, v] of counts) agg.set(k, Buffer.from(String(v)))
     return bee
   }
 
@@ -95,10 +120,43 @@ describe("CensusReader.listAndCountWeavers — indexed facets", () => {
     )
 
     const ids = res.weavers.map((w: any) => w.census_id).sort((a: number, b: number) => a - b)
-    expect(ids).toEqual([9000001, 9000002])
-    expect(res.count).toBe(2)
-    // name has no agg cell → flagged estimated
+    // 9000003 is "Abdul Mustaq" — found through its TOKEN, which the old
+    // full-name-prefix-only index answered with a silent zero.
+    expect(ids).toEqual([9000001, 9000002, 9000003])
+    expect(res.count).toBe(3)
+    // a name prefix has no agg cell → flagged estimated
     expect((res as any).estimated).toBe(true)
+  })
+
+  it("returns a weaver ONCE even when several of its name keys match", async () => {
+    ;(censusReader as any).proxyUrl = null
+    ;(censusReader as any).bee = buildBee()
+
+    // "Ravi Ravindra Ravi" is indexed under ravi_ravindra_ravi, ravi and ravindra
+    // — a `ravi` prefix hits all three. Without dedupe the same weaver pages out
+    // repeatedly.
+    const res = await censusReader.listAndCountWeavers({ name: "ravi" }, { limit: 10, offset: 0 })
+    expect(res.weavers.map((w: any) => w.census_id)).toEqual([9000005])
+    expect(res.count).toBe(1)
+  })
+
+  it("emits no cursor for a name scan (it is ordered by token, not id)", async () => {
+    ;(censusReader as any).proxyUrl = null
+    ;(censusReader as any).bee = buildBee()
+
+    const res = await censusReader.listAndCountWeavers({ name: "mustaq" }, { limit: 1, offset: 0 })
+    // an id-shaped `after` cannot resume a (token, id) ordering — handing one back
+    // would make the next page repeat page one forever.
+    expect(res.next).toBeNull()
+  })
+
+  it("keeps the reader's facet list identical to the seeder's", () => {
+    // drift here is silent: the index writes one key, the reader reads another.
+    expect(listFromMjs("EQ_FIELDS")).toEqual([
+      "village", "block", "district", "education", "ownership_type",
+      "household_type", "dwelling_type", "rural_urban",
+      "own_looms", "natural_dye_used", "electricity",
+    ])
   })
 
   it("falls back to the bounded scan when the name index is not backfilled", async () => {
@@ -129,9 +187,12 @@ describe("CensusReader.listAndCountWeavers — indexed facets", () => {
 
     const ids = res.weavers.map((w: any) => w.census_id).sort((a: number, b: number) => a - b)
     expect(ids).toEqual([9000001, 9000002])
+    // the count comes from `agg/eq/education/Middle` in O(1) — NOT from draining
+    // the family, which is what kept this request at the corpus-scan ceiling.
     expect(res.count).toBe(2)
-    expect((res as any).estimated).toBe(true)
+    expect((res as any).estimated).toBeUndefined()
   })
+
 
   it("boolean facet (own_looms) matches stringified true/false", async () => {
     ;(censusReader as any).proxyUrl = null
@@ -141,7 +202,7 @@ describe("CensusReader.listAndCountWeavers — indexed facets", () => {
       { own_looms: "true" },
       { limit: 10, offset: 0 }
     )
-    expect(owners.weavers.map((w: any) => w.census_id).sort((a: number, b: number) => a - b)).toEqual([9000001, 9000003])
+    expect(owners.weavers.map((w: any) => w.census_id).sort((a: number, b: number) => a - b)).toEqual([9000001, 9000003, 9000005])
 
     const nonOwners = await censusReader.listAndCountWeavers(
       { own_looms: "false" },

--- a/apps/backend/src/modules/census/__tests__/reader-name-index.unit.spec.ts
+++ b/apps/backend/src/modules/census/__tests__/reader-name-index.unit.spec.ts
@@ -1,0 +1,165 @@
+import { brotliCompressSync } from "node:zlib"
+
+import { censusReader, normalizeName } from "../reader"
+
+// Minimal in-memory stand-in for the narrow Bee/Sub surface reader.ts consumes
+// (sub → { get, createReadStream }). Keys are plain strings; the reader passes
+// RELATIVE keys (e.g. "name/mustaq/…", "idx-name-version") which we store per-sub.
+class FakeBee {
+  subs = new Map<string, Map<string, Buffer>>()
+
+  constructor() {
+    for (const n of ["rec", "meta", "agg", "idx"]) this.subs.set(n, new Map())
+  }
+
+  sub(name: string): any {
+    const m = this.subs.get(name)!
+    return {
+      get: async (key: string) => {
+        const v = m.get(key)
+        return v != null ? { value: v } : null
+      },
+      createReadStream: (range?: { gte?: string; gt?: string; lte?: string; lt?: string }) => {
+        const keys = [...m.keys()].sort()
+        const out = keys.filter((k) => {
+          if (range?.gte != null && k < range.gte) return false
+          if (range?.gt != null && k <= range.gt) return false
+          if (range?.lt != null && k >= range.lt) return false
+          if (range?.lte != null && k > range.lte) return false
+          return true
+        })
+        const self = m
+        return (async function* () {
+          for (const k of out) yield { key: k, value: self.get(k)! }
+        })()
+      },
+    }
+  }
+}
+
+const padId = (id: number) => String(id).padStart(10, "0")
+const compress = (o: object) => brotliCompressSync(Buffer.from(JSON.stringify(o)))
+
+describe("CensusReader.listAndCountWeavers — indexed facets", () => {
+  const records = [
+    { census_id: 9000001, name: "MUSTAQ AHMED", state: "BIHAR", district: "GAYA", gender: "Male", education: "Middle", own_looms: true },
+    { census_id: 9000002, name: "Mustaq Ali", state: "UTTAR PRADESH", district: "LUCKNOW", gender: "Male", education: "Middle", own_looms: false },
+    { census_id: 9000003, name: "Abdul Mustaq", state: "BIHAR", district: "GAYA", gender: "Male", education: "High", own_looms: true },
+    { census_id: 9000004, name: "Ramesh Kumar", state: "BIHAR", district: "GAYA", gender: "Male", education: "High", own_looms: false },
+  ]
+
+  // Build an index that mirrors what the seeder emits: `all/*` + `name/<normalized>/*`
+  // + equality facets (`education/*`, `own_looms/*`), each value carrying the inline payload.
+  const buildBee = () => {
+    const bee = new FakeBee()
+    const meta = bee.subs.get("meta")!
+    meta.set("idx-version", Buffer.from("idx-v1"))
+    meta.set("idx-all-version", Buffer.from("idxall-v1"))
+    meta.set("idx-name-version", Buffer.from("idxname-v1"))
+    meta.set("idx-eq-version", Buffer.from("idxeq-v1"))
+    meta.set("idx-geo-version", Buffer.from("geo-v1"))
+
+    const idx = bee.subs.get("idx")!
+    for (const r of records) {
+      const payload = compress(r)
+      const p = padId(r.census_id)
+      idx.set(`all/${p}`, payload)
+      idx.set(`name/${normalizeName(r.name)}/${p}`, payload)
+      idx.set(`education/${r.education}/${p}`, payload)
+      idx.set(`own_looms/${String(r.own_looms)}/${p}`, payload)
+    }
+    return bee
+  }
+
+  const prevBee = (censusReader as any).bee
+  const prevProxy = (censusReader as any).proxyUrl
+
+  afterAll(() => {
+    ;(censusReader as any).bee = prevBee
+    ;(censusReader as any).proxyUrl = prevProxy
+  })
+
+  it("normalizeName lowercases and collapses separators", () => {
+    expect(normalizeName("MUSTAQ AHMED")).toBe("mustaq_ahmed")
+    expect(normalizeName("  Mohd. Shahid  ")).toBe("mohd_shahid")
+    expect(normalizeName("")).toBe("")
+  })
+
+  it("name search range-scans the name index (prefix) instead of the whole corpus", async () => {
+    ;(censusReader as any).proxyUrl = null
+    ;(censusReader as any).bee = buildBee()
+
+    const res = await censusReader.listAndCountWeavers(
+      { name: "mustaq" },
+      { limit: 10, offset: 0 }
+    )
+
+    const ids = res.weavers.map((w: any) => w.census_id).sort((a: number, b: number) => a - b)
+    expect(ids).toEqual([9000001, 9000002])
+    expect(res.count).toBe(2)
+    // name has no agg cell → flagged estimated
+    expect((res as any).estimated).toBe(true)
+  })
+
+  it("falls back to the bounded scan when the name index is not backfilled", async () => {
+    const bee = buildBee()
+    bee.subs.get("meta")!.delete("idx-name-version")
+    ;(censusReader as any).proxyUrl = null
+    ;(censusReader as any).bee = bee
+
+    const res = await censusReader.listAndCountWeavers(
+      { name: "mustaq" },
+      { limit: 10, offset: 0 }
+    )
+
+    // Without the name index, the fallback scans rec/* — but this fake has no
+    // rec/* rows, so nothing matches. The point is that it does NOT throw and
+    // flags indexed:false.
+    expect((res as any).indexed).toBe(false)
+  })
+
+  it("equality facet (education) range-scans its family instead of the corpus", async () => {
+    ;(censusReader as any).proxyUrl = null
+    ;(censusReader as any).bee = buildBee()
+
+    const res = await censusReader.listAndCountWeavers(
+      { education: "Middle" },
+      { limit: 10, offset: 0 }
+    )
+
+    const ids = res.weavers.map((w: any) => w.census_id).sort((a: number, b: number) => a - b)
+    expect(ids).toEqual([9000001, 9000002])
+    expect(res.count).toBe(2)
+    expect((res as any).estimated).toBe(true)
+  })
+
+  it("boolean facet (own_looms) matches stringified true/false", async () => {
+    ;(censusReader as any).proxyUrl = null
+    ;(censusReader as any).bee = buildBee()
+
+    const owners = await censusReader.listAndCountWeavers(
+      { own_looms: "true" },
+      { limit: 10, offset: 0 }
+    )
+    expect(owners.weavers.map((w: any) => w.census_id).sort((a: number, b: number) => a - b)).toEqual([9000001, 9000003])
+
+    const nonOwners = await censusReader.listAndCountWeavers(
+      { own_looms: "false" },
+      { limit: 10, offset: 0 }
+    )
+    expect(nonOwners.weavers.map((w: any) => w.census_id).sort((a: number, b: number) => a - b)).toEqual([9000002, 9000004])
+  })
+
+  it("falls back to the bounded scan when the eq index is not backfilled", async () => {
+    const bee = buildBee()
+    bee.subs.get("meta")!.delete("idx-eq-version")
+    ;(censusReader as any).proxyUrl = null
+    ;(censusReader as any).bee = bee
+
+    const res = await censusReader.listAndCountWeavers(
+      { education: "Middle" },
+      { limit: 10, offset: 0 }
+    )
+    expect((res as any).indexed).toBe(false)
+  })
+})

--- a/apps/backend/src/modules/census/reader.ts
+++ b/apps/backend/src/modules/census/reader.ts
@@ -68,6 +68,20 @@ class TtlLru<V> {
 // an empty `idx/all/*` family and return nothing).
 const FACET_IDX_META = "idx-version"
 const ALL_IDX_META = "idx-all-version"
+// Name facet family (`idx/name/*`) — added later, gates independently so a name
+// search only rides the index once its backfill has emitted it. MUST match
+// census_index.mjs (meta key "idx-name-version").
+const NAME_IDX_META = "idx-name-version"
+// Equality facet families (`idx/<field>/<value>/*`) — added later, gated
+// independently. MUST match census_index.mjs (meta key "idx-eq-version").
+const EQ_IDX_META = "idx-eq-version"
+// Filterable equality facets indexed beyond state/gender/sd. MUST match
+// census_index.mjs EQ_FIELDS (same set). Exact-equality lookups.
+const EQ_FACETS = [
+  "district", "block", "village", "rural_urban", "education",
+  "ownership_type", "household_type", "dwelling_type",
+  "own_looms", "natural_dye_used", "electricity",
+] as const
 // Set once the backfill has written the inline DISPLAY PAYLOAD into every index
 // family value (see census_index.mjs geoPayload). When present, browse decodes
 // that small payload straight off the ordered index scan instead of doing a
@@ -177,6 +191,14 @@ export function matchesWeaverFilters(
 // (ids are < 10^10). MUST match the seeder/backfill's padding width.
 const ID_PAD = 10
 const padId = (id: string | number) => String(id).padStart(ID_PAD, "0")
+
+// Normalise a name into a facet value safe as a range-scanned key — lowercased,
+// runs of anything that isn't a Unicode letter/digit collapsed to "_" (so no
+// byte sorts below "/" 0x2f and breaks the prefix range). MUST match
+// census_index.mjs `normalizeName` exactly or the index and reader compute
+// different prefixes and never match.
+export const normalizeName = (n: unknown) =>
+  String(n ?? "").toLowerCase().replace(/[^\p{L}\p{N}]+/gu, "_").replace(/^_+|_+$/g, "")
 
 /**
  * Read-only query surface over the handloom census PUBLIC core (masked, PII-free
@@ -375,13 +397,15 @@ export class CensusReader {
    */
   private resolveIndexDriver(filters: WeaverFilters): {
     prefix: string
-    aggKey: string
+    aggKey: string | null
     residual: WeaverFilters
     metaKey: string
+    nameQuery?: string
   } {
     const state = filters.state != null ? String(filters.state) : null
     const district = filters.district != null ? String(filters.district) : null
     const gender = filters.gender != null ? String(filters.gender) : null
+    const name = filters.name != null && String(filters.name).trim() !== "" ? String(filters.name) : null
 
     const without = (...keys: string[]): WeaverFilters => {
       const r = { ...filters }
@@ -397,6 +421,24 @@ export class CensusReader {
     }
     if (gender) {
       return { prefix: `gender/${gender}/`, aggKey: `gender/${gender}`, residual: without("gender"), metaKey: FACET_IDX_META }
+    }
+    // Equality facets (district-alone, block, village, education, …). Exact-
+    // equality range-scan over `idx/<field>/<value>/*` so a filter on these no
+    // longer rides the O(corpus) residual scan. The field stays in residual so the
+    // equality predicate double-checks within the (already narrowed) family, and
+    // the count stays "estimated" (no per-facet agg cell).
+    for (const field of EQ_FACETS) {
+      const v = filters[field]
+      if (v === null || v === undefined || v === "") continue
+      return { prefix: `${field}/${String(v)}/`, aggKey: null, residual: { ...filters }, metaKey: EQ_IDX_META }
+    }
+    // Name — the free-text search facet. Range-scan the `name/*` family by prefix
+    // so a name search is O(page) instead of the O(corpus) residual scan that
+    // timed the request out (504). `name` stays in residual so the substring
+    // predicate double-checks within the (already name-narrowed) range; the count
+    // stays "estimated" (there is no agg cell for a name prefix).
+    if (name) {
+      return { prefix: "name/", nameQuery: normalizeName(name), aggKey: null, residual: { ...filters }, metaKey: NAME_IDX_META }
     }
     // No indexed facet → browse the whole corpus in id order. Exact total comes
     // from the O(1) `total/weavers` aggregate; any non-facet filters (district
@@ -500,7 +542,7 @@ export class CensusReader {
   private async listViaIndex(
     bee: Bee,
     rec: Sub,
-    driver: { prefix: string; aggKey: string; residual: WeaverFilters },
+    driver: { prefix: string; aggKey: string | null; residual: WeaverFilters; nameQuery?: string },
     { limit, offset, after }: { limit: number; offset: number; after?: string | number },
     geoReady = false
   ) {
@@ -518,12 +560,20 @@ export class CensusReader {
         ? Promise.all(rows.map((r) => this.decodeIndexRow(rec, r.id, r.value)))
         : this.hydrateInOrder(rec, rows.map((r) => r.id))
 
-    // sub-relative range over `<prefix><paddedId>`. ":" (0x3a) is the first byte
-    // above "9" (0x39), so it upper-bounds the all-digit id suffix.
+    // id is always the final "/"-delimited segment (`<family>/<value>/<padId>` or,
+    // for name prefix, `<name>/<query…>/<padId>`), so derive it from the last
+    // "/" rather than the fixed family prefix.
+    const idOf = (key: string) => String(Number(key.slice(key.lastIndexOf("/") + 1)))
+
+    // sub-relative range. Facets bound the all-digit id suffix with ":" (0x3a,
+    // first byte above "9"). A name prefix search instead bounds the NAME part
+    // with "\uffff" (a byte beyond any letter) — `name/<query>…` up to `name/<query>\uffff`.
     const range: { gte?: string; gt?: string; lt: string } =
-      after != null
-        ? { gt: `${driver.prefix}${padId(after)}`, lt: `${driver.prefix}:` }
-        : { gte: driver.prefix, lt: `${driver.prefix}:` }
+      driver.nameQuery != null
+        ? { gte: `name/${driver.nameQuery}`, lt: `name/${driver.nameQuery}\uffff` }
+        : after != null
+          ? { gt: `${driver.prefix}${padId(after)}`, lt: `${driver.prefix}:` }
+          : { gte: driver.prefix, lt: `${driver.prefix}:` }
 
     const weavers: Record<string, any>[] = []
     let count = 0
@@ -543,7 +593,7 @@ export class CensusReader {
           break
         }
         if (count >= offset && pageRows.length < limit) {
-          pageRows.push({ id: String(Number(key.slice(driver.prefix.length))), value })
+          pageRows.push({ id: idOf(key), value })
         }
         count++
         if (pageRows.length >= limit) break
@@ -579,7 +629,7 @@ export class CensusReader {
           capped = true
           break
         }
-        batch.push({ id: String(Number(key.slice(driver.prefix.length))), value })
+        batch.push({ id: idOf(key), value })
         if (batch.length >= HYDRATE_BATCH) await drain()
       }
       if (batch.length) await drain()
@@ -590,7 +640,7 @@ export class CensusReader {
     // matches actually scanned (flagged estimated / capped).
     let total = count
     let estimated = hasResidual
-    if (!hasResidual) {
+    if (!hasResidual && driver.aggKey) {
       const aggNode = await bee
         .sub("agg", { valueEncoding: "utf-8" })
         .get(driver.aggKey)

--- a/apps/backend/src/modules/census/reader.ts
+++ b/apps/backend/src/modules/census/reader.ts
@@ -75,13 +75,20 @@ const NAME_IDX_META = "idx-name-version"
 // Equality facet families (`idx/<field>/<value>/*`) — added later, gated
 // independently. MUST match census_index.mjs (meta key "idx-eq-version").
 const EQ_IDX_META = "idx-eq-version"
-// Filterable equality facets indexed beyond state/gender/sd. MUST match
-// census_index.mjs EQ_FIELDS (same set). Exact-equality lookups.
+// Filterable equality facets indexed beyond state/gender/sd. Exact-equality
+// lookups. ORDER MATTERS — the first of these present in a query drives the
+// scan, so they run most-selective-first. MUST match census_index.mjs EQ_FIELDS
+// exactly, same members AND same order (a unit test asserts it).
 const EQ_FACETS = [
-  "district", "block", "village", "rural_urban", "education",
-  "ownership_type", "household_type", "dwelling_type",
+  "village", "block", "district", "education", "ownership_type",
+  "household_type", "dwelling_type", "rural_urban",
   "own_looms", "natural_dye_used", "electricity",
 ] as const
+// Equality-facet aggregate cells: `agg/eq/<field>/<value>`, written by the same
+// backfill/seeder pass that emits the families. Namespaced under `eq/` so they
+// never collide with the seeder's analytics dims (`district/<state>|<district>`).
+// MUST match census_index.mjs EQ_AGG_PREFIX.
+const EQ_AGG_PREFIX = "eq"
 // Set once the backfill has written the inline DISPLAY PAYLOAD into every index
 // family value (see census_index.mjs geoPayload). When present, browse decodes
 // that small payload straight off the ordered index scan instead of doing a
@@ -422,15 +429,25 @@ export class CensusReader {
     if (gender) {
       return { prefix: `gender/${gender}/`, aggKey: `gender/${gender}`, residual: without("gender"), metaKey: FACET_IDX_META }
     }
-    // Equality facets (district-alone, block, village, education, …). Exact-
-    // equality range-scan over `idx/<field>/<value>/*` so a filter on these no
-    // longer rides the O(corpus) residual scan. The field stays in residual so the
-    // equality predicate double-checks within the (already narrowed) family, and
-    // the count stays "estimated" (no per-facet agg cell).
+    // Equality facets (village, block, district-alone, education, …). Exact-
+    // equality range-scan over `idx/<field>/<value>/*` with the count lifted from
+    // the family's own `agg/eq/<field>/<value>` cell in O(1). The driving field is
+    // dropped from the residual — keeping it would force the residual branch to
+    // hydrate and brotli-inflate the whole family up to MAX_SCAN just to arrive at
+    // a count, which is the same per-request ceiling as the corpus scan it
+    // replaces (a narrower scan of the same size is not a faster request).
+    // Dropping it is safe: the family range is `<field>/<value>/` → `<field>/<value>/:`,
+    // and every key under it is that value's own id suffix (all digits, and ":" is
+    // the first byte above "9") — nothing from a neighbouring value can appear.
     for (const field of EQ_FACETS) {
       const v = filters[field]
       if (v === null || v === undefined || v === "") continue
-      return { prefix: `${field}/${String(v)}/`, aggKey: null, residual: { ...filters }, metaKey: EQ_IDX_META }
+      return {
+        prefix: `${field}/${String(v)}/`,
+        aggKey: `${EQ_AGG_PREFIX}/${field}/${String(v)}`,
+        residual: without(field),
+        metaKey: EQ_IDX_META,
+      }
     }
     // Name — the free-text search facet. Range-scan the `name/*` family by prefix
     // so a name search is O(page) instead of the O(corpus) residual scan that
@@ -564,6 +581,10 @@ export class CensusReader {
     // for name prefix, `<name>/<query…>/<padId>`), so derive it from the last
     // "/" rather than the fixed family prefix.
     const idOf = (key: string) => String(Number(key.slice(key.lastIndexOf("/") + 1)))
+    // A name is indexed under its full normalized form AND each of its tokens, so
+    // one record can match a prefix scan several times ("Ram Ramesh" answers `ram`
+    // three ways). Dedupe by id or the same weaver is paged out repeatedly.
+    const seen: Set<string> | null = driver.nameQuery != null ? new Set() : null
 
     // sub-relative range. Facets bound the all-digit id suffix with ":" (0x3a,
     // first byte above "9"). A name prefix search instead bounds the NAME part
@@ -592,8 +613,13 @@ export class CensusReader {
           capped = true
           break
         }
+        const id = idOf(key)
+        if (seen) {
+          if (seen.has(id)) continue
+          seen.add(id)
+        }
         if (count >= offset && pageRows.length < limit) {
-          pageRows.push({ id: idOf(key), value })
+          pageRows.push({ id, value })
         }
         count++
         if (pageRows.length >= limit) break
@@ -629,7 +655,12 @@ export class CensusReader {
           capped = true
           break
         }
-        batch.push({ id: idOf(key), value })
+        const id = idOf(key)
+        if (seen) {
+          if (seen.has(id)) continue
+          seen.add(id)
+        }
+        batch.push({ id, value })
         if (batch.length >= HYDRATE_BATCH) await drain()
       }
       if (batch.length) await drain()
@@ -649,6 +680,12 @@ export class CensusReader {
         estimated = false
       }
     }
+
+    // A name scan is ordered by (token, id), not by id, so an id-shaped `after`
+    // cursor cannot resume it. Emit no cursor at all rather than one the next
+    // request would silently ignore and hand back page one forever — name paging
+    // rides `offset`.
+    if (driver.nameQuery != null) next = null
 
     return {
       weavers,

--- a/scripts/handloom-scrape/hyperbee-slice/census_index.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/census_index.mjs
@@ -48,11 +48,30 @@ export const IDX_EQ_VERSION = "idxeq-v1"
 // Filterable equality facets indexed beyond state/gender/sd. Exact-equality
 // lookups (not prefix scans), so their values ride the key verbatim. Booleans
 // are stringified ("true"/"false"). Values must not contain "/" (unlikely here).
+// ORDER MATTERS: the reader drives its scan off the FIRST of these present in a
+// query, so they run most-selective-first (a village family is thousands of rows,
+// an electricity family is millions). MUST match reader.ts EQ_FACETS exactly —
+// same members, same order (a unit test asserts it).
 export const EQ_FIELDS = [
-  "district", "block", "village", "rural_urban", "education",
-  "ownership_type", "household_type", "dwelling_type",
+  "village", "block", "district", "education", "ownership_type",
+  "household_type", "dwelling_type", "rural_urban",
   "own_looms", "natural_dye_used", "electricity",
 ]
+// Equality-facet aggregate cells live at `agg/eq/<field>/<value>`. Namespaced
+// under `eq/` so they never collide with the seeder's analytics dims (its
+// `district/<state>|<district>` vs this `eq/district/<district>`) and so a fresh
+// backfill can reset the whole group without touching them. These are what let
+// the reader answer an equality-facet count in O(1) instead of draining the
+// family to MAX_SCAN. MUST match reader.ts EQ_AGG_PREFIX.
+export const EQ_AGG_PREFIX = "eq"
+// Cursor generation. The backfill checkpoints under a cursor key carrying this
+// suffix, so ADDING a family — which requires a fresh whole-corpus walk — starts
+// from an absent key, while an interrupted run of the CURRENT generation still
+// resumes from its checkpoint. Bump whenever the emitted family SET or the value
+// format changes. (Before this existed, "a family is missing" was itself the
+// reset rule, which meant every crash before completion restarted from zero —
+// the one thing a multi-million-record walk cannot afford.)
+export const IDX_CURSOR_GENERATION = "g2"
 // Bumped when the index VALUE format changes. v1 stored empty values (keys only,
 // so browse range-scanned the index for ids then hydrated each fat rec/* record);
 // "geo-v1" stores an inline display payload in every family value so browse reads
@@ -132,7 +151,28 @@ export function idxRelKeys(r) {
   const nm = r.name ?? r.survey?.Name ?? r.survey?.name
   if (typeof nm === "string" && nm.trim()) {
     const n = normalizeName(nm)
-    if (n) keys.push(`name/${n}/${p}`)
+    // The full normalized name AND each token. A prefix range-scan over the full
+    // name alone finds "Mustaq Ahmed" for `mustaq` but NOT "Abdul Mustaq" — a
+    // silent zero-row answer where the old substring scan was merely slow. One
+    // key per token fixes that for ~2 extra keys a record. A record can therefore
+    // appear under several name keys for one query, so the READER dedupes by id.
+    for (const t of new Set(n ? [n, ...n.split("_")] : [])) {
+      if (t) keys.push(`name/${t}/${p}`)
+    }
+  }
+  return keys
+}
+
+/** Equality-facet aggregate cells for one record — `eq/<field>/<value>`, one per
+ * populated facet. Emitted by BOTH the backfill and the seeder's incremental
+ * ingest so the counts stay exact as the corpus grows. */
+export function eqAggKeys(r) {
+  const keys = []
+  if (r == null) return keys
+  for (const f of EQ_FIELDS) {
+    const v = r[f]
+    if (v === null || v === undefined || v === "") continue
+    keys.push(`${EQ_AGG_PREFIX}/${f}/${String(v)}`)
   }
   return keys
 }
@@ -164,35 +204,59 @@ export async function backfillIndex(bee, { subKey, decode, encodePayload, batchS
     return { indexed: 0, alreadyDone: true }
   }
 
-  // The geo generation rewrites EVERY family value (payload, not empty), so it
-  // must re-walk the whole corpus — a legacy cursor is parked at the end and
-  // would emit nothing. Track the geo pass under its OWN cursor so a crash mid-
-  // backfill resumes instead of restarting. Legacy (no-geo) runs keep using the
-  // old cursor and its facet/all-only reset rule. A missing family added later
-  // (name / eq) forces a fresh walk in EITHER mode for the same reason. Puts are
+  // A new family SET (or a new value format) has to re-walk the whole corpus — a
+  // cursor from the previous generation is parked at the end and would emit
+  // nothing. That is expressed as the cursor KEY carrying the generation, so a
+  // fresh walk starts from an absent key while an interrupted run of THIS
+  // generation resumes from its own checkpoint. Geo and legacy (keys-only) runs
+  // keep separate cursors because they write different values. Puts are
   // idempotent overwrites, so re-emitting keys is always harmless.
-  const CURSOR = emitGeo ? "idx-geo-cursor" : "idx-backfill-cursor"
-  const cursorNode =
-    (!emitGeo && facetsDone && !allDone) || !nameDone || !eqDone ? null : await meta.get(CURSOR)
+  const CURSOR = `${emitGeo ? "idx-geo-cursor" : "idx-backfill-cursor"}-${IDX_CURSOR_GENERATION}`
+  const cursorNode = await meta.get(CURSOR)
   let resumeAfter = cursorNode ? cursorNode.value : null
 
   const rec = bee.sub("rec", { valueEncoding: "binary" })
+  const aggSub = bee.sub("agg", { valueEncoding: "utf-8" })
+
+  if (resumeAfter == null) {
+    // A fresh whole-corpus walk counts every record again, so eq cells left by a
+    // previous generation (or by a run that was reset) would double-count. Clear
+    // ONLY the `eq/*` group — the seeder's analytics dims share this sub. "0"
+    // (0x30) is the first byte above "/" (0x2f), so it upper-bounds the prefix.
+    const stale = []
+    for await (const { key } of aggSub.createReadStream({ gte: `${EQ_AGG_PREFIX}/`, lt: `${EQ_AGG_PREFIX}0` })) stale.push(key)
+    for (const k of stale) await aggSub.del(k)
+    if (stale.length) log(`[idx-backfill] cleared ${stale.length} stale ${EQ_AGG_PREFIX}/* agg cells before a fresh walk`)
+  }
+
   // rec sub keys are the unpadded census_id strings; resume strictly after the
   // last processed key (Hyperbee streams in key order).
   const range = resumeAfter != null ? { gt: resumeAfter } : {}
 
   let indexed = 0
   let pending = [] // [relKey, valueBuffer]
+  let aggDelta = new Map() // eq agg key -> count within THIS batch
   let lastKey = resumeAfter
 
   const flush = async () => {
-    if (pending.length === 0) return
+    if (pending.length === 0 && aggDelta.size === 0) return
+    // Fold this batch's equality-facet counts into the stored cells BEFORE opening
+    // the batch (single writer → no race), so the counts land atomically with the
+    // records they came from AND the cursor that will skip those records on
+    // resume — a crash can neither double-count nor lose a count.
+    const newAgg = []
+    for (const [k, d] of aggDelta) {
+      const cur = await aggSub.get(k)
+      newAgg.push([k, (cur ? Number(cur.value) : 0) + d])
+    }
     const batch = bee.batch({ keyEncoding: "binary", valueEncoding: "binary" })
     for (const [relKey, val] of pending) await batch.put(subKey("idx", relKey), val)
+    for (const [k, v] of newAgg) await batch.put(subKey("agg", k), Buffer.from(String(v)))
     // checkpoint the cursor in the SAME batch → backfill is itself crash-exact.
     if (lastKey != null) await batch.put(subKey("meta", CURSOR), Buffer.from(String(lastKey)))
     await batch.flush()
     pending = []
+    aggDelta = new Map()
   }
 
   let sinceFlush = 0
@@ -206,6 +270,7 @@ export async function backfillIndex(bee, { subKey, decode, encodePayload, batchS
     }
     const val = emitGeo ? encodePayload(geoPayload(record)) : EMPTY
     for (const rk of idxRelKeys(record)) pending.push([rk, val])
+    for (const ak of eqAggKeys(record)) aggDelta.set(ak, (aggDelta.get(ak) || 0) + 1)
     indexed++
     if (++sinceFlush >= batchSize) {
       await flush()
@@ -255,7 +320,7 @@ if (_isMain && process.argv.includes("--test")) {
     // → the payload must promote them to typed lat/long.
     { census_id: 10, state: "KARNATAKA", district: "BAGALKOT", gender: "Male", village: "ILKAL", education: "Middle", own_looms: true, survey: { Name: "SHANTAVVA", Latitude: "16.1329", Longitude: "75.9587" } },
     { census_id: 11, state: "KARNATAKA", district: "BAGALKOT", gender: "Female", education: "Middle", own_looms: false },
-    { census_id: 12, state: "KARNATAKA", district: "BELGAUM", gender: "Male", education: "High", own_looms: true },
+    { census_id: 12, state: "KARNATAKA", district: "BELGAUM", gender: "Male", education: "High", own_looms: true, survey: { Name: "ABDUL MUSTAQ" } },
     { census_id: 13, state: "PUNJAB", district: "AMRITSAR", gender: "Female" },
     { census_id: 14, state: "KARNATAKA", district: "BAGALKOT", gender: "Male" },
   ]
@@ -328,6 +393,17 @@ if (_isMain && process.argv.includes("--test")) {
     namePrefixIds.push(Number(key.slice(key.lastIndexOf("/") + 1)))
   }
   ok("name index supports a prefix range scan", JSON.stringify(namePrefixIds) === JSON.stringify([10]))
+  // a NON-leading token must be findable — the whole point of emitting tokens.
+  const nameToken = []
+  for await (const { key } of idx.createReadStream({ gte: "name/mustaq", lt: "name/mustaq\uffff" })) {
+    nameToken.push(Number(key.slice(key.lastIndexOf("/") + 1)))
+  }
+  ok("name index finds a record by a NON-leading token", JSON.stringify(nameToken) === JSON.stringify([12]))
+  const nameFull = []
+  for await (const { key } of idx.createReadStream({ gte: "name/abdul_mustaq", lt: "name/abdul_mustaq\uffff" })) {
+    nameFull.push(Number(key.slice(key.lastIndexOf("/") + 1)))
+  }
+  ok("name index still answers the full multi-word name", JSON.stringify(nameFull) === JSON.stringify([12]))
 
   // equality facets — exact-equality lookups (same ":" id-suffix bound as state/gender).
   const eqEducation = []
@@ -346,6 +422,15 @@ if (_isMain && process.argv.includes("--test")) {
   }
   ok("own_looms=false facet returns non-owners", JSON.stringify(eqOwnFalse) === JSON.stringify([11]))
 
+  // equality-facet AGG cells — what makes an eq-facet count O(1) instead of a
+  // drain to MAX_SCAN. Namespaced under `eq/` so they never collide with the
+  // seeder's own `district/<state>|<district>` analytics dim.
+  const aggS = bee.sub("agg", { valueEncoding: "utf-8" })
+  const aggN = async (k) => Number((await aggS.get(k))?.value ?? -1)
+  ok("eq agg counts the education family", (await aggN("eq/education/Middle")) === 2)
+  ok("eq agg counts a boolean facet", (await aggN("eq/own_looms/true")) === 2 && (await aggN("eq/own_looms/false")) === 1)
+  ok("eq agg is namespaced under eq/", (await aggN("eq/district/BAGALKOT")) === 3 && (await aggN("district/BAGALKOT")) === -1)
+
   // idempotent: a second backfill is a no-op.
   const again = await backfillIndex(bee, { subKey, decode })
   ok("second backfill is a no-op (already done)", again.alreadyDone === true)
@@ -356,6 +441,43 @@ if (_isMain && process.argv.includes("--test")) {
   ok("idxRelKeys still emits the all family for a bare record", idxRelKeys({ census_id: 9 }).length === 1 && idxRelKeys({ census_id: 9 })[0] === "all/0000000009")
 
   await store.close()
+
+  // ── resumability: a run interrupted BEFORE its completion flags are set must
+  // resume from its checkpoint, not restart the corpus. On a 3.5M-record walk
+  // with the seeder stopped, a restart-from-zero is the difference between a
+  // recoverable crash and a lost window.
+  const DIR2 = "./.idx-selftest-resume"
+  rmSync(DIR2, { recursive: true, force: true })
+  const store2 = new Corestore(DIR2)
+  const core2 = store2.get({ name: "idx-resume" })
+  await core2.ready()
+  const bee2 = new Hyperbee(core2, { keyEncoding: "utf-8", valueEncoding: "binary" })
+  await bee2.ready()
+  const rec2 = bee2.sub("rec", { valueEncoding: "binary" })
+  for (let i = 1; i <= 40; i++) {
+    await rec2.put(String(i).padStart(10, "0"), enc({ census_id: i, state: "GOA", gender: "Male", education: "Middle", name: "Weaver " + i }))
+  }
+  const meta2 = bee2.sub("meta", { valueEncoding: "utf-8" })
+  // a previous generation completed; this generation's run then died at record 30.
+  await meta2.put("idx-version", IDX_VERSION)
+  await meta2.put("idx-all-version", IDX_ALL_VERSION)
+  await meta2.put("idx-geo-version", IDX_GEO_VERSION)
+  await meta2.put(`idx-geo-cursor-${IDX_CURSOR_GENERATION}`, String(30).padStart(10, "0"))
+  const resumed = await backfillIndex(bee2, { subKey, decode, encodePayload, batchSize: 5, log: () => {} })
+  ok("an interrupted backfill resumes from its checkpoint", resumed.indexed === 10)
+
+  // a genuinely new generation has no cursor of its own → it re-walks everything.
+  await meta2.del("idx-name-version")
+  await meta2.del("idx-eq-version")
+  await meta2.del(`idx-geo-cursor-${IDX_CURSOR_GENERATION}`)
+  const fresh = await backfillIndex(bee2, { subKey, decode, encodePayload, batchSize: 5, log: () => {} })
+  ok("a new family generation re-walks the whole corpus", fresh.indexed === 40)
+  // and that re-walk must not double-count the eq cells it already wrote.
+  const agg2 = bee2.sub("agg", { valueEncoding: "utf-8" })
+  ok("a re-walk resets eq agg instead of double-counting", Number((await agg2.get("eq/education/Middle"))?.value) === 40)
+
+  await store2.close()
+  rmSync(DIR2, { recursive: true, force: true })
   rmSync(DIR, { recursive: true, force: true })
   console.log(`\n✅ ${pass}/${pass} — census index emission + resumable backfill + range query hold.`)
   process.exit(0)

--- a/scripts/handloom-scrape/hyperbee-slice/census_index.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/census_index.mjs
@@ -37,6 +37,22 @@ export const ID_PAD = 10
 // range-scan an empty family). MUST match reader.ts FACET_IDX_META/ALL_IDX_META.
 export const IDX_VERSION = "idx-v1"
 export const IDX_ALL_VERSION = "idxall-v1"
+// Name facet family (`idx/name/<normalized>/<pad10(id)>`) — added later than the
+// others so it rolls out independently; MUST match reader.ts NAME_IDX_META.
+export const IDX_NAME_VERSION = "idxname-v1"
+// Equality facet families (`idx/<field>/<value>/<pad10(id)>` for each field in
+// EQ_FIELDS) — added later, gated independently (reader.ts EQ_IDX_META). These
+// are the remaining filterable equality dims that previously rode a residual
+// O(corpus) scan. MUST match reader.ts EQ_FACETS (same set).
+export const IDX_EQ_VERSION = "idxeq-v1"
+// Filterable equality facets indexed beyond state/gender/sd. Exact-equality
+// lookups (not prefix scans), so their values ride the key verbatim. Booleans
+// are stringified ("true"/"false"). Values must not contain "/" (unlikely here).
+export const EQ_FIELDS = [
+  "district", "block", "village", "rural_urban", "education",
+  "ownership_type", "household_type", "dwelling_type",
+  "own_looms", "natural_dye_used", "electricity",
+]
 // Bumped when the index VALUE format changes. v1 stored empty values (keys only,
 // so browse range-scanned the index for ids then hydrated each fat rec/* record);
 // "geo-v1" stores an inline display payload in every family value so browse reads
@@ -45,6 +61,14 @@ export const IDX_ALL_VERSION = "idxall-v1"
 // meta/idx-geo-version is set. MUST match reader.ts GEO_IDX_META.
 export const IDX_GEO_VERSION = "geo-v1"
 export const padId = (id) => String(id).padStart(ID_PAD, "0")
+
+// Normalise a weaver name into a facet value that is safe as a range-scanned key:
+// lowercased, runs of anything that isn't a Unicode letter/digit collapsed to a
+// single "_" (so no byte sorts below "/" 0x2f and breaks the `prefix/`→`prefix:`
+// range). MUST match reader.ts `normalizeName` exactly or the index and the
+// reader will compute different prefixes and never match.
+export const normalizeName = (n) =>
+  String(n ?? "").toLowerCase().replace(/[^\p{L}\p{N}]+/gu, "_").replace(/^_+|_+$/g, "")
 
 const EMPTY = Buffer.from("")
 
@@ -96,6 +120,20 @@ export function idxRelKeys(r) {
   if (r.state) keys.push(`state/${r.state}/${p}`)
   if (r.gender) keys.push(`gender/${r.gender}/${p}`)
   if (r.state && r.district) keys.push(`sd/${r.state}|${r.district}/${p}`)
+  // equality facets — exact-equality families. Skip null/empty; booleans are
+  // emitted for both true and false (so `own_looms=false` is filterable).
+  for (const f of EQ_FIELDS) {
+    const v = r[f]
+    if (v === null || v === undefined || v === "") continue
+    keys.push(`${f}/${String(v)}/${p}`)
+  }
+  // name facet — the free-text search family. Name lives at top level (promoted
+  // by the parser) or inside the raw survey bag, exactly as geoPayload resolves it.
+  const nm = r.name ?? r.survey?.Name ?? r.survey?.name
+  if (typeof nm === "string" && nm.trim()) {
+    const n = normalizeName(nm)
+    if (n) keys.push(`name/${n}/${p}`)
+  }
   return keys
 }
 
@@ -116,11 +154,13 @@ export async function backfillIndex(bee, { subKey, decode, encodePayload, batchS
   const meta = bee.sub("meta", { valueEncoding: "utf-8" })
   const facetsDone = (await meta.get("idx-version"))?.value === IDX_VERSION
   const allDone = (await meta.get("idx-all-version"))?.value === IDX_ALL_VERSION
+  const nameDone = (await meta.get("idx-name-version"))?.value === IDX_NAME_VERSION
+  const eqDone = (await meta.get("idx-eq-version"))?.value === IDX_EQ_VERSION
   // Only emit inline payloads when the caller wired an encoder; without it we
   // preserve the legacy keys-only behaviour (empty values) for old callers.
   const emitGeo = typeof encodePayload === "function"
   const geoDone = (await meta.get("idx-geo-version"))?.value === IDX_GEO_VERSION
-  if (facetsDone && allDone && (!emitGeo || geoDone)) {
+  if (facetsDone && allDone && nameDone && eqDone && (!emitGeo || geoDone)) {
     return { indexed: 0, alreadyDone: true }
   }
 
@@ -128,11 +168,12 @@ export async function backfillIndex(bee, { subKey, decode, encodePayload, batchS
   // must re-walk the whole corpus — a legacy cursor is parked at the end and
   // would emit nothing. Track the geo pass under its OWN cursor so a crash mid-
   // backfill resumes instead of restarting. Legacy (no-geo) runs keep using the
-  // old cursor and its facet/all-only reset rule. Puts are idempotent overwrites,
-  // so re-emitting keys is always harmless.
+  // old cursor and its facet/all-only reset rule. A missing family added later
+  // (name / eq) forces a fresh walk in EITHER mode for the same reason. Puts are
+  // idempotent overwrites, so re-emitting keys is always harmless.
   const CURSOR = emitGeo ? "idx-geo-cursor" : "idx-backfill-cursor"
   const cursorNode =
-    !emitGeo && facetsDone && !allDone ? null : await meta.get(CURSOR)
+    (!emitGeo && facetsDone && !allDone) || !nameDone || !eqDone ? null : await meta.get(CURSOR)
   let resumeAfter = cursorNode ? cursorNode.value : null
 
   const rec = bee.sub("rec", { valueEncoding: "binary" })
@@ -176,8 +217,10 @@ export async function backfillIndex(bee, { subKey, decode, encodePayload, batchS
 
   await meta.put("idx-version", IDX_VERSION)
   await meta.put("idx-all-version", IDX_ALL_VERSION)
+  await meta.put("idx-name-version", IDX_NAME_VERSION)
+  await meta.put("idx-eq-version", IDX_EQ_VERSION)
   if (emitGeo) await meta.put("idx-geo-version", IDX_GEO_VERSION)
-  log(`[idx-backfill] DONE — ${indexed} records indexed, idx-version=${IDX_VERSION}, idx-all-version=${IDX_ALL_VERSION}${emitGeo ? `, idx-geo-version=${IDX_GEO_VERSION}` : ""}`)
+  log(`[idx-backfill] DONE — ${indexed} records indexed, idx-version=${IDX_VERSION}, idx-all-version=${IDX_ALL_VERSION}, idx-name-version=${IDX_NAME_VERSION}, idx-eq-version=${IDX_EQ_VERSION}${emitGeo ? `, idx-geo-version=${IDX_GEO_VERSION}` : ""}`)
   return { indexed, alreadyDone: false }
 }
 
@@ -210,9 +253,9 @@ if (_isMain && process.argv.includes("--test")) {
   const records = [
     // id 10 carries coords in the raw survey bag (as the fast parser leaves them)
     // → the payload must promote them to typed lat/long.
-    { census_id: 10, state: "KARNATAKA", district: "BAGALKOT", gender: "Male", village: "ILKAL", survey: { Name: "SHANTAVVA", Latitude: "16.1329", Longitude: "75.9587" } },
-    { census_id: 11, state: "KARNATAKA", district: "BAGALKOT", gender: "Female" },
-    { census_id: 12, state: "KARNATAKA", district: "BELGAUM", gender: "Male" },
+    { census_id: 10, state: "KARNATAKA", district: "BAGALKOT", gender: "Male", village: "ILKAL", education: "Middle", own_looms: true, survey: { Name: "SHANTAVVA", Latitude: "16.1329", Longitude: "75.9587" } },
+    { census_id: 11, state: "KARNATAKA", district: "BAGALKOT", gender: "Female", education: "Middle", own_looms: false },
+    { census_id: 12, state: "KARNATAKA", district: "BELGAUM", gender: "Male", education: "High", own_looms: true },
     { census_id: 13, state: "PUNJAB", district: "AMRITSAR", gender: "Female" },
     { census_id: 14, state: "KARNATAKA", district: "BAGALKOT", gender: "Male" },
   ]
@@ -230,6 +273,8 @@ if (_isMain && process.argv.includes("--test")) {
   ok("idx-version flag set", (await bee.sub("meta", { valueEncoding: "utf-8" }).get("idx-version"))?.value === "idx-v1")
   ok("idx-all-version flag set", (await bee.sub("meta", { valueEncoding: "utf-8" }).get("idx-all-version"))?.value === "idxall-v1")
   ok("idx-geo-version flag set", (await bee.sub("meta", { valueEncoding: "utf-8" }).get("idx-geo-version"))?.value === "geo-v1")
+  ok("idx-name-version flag set", (await bee.sub("meta", { valueEncoding: "utf-8" }).get("idx-name-version"))?.value === "idxname-v1")
+  ok("idx-eq-version flag set", (await bee.sub("meta", { valueEncoding: "utf-8" }).get("idx-eq-version"))?.value === "idxeq-v1")
 
   // whole-corpus `all` family → every id, ascending (powers the unfiltered browse).
   const idxAll = bee.sub("idx", { valueEncoding: "binary" })
@@ -270,13 +315,44 @@ if (_isMain && process.argv.includes("--test")) {
   }
   ok("cursor (after=11) yields the next ids", JSON.stringify(after) === JSON.stringify([12, 14]))
 
+  // name facet — the reader range-scans the NAME part with a "\uffff" upper bound
+  // (not the id-suffix ":" bound used by state/gender/sd), so both exact and
+  // prefix queries resolve by scanning `name/<query>` → `name/<query>\uffff`.
+  const nameExact = []
+  for await (const { key } of idx.createReadStream({ gte: "name/shantavva", lt: "name/shantavva\uffff" })) {
+    nameExact.push(Number(key.slice(key.lastIndexOf("/") + 1)))
+  }
+  ok("name index returns the SHANTAVVA id (exact)", JSON.stringify(nameExact) === JSON.stringify([10]))
+  const namePrefixIds = []
+  for await (const { key } of idx.createReadStream({ gte: "name/shant", lt: "name/shant\uffff" })) {
+    namePrefixIds.push(Number(key.slice(key.lastIndexOf("/") + 1)))
+  }
+  ok("name index supports a prefix range scan", JSON.stringify(namePrefixIds) === JSON.stringify([10]))
+
+  // equality facets — exact-equality lookups (same ":" id-suffix bound as state/gender).
+  const eqEducation = []
+  for await (const { key } of idx.createReadStream({ gte: "education/Middle/", lt: "education/Middle:" })) {
+    eqEducation.push(Number(key.slice(key.lastIndexOf("/") + 1)))
+  }
+  ok("education facet returns the 'Middle' ids", JSON.stringify(eqEducation) === JSON.stringify([10, 11]))
+  const eqOwnTrue = []
+  for await (const { key } of idx.createReadStream({ gte: "own_looms/true/", lt: "own_looms/true:" })) {
+    eqOwnTrue.push(Number(key.slice(key.lastIndexOf("/") + 1)))
+  }
+  ok("own_looms=true facet returns loom owners", JSON.stringify(eqOwnTrue) === JSON.stringify([10, 12]))
+  const eqOwnFalse = []
+  for await (const { key } of idx.createReadStream({ gte: "own_looms/false/", lt: "own_looms/false:" })) {
+    eqOwnFalse.push(Number(key.slice(key.lastIndexOf("/") + 1)))
+  }
+  ok("own_looms=false facet returns non-owners", JSON.stringify(eqOwnFalse) === JSON.stringify([11]))
+
   // idempotent: a second backfill is a no-op.
   const again = await backfillIndex(bee, { subKey, decode })
   ok("second backfill is a no-op (already done)", again.alreadyDone === true)
 
-  // forward emission helper (all + state + gender + sd = 4 for a full record).
-  ok("idxRelKeys emits 4 families for a full record", idxRelKeys(records[0]).length === 4)
-  ok("idxRelKeys skips district family when district missing", idxRelKeys({ census_id: 9, state: "GOA", gender: "Male" }).length === 3)
+  // forward emission helper — record 10: all + state + gender + sd + 4 eq (district, village, education, own_looms) + name = 9.
+  ok("idxRelKeys emits 9 families for a full named record", idxRelKeys(records[0]).length === 9)
+  ok("idxRelKeys skips district+name+eq families when missing", idxRelKeys({ census_id: 9, state: "GOA", gender: "Male" }).length === 3)
   ok("idxRelKeys still emits the all family for a bare record", idxRelKeys({ census_id: 9 }).length === 1 && idxRelKeys({ census_id: 9 })[0] === "all/0000000009")
 
   await store.close()

--- a/scripts/handloom-scrape/hyperbee-slice/seed_p2p.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/seed_p2p.mjs
@@ -26,7 +26,7 @@ import { readdirSync, writeFileSync, existsSync, createReadStream, openSync, fst
 import { createInterface } from "node:readline";
 import { join } from "node:path";
 import assert from "node:assert";
-import { idxRelKeys, geoPayload } from "./census_index.mjs";
+import { idxRelKeys, geoPayload, eqAggKeys, EQ_AGG_PREFIX } from "./census_index.mjs";
 
 const DATA_DIR = "../data/live";
 const STORE_DIR = process.env.P2P_STORE || "./p2p-store";
@@ -80,6 +80,11 @@ function bumpInto(m, r, sens) {
   for (const ch of ["local_market", "master_weaver", "cooperative", "ecommerce"])
     if (r[`sells_${ch}`]) inc(`sales/${ch}`);
   for (const t of ["pit", "frame", "loin", "other"]) add(`loom_type/${t}`, r[`${t}_loom_count`]);
+  // equality-facet counts (`eq/<field>/<value>`) — the cells the reader lifts an
+  // O(1) total from for a village/education/own_looms browse. Maintained on the
+  // incremental path too, or the backfill's counts would go stale the moment the
+  // next chunk lands.
+  for (const k of eqAggKeys(r)) inc(k);
   add(`total/looms_owned`, r.total_looms_owned);
   add(`total/weavers`, 1);
 }
@@ -281,6 +286,9 @@ export async function readStats(pub, { minCell = MIN_CELL } = {}) {
   const dims = {};
   for await (const { key, value } of pub.sub("agg", { valueEncoding: "utf-8" }).createReadStream()) {
     const [dim, ...rest] = key.split("/");
+    // `eq/*` cells are a READER index (one per facet VALUE — hundreds of thousands
+    // of villages), not an analytics dim. They would swamp this feed.
+    if (dim === EQ_AGG_PREFIX) continue;
     const label = rest.join("/");
     const count = Number(value);
     (dims[dim] ??= {})[label] = dim === "total" || dim === "loom_type" ? count


### PR DESCRIPTION
## Problem

Free-text name search (`q=`) and filters on `block`, `village`, `education`, `own_looms`, etc. ride a residual predicate over the **whole corpus** (up to `MAX_SCAN=50_000` brotli inflates per request), which 504s `GET /admin/persons?...&include_weavers=true` once the sweep is large. Verified live: `q=mustaq` and even `region_state=ASSAM` time out on the reader node.

## What this does

Adds two secondary-index families to the seeder/backfill + reader:

1. **`idx/name/<normalized>/<padId>`** — free-text name search becomes a **prefix range-scan** (`name/<query>` → `name/<query>\uffff`) instead of an O(corpus) residual scan.
2. **`idx/<field>/<value>/<padId>`** — exact-equality families for 11 filterable facets (`district`, `block`, `village`, `rural_urban`, `education`, `ownership_type`, `household_type`, `dwelling_type`, `own_looms`, `natural_dye_used`, `electricity`).

Both are gated behind `idx-name-version` / `idx-eq-version` meta flags so they roll out independently; absent a flag the reader keeps the existing bounded-scan fallback.

## Notes / caveats

- **Name search is now prefix-match** (substring retained only as the residual double-check within the prefix + fallback when the index is absent). Searching `mustaq` matches "Mustaq Ahmed" but not "Abdul Mustaq".
- **Counts for the new facets are `estimated`** (no per-facet agg cell yet) — same lower-bound behaviour the residual path already had, now with a narrowed scan.
- **Deploy needs a one-time re-backfill** on the OCI seeder to emit the new families + flags, and the reader change must be mirrored to `census-reader.mjs` (the deployed node reader, not in this repo).

## Tests

- `census_index.mjs --test`: 23/23 (name + equality facet emission, prefix/exact range scans)
- census unit tests: 19/19 (incl. new `reader-name-index.unit.spec.ts`)
- `tsc --noEmit`: no errors in `modules/census`