### PR TITLE
fix(designs,production-runs): the spine the run already carries, and a variant that can be told apart (#1872, #1874)

### DIFF
--- a/apps/backend/src/workflows/designs/__tests__/create-product-from-design.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/create-product-from-design.unit.spec.ts
@@ -1,4 +1,4 @@
-import { resolveListedPrice } from "../create-product-from-design"
+import { designOptionValue, resolveListedPrice } from "../create-product-from-design"
 
 /**
  * The price a design is listed at. Medusa 2.x amounts are DECIMAL major units —
@@ -48,5 +48,35 @@ describe("resolveListedPrice", () => {
     expect(
       resolveListedPrice({ estimated_cost: 10, unit_price: Number("nope") })
     ).toBe(0)
+  })
+})
+
+describe("designOptionValue — #1874", () => {
+  it("claims the design's own name, so two designs on one product differ", () => {
+    const a = designOptionValue({ id: "des_a", name: "Kalamkari Stole" }, ["Custom"])
+    const b = designOptionValue({ id: "des_b", name: "Ajrakh Stole" }, ["Custom", a])
+    expect(a).toBe("Kalamkari Stole")
+    expect(b).toBe("Ajrakh Stole")
+    // The whole point: the tuple Medusa resolves a variant by is now distinct.
+    expect(a).not.toBe(b)
+  })
+
+  it("never returns a value the product already carries", () => {
+    // Two designs sharing a name would otherwise collide exactly as "Custom" did.
+    const first = designOptionValue({ id: "des_aaa111", name: "Stole" }, [])
+    const second = designOptionValue({ id: "des_bbb222", name: "Stole" }, [first])
+    expect(first).toBe("Stole")
+    expect(second).toBe("Stole (bbb222)")
+    expect(second).not.toBe(first)
+  })
+
+  it("falls back to the id when a design has no usable name", () => {
+    expect(designOptionValue({ id: "des_x", name: "" })).toBe("Design des_x")
+    expect(designOptionValue({ id: "des_x", name: "   " })).toBe("Design des_x")
+    expect(designOptionValue({ id: "des_x", name: null })).toBe("Design des_x")
+  })
+
+  it("does not reuse the legacy literal that caused the collision", () => {
+    expect(designOptionValue({ id: "des_a", name: "Kalamkari" }, ["Custom"])).not.toBe("Custom")
   })
 })

--- a/apps/backend/src/workflows/designs/create-product-from-design.ts
+++ b/apps/backend/src/workflows/designs/create-product-from-design.ts
@@ -87,6 +87,31 @@ type CreateProductFromDesignOutput = {
 };
 
 /**
+ * PURE: the option value an appended variant claims on the product it joins.
+ *
+ * 🔴 #1874. Every appended variant used to claim the literal `"Custom"` on every
+ * option. A design-created product carries one option, `Type`, whose only value
+ * is `Custom` — so the second design appended to a product produced an option
+ * tuple IDENTICAL to the first. Titles differed, SKUs differed by a millisecond,
+ * and the tuple Medusa actually resolves a variant by did not.
+ *
+ * The design's own name is the natural value: it is already what the variant
+ * title carries, and it is what a human picking from a dropdown would expect to
+ * see. Two designs sharing a name fall back to a short id suffix rather than
+ * colliding — rare, and better than silently producing a duplicate.
+ *
+ * Exported for tests.
+ */
+export const designOptionValue = (
+  design: { id: string; name?: string | null },
+  existingValues: readonly string[] = []
+): string => {
+  const base = String(design.name ?? "").trim() || `Design ${design.id}`
+  if (!existingValues.includes(base)) return base
+  return `${base} (${String(design.id).slice(-6)})`
+}
+
+/**
  * PURE: the amount written to `variant.prices[].amount`. Exported for tests.
  *
  * Medusa 2.x prices are DECIMAL major units — the seed lists a €10 shirt as
@@ -178,34 +203,37 @@ const createProductAndVariantStep = createStep(
       const variantOptions: Record<string, string> = {};
 
       if (productOptions.length > 0) {
-        // For each existing option, add "Custom" as a new value if it doesn't exist
+        // Each option gains a value that identifies THIS design, so a product can
+        // accumulate one variant per design without two of them claiming the same
+        // tuple (#1874).
         for (const option of productOptions) {
           const existingValues = option.values?.map((v: any) => v.value) || [];
+          const value = designOptionValue(design, existingValues);
 
-          // Add "Custom" value if it doesn't exist
-          if (!existingValues.includes("Custom")) {
+          if (!existingValues.includes(value)) {
             await productService.upsertProductOptions([
               {
                 id: option.id,
                 product_id: product_id,
                 title: option.title,
-                values: [...existingValues, "Custom"],
+                values: [...existingValues, value],
               },
             ]);
           }
 
-          variantOptions[option.title] = "Custom";
+          variantOptions[option.title] = value;
         }
       } else {
         // If product has no options, create a default one
+        const value = designOptionValue(design);
         await productService.upsertProductOptions([
           {
             product_id: product_id,
             title: "Type",
-            values: ["Custom"],
+            values: [value],
           },
         ]);
-        variantOptions["Type"] = "Custom";
+        variantOptions["Type"] = value;
       }
 
       const variantData = {

--- a/apps/backend/src/workflows/production-runs/complete-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/complete-production-run.ts
@@ -529,6 +529,9 @@ export const completeProductionRunWorkflow = createWorkflow(
           production_run_id: data.input.production_run_id,
           design_id: r.design_id,
           partner_id: data.input.partner_id,
+          // #1872 — the run's own variant, when it has one. Falls back to the
+          // design lookup inside the step.
+          variant_id: r.variant_id ?? null,
           good_quantity: goodQty,
           location_id: data.partnerLocation.location_id,
           order_id: r.order_id || null,

--- a/apps/backend/src/workflows/production-runs/partner-run-steps.ts
+++ b/apps/backend/src/workflows/production-runs/partner-run-steps.ts
@@ -314,6 +314,18 @@ export type StockFinishedGoodsInput = {
   order_id: string | null
   order_line_item_id: string | null
   run_quantity: number
+  /**
+   * #1872 — the run's OWN variant, when it has one.
+   *
+   * `production_runs` has carried `variant_id` and `product_id` since it was
+   * written, and nothing ever read them: this step re-derived the target from
+   * `design_product_variant[0]` instead. A design with two variants would
+   * therefore bank every customer's goods onto whichever variant came back
+   * first. Prod has no such design today (#1871), which is why this has never
+   * bitten — but #1874 is what makes a design able to accumulate variants, so
+   * the two land together.
+   */
+  variant_id?: string | null
 }
 
 type StockRollbackData = {
@@ -332,14 +344,37 @@ export const stockFinishedGoodsStep = createStep(
     const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
     const inventoryService = container.resolve(Modules.INVENTORY) as any
 
-    // Resolve design → variant → inventory item
-    const { data: designVariants } = await query.graph({
-      entity: "design_product_variant",
-      filters: { design_id: input.design_id },
-      fields: ["product_variant_id"],
+    /**
+     * A run with children is an AGGREGATE, not work (#1877). Its
+     * `produced_quantity` is the rollup of children that each bank their own
+     * output, so stocking it would count the same goods twice. The cascade in
+     * `complete-production-run` completes a parent by a direct service update
+     * and never runs this workflow for it — this guard is what makes that
+     * property explicit rather than incidental, for anyone who completes a
+     * parent directly.
+     */
+    const { data: children } = await query.graph({
+      entity: "production_runs",
+      filters: { parent_run_id: input.production_run_id },
+      fields: ["id"],
     })
+    if (children?.length) {
+      return new StepResponse({ stocked: false }, null as StockRollbackData)
+    }
 
-    const variantId = designVariants?.[0]?.product_variant_id
+    // The run's own variant wins; the design lookup is the fallback for the runs
+    // that predate it (16 of 131 carry the column today).
+    let variantId: string | undefined = input.variant_id ?? undefined
+
+    if (!variantId) {
+      const { data: designVariants } = await query.graph({
+        entity: "design_product_variant",
+        filters: { design_id: input.design_id },
+        fields: ["product_variant_id"],
+      })
+      variantId = designVariants?.[0]?.product_variant_id
+    }
+
     if (!variantId) {
       return new StepResponse({ stocked: false }, null as StockRollbackData)
     }


### PR DESCRIPTION
Closes #1872. Closes #1874. Part of #1871.

Two changes that land together, because the first is what makes the second's defect reachable.

## #1874 — an appended variant claimed `"Custom"` on every option

When a design's product already exists, `create-product-from-design` appends a variant and forced **every** product option to the literal `"Custom"`. A design-created product carries one option, `Type`, whose only value is `Custom` — so the second design appended to a product produced an option tuple **identical** to the first. Titles differed, SKUs differed by a millisecond, and the tuple Medusa actually resolves a variant by did not.

`designOptionValue` claims the design's own name instead — already what the variant title carries. Two designs sharing a name fall back to a short id suffix rather than colliding.

This is the flow behind *"a second design that resembles the first"*: `POST /admin/products/:id/linkDesign`, then approve, and the product accumulates a variant per design. **It worked exactly once before this.**

## #1872 — the stocking step ignored the run's own variant

`production_runs` has carried `variant_id` and `product_id` since it was written and **nothing ever read them**. `stockFinishedGoodsStep` re-derived the target from `design_product_variant[0]`, so a design with two variants would bank every customer's goods onto whichever came back first.

It now prefers `run.variant_id` and falls back to the design lookup for runs that predate it (16 of 131 carry the column). No migration; no behaviour change on existing data.

## Why together

Measured on prod before writing this: **0 designs have more than one variant**, so #1872 has never bitten. #1874 is precisely what changes that. Shipping #1874 alone would activate a latent collision.

## Plus the guard from #1877

A run with children is an **aggregate**, not work — its `produced_quantity` is a rollup of children that each bank their own output. The cascade completes a parent by a direct service update and never runs this workflow for it, so this has never fired; the guard makes that property explicit rather than incidental. **49 of 131 runs are parents**, so the shape is common even where the path is not.

## Tests

- 4 new for `designOptionValue`, **red-checked** by restoring the literal → 4 fail
- designs + production-runs unit suites: **357/357**
- `tsc --noEmit`: clean for the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4