### PR TITLE
fix(production-runs): a rollup is a heading over jobs, not a job to pay for (#1877)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/refresh-stale-draft-payouts-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/refresh-stale-draft-payouts-job.ts
@@ -1,5 +1,6 @@
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 import { assessRunPayout } from "../../../../workflows/production-runs/lib/run-payable"
+import { hydrateRunKind } from "../../../../workflows/production-runs/lib/run-kind"
 import {
   assessDraftLine,
   summarizeDraftSweep,
@@ -141,7 +142,9 @@ export const refreshStaleDraftPayoutsJob: MaintenanceJob = {
         if (!payoutCache.has(runId)) {
           try {
             const run = await runService.retrieveProductionRun(runId)
-            const payout = assessRunPayout(run)
+            // #1877 — the rollup guard needs a fetched child count; see
+            // `run-kind.ts`.
+            const payout = assessRunPayout(await hydrateRunKind(container, run))
             /**
              * 🔑 Narrowed on `eligible`, because the ineligible branch of
              * `PayoutEligibility` carries only a `reason` — it has no money

--- a/apps/backend/src/workflows/payment_submissions/__tests__/auto-draft-rollup-guard.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/auto-draft-rollup-guard.unit.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * #1877 — the rollup guard in `assessRunPayout` reads `child_run_count`, which
+ * is FETCHED rather than stored. A call site that forgets to hydrate gets no
+ * guard at all, and it types perfectly. This is the test that says the call
+ * site actually asks.
+ */
+const runMock = jest.fn()
+jest.mock("../create-payment-submission", () => ({
+  createPaymentSubmissionWorkflow: jest.fn(() => ({ run: runMock })),
+}))
+
+import { autoDraftRunPayout } from "../lib/auto-draft-run-payout"
+
+const PARENT = {
+  id: "run_parent",
+  status: "completed",
+  design_id: "des_1",
+  partner_id: "part_1",
+  // The SUM of its children's quantities — what would have been billed.
+  quantity: 10,
+  partner_cost_estimate: 850,
+  cost_type: "per_unit" as const,
+}
+
+const buildContainer = (run: any, children: any[]) => {
+  const listProductionRuns = jest.fn().mockResolvedValue(children)
+  const productionRuns = {
+    retrieveProductionRun: jest.fn().mockResolvedValue(run),
+    listProductionRuns,
+  }
+  const paymentSubmissions = {
+    listPaymentSubmissionItems: jest.fn().mockResolvedValue([]),
+  }
+  return {
+    listProductionRuns,
+    container: {
+      resolve: jest.fn((key: string) => {
+        if (key === "production_runs") return productionRuns
+        if (key === "logger") return { info: jest.fn(), error: jest.fn() }
+        return paymentSubmissions
+      }),
+    } as any,
+  }
+}
+
+describe("autoDraftRunPayout — a rollup is never drafted", () => {
+  beforeEach(() => {
+    runMock.mockReset()
+    runMock.mockResolvedValue({ result: { submission: { id: "psub_1" } } })
+  })
+
+  it("asks whether the run has children before judging it", async () => {
+    const { container, listProductionRuns } = buildContainer(PARENT, [
+      { id: "c1" },
+      { id: "c2" },
+    ])
+
+    await autoDraftRunPayout(container, "run_parent")
+
+    // Asserted on mock.calls AFTER the call — an expect() inside a mock body
+    // can be swallowed by a catch.
+    expect(listProductionRuns).toHaveBeenCalled()
+    expect(listProductionRuns.mock.calls[0][0]).toEqual({
+      parent_run_id: "run_parent",
+    })
+  })
+
+  it("refuses with the aggregate reason and creates NOTHING", async () => {
+    const { container } = buildContainer(PARENT, [{ id: "c1" }, { id: "c2" }])
+
+    const out = await autoDraftRunPayout(container, "run_parent")
+
+    expect(out.drafted).toBe(false)
+    expect(out.reason).toBe("aggregate_run")
+    // The money half: no submission was raised for the summed quantity.
+    expect(runMock).not.toHaveBeenCalled()
+  })
+
+  it("still drafts for an ordinary run with no children", async () => {
+    const { container } = buildContainer({ ...PARENT, id: "run_solo" }, [])
+
+    const out = await autoDraftRunPayout(container, "run_solo")
+
+    expect(out.reason).toBe("drafted")
+    expect(out.drafted).toBe(true)
+    expect(runMock).toHaveBeenCalledTimes(1)
+    // 10 units at 850 — the guard must not have changed what an ordinary run pays.
+    const input = runMock.mock.calls[0][0].input
+    expect(input.quantities).toEqual({ des_1: 10 })
+    expect(input.unit_amounts).toEqual({ des_1: 850 })
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/auto-draft-run-payout.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/auto-draft-run-payout.ts
@@ -3,6 +3,7 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../modules/payment_submissions"
 import { assessRunPayout } from "../../production-runs/lib/run-payable"
+import { hydrateRunKind } from "../../production-runs/lib/run-kind"
 import { createPaymentSubmissionWorkflow } from "../create-payment-submission"
 
 /**
@@ -88,6 +89,11 @@ export const autoDraftRunPayout = async (
   } catch {
     return { drafted: false, reason: "run_not_found", source }
   }
+
+  // #1877 — `assessRunPayout` refuses a ROLLUP, but only if it is told the run
+  // has children. `child_run_count` is fetched, not stored; without this the
+  // guard is dead code that types perfectly.
+  run = await hydrateRunKind(container, run)
 
   const payout = assessRunPayout(run)
   if (!payout.eligible) {

--- a/apps/backend/src/workflows/payment_submissions/lib/refresh-draft-payouts.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/refresh-draft-payouts.ts
@@ -1,5 +1,6 @@
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../modules/payment_submissions"
 import { assessRunPayout } from "../../production-runs/lib/run-payable"
+import { hydrateRunKind } from "../../production-runs/lib/run-kind"
 
 /**
  * Re-price the unclaimed DRAFT payouts that were pre-filled from a run, after
@@ -51,7 +52,9 @@ export const refreshUnclaimedDraftPayouts = async (
   const runService: any = scope.resolve("production_runs")
   const run = await runService.retrieveProductionRun(runId)
 
-  const payout = assessRunPayout(run)
+  // #1877 — see `run-kind.ts`: the rollup guard reads a count that has to be
+  // fetched, so a caller that skips this gets no guard at all.
+  const payout = assessRunPayout(await hydrateRunKind(scope, run))
   if (!payout.eligible) {
     // No payable figure any more (rate cleared, run reopened). Leaving the
     // Draft alone is safer than zeroing it: a zero payout reads as a decision

--- a/apps/backend/src/workflows/production-runs/__tests__/run-kind.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/run-kind.unit.spec.ts
@@ -1,0 +1,149 @@
+import {
+  countChildRuns,
+  describeRunKind,
+  hydrateRunKind,
+  isAggregateRun,
+  isStageRun,
+} from "../lib/run-kind"
+import { assessRunPayout } from "../lib/run-payable"
+
+/**
+ * #1877 — `production_runs` holds work, rollups and stages in one table.
+ * These are the three readings that were previously left to every caller.
+ */
+describe("run kind predicates", () => {
+  it("calls a plain run work", () => {
+    expect(describeRunKind({ id: "r1" })).toBe("work")
+    expect(isStageRun({ id: "r1" })).toBe(false)
+    expect(isAggregateRun({ id: "r1" })).toBe(false)
+  })
+
+  it("calls a run with a parent a stage — real work, not an aggregate", () => {
+    const stage = { id: "r2", parent_run_id: "r1", role: "Cutting" }
+    expect(describeRunKind(stage)).toBe("stage")
+    expect(isStageRun(stage)).toBe(true)
+    expect(isAggregateRun(stage)).toBe(false)
+  })
+
+  it("calls a run with children a rollup", () => {
+    const parent = { id: "r1", child_run_count: 3 }
+    expect(describeRunKind(parent)).toBe("rollup")
+    expect(isAggregateRun(parent)).toBe(true)
+  })
+
+  it("calls a run that is BOTH a child and a parent a rollup — depth-agnostic", () => {
+    expect(
+      describeRunKind({ id: "r2", parent_run_id: "r1", child_run_count: 2 })
+    ).toBe("rollup")
+  })
+
+  it("treats an UNASKED child count as not-an-aggregate, never as zero children", () => {
+    // undefined means nobody looked. The answer is the pre-#1877 behaviour,
+    // not a claim that the run has no children.
+    expect(isAggregateRun({ id: "r1" })).toBe(false)
+    expect(isAggregateRun({ id: "r1", child_run_count: null })).toBe(false)
+    expect(isAggregateRun({ id: "r1", child_run_count: 0 })).toBe(false)
+  })
+
+  it("ignores a blank parent_run_id rather than reading '' as a parent", () => {
+    expect(isStageRun({ id: "r1", parent_run_id: "" })).toBe(false)
+    expect(isStageRun({ id: "r1", parent_run_id: "   " })).toBe(false)
+  })
+})
+
+describe("countChildRuns / hydrateRunKind", () => {
+  const scopeWith = (children: any[], listMock?: jest.Mock) => {
+    const list = listMock ?? jest.fn().mockResolvedValue(children)
+    return {
+      scope: { resolve: jest.fn().mockReturnValue({ listProductionRuns: list }) },
+      list,
+    }
+  }
+
+  it("asks for the runs that name this one as parent", async () => {
+    const { scope, list } = scopeWith([{ id: "c1" }, { id: "c2" }])
+    expect(await countChildRuns(scope, "r1")).toBe(2)
+    expect(list.mock.calls[0][0]).toEqual({ parent_run_id: "r1" })
+  })
+
+  it("does not query at all for a missing id", async () => {
+    const { scope, list } = scopeWith([])
+    expect(await countChildRuns(scope, null)).toBe(0)
+    expect(list).not.toHaveBeenCalled()
+  })
+
+  it("fills child_run_count in without disturbing the run", async () => {
+    const { scope } = scopeWith([{ id: "c1" }])
+    const run = { id: "r1", status: "completed", quantity: 9 }
+    expect(await hydrateRunKind(scope, run)).toEqual({
+      ...run,
+      child_run_count: 1,
+    })
+  })
+
+  it("leaves the count UNASKED when the query fails — a failure is not evidence of zero", async () => {
+    const list = jest.fn().mockRejectedValue(new Error("db down"))
+    const { scope } = scopeWith([], list)
+    const run = { id: "r1" }
+    const out: any = await hydrateRunKind(scope, run)
+    expect(out.child_run_count).toBeUndefined()
+    expect(isAggregateRun(out)).toBe(false)
+  })
+})
+
+/**
+ * The payout half of #1877. A rollup carries the SUMMED quantity of its
+ * children, and every child is payable in its own right — so billing the
+ * parent pays the partner for the sum AND for each part of it.
+ */
+describe("assessRunPayout — the rollup guard", () => {
+  const parent = {
+    id: "run_parent",
+    status: "completed",
+    design_id: "des_1",
+    partner_id: "part_1",
+    // The summed quantity of its children — this is what would be billed.
+    quantity: 10,
+    partner_cost_estimate: 850,
+    cost_type: "per_unit" as const,
+  }
+
+  it("refuses a completed, fully-priced rollup", () => {
+    expect(assessRunPayout({ ...parent, child_run_count: 2 })).toEqual({
+      eligible: false,
+      reason: "aggregate_run",
+    })
+  })
+
+  it("still pays each STAGE — a child is real work", () => {
+    const stage = {
+      ...parent,
+      id: "run_child",
+      parent_run_id: "run_parent",
+      role: "Cutting",
+      quantity: 4,
+      child_run_count: 0,
+    }
+    const payout = assessRunPayout(stage)
+    expect(payout.eligible).toBe(true)
+    expect((payout as any).amount).toBe(3400)
+  })
+
+  it("refuses the rollup BEFORE the no-cost check, so the reason survives someone filling the cost in", () => {
+    // Today every parent is refused as `no_cost` purely by accident: nothing
+    // sets a cost on one. The reason must not depend on that accident.
+    expect(
+      assessRunPayout({
+        ...parent,
+        partner_cost_estimate: null,
+        child_run_count: 2,
+      })
+    ).toEqual({ eligible: false, reason: "aggregate_run" })
+  })
+
+  it("is unchanged for an ordinary run whose child count was fetched as zero", () => {
+    const payout = assessRunPayout({ ...parent, child_run_count: 0 })
+    expect(payout.eligible).toBe(true)
+    expect((payout as any).amount).toBe(8500)
+  })
+})

--- a/apps/backend/src/workflows/production-runs/lib/run-kind.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-kind.ts
@@ -1,0 +1,108 @@
+/**
+ * Which KIND of row a `production_run` is (#1877).
+ *
+ * `production_runs` holds at least three different things, and nothing in the
+ * schema says which is which:
+ *
+ *   · **work**   — a real job someone did. `parent_run_id` null, no children.
+ *   · **rollup** — an aggregate over children. Its `quantity` and
+ *                  `produced_quantity` are the SUM of the children's, so it is
+ *                  not a job at all; it is a heading over jobs.
+ *   · **stage**  — one step of making a batch. `parent_run_id` set, `role`
+ *                  naming the step (Cutting, Block Printing, Tailoring,
+ *                  Sampling, manufacturer). Real work, really payable.
+ *
+ * The distinction is carried implicitly by `parent_run_id`, and every reader is
+ * left to know it. The ones that do not are wrong in a way that types
+ * perfectly: a rollup passes every status/design/partner gate a real run does,
+ * and its quantity is a number like any other. Three separate defects have been
+ * the same mistake made by three different readers.
+ *
+ * ## Which helper to use
+ *
+ * 🔑 If you already hold the whole SET of a design's runs, do NOT use this —
+ * use `leafProductionRuns` in `src/admin/lib/production-run-totals.ts`, which
+ * settles the same question from the set alone (#498) and needs no query.
+ * These helpers exist for the readers that hold ONE run and cannot see its
+ * siblings: they must ask the database whether anything calls it parent.
+ */
+
+export type RunKindLike = {
+  id?: string | null
+  parent_run_id?: string | null
+  role?: string | null
+  /**
+   * How many runs name this one as their parent.
+   *
+   * ⚠️ NOT a column — it is fetched. `undefined` therefore means UNASKED, not
+   * zero, and `isAggregateRun` answers false for it, which is exactly the
+   * pre-#1877 behaviour. A guard reading a field its caller never populated is
+   * dead code that types perfectly (the same trap `RunForPayout.metadata`
+   * carries a warning about), so anything relying on the answer must call
+   * `hydrateRunKind` first.
+   */
+  child_run_count?: number | null
+}
+
+/** One step of a batch — real work, and really payable. */
+export const isStageRun = (run: RunKindLike | null | undefined): boolean =>
+  Boolean(String(run?.parent_run_id ?? "").trim())
+
+/**
+ * A heading over other runs, not a job.
+ *
+ * False when the count was never fetched — see the warning on
+ * `child_run_count`.
+ */
+export const isAggregateRun = (run: RunKindLike | null | undefined): boolean =>
+  Number(run?.child_run_count ?? 0) > 0
+
+export type RunKind = "work" | "rollup" | "stage"
+
+/**
+ * A rollup is a rollup even when it also has a parent: what makes it uncountable
+ * is that something else sums up to it, and that is true at any depth.
+ */
+export const describeRunKind = (run: RunKindLike | null | undefined): RunKind =>
+  isAggregateRun(run) ? "rollup" : isStageRun(run) ? "stage" : "work"
+
+/**
+ * How many runs name `runId` as their parent.
+ *
+ * Cheap by construction — an id-only listing against the indexed column, asked
+ * once per run the caller is about to judge.
+ */
+export const countChildRuns = async (
+  scope: any,
+  runId: string | null | undefined
+): Promise<number> => {
+  const id = String(runId ?? "").trim()
+  if (!id) return 0
+
+  const service: any = scope.resolve("production_runs")
+  const children = await service.listProductionRuns(
+    { parent_run_id: id },
+    { select: ["id"] }
+  )
+  return Array.isArray(children) ? children.length : 0
+}
+
+/**
+ * The run, with `child_run_count` filled in — what `isAggregateRun` needs to
+ * answer anything at all.
+ *
+ * Best-effort: a failed count leaves the field UNASKED rather than asserting
+ * zero, because zero is a claim ("this is ordinary work") and a failed query is
+ * not evidence for it.
+ */
+export const hydrateRunKind = async <T extends RunKindLike>(
+  scope: any,
+  run: T | null | undefined
+): Promise<T | null | undefined> => {
+  if (!run) return run
+  try {
+    return { ...run, child_run_count: await countChildRuns(scope, run.id) }
+  } catch {
+    return run
+  }
+}

--- a/apps/backend/src/workflows/production-runs/lib/run-payable.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-payable.ts
@@ -12,6 +12,7 @@
 // a partner's output figure therefore does NOT move the money — deliberately.
 
 import { isProvenanceRun } from "../../consumption-logs/lib/reconcile-production-consumption"
+import { isAggregateRun } from "./run-kind"
 
 export type RunForPayout = {
   id?: string
@@ -27,6 +28,15 @@ export type RunForPayout = {
    * never asked for is dead code that types perfectly.
    */
   metadata?: Record<string, any> | null
+  /**
+   * #1877 — how many runs name this one as their parent. A run with children is
+   * a ROLLUP: its `quantity` is the sum of theirs, and they are each payable in
+   * their own right.
+   *
+   * ⚠️ Not a column. `hydrateRunKind` fills it in, and a caller that forgets
+   * gets the pre-#1877 answer rather than a wrong one — see `run-kind.ts`.
+   */
+  child_run_count?: number | null
 }
 
 /**
@@ -307,6 +317,29 @@ export const assessRunPayout = (
    */
   if (isProvenanceRun(run)) {
     return { eligible: false, reason: "provenance_run" }
+  }
+
+  /**
+   * A ROLLUP is a heading over other runs, not a job (#1877). Its `quantity` is
+   * the SUM of its children's, and each of those children is payable in its own
+   * right — so billing the parent too pays the partner for the sum AND for
+   * every part of it.
+   *
+   * Measured on prod (#1871) and again on the local database while writing
+   * this (398 runs, 22 parents, 0 of them priced): no parent carries a
+   * `partner_cost_estimate` at any status, so this has never fired. That is the whole problem — the only
+   * thing standing between the platform and a double payout was an ABSENCE.
+   * One admin typing a cost into a parent's drawer, or any path that propagates
+   * costs down a bundle, removes it. `runPayableAmount` would then bill the
+   * summed quantity on top of the children that already billed their share.
+   *
+   * ⚠️ Ordered BEFORE the `no_cost` check deliberately: a parent that acquires
+   * a cost must be refused for being a parent, not incidentally for having no
+   * money on it. The reason a caller logs should survive the day someone fills
+   * that field in.
+   */
+  if (isAggregateRun(run)) {
+    return { eligible: false, reason: "aggregate_run" }
   }
 
   const amount = runPayableAmount(run)


### PR DESCRIPTION
Closes #1877. Part of #1871. Follows #1881, which closed the stocking half.

## The defect

`assessRunPayout` bills the ordered `run.quantity` with **no parent/child awareness**. A completed rollup passes every gate — status, `design_id` (inherited from its first child), `partner_id`, not a provenance run — and its quantity is the **sum** of children that are each payable in their own right.

The only thing standing between the platform and paying a partner for the sum **and** for every part of it is that nothing sets a cost on a parent. That is a guard by absence: one admin typing into a parent's cost drawer removes it.

## The change

**`workflows/production-runs/lib/run-kind.ts`** — `isStageRun` / `isAggregateRun` / `describeRunKind`, plus `hydrateRunKind` to fetch the child count a single-run reader cannot see. It names an existing distinction rather than adding a concept, and points readers who hold a whole **set** at `leafProductionRuns` (#498), which already settles the same question with no query.

**`assessRunPayout`** refuses a rollup with `reason: "aggregate_run"`, ordered **before** the no-cost check — a parent that acquires a cost must be refused for *being a parent*, not incidentally for having no money on it.

**All three payout call sites hydrate**: the completion auto-draft, the re-price-on-correction path, and the stale-draft maintenance job. A guard reading a field its caller never fetched is dead code that types perfectly — the warning `RunForPayout.metadata` already carries — so a call-site test asserts the fetch actually happens.

A **stage** stays payable. It is real work; only the heading over it is not.

## Measured

Prod (#1871) and the local database while writing this — 398 runs, 22 parents, **0 of them priced**: no parent carries a `partner_cost_estimate` at any status. This fires on nothing today, which is exactly why it is cheap now and a data mystery later.

## Tests

- **17 new**, red-checked **twice**: neutralising the guard fails exactly the 2 payout tests (predicates and the stage case stay green); removing the hydration from the auto-draft call site fails exactly the 2 that watch for it.
- production-runs + payment_submissions + admin/lib: **560/560 across 46 suites**.
- `check:prod-build`: **passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4