### PR TITLE
fix(census): the inline geo payload does not fit on the box that writes it

### DIFF
--- a/scripts/handloom-scrape/hyperbee-slice/backfill_index.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/backfill_index.mjs
@@ -31,6 +31,23 @@ const subKey = (name, k) => Buffer.concat([Buffer.from(name), SEP, Buffer.from(S
 const decode = (buf) => JSON.parse(brotliDecompressSync(buf).toString())
 // Encodes the lean inline display payload written onto every index value (the
 // geo generation). Passing this flips backfillIndex into payload mode.
+//
+// OFF BY DEFAULT, and the reason is arithmetic, not taste. Measured against real
+// prod records the payload is ~288 B, and a record now emits ~18 index families;
+// across 3,587,570 records that is ~66M entries ≈ 20 GB in the core, ~28 GB once
+// RocksDB has it. The seeder box (VM.Standard.E2.1.Micro, 45 GB boot volume) has
+// 11 GB free. Keys-only is ~0.9 GB / ~1.3 GB on disk.
+//
+// It costs that much to save ONE rec/* seek per row during a scan — which mattered
+// when a filtered browse drained a family to MAX_SCAN. It no longer does: every
+// equality facet now carries its own `agg/eq/<field>/<value>` cell, so a browse is
+// an O(1) count plus ONE PAGE of hydrates. The payload now saves ~20 seeks per
+// request, for 27 GB. The reader handles empty values by design (decodeIndexRow
+// falls back to rec/* when the buffer is empty), so a keys-only store — or a store
+// with a mix — is correct, just one seek per displayed row.
+//
+// Set IDX_GEO=1 to opt in, on hardware that has the room.
+const emitGeoPayload = process.env.IDX_GEO === "1"
 const encodePayload = (obj) => brotliCompressSync(Buffer.from(JSON.stringify(obj)))
 
 const store = new Corestore(STORE_DIR)
@@ -49,12 +66,15 @@ if (!core.writable) {
 const bee = new Hyperbee(core, { keyEncoding: "utf-8", valueEncoding: "binary" })
 await bee.ready()
 
-console.log(`→ backfilling census index over "${CORE_NAME}" (${STORE_DIR}), core length=${core.length}…`)
+console.log(
+  `→ backfilling census index over "${CORE_NAME}" (${STORE_DIR}), core length=${core.length}, ` +
+  `${emitGeoPayload ? "WITH inline geo payload (~288 B/entry — check free disk!)" : "keys only"}…`
+)
 const t0 = Date.now()
 const { indexed, alreadyDone } = await backfillIndex(bee, {
   subKey,
   decode,
-  encodePayload,
+  ...(emitGeoPayload ? { encodePayload } : {}),
   batchSize: Number(process.env.IDX_BATCH || 5000),
   log: (m) => console.log(m),
 })

--- a/scripts/handloom-scrape/hyperbee-slice/seed_p2p.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/seed_p2p.mjs
@@ -31,6 +31,10 @@ import { idxRelKeys, geoPayload, eqAggKeys, EQ_AGG_PREFIX } from "./census_index
 const DATA_DIR = "../data/live";
 const STORE_DIR = process.env.P2P_STORE || "./p2p-store";
 const MIN_CELL = 5;                       // k-anonymity: suppress aggregate cells below this
+// Inline geo payload on index values — see backfill_index.mjs for the arithmetic.
+// Both writers read this same flag so the store never ends up half-populated.
+const EMIT_GEO_PAYLOAD = process.env.IDX_GEO === "1";
+const EMPTY_IDX_VALUE = Buffer.from("");
 
 // fields that must NEVER enter the public core (encrypted core only)
 const SENSITIVE = ["mobile", "name", "head_of_household", "latitude", "longitude",
@@ -215,11 +219,17 @@ async function ingestCore(bee, file, sens) {
       r.profile_photo_url = photos.get(String(r.census_id));
     const { pub: pubRow, sensitive } = splitRecord(r);
     recPuts.push([String(r.census_id), brotliCompressSync(Buffer.from(JSON.stringify(sens ? sensitive : pubRow)))]);
-    // Carry the lean display payload inline on every index family value so the
-    // reader browses without a fat rec/* seek (see census_index.geoPayload). The
-    // payload is identical across a record's families → encode once.
+    // Optionally carry the lean display payload inline on every index family value
+    // so the reader browses without a fat rec/* seek (see census_index.geoPayload).
+    // OFF by default, gated on the SAME flag as backfill_index.mjs (which carries the
+    // arithmetic): ~288 B across ~18 families is ~5 KB of COPIES per weaver, of fields
+    // that already live in rec/*. The two writers must agree or the store drifts into
+    // a half-payload state nobody planned. The reader only reads these values when
+    // meta/idx-geo-version is set, which the keys-only backfill never sets.
     if (!sens) {
-      const idxVal = brotliCompressSync(Buffer.from(JSON.stringify(geoPayload(pubRow))));
+      const idxVal = EMIT_GEO_PAYLOAD
+        ? brotliCompressSync(Buffer.from(JSON.stringify(geoPayload(pubRow))))
+        : EMPTY_IDX_VALUE;
       for (const rk of idxRelKeys(pubRow)) idxPuts.push([rk, idxVal]);
     }
     bumpInto(delta, r, sens);


### PR DESCRIPTION
Measured on the live seeder before running the backfill #1869 asked for.

`backfill_index.mjs` passed `encodePayload` unconditionally. Against real prod records that is a 288 B brotli payload on every index value, ~18.4 families a record, 3,587,570 records:

| | core | on disk |
|---|---|---|
| with geo payload | 19.9 GB | ~27.9 GB |
| keys only | 0.9 GB | ~1.3 GB |

The seeder box (`VM.Standard.E2.1.Micro`, 45 GB boot volume) has **11 GB free**. The run would have filled the disk on the *writer*, mid-walk, with `handloom-seed` stopped.

Probe output from the box:
```
core.byteLength      5.97 GB   (8.3 GB on disk, RocksDB overhead ~1.4x)
agg/total/weavers    3,587,570
meta/idx-geo-version (unset)    <- the payload generation has NEVER run in prod
all/* entry          value 0 B, key 14 B
```

The payload is not data, it is **copies** — 288 B of fields that already live in `rec/*`, written 18 times per weaver. Compression is no help: it is already brotli, and compressing a thing 18 times still stores it 18 times.

It bought one avoided `rec/*` seek per row while a filtered browse drained a family to `MAX_SCAN`. It no longer does that — every equality facet now carries its own `agg/eq/<field>/<value>` cell, so a browse is an O(1) count plus one page of hydrates. It now saves ~20 seeks per request, for 27 GB, on **both** boxes (the mirror replicates every block and is what serves prod).

Gated behind `IDX_GEO=1` in both writers — the backfill and the seeder's incremental path, which must agree or the store drifts into a half-payload state. The reader already tolerates this: `decodeIndexRow` falls back to a `rec/*` seek when the buffer is empty, so keys-only and mixed stores are both correct.

Tests: `census_index.mjs --test` 31/31, `node --check` on both writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4