### PR TITLE
feat(admin-mcp): the assistant can file a partner's capabilities and onboarding questionnaire

### DIFF
--- a/apps/backend/integration-tests/http/admin-mcp/admin-mcp-partner-ops.spec.ts
+++ b/apps/backend/integration-tests/http/admin-mcp/admin-mcp-partner-ops.spec.ts
@@ -65,6 +65,11 @@ setupSharedTestSuite(() => {
         "create_partner_feedback",
         "link_partner_people",
         "create_partner_subscription",
+        "list_partner_capabilities",
+        "create_partner_capability",
+        "delete_partner_capability",
+        "get_partner_onboarding_profile",
+        "update_partner_onboarding_profile",
       ]) {
         expect(names).toContain(name)
       }
@@ -223,6 +228,91 @@ setupSharedTestSuite(() => {
       expect(payload.ok).toBe(true)
       expect(payload.data.fees).toEqual([])
       expect(payload.data.summary).toBeDefined()
+    })
+
+    it("create_partner_capability files a sample readable via list_partner_capabilities (confirm required)", async () => {
+      const empty = await callTool("list_partner_capabilities", { id: partnerId })
+      expect(parse(empty).data.samples).toEqual([])
+      expect(parse(empty).data.count).toBe(0)
+
+      // Without confirm: sensitive write is only planned, never executed.
+      const unconfirmed = await callTool("create_partner_capability", {
+        id: partnerId,
+        title: "kani twill, off-white",
+        technique: "kani twill",
+      })
+      const unconfirmedPayload = parse(unconfirmed)
+      expect(unconfirmedPayload.requires_confirmation).toBe(true)
+      expect(unconfirmedPayload.plan.method).toBe("POST")
+      expect(unconfirmedPayload.plan.path).toBe(
+        `/admin/partners/${partnerId}/capabilities`
+      )
+
+      const stillEmpty = await callTool("list_partner_capabilities", { id: partnerId })
+      expect(parse(stillEmpty).data.count).toBe(0)
+
+      // With confirm: executes against the wrapped route, stamped source='admin'.
+      const created = await callTool("create_partner_capability", {
+        id: partnerId,
+        title: "kani twill, off-white",
+        technique: "kani twill",
+        material: "pashmina",
+        confirm: true,
+      })
+      const createdPayload = parse(created)
+      expect(createdPayload.ok).toBe(true)
+      expect(createdPayload.data.sample.source).toBe("admin")
+      expect(createdPayload.data.captured_at_defaulted).toBe(true)
+
+      const listed = await callTool("list_partner_capabilities", { id: partnerId })
+      const samples = parse(listed).data.samples
+      expect(samples).toHaveLength(1)
+      expect(samples[0].id).toBe(createdPayload.data.sample.id)
+      expect(samples[0].technique).toBe("kani twill")
+    })
+
+    it("update_partner_onboarding_profile files answers readable via get_partner_onboarding_profile", async () => {
+      const before = await callTool("get_partner_onboarding_profile", { id: partnerId })
+      expect(parse(before).data.onboarding_profile).toBeNull()
+
+      const updated = await callTool("update_partner_onboarding_profile", {
+        id: partnerId,
+        does_weaving: true,
+        selling_mode: "core_channel_listing",
+        confirm: true,
+      })
+      expect(parse(updated).ok).toBe(true)
+
+      const after = await callTool("get_partner_onboarding_profile", { id: partnerId })
+      const profile = parse(after).data.onboarding_profile
+      expect(profile.does_weaving).toBe(true)
+      expect(profile.selling_mode).toBe("core_channel_listing")
+    })
+
+    it("delete_partner_capability removes a sample and previews the library first", async () => {
+      const created = await callTool("create_partner_capability", {
+        id: partnerId,
+        title: "to remove",
+        confirm: true,
+      })
+      const sampleId = parse(created).data.sample.id
+
+      // A DELETE is confirm-gated like every other mutation.
+      const unconfirmed = await callTool("delete_partner_capability", {
+        id: partnerId,
+        sampleId,
+      })
+      expect(parse(unconfirmed).requires_confirmation).toBe(true)
+
+      const deleted = await callTool("delete_partner_capability", {
+        id: partnerId,
+        sampleId,
+        confirm: true,
+      })
+      expect(parse(deleted).ok).toBe(true)
+
+      const after = await callTool("list_partner_capabilities", { id: partnerId })
+      expect(parse(after).data.count).toBe(0)
     })
   })
 })

--- a/apps/backend/integration-tests/http/admin-partner-capabilities-onboarding.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partner-capabilities-onboarding.spec.ts
@@ -1,0 +1,334 @@
+/**
+ * Admin API — partner capability library + onboarding questionnaire (#1531/#648).
+ *
+ * The admin half of two partner-owned surfaces: the photographs of what a
+ * partner has made, and the questionnaire that used to be write-only from
+ * the platform's point of view. The contracts worth pinning:
+ *
+ *   - the capability write stamps source='admin' and says when captured_at
+ *     was defaulted (the library is only searchable if it admits staleness)
+ *   - a sample is only reachable THROUGH its partner — another partner's
+ *     sample id is a 404, not a deletion
+ *   - the onboarding upsert is partial: one answer at a time, first-save
+ *     creates, later saves merge rather than replace
+ *   - both surfaces speak admin auth and 404 cleanly on an unknown partner
+ */
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+
+jest.setTimeout(90 * 1000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Admin Partners API — capabilities", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let partnerId: string
+    let otherPartnerId: string
+
+    const postSample = (body: Record<string, unknown>, id = partnerId) =>
+      api.post(`/admin/partners/${id}/capabilities`, body, adminHeaders)
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const partnerService: any = container.resolve(PARTNER_MODULE)
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const partner = await partnerService.createPartners({
+        name: `Capability Admin ${unique}`,
+        handle: `capability-admin-${unique}`,
+      })
+      partnerId = partner.id
+
+      const other = await partnerService.createPartners({
+        name: `Capability Other ${unique}`,
+        handle: `capability-other-${unique}`,
+      })
+      otherPartnerId = other.id
+    })
+
+    it("lists empty for a fresh partner", async () => {
+      const res = await api.get(
+        `/admin/partners/${partnerId}/capabilities`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.samples).toEqual([])
+      expect(res.data.count).toBe(0)
+    })
+
+    it("creates a sample stamped source='admin', and says when captured_at defaulted", async () => {
+      const res = await postSample({
+        title: "kani twill, off-white",
+        technique: "kani twill",
+        material: "pashmina",
+        notes: "from Monday's call",
+      })
+
+      expect(res.status).toBe(201)
+      const sample = res.data.sample
+      expect(sample.id).toEqual(expect.stringContaining("pcap"))
+      expect(sample.partner_id).toBe(partnerId)
+      expect(sample.title).toBe("kani twill, off-white")
+      expect(sample.technique).toBe("kani twill")
+      expect(sample.material).toBe("pashmina")
+      // The evidence trail: an operator typed this up, the partner did not
+      // answer a wizard.
+      expect(sample.source).toBe("admin")
+      expect(res.data.captured_at_defaulted).toBe(true)
+
+      // An id is not a URL, and the read path must say so — `media` is always
+      // an array (best-effort resolution of unknown ids to nothing).
+      expect(Array.isArray(sample.media)).toBe(true)
+    })
+
+    it("honours an explicit captured_at and reports captured_at_defaulted=false", async () => {
+      const taken = "2026-01-15T10:00:00.000Z"
+      const res = await postSample({
+        title: "jamdani swatch",
+        captured_at: taken,
+      })
+
+      expect(res.status).toBe(201)
+      expect(res.data.captured_at_defaulted).toBe(false)
+      expect(new Date(res.data.sample.captured_at).toISOString()).toBe(taken)
+    })
+
+    it("requires a title", async () => {
+      const err = await postSample({ technique: "kani twill" }).catch(
+        (e: any) => e
+      )
+      expect(err.response.status).toBe(400)
+    })
+
+    it("rejects partner_id in the body — the URL owns the attribution", async () => {
+      const err = await postSample({
+        title: "attributed elsewhere",
+        partner_id: otherPartnerId,
+      }).catch((e: any) => e)
+
+      // Medusa's zodValidator forces strict: a stray field is a 400, never a
+      // silently-ignored re-attribution of a competitor's work.
+      expect(err.response.status).toBe(400)
+    })
+
+    it("lists newest captured_at first and forwards the technique/material filters", async () => {
+      await postSample({ title: "old work", captured_at: "2026-01-01T00:00:00.000Z" })
+      await postSample({ title: "new work", captured_at: "2026-02-01T00:00:00.000Z" })
+
+      const all = await api.get(
+        `/admin/partners/${partnerId}/capabilities`,
+        adminHeaders
+      )
+      expect(all.data.count).toBe(2)
+      expect(all.data.samples.map((s: any) => s.title)).toEqual([
+        "new work",
+        "old work",
+      ])
+
+      const filtered = await api.get(
+        `/admin/partners/${partnerId}/capabilities?technique=handloom`,
+        adminHeaders
+      )
+      expect(filtered.data.count).toBe(0)
+
+      await postSample({ title: "handloom piece", technique: "handloom" })
+      const hit = await api.get(
+        `/admin/partners/${partnerId}/capabilities?technique=handloom`,
+        adminHeaders
+      )
+      expect(hit.data.count).toBe(1)
+      expect(hit.data.samples[0].title).toBe("handloom piece")
+    })
+
+    it("caps the page at 100 per request", async () => {
+      for (let i = 0; i < 3; i++) {
+        await postSample({ title: `sample ${i}` })
+      }
+      const res = await api.get(
+        `/admin/partners/${partnerId}/capabilities?limit=2`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.samples).toHaveLength(2)
+      expect(res.data.count).toBe(3)
+    })
+
+    it("deletes a sample through the owning partner", async () => {
+      const created = await postSample({ title: "to delete" })
+      const sampleId = created.data.sample.id
+
+      const del = await api.delete(
+        `/admin/partners/${partnerId}/capabilities/${sampleId}`,
+        adminHeaders
+      )
+      expect(del.status).toBe(200)
+      expect(del.data.deleted).toBe(true)
+      expect(del.data.id).toBe(sampleId)
+
+      const after = await api.get(
+        `/admin/partners/${partnerId}/capabilities`,
+        adminHeaders
+      )
+      expect(after.data.count).toBe(0)
+    })
+
+    it("refuses to delete another partner's sample (tenant guard, 404)", async () => {
+      const created = await postSample(
+        { title: "theirs, not ours" },
+        otherPartnerId
+      )
+      const sampleId = created.data.sample.id
+
+      const err = await api
+        .delete(
+          `/admin/partners/${partnerId}/capabilities/${sampleId}`,
+          adminHeaders
+        )
+        .catch((e: any) => e)
+
+      expect(err.response.status).toBe(404)
+
+      // The evidence survives the attempt.
+      const theirs = await api.get(
+        `/admin/partners/${otherPartnerId}/capabilities`,
+        adminHeaders
+      )
+      expect(theirs.data.count).toBe(1)
+      expect(theirs.data.samples[0].id).toBe(sampleId)
+    })
+
+    it("404s for an unknown partner", async () => {
+      const err = await api
+        .get("/admin/partners/partner_does_not_exist/capabilities", adminHeaders)
+        .catch((e: any) => e)
+      expect(err.response.status).toBe(404)
+      expect(err.response.data.message).toBe("Partner not found")
+    })
+
+    it("requires admin auth", async () => {
+      const err = await api
+        .get(`/admin/partners/${partnerId}/capabilities`)
+        .catch((e: any) => e)
+      expect(err.response.status).toBe(401)
+    })
+  })
+
+  describe("Admin Partners API — onboarding profile", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let partnerId: string
+
+    const putProfile = (body: Record<string, unknown>, id = partnerId) =>
+      api.put(`/admin/partners/${id}/onboarding-profile`, body, adminHeaders)
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const partnerService: any = container.resolve(PARTNER_MODULE)
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const partner = await partnerService.createPartners({
+        name: `Onboarding Admin ${unique}`,
+        handle: `onboarding-admin-${unique}`,
+      })
+      partnerId = partner.id
+    })
+
+    it("reads null for a partner who has not started the wizard", async () => {
+      const res = await api.get(
+        `/admin/partners/${partnerId}/onboarding-profile`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.onboarding_profile).toBeNull()
+    })
+
+    it("first PUT creates the profile; later PUTs merge, not replace", async () => {
+      const first = await putProfile({ does_weaving: true, team_size: 4 })
+      expect(first.status).toBe(200)
+      expect(first.data.onboarding_profile.partner_id).toBe(partnerId)
+      expect(first.data.onboarding_profile.does_weaving).toBe(true)
+      expect(first.data.onboarding_profile.team_size).toBe(4)
+
+      // A second answer in a second call — the wizard's own partial-progress
+      // semantics, reached by an operator filing a conversation.
+      const second = await putProfile({ what_they_sell: "fabric" })
+      expect(second.status).toBe(200)
+
+      const read = await api.get(
+        `/admin/partners/${partnerId}/onboarding-profile`,
+        adminHeaders
+      )
+      const profile = read.data.onboarding_profile
+      expect(profile.does_weaving).toBe(true) // survived the merge
+      expect(profile.team_size).toBe(4)
+      expect(profile.what_they_sell).toBe("fabric")
+    })
+
+    it("accepts the commercial fields (selling mode, commission, supplier flag)", async () => {
+      const res = await putProfile({
+        selling_mode: "core_channel_listing",
+        commission_bps: 1500,
+        supplies_to_platform: true,
+        payment_collection: "through_us",
+        completed: true,
+      })
+      expect(res.status).toBe(200)
+
+      const read = await api.get(
+        `/admin/partners/${partnerId}/onboarding-profile`,
+        adminHeaders
+      )
+      const profile = read.data.onboarding_profile
+      expect(profile.selling_mode).toBe("core_channel_listing")
+      expect(profile.commission_bps).toBe(1500)
+      expect(profile.supplies_to_platform).toBe(true)
+      expect(profile.payment_collection).toBe("through_us")
+      expect(profile.completed).toBe(true)
+    })
+
+    it("rejects an enum value the model does not know", async () => {
+      const err = await putProfile({
+        what_they_sell: "spacecraft",
+      }).catch((e: any) => e)
+      expect(err.response.status).toBe(400)
+    })
+
+    it("PUT 404s for an unknown partner", async () => {
+      const err = await putProfile(
+        { does_weaving: true },
+        "partner_does_not_exist"
+      ).catch((e: any) => e)
+      expect(err.response.status).toBe(404)
+      expect(err.response.data.message).toBe("Partner not found")
+    })
+
+    it("GET 404s for an unknown partner", async () => {
+      const err = await api
+        .get(
+          "/admin/partners/partner_does_not_exist/onboarding-profile",
+          adminHeaders
+        )
+        .catch((e: any) => e)
+      expect(err.response.status).toBe(404)
+    })
+
+    it("requires admin auth", async () => {
+      const err = await api
+        .get(`/admin/partners/${partnerId}/onboarding-profile`)
+        .catch((e: any) => e)
+      expect(err.response.status).toBe(401)
+
+      const putErr = await api
+        .put(`/admin/partners/${partnerId}/onboarding-profile`, {
+          does_weaving: true,
+        })
+        .catch((e: any) => e)
+      expect(putErr.response.status).toBe(401)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -260,6 +260,147 @@ describe("admin-mcp registry + dispatch", () => {
     })
   })
 
+  describe("partner capability + onboarding tools: the admin half of the partner surfaces", () => {
+    it("registers the capability reads and the onboarding read", () => {
+      const reads = [
+        ["list_partner_capabilities", "/admin/partners/:id/capabilities"],
+        ["get_partner_onboarding_profile", "/admin/partners/:id/onboarding-profile"],
+      ] as const
+      for (const [name, path] of reads) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.method ?? "GET").toBe("GET")
+        expect(def!.path).toBe(path)
+        expect(def!.write).toBeFalsy()
+        expect(isSensitive(def!)).toBe(false)
+      }
+    })
+
+    it("registers the capability + onboarding writes as sensitive (confirm only)", () => {
+      const writes = [
+        ["create_partner_capability", "POST", "/admin/partners/:id/capabilities"],
+        [
+          "update_partner_onboarding_profile",
+          "PUT",
+          "/admin/partners/:id/onboarding-profile",
+        ],
+      ] as const
+      for (const [name, method, path] of writes) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.write).toBe(true)
+        expect(def!.method).toBe(method)
+        expect(def!.path).toBe(path)
+        expect(isSensitive(def!)).toBe(true)
+        expect(isDangerous(def!)).toBe(false)
+      }
+    })
+
+    it("registers delete_partner_capability as a DELETE (confirm, not dangerous)", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "delete_partner_capability")
+      expect(def).toBeTruthy()
+      expect(def!.method).toBe("DELETE")
+      expect(def!.path).toBe("/admin/partners/:id/capabilities/:sampleId")
+      expect(def!.pathParams).toEqual(["id", "sampleId"])
+      expect(def!.write).toBe(true)
+      expect(isSensitive(def!)).toBe(true) // every DELETE is confirm-gated
+      expect(isDangerous(def!)).toBe(false)
+      expect(def!.previewPath).toBe("/admin/partners/:id/capabilities")
+    })
+
+    it("update_partner_onboarding_profile declares a previewPath for dry_run", () => {
+      const def = ADMIN_MCP_TOOLS.find(
+        (t) => t.name === "update_partner_onboarding_profile"
+      )!
+      expect(def.previewPath).toBe("/admin/partners/:id/onboarding-profile")
+    })
+
+    it("update_partner_onboarding_profile advertises every questionnaire field the route accepts", () => {
+      const def = ADMIN_MCP_TOOLS.find(
+        (t) => t.name === "update_partner_onboarding_profile"
+      )!
+      expect(def.bodyParams).toEqual([
+        "what_they_sell",
+        "price_range",
+        "has_inventory_info",
+        "does_stock",
+        "does_weaving",
+        "person_type",
+        "team_size",
+        "payment_collection",
+        "selling_mode",
+        "commission_bps",
+        "supplies_to_platform",
+        "completed",
+      ])
+    })
+
+    it("create_partner_capability dry_run previews the plan without executing", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "create_partner_capability",
+        {
+          id: "partner_1",
+          title: "kani twill, off-white",
+          technique: "kani twill",
+          dry_run: true,
+        }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.dry_run).toBe(true)
+      expect(res.plan?.method).toBe("POST")
+      expect(res.plan?.path).toBe("/admin/partners/partner_1/capabilities")
+      expect((res.plan?.body as any)?.title).toBe("kani twill, off-white")
+    })
+
+    it("create_partner_capability without confirm returns requires_confirmation, not executed", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "create_partner_capability",
+        { id: "partner_1", title: "kani twill, off-white" }
+      )
+      expect(res.requires_confirmation).toBe(true)
+      expect(res.plan?.path).toBe("/admin/partners/partner_1/capabilities")
+    })
+
+    it("update_partner_onboarding_profile dry_run previews the plan", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "update_partner_onboarding_profile",
+        { id: "partner_1", does_weaving: true, dry_run: true }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.dry_run).toBe(true)
+      expect(res.plan?.method).toBe("PUT")
+      expect(res.plan?.path).toBe("/admin/partners/partner_1/onboarding-profile")
+      expect((res.plan?.body as any)?.does_weaving).toBe(true)
+    })
+
+    it("delete_partner_capability substitutes both id and sampleId path params", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "delete_partner_capability",
+        { id: "partner_1", sampleId: "pcap_1", dry_run: true }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.plan?.path).toBe(
+        "/admin/partners/partner_1/capabilities/pcap_1"
+      )
+    })
+
+    it("list_partner_capabilities forwards technique and material as query params", async () => {
+      const def = ADMIN_MCP_TOOLS.find(
+        (t) => t.name === "list_partner_capabilities"
+      )!
+      expect(def.queryParams).toEqual([
+        "technique",
+        "material",
+        "limit",
+        "offset",
+      ])
+    })
+  })
+
   describe("orders ops (#1165): fulfillment, shipping and order edits", () => {
     it("registers the order read companions", () => {
       const reads = [

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -43,6 +43,35 @@ describe("admin-mcp per-ask tool slicing", () => {
       ).toBe("partners")
     })
 
+    it("classifies the capability + onboarding-profile tools as partners", () => {
+      const domainOf = (name: string) =>
+        toolDomain(ADMIN_MCP_TOOLS.find((t) => t.name === name)!)
+      expect(domainOf("list_partner_capabilities")).toBe("partners")
+      expect(domainOf("create_partner_capability")).toBe("partners")
+      expect(domainOf("delete_partner_capability")).toBe("partners")
+      expect(domainOf("get_partner_onboarding_profile")).toBe("partners")
+      expect(domainOf("update_partner_onboarding_profile")).toBe("partners")
+    })
+
+    it("loads the capability + onboarding tools for a partners ask", () => {
+      // "record this kani twill capability" names no partner-domain noun the
+      // keyword list knew before "capability" was added — without the word,
+      // the ask lights no slice and the tools never load.
+      const slice = selectAdminToolSlice(
+        "record this kani twill capability for the loom partner",
+        ADMIN_MCP_TOOLS
+      )
+      expect(slice.names).toContain("create_partner_capability")
+      expect(slice.names).toContain("list_partner_capabilities")
+
+      const onboarding = selectAdminToolSlice(
+        "file the onboarding questionnaire answers he gave on the call",
+        ADMIN_MCP_TOOLS
+      )
+      expect(onboarding.names).toContain("update_partner_onboarding_profile")
+      expect(onboarding.names).toContain("get_partner_onboarding_profile")
+    })
+
     it("resolves the longest matching prefix, not the first", () => {
       // /admin/production-run-policy must not be swallowed by a shorter prefix,
       // and /admin/mcp/usage must land on observability rather than core.

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -2156,6 +2156,141 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
     sideEffects: "Marks the partner admin's email verified so they can log in without clicking the email link.",
   },
+
+  // ---- Capability library + onboarding questionnaire: the admin half of the
+  // partner surfaces (#1531 / #648). Until these existed, "what can this
+  // partner make" and "how far did onboarding get" were questions the admin
+  // assistant could not touch — the capability library and the questionnaire
+  // were reachable only behind partner auth, so an operator onboarding a
+  // partner over WhatsApp had no way to file what was said.
+  {
+    name: "list_partner_capabilities",
+    description:
+      "List a partner's capability samples — photographs of things they have actually made, with the technique and material beside each. Read this BEFORE asking a partner for a new photograph: they have usually already shown you the thing they are being asked about. Filter by technique or material to answer 'who can do kani in pashmina' style questions for THIS partner. Each row carries captured_at — when the work was actually on the loom, NOT when it was recorded — and the source (partner wizard/WhatsApp vs an admin typing it up).",
+    method: "GET",
+    path: "/admin/partners/:id/capabilities",
+    pathParams: ["id"],
+    queryParams: ["technique", "material", "limit", "offset"],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        technique: STR("Filter by technique, e.g. 'kani twill'."),
+        material: STR("Filter by material, e.g. 'pashmina'."),
+        limit: { type: "integer", description: "Max results (default 20, max 100)." },
+        offset: { type: "integer", description: "Pagination offset." },
+      },
+      ["id"]
+    ),
+    nextSteps: ["create_partner_capability", "delete_partner_capability"],
+  },
+  {
+    name: "create_partner_capability",
+    description:
+      "Record a capability sample for a partner: a photograph of something they have made, with the textile facts beside it (technique, material, notes). Use when a partner shows work in a conversation and you are filing it as evidence — the sample OUTLIVES the conversation and is what future 'can they make this' searches run against. The photograph must be UPLOADED FIRST — pass the resulting media ids as media_file_ids, this tool cannot receive a file. 🔑 ASK when the photo was taken and pass it as captured_at: a photo typed up three weeks later describes a capability that may already be gone, and when it is omitted the route defaults it to now and says so in captured_at_defaulted. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/partners/:id/capabilities",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["title", "technique", "material", "media_file_ids", "notes", "captured_at"],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        title: STR("What this is, in the partner's own words (required), e.g. 'kani twill, off-white'."),
+        technique: STR("The weaving technique, e.g. 'kani twill'."),
+        material: STR("The material, e.g. 'pashmina'."),
+        media_file_ids: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Ids of already-uploaded photographs. 🔴 There is no way to pass a file through this tool. Without ids the sample is a title with no evidence, which is exactly what the library exists to stop.",
+        },
+        notes: STR("Free-form notes about this sample."),
+        captured_at: STR("ISO date the photograph was TAKEN (ask, do not default silently)."),
+      },
+      ["id", "title"]
+    ),
+    sideEffects:
+      "Adds a permanent sample to the partner's library, stamped source='admin'. Does NOT attach itself to anything; it is searchable by technique and material from then on.",
+    nextSteps: ["list_partner_capabilities"],
+  },
+  {
+    name: "delete_partner_capability",
+    description:
+      "Delete a capability sample from a partner's library — a wrong or obsolete entry. Sensitive (every DELETE is): requires confirm:true. Use list_partner_capabilities first to find the sample id. The sample must belong to the named partner; another partner's id is a 404, not a deletion. The uploaded photographs are NOT deleted.",
+    method: "DELETE",
+    path: "/admin/partners/:id/capabilities/:sampleId",
+    pathParams: ["id", "sampleId"],
+    previewPath: "/admin/partners/:id/capabilities",
+    write: true,
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        sampleId: STR("Capability sample id, e.g. 'pcap_...'. Get it from list_partner_capabilities."),
+      },
+      ["id", "sampleId"]
+    ),
+    sideEffects: "Removes the sample row. The uploaded photographs survive — other samples may reference them.",
+    nextSteps: ["list_partner_capabilities"],
+  },
+  {
+    name: "get_partner_onboarding_profile",
+    description:
+      "Read a partner's onboarding questionnaire (what they sell, price range, person type, team size, payment/selling mode, commission, supplier capability, completion flag). Returns null when the partner has not started the wizard — a partner with no profile is an ordinary state, not an error. Use to see how far onboarding has progressed and what is still missing.",
+    method: "GET",
+    path: "/admin/partners/:id/onboarding-profile",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
+    nextSteps: ["update_partner_onboarding_profile"],
+  },
+  {
+    name: "update_partner_onboarding_profile",
+    description:
+      "Upsert a partner's onboarding questionnaire — file answers the partner gave outside the wizard (a call, WhatsApp) rather than making them complete it themselves. Only supplied fields are written, so you can record one answer at a time. Use dry_run to see the current answers first. Sensitive: requires confirm:true.",
+    method: "PUT",
+    path: "/admin/partners/:id/onboarding-profile",
+    pathParams: ["id"],
+    previewPath: "/admin/partners/:id/onboarding-profile",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "what_they_sell",
+      "price_range",
+      "has_inventory_info",
+      "does_stock",
+      "does_weaving",
+      "person_type",
+      "team_size",
+      "payment_collection",
+      "selling_mode",
+      "commission_bps",
+      "supplies_to_platform",
+      "completed",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        what_they_sell: STR("'apparel' | 'home_textiles' | 'fabric' | 'yarn' | 'accessories' | 'other'."),
+        price_range: STR("'economy' | 'mid' | 'premium' | 'luxury'."),
+        has_inventory_info: BOOL("Whether they can share inventory info."),
+        does_stock: BOOL("Whether they hold stock themselves."),
+        does_weaving: BOOL("Whether they do weaving in-house."),
+        person_type: STR("'individual' | 'business' | 'manufacturer' | 'wholesaler' | 'retailer' | 'artisan' | 'other'."),
+        team_size: INT("How many people work in their team (0–100000)."),
+        payment_collection: STR("'through_us' (JYT collects customer payments) | 'themselves'."),
+        selling_mode: STR("'dedicated_storefront' | 'core_channel_listing' (listing on the core channel at an agreed commission)."),
+        commission_bps: INT(
+          "Agreed commission in basis points (1000 = 10.00%, max 10000). This is the per-partner BILLING override — what the platform keeps on this partner's sales. Set it deliberately, never incidentally."
+        ),
+        supplies_to_platform: BOOL("Whether the platform places production/inventory orders WITH this partner (a supplier) — orthogonal to selling_mode."),
+        completed: BOOL("Mark the questionnaire complete."),
+      },
+      ["id"]
+    ),
+    sideEffects:
+      "Creates the profile on first save, updates it thereafter. commission_bps overrides the platform default fee rate for this partner.",
+    nextSteps: ["get_partner_onboarding_profile"],
+  },
   {
     name: "get_partner_product_proposal",
     description:

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -205,6 +205,10 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "maker", "makers", "artisan", "artisans", "weaver", "weavers", "vendor",
     "vendors", "onboard", "onboarding", "whatsapp", "subscription", "plan",
     "commission", "fee", "fees", "admin user", "verify", "verification",
+    // The capability library — "what can this partner actually make" is the
+    // ask the samples exist to answer, and it need not contain the word
+    // "partner" at all ("record this kani twill capability").
+    "capability", "capabilities",
     // People onboarding from an identity document (#1787 follow-on). "id card"
     // and "aadhaar" are what an operator actually types; without them the ask
     // "add this weaver from her aadhaar" matches only on "weaver".

--- a/apps/backend/src/api/admin/partners/[id]/capabilities/[sampleId]/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/capabilities/[sampleId]/route.ts
@@ -1,0 +1,46 @@
+/**
+ * @route DELETE /admin/partners/:id/capabilities/:sampleId
+ * @scope admin
+ *
+ * Remove a wrong or obsolete entry from a partner's capability library.
+ *
+ * 🔴 The workflow looks the sample up THROUGH the partner: filtered by both
+ * id and partner_id, so a sample id that belongs to another partner 404s
+ * rather than deleting their evidence. The uploaded photographs are NOT
+ * deleted — other samples may reference them, and the media module owns their
+ * lifecycle.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { deletePartnerCapabilityWorkflow } from "../../../../../../workflows/partner/delete-partner-capability"
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId, sampleId } = req.params
+
+  const { result, errors } = await deletePartnerCapabilityWorkflow(
+    req.scope
+  ).run({
+    input: {
+      partner_id: partnerId,
+      sample_id: sampleId,
+    },
+  })
+
+  if (errors?.length) {
+    throw (
+      errors[0].error ||
+      new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "Failed to delete capability sample"
+      )
+    )
+  }
+
+  return res.json({
+    id: result.id,
+    partner_id: partnerId,
+    object: "partner_capability_sample",
+    deleted: true,
+  })
+}

--- a/apps/backend/src/api/admin/partners/[id]/capabilities/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/capabilities/route.ts
@@ -1,0 +1,93 @@
+/**
+ * @file Admin read/write for a partner's capability library (#1531).
+ * @description The partner's photographs of what they have actually made,
+ *   with the textile facts beside them — surfaced for an operator so the
+ *   admin assistant can answer "what can this partner produce" and file
+ *   evidence from a conversation, without waiting for the partner to run
+ *   the wizard themselves.
+ * @module API/Admin/Partners/Capabilities
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { listPartnerCapabilitiesWorkflow } from "../../../../../workflows/partner/list-partner-capabilities"
+import { createPartnerCapabilityWorkflow } from "../../../../../workflows/partner/create-partner-capability"
+import type {
+  AdminListPartnerCapabilitiesQuery,
+  AdminCreatePartnerCapabilityReq,
+} from "./validators"
+
+/**
+ * GET /admin/partners/:id/capabilities
+ *
+ * Mirrors GET /partners/capabilities, with the partner named in the URL rather
+ * than derived from the auth context. Returns the library newest-first by
+ * captured_at, filterable by technique and material.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+  const validated = ((req as any).validatedQuery || req.query ||
+    {}) as AdminListPartnerCapabilitiesQuery
+
+  const { result } = await listPartnerCapabilitiesWorkflow(req.scope).run({
+    input: {
+      partner_id: partnerId,
+      technique: validated.technique,
+      material: validated.material,
+      limit: validated.limit,
+      offset: validated.offset,
+    },
+  })
+
+  return res.json({ samples: result.samples, count: result.count })
+}
+
+/**
+ * POST /admin/partners/:id/capabilities — file a sample on the partner's behalf.
+ *
+ * Same shape as POST /partners/capabilities with two deliberate differences:
+ * `partner_id` comes from the URL rather than the auth context, and the
+ * workflow stamps `source: "admin"` — someone typing up a conversation, which
+ * the model distinguishes from the partner's own structured answer.
+ *
+ * 🔑 `captured_at` defaults to now and SAYS SO in the response, for the same
+ * reason as the partner route: silence would make every back-filled row look
+ * fresh, and the library is only worth searching if it admits how stale it is.
+ */
+export const POST = async (
+  req: MedusaRequest<AdminCreatePartnerCapabilityReq>,
+  res: MedusaResponse
+) => {
+  const { id: partnerId } = req.params
+  const body = ((req as any).validatedBody ||
+    req.body) as AdminCreatePartnerCapabilityReq
+
+  const { result, errors } = await createPartnerCapabilityWorkflow(
+    req.scope
+  ).run({
+    input: {
+      partner_id: partnerId,
+      title: body.title,
+      technique: body.technique ?? null,
+      material: body.material ?? null,
+      media_file_ids: body.media_file_ids,
+      notes: body.notes ?? null,
+      captured_at: body.captured_at ?? null,
+    },
+  })
+
+  if (errors?.length) {
+    throw (
+      errors[0].error ||
+      new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "Failed to create capability sample"
+      )
+    )
+  }
+
+  return res.status(201).json({
+    sample: result.sample,
+    captured_at_defaulted: !body.captured_at,
+  })
+}

--- a/apps/backend/src/api/admin/partners/[id]/capabilities/validators.ts
+++ b/apps/backend/src/api/admin/partners/[id]/capabilities/validators.ts
@@ -1,0 +1,40 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * The admin half of the capability library (#1531): photographs of what a
+ * partner has actually made, filed by an operator.
+ *
+ * Mirrors the partner-portal schemas (`PartnerListCapabilitySamplesQuery` /
+ * `PartnerPostCapabilitySampleReq` in src/api/partners/inquiries/validators.ts)
+ * field-for-field. `partner_id` appears in NONE of these schemas deliberately —
+ * it is taken from the URL, never the body, so the sample lands on the partner
+ * the path names and nowhere else.
+ */
+
+export const AdminListPartnerCapabilitiesQuery = z.object({
+  technique: z.string().optional(),
+  material: z.string().optional(),
+  limit: z.coerce.number().int().positive().max(100).optional(),
+  offset: z.coerce.number().int().nonnegative().optional(),
+})
+export type AdminListPartnerCapabilitiesQuery = z.infer<
+  typeof AdminListPartnerCapabilitiesQuery
+>
+
+/**
+ * `captured_at` is optional but NOT defaulted to now in the schema: the route
+ * defaults it and SAYS SO in the response. A photo typed up three weeks after
+ * it was taken describes a capability that may already be gone, and the
+ * library is only trustworthy if it says how stale each row is.
+ */
+export const AdminCreatePartnerCapabilityReq = z.object({
+  title: z.string().min(1),
+  technique: z.string().optional().nullable(),
+  material: z.string().optional().nullable(),
+  media_file_ids: z.array(z.string().min(1)).optional(),
+  notes: z.string().optional().nullable(),
+  captured_at: z.coerce.date().optional().nullable(),
+})
+export type AdminCreatePartnerCapabilityReq = z.infer<
+  typeof AdminCreatePartnerCapabilityReq
+>

--- a/apps/backend/src/api/admin/partners/[id]/onboarding-profile/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/onboarding-profile/route.ts
@@ -1,13 +1,17 @@
 /**
- * @file Admin read-proxy: a partner's onboarding questionnaire (#843).
- * @description The onboarding profile (#648) is captured at registration but
- *   has never had an admin-side read surface — it was write-only from the
- *   platform's point of view. This exposes it for inspection.
+ * @file Admin surface for a partner's onboarding questionnaire (#843, #648).
+ * @description The onboarding profile is captured at registration by the
+ *   partner's own wizard; this exposes it to an operator — read it, and file
+ *   answers the partner gave over a call or WhatsApp rather than in the
+ *   wizard, through the same upsert semantics the wizard itself uses.
  * @module API/Admin/Partners/OnboardingProfile
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
 import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../../../modules/partner-onboarding-profile"
+import { upsertPartnerOnboardingProfileWorkflow } from "../../../../../workflows/partner/upsert-partner-onboarding-profile"
 import { assertPartnerExists } from "../lib/partner-inspection"
+import type { OnboardingProfileUpdateInput } from "../../../../../api/partners/onboarding-profile/validators"
 
 /**
  * GET /admin/partners/:id/onboarding-profile
@@ -15,8 +19,6 @@ import { assertPartnerExists } from "../lib/partner-inspection"
  * Mirrors `GET /partners/onboarding-profile`. Returns `null` when the partner
  * has not started the wizard — a partner with no profile is an ordinary state
  * (and, for the console, a useful signal), not a 404.
- *
- * READ-ONLY: the partner owns their own answers; admin does not edit them here.
  */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id: partnerId } = req.params
@@ -27,4 +29,40 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const profile = await service.findByPartner(partnerId)
 
   return res.status(200).json({ onboarding_profile: profile ?? null })
+}
+
+/**
+ * PUT /admin/partners/:id/onboarding-profile
+ *
+ * Upserts the partner's questionnaire, filed by an operator. The partner-side
+ * wizard owns the answers in the ordinary flow; this exists for the cases the
+ * wizard cannot reach — the partner answered over WhatsApp or a call, and the
+ * operator is filing what was said. Same partial-progress semantics as the
+ * partner route: only the supplied fields are written, so an operator can
+ * record one answer at a time.
+ */
+export const PUT = async (
+  req: MedusaRequest<OnboardingProfileUpdateInput>,
+  res: MedusaResponse
+) => {
+  const { id: partnerId } = req.params
+  const data = ((req as any).validatedBody || {}) as OnboardingProfileUpdateInput
+
+  const { result, errors } = await upsertPartnerOnboardingProfileWorkflow(
+    req.scope
+  ).run({
+    input: { partner_id: partnerId, data },
+  })
+
+  if (errors?.length) {
+    throw (
+      errors[0].error ||
+      new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "Failed to save onboarding profile"
+      )
+    )
+  }
+
+  return res.status(200).json({ onboarding_profile: result.profile })
 }

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -299,6 +299,10 @@ import { AdminPostDesignTaskAssignReq } from "./admin/designs/[id]/tasks/[taskId
 import { AdminPostPartnerTaskAssignReq } from "./admin/partners/[id]/tasks/[taskId]/assign/validators";
 import { AdminCreatePartnerTaskReq, AdminUpdatePartnerTaskReq } from "./admin/partners/[id]/tasks/validators";
 import {
+  AdminListPartnerCapabilitiesQuery,
+  AdminCreatePartnerCapabilityReq,
+} from "./admin/partners/[id]/capabilities/validators";
+import {
   ListPaymentsByPartnerQuerySchema as PartnerListPaymentsByPartnerQuerySchema,
   ListPaymentMethodsByPartnerQuerySchema as PartnerListPaymentMethodsByPartnerQuerySchema,
   CreatePaymentMethodForPartnerSchema as PartnerCreatePaymentMethodForPartnerSchema,
@@ -4664,6 +4668,37 @@ export default defineMiddlewares({
     {
       matcher: "/admin/partners/:id/bypass-email-verification",
       method: "POST",
+    },
+    // Admin Partner Capabilities (#1531) — the partner's capability library,
+    // surfaced for an operator. POST is validated; DELETE carries no body.
+    {
+      matcher: "/admin/partners/:id/capabilities",
+      method: "GET",
+      middlewares: [
+        validateAndTransformQuery(wrapSchema(AdminListPartnerCapabilitiesQuery), {}),
+      ],
+    },
+    {
+      matcher: "/admin/partners/:id/capabilities",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(AdminCreatePartnerCapabilityReq)),
+      ],
+    },
+    {
+      matcher: "/admin/partners/:id/capabilities/:sampleId",
+      method: "DELETE",
+    },
+    // Admin Partner Onboarding Profile — the upsert behind the admin-assistant
+    // filing of questionnaire answers a partner gave outside the wizard. Same
+    // schema the partner's own PUT registers, so the two surfaces cannot
+    // disagree about what an answer looks like.
+    {
+      matcher: "/admin/partners/:id/onboarding-profile",
+      method: "PUT",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(onboardingProfileUpdateSchema)),
+      ],
     },
     {
       matcher: "/admin/persons/partner",

--- a/apps/backend/src/workflows/partner/capability-media.ts
+++ b/apps/backend/src/workflows/partner/capability-media.ts
@@ -1,0 +1,27 @@
+/**
+ * Attach renderable `media` to capability-sample rows.
+ *
+ * The row stores `media_file` ids, and an id is not a URL: nothing turning one
+ * into the other on the read path is how the partner surface shipped a
+ * write-only library (see `resolveMediaFiles` in src/api/partners/media-urls.ts,
+ * which exists for exactly that failure).
+ *
+ * Shared by the list and create capability workflows so both return the SAME
+ * shape — two shapes for one row is how a `media` key ends up read as
+ * `media_files` on one screen and silently renders nothing.
+ */
+import { resolveMediaFiles } from "../../api/partners/media-urls"
+
+export const attachCapabilityMedia = async (
+  container: any,
+  samples: any[]
+): Promise<any[]> =>
+  Promise.all(
+    samples.map(async (s) => ({
+      ...s,
+      media: await resolveMediaFiles(
+        container,
+        Array.isArray(s?.media_file_ids) ? s.media_file_ids : []
+      ),
+    }))
+  )

--- a/apps/backend/src/workflows/partner/create-partner-capability.ts
+++ b/apps/backend/src/workflows/partner/create-partner-capability.ts
@@ -1,0 +1,76 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PARTNER_CAPABILITY_MODULE } from "../../modules/partner_capability"
+import { attachCapabilityMedia } from "./capability-media"
+import { assertPartnerExistsStep } from "./steps/assert-partner-exists"
+
+export type CreatePartnerCapabilityWorkflowInput = {
+  /**
+   * The partner whose library this lands in. Always the caller's to name —
+   * never from a body the end user could point at a competitor.
+   */
+  partner_id: string
+  title: string
+  technique?: string | null
+  material?: string | null
+  /** media_file ids — the photograph itself must be uploaded beforehand. */
+  media_file_ids?: string[] | null
+  notes?: string | null
+  /**
+   * When the photographed work was actually on the loom. NOT created_at: a
+   * photo typed up three weeks later describes a capability that may already
+   * be gone, and the library is only trustworthy if it says how stale it is.
+   * The route defaults this to now and SAYS SO in the response.
+   */
+  captured_at?: Date | null
+}
+
+const createPartnerCapabilityStep = createStep(
+  "create-partner-capability-step",
+  async (input: CreatePartnerCapabilityWorkflowInput, { container }) => {
+    const service: any = container.resolve(PARTNER_CAPABILITY_MODULE)
+
+    const sample = await service.createPartnerCapabilitySamples({
+      partner_id: input.partner_id,
+      title: input.title,
+      technique: input.technique ?? null,
+      material: input.material ?? null,
+      media_file_ids: input.media_file_ids?.length ? input.media_file_ids : null,
+      notes: input.notes ?? null,
+      // The model distinguishes an operator typing up a conversation from the
+      // partner's own structured answer — `source` is the evidence trail.
+      source: "admin",
+      captured_at: input.captured_at ?? new Date(),
+    } as any)
+
+    // Attached here so a caller rendering from the create result and one
+    // rendering from the listing see the SAME shape.
+    const [withMedia] = await attachCapabilityMedia(container, [sample])
+
+    return new StepResponse(
+      { sample: withMedia ?? sample },
+      { sample_id: sample.id }
+    )
+  },
+  async (comp: { sample_id: string } | undefined, { container }) => {
+    if (!comp) return
+    const service: any = container.resolve(PARTNER_CAPABILITY_MODULE)
+    await service.deletePartnerCapabilitySamples(comp.sample_id)
+  }
+)
+
+export const createPartnerCapabilityWorkflow = createWorkflow(
+  "create-partner-capability",
+  (input: CreatePartnerCapabilityWorkflowInput) => {
+    assertPartnerExistsStep({ partner_id: input.partner_id })
+    const result = createPartnerCapabilityStep(input)
+    return new WorkflowResponse(result)
+  }
+)
+
+export default createPartnerCapabilityWorkflow

--- a/apps/backend/src/workflows/partner/delete-partner-capability.ts
+++ b/apps/backend/src/workflows/partner/delete-partner-capability.ts
@@ -1,0 +1,72 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_CAPABILITY_MODULE } from "../../modules/partner_capability"
+import { assertPartnerExistsStep } from "./steps/assert-partner-exists"
+
+export type DeletePartnerCapabilityWorkflowInput = {
+  partner_id: string
+  sample_id: string
+}
+
+const deletePartnerCapabilityStep = createStep(
+  "delete-partner-capability-step",
+  async (input: DeletePartnerCapabilityWorkflowInput, { container }) => {
+    const service: any = container.resolve(PARTNER_CAPABILITY_MODULE)
+
+    /**
+     * 🔴 The sample is looked up THROUGH the partner: filtered by both id and
+     * partner_id, so a sample id that belongs to another partner 404s rather
+     * than deleting their evidence — the same tenant guard the credit-apply
+     * route uses.
+     */
+    const rows = await service.listPartnerCapabilitySamples({
+      id: input.sample_id,
+      partner_id: input.partner_id,
+    } as any)
+
+    const sample = rows?.[0]
+    if (!sample) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `capability sample ${input.sample_id} does not belong to partner ${input.partner_id}`
+      )
+    }
+
+    await service.deletePartnerCapabilitySamples(input.sample_id)
+
+    return new StepResponse(
+      { id: input.sample_id, deleted: true },
+      // Compensation: restore the row as it was, photographs included. The
+      // uploaded media files are never touched — other samples may reference
+      // them, and the media module owns their lifecycle.
+      { sample: { ...sample } as Record<string, unknown> }
+    )
+  },
+  async (
+    comp: { sample: Record<string, unknown> } | undefined,
+    { container }
+  ) => {
+    if (!comp?.sample) return
+    const service: any = container.resolve(PARTNER_CAPABILITY_MODULE)
+    // Recreated with its original id, so links held by other rows (e.g.
+    // design-inquiry answers) survive the round trip.
+    await service.createPartnerCapabilitySamples(comp.sample as any)
+  }
+)
+
+export const deletePartnerCapabilityWorkflow = createWorkflow(
+  "delete-partner-capability",
+  (input: DeletePartnerCapabilityWorkflowInput) => {
+    assertPartnerExistsStep({ partner_id: input.partner_id })
+    const result = deletePartnerCapabilityStep(input)
+    return new WorkflowResponse(result)
+  }
+)
+
+export default deletePartnerCapabilityWorkflow

--- a/apps/backend/src/workflows/partner/list-partner-capabilities.ts
+++ b/apps/backend/src/workflows/partner/list-partner-capabilities.ts
@@ -1,0 +1,62 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PARTNER_CAPABILITY_MODULE } from "../../modules/partner_capability"
+import { attachCapabilityMedia } from "./capability-media"
+import { assertPartnerExistsStep } from "./steps/assert-partner-exists"
+
+export type ListPartnerCapabilitiesWorkflowInput = {
+  partner_id: string
+  technique?: string
+  material?: string
+  limit?: number
+  offset?: number
+}
+
+/** A ceiling on one partner's library page, not pagination. */
+const MAX_CAPABILITY_PAGE = 100
+
+/**
+ * One partner's capability library, newest-first by captured_at — NOT
+ * created_at: the row is evidence about a loom at a moment in time, and its
+ * order should say when the work was made, not when it was typed up.
+ */
+const listPartnerCapabilitiesStep = createStep(
+  "list-partner-capabilities-step",
+  async (input: ListPartnerCapabilitiesWorkflowInput, { container }) => {
+    const service: any = container.resolve(PARTNER_CAPABILITY_MODULE)
+
+    const filters: Record<string, unknown> = { partner_id: input.partner_id }
+    if (input.technique) filters.technique = input.technique
+    if (input.material) filters.material = input.material
+
+    const [samples, count] = await service.listAndCountPartnerCapabilitySamples(
+      filters as any,
+      {
+        order: { captured_at: "DESC" },
+        take: Math.min(Number(input.limit ?? 20), MAX_CAPABILITY_PAGE),
+        skip: Number(input.offset ?? 0),
+      }
+    )
+
+    return new StepResponse({
+      samples: await attachCapabilityMedia(container, samples ?? []),
+      count,
+    })
+  }
+)
+
+export const listPartnerCapabilitiesWorkflow = createWorkflow(
+  "list-partner-capabilities",
+  (input: ListPartnerCapabilitiesWorkflowInput) => {
+    assertPartnerExistsStep({ partner_id: input.partner_id })
+    const result = listPartnerCapabilitiesStep(input)
+    return new WorkflowResponse(result)
+  }
+)
+
+export default listPartnerCapabilitiesWorkflow

--- a/apps/backend/src/workflows/partner/steps/assert-partner-exists.ts
+++ b/apps/backend/src/workflows/partner/steps/assert-partner-exists.ts
@@ -1,0 +1,36 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { RemoteQueryFunction } from "@medusajs/types"
+
+/**
+ * 404 for an unknown partner, thrown from inside the workflow so every caller
+ * inherits it.
+ *
+ * An admin naming a partner that does not exist is a typo. Without this check
+ * a write creates a row nobody can reach and a read answers an empty result
+ * that reads as "this partner has nothing" — both worse than a clean 404,
+ * which is what the sibling admin partner routes throw.
+ */
+export const assertPartnerExistsStep = createStep(
+  "assert-partner-exists-step",
+  async (input: { partner_id: string }, { container }) => {
+    const query = container.resolve(
+      ContainerRegistrationKeys.QUERY
+    ) as Omit<RemoteQueryFunction, symbol>
+
+    const { data } = await query.graph({
+      entity: "partner",
+      fields: ["id", "name"],
+      filters: { id: input.partner_id },
+    })
+
+    if (!data?.length) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+    }
+
+    return new StepResponse(data[0])
+  }
+)

--- a/apps/backend/src/workflows/partner/upsert-partner-onboarding-profile.ts
+++ b/apps/backend/src/workflows/partner/upsert-partner-onboarding-profile.ts
@@ -1,0 +1,82 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../modules/partner-onboarding-profile"
+import type { OnboardingProfileUpdateInput } from "../../api/partners/onboarding-profile/validators"
+import { assertPartnerExistsStep } from "./steps/assert-partner-exists"
+
+export type UpsertPartnerOnboardingProfileWorkflowInput = {
+  partner_id: string
+  /**
+   * Only the supplied fields are written, so a caller can file one answer at
+   * a time — same partial-progress semantics as the partner's own wizard.
+   */
+  data: OnboardingProfileUpdateInput
+}
+
+const upsertPartnerOnboardingProfileStep = createStep(
+  "upsert-partner-onboarding-profile-step",
+  async (
+    input: UpsertPartnerOnboardingProfileWorkflowInput,
+    { container }
+  ) => {
+    const service: any = container.resolve(PARTNER_ONBOARDING_PROFILE_MODULE)
+
+    const existing = await service.findByPartner(input.partner_id)
+
+    let profile
+    if (existing) {
+      profile = await service.updatePartnerOnboardingProfiles({
+        id: existing.id,
+        ...input.data,
+      })
+    } else {
+      profile = await service.createPartnerOnboardingProfiles({
+        partner_id: input.partner_id,
+        ...input.data,
+      })
+    }
+
+    return new StepResponse(
+      { profile },
+      // Compensation: restore what was there before — the prior row, or none.
+      { previous: existing ?? null, partner_id: input.partner_id }
+    )
+  },
+  async (
+    comp: {
+      previous: Record<string, unknown> | null
+      partner_id: string
+    } | undefined,
+    { container }
+  ) => {
+    if (!comp) return
+    const service: any = container.resolve(PARTNER_ONBOARDING_PROFILE_MODULE)
+
+    if (comp.previous) {
+      // A partial update that is rolled back must not leave the new answers
+      // standing — restore the prior values on the same row.
+      const { id, ...prev } = comp.previous
+      await service.updatePartnerOnboardingProfiles({ id, ...prev })
+    } else {
+      // There was no profile before this run — remove the row we created.
+      const created = await service.findByPartner(comp.partner_id)
+      if (created) await service.deletePartnerOnboardingProfiles(created.id)
+    }
+  }
+)
+
+export const upsertPartnerOnboardingProfileWorkflow = createWorkflow(
+  "upsert-partner-onboarding-profile",
+  (input: UpsertPartnerOnboardingProfileWorkflowInput) => {
+    assertPartnerExistsStep({ partner_id: input.partner_id })
+    const result = upsertPartnerOnboardingProfileStep(input)
+    return new WorkflowResponse(result)
+  }
+)
+
+export default upsertPartnerOnboardingProfileWorkflow


### PR DESCRIPTION
## What

Closes the two gaps that made partner onboarding a two-surface chore: the **capability library** and the **onboarding questionnaire** were reachable only behind partner auth, so the admin assistant could create a partner, assign its subscription and connect WhatsApp — but could not file what the partner actually makes or record the answers given in conversation.

## Changes

**MCP registry (5 tools)** — `apps/backend/src/api/admin/mcp/lib/registry.ts`
| Tool | Route | Rails |
|---|---|---|
| `list_partner_capabilities` | GET `/admin/partners/:id/capabilities` | read |
| `create_partner_capability` | POST `/admin/partners/:id/capabilities` | sensitive (confirm) |
| `delete_partner_capability` | DELETE `/admin/partners/:id/capabilities/:sampleId` | DELETE-confirm |
| `get_partner_onboarding_profile` | GET `/admin/partners/:id/onboarding-profile` | read |
| `update_partner_onboarding_profile` | PUT `/admin/partners/:id/onboarding-profile` | sensitive (confirm) + previewPath for dry-run |

**Workflows own every service call** — routes are thin (validate → workflow → respond):
- `list/create/delete-partner-capability`, `upsert-partner-onboarding-profile`
- Shared `assert-partner-exists` step so every workflow 404s cleanly on an unknown partner
- Create compensates by deleting; delete compensates by recreating with the original id; upsert compensates by restoring prior state
- `source: "admin"` stamped on operator-filed samples (the evidence trail the model defines)
- Delete is **tenant-guarded**: a sample id is looked up through the partner, so another partner's id is a 404, never a deletion

**One schema, two surfaces** — the admin onboarding PUT registers the partner wizard's own zod schema (`onboardingProfileUpdateSchema`), so the surfaces cannot disagree about what an answer looks like. Same partial-progress semantics: only supplied fields are written.

**Slice vocabulary** — `capability`/`capabilities` added to the partners domain keywords, so "record this kani twill capability" lights the partners slice even when it never says "partner".

## Behavior notes
- `captured_at` defaults to now and the response says so (`captured_at_defaulted`) — the library is only trustworthy if it admits staleness
- `partner_id` never accepted in a body; the URL owns attribution (strict validator makes it a 400)
- Media ids resolved to URLs on every read (`media: []` at worst), so the library can't ship write-only

## Tests
- **301 unit assertions** across all 15 MCP suites pass — including mechanical route-validator field coverage (registry rows vs the actual zod each route registers), tool tiers, scope invariants, and the new dispatch/slice tests
- **18 API integration tests** (`admin-partner-capabilities-onboarding.spec.ts`): CRUD + tenant guard + 404/401 contracts, merge-not-replace upsert, commercial fields round-trip
- **3 new MCP end-to-end tests** in `admin-mcp-partner-ops.spec.ts` (confirm gating, read-back, tools/list exposure)

```
PASS admin-partner-capabilities-onboarding.spec.ts   18 passed
PASS admin-mcp/admin-mcp-partner-ops.spec.ts          10 passed
MCP unit suites                                       301 passed
```

Pre-existing untracked files (`sdk-spy.ts`, `scripts/search/*`, session notes) and the `storefront-starter` submodule change were left out of this PR.