### PR TITLE
fix(admin): create_partner 500s — derive the handle and validate duplicates before the first insert

### DIFF
--- a/apps/backend/integration-tests/http/admin-partners-api.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partners-api.spec.ts
@@ -67,6 +67,85 @@ setupSharedTestSuite(({ api, getContainer }) => {
       expect(res.data.partner_admin.email).toBe(payload.admin.email)
     })
 
+    test("POST /admin/partners without a handle derives partner_<name-slug>", async () => {
+      // The MCP tool has always advertised "auto-derived if omitted"; until the
+      // prod 500s of 2026-09-07 nothing derived it — the workflow passed
+      // undefined to MikroORM's required column and the route answered 500.
+      const unique = Date.now()
+      const payload = {
+        partner: {
+          name: `JP Handloom ${unique}`,
+          // no handle on purpose
+        },
+        admin: {
+          email: `partner-nohandle-${unique}@jyt.test`,
+          first_name: "Admin",
+          last_name: "User",
+        },
+      }
+
+      const res = await api.post("/admin/partners", payload, adminHeaders)
+
+      expect(res.status).toBe(201)
+      expect(res.data.partner.handle).toBe(`partner_jp-handloom-${unique}`)
+    })
+
+    test("POST /admin/partners with a duplicate admin email returns 422, not a 500", async () => {
+      const unique = Date.now()
+      const email = `partner-dupe-email-${unique}@jyt.test`
+
+      const first = {
+        partner: { name: `First ${unique}`, handle: `dupe-email-first-${unique}` },
+        admin: { email, first_name: "First", last_name: "Admin" },
+      }
+      const ok = await api.post("/admin/partners", first, adminHeaders)
+      expect(ok.status).toBe(201)
+
+      // Same email, different partner: the unique column on partner_admin is
+      // a validation question and must be answered before the first insert.
+      const second = {
+        partner: {
+          name: `Second ${unique}`,
+          handle: `dupe-email-second-${unique}`,
+        },
+        admin: { email, first_name: "Second", last_name: "Admin" },
+      }
+      const err = await api
+        .post("/admin/partners", second, adminHeaders)
+        .catch((e: any) => e)
+
+      expect(err.response.status).toBe(422)
+      expect(err.response.data?.message).toBe(
+        `A partner admin with email "${email}" already exists. Please use a different email.`
+      )
+    })
+
+    test("POST /admin/partners with an explicit taken handle returns the duplicate message", async () => {
+      const unique = Date.now()
+      const handle = `explicit-taken-${unique}`
+      const first = {
+        partner: { name: `Taken ${unique}`, handle },
+        admin: { email: `taken-first-${unique}@jyt.test`, first_name: "A", last_name: "B" },
+      }
+      const ok = await api.post("/admin/partners", first, adminHeaders)
+      expect(ok.status).toBe(201)
+
+      // No handle on the second — it derives partner_taken-<unique>, which is
+      // free; so instead assert the EXPLICIT path: same handle again.
+      const second = {
+        partner: { name: `Taken Again ${unique}`, handle },
+        admin: { email: `taken-second-${unique}@jyt.test`, first_name: "A", last_name: "B" },
+      }
+      const err = await api
+        .post("/admin/partners", second, adminHeaders)
+        .catch((e: any) => e)
+
+      expect(err.response.status).toBe(422)
+      expect(err.response.data?.message).toBe(
+        `A partner with handle "${handle}" already exists. Please use a unique handle.`
+      )
+    })
+
     test("POST /admin/partners with duplicate handle returns 422", async () => {
       const unique = Date.now()
       const baseHandle = `acme-admin-dupe-${unique}`

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1907,7 +1907,9 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
           description: "Partner data: { name (required), handle, logo, status, is_verified, workspace_type }.",
           properties: {
             name: STR("Partner name (required)."),
-            handle: STR("Unique handle (auto-derived if omitted)."),
+            handle: STR(
+              "Unique handle. Omitted/blank derives one as partner_<name-slug> (suffixed -2, -3, … if taken); an explicit handle that already exists is a 422."
+            ),
             logo: STR("Logo URL."),
             status: STR("'active' | 'inactive' | 'pending' (defaults to 'pending')."),
             is_verified: { type: "boolean", description: "Verification flag (defaults to false)." },

--- a/apps/backend/src/workflows/partner/__tests__/create-partner-admin.unit.spec.ts
+++ b/apps/backend/src/workflows/partner/__tests__/create-partner-admin.unit.spec.ts
@@ -1,0 +1,70 @@
+import { derivePartnerHandle, slugifyPartnerName } from "../create-partner-admin"
+
+/**
+ * Handle derivation — the behaviour the MCP tool has always advertised and,
+ * until the 500s of 2026-09-07, never had. `partner.handle` is a required,
+ * unique column; these tests pin what "auto-derived" actually means now that
+ * something derives it: `partner_` + the name slug, per the operator's call.
+ */
+describe("slugifyPartnerName", () => {
+  it("lowercases and dash-joins a normal name", () => {
+    expect(slugifyPartnerName("JP Handloom")).toBe("jp-handloom")
+  })
+
+  it("collapses runs of non-alphanumerics into one dash", () => {
+    expect(slugifyPartnerName("JP  Handloom ---  Exporter!!")).toBe(
+      "jp-handloom-exporter"
+    )
+  })
+
+  it("folds accents so an Indian-English name keeps its letters", () => {
+    expect(slugifyPartnerName("Chennamangalam Sāri")).toBe("chennamangalam-sari")
+  })
+
+  it("trims leading and trailing dashes", () => {
+    expect(slugifyPartnerName("-- Kani Weavers --")).toBe("kani-weavers")
+  })
+
+  it("caps the slug at 48 characters without a trailing dash", () => {
+    const slug = slugifyPartnerName(
+      "jp handloom Manufacturer and Exporter of Sustainable Indian Textile and Accessories"
+    )
+    expect(slug.length).toBeLessThanOrEqual(48)
+    expect(slug).not.toMatch(/-$/)
+    expect(slug).toBe(
+      "jp-handloom-manufacturer-and-exporter-of-sustain"
+    )
+  })
+
+  it("yields an empty string for a name with nothing slug-able", () => {
+    expect(slugifyPartnerName("---")).toBe("")
+    expect(slugifyPartnerName("")).toBe("")
+  })
+
+  it("survives an undefined-ish name without throwing", () => {
+    expect(slugifyPartnerName(undefined as unknown as string)).toBe("")
+  })
+})
+
+describe("derivePartnerHandle", () => {
+  it("prefixes the name slug with partner_", () => {
+    expect(derivePartnerHandle("JP Handloom")).toBe("partner_jp-handloom")
+  })
+
+  it("falls back to a timestamp suffix when the name has no slug-able characters", () => {
+    // The undefined that used to reach the database becomes a handle that is
+    // merely ugly — never a 500.
+    const handle = derivePartnerHandle("---")
+    expect(handle).toMatch(/^partner_[a-z0-9]+$/)
+    expect(handle).not.toBe("partner_")
+  })
+
+  it("caps long names so the handle stays a handle, not a sentence", () => {
+    const handle = derivePartnerHandle(
+      "jp handloom Manufacturer and Exporter of Sustainable Indian Textile and Accessories"
+    )
+    expect(handle.startsWith("partner_jp-handloom")).toBe(true)
+    expect(handle.length).toBeLessThanOrEqual(48 + "partner_".length)
+    expect(handle).not.toMatch(/-$/)
+  })
+})

--- a/apps/backend/src/workflows/partner/create-partner-admin.ts
+++ b/apps/backend/src/workflows/partner/create-partner-admin.ts
@@ -2,6 +2,7 @@ import {
     createStep,
     createWorkflow,
     StepResponse,
+    transform,
     WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { 
@@ -34,6 +35,113 @@ export type CreatePartnerAdminWorkflowInput = {
 }
 
 import Scrypt from "scrypt-kdf"
+
+// ---- Handle derivation + pre-DB validation ---------------------------------
+//
+// `partner.handle` is a REQUIRED, UNIQUE column, and until now nothing on
+// either create path derived it — the MCP tool advertised "auto-derived if
+// omitted" while the workflow passed `undefined` straight to MikroORM, which
+// answered `ValidationError: Value for Partner.handle is required` → 500
+// (seen on prod, 2026-09-07: three 500s while the assistant created the JP
+// Handloom partner). A dry-run rehearsed fine because it never touches the DB,
+// which is exactly why the gap survived.
+//
+// The same story for `partner_admin.email`: unique column, no pre-write check,
+// raw constraint error → 500. Both are validation questions and both belong
+// BEFORE the first insert, not inside it.
+
+/** Cap on the name-derived part of the handle. */
+const HANDLE_SLUG_MAX = 48
+
+/**
+ * Slugify a partner name: lowercase, accents folded, runs of non-alphanumerics
+ * collapsed to single dashes, dashes trimmed. Pure on purpose — unit-tested.
+ */
+export const slugifyPartnerName = (name: string): string =>
+    (name ?? "")
+        .toLowerCase()
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, HANDLE_SLUG_MAX)
+        .replace(/-+$/g, "")
+
+/**
+ * The handle a partner gets when nobody supplied one: `partner_` + the name
+ * slug. A name with no slug-able characters ("株式会社" transliterates to
+ * nothing here) still yields a handle — a timestamp fallback rather than the
+ * undefined that used to reach the database.
+ */
+export const derivePartnerHandle = (name: string): string => {
+    const slug = slugifyPartnerName(name)
+    return `partner_${slug || Date.now().toString(36)}`
+}
+
+/**
+ * Resolve handle + admin email BEFORE any write.
+ *
+ * - an EXPLICIT handle is kept as-is (trimmed), but checked for uniqueness so
+ *   the caller gets the same 422 the route always aimed at, instead of the
+ *   raw unique-constraint 500 a race would otherwise surface
+ * - an omitted/blank handle is derived from the name (`partner_<name-slug>`),
+ *   suffixed -2, -3, … until free
+ * - the admin email is checked against partner_admins for the same reason:
+ *   the unique column is a validation question, not a post-insert surprise
+ */
+const resolvePartnerIdentityStep = createStep(
+    "resolve-partner-handle-and-validate-admin",
+    async (
+        input: { name: string; handle?: string; admin_email: string },
+        { container }
+    ) => {
+        const partnerService: PartnerService = container.resolve(PARTNER_MODULE)
+
+        let handle: string
+        const explicit = (input.handle ?? "").trim()
+
+        if (explicit) {
+            const taken = await partnerService.listPartners({ handle: explicit })
+            if (taken?.length) {
+                throw new MedusaError(
+                    MedusaError.Types.DUPLICATE_ERROR,
+                    `A partner with handle "${explicit}" already exists. Please use a unique handle.`
+                )
+            }
+            handle = explicit
+        } else {
+            const base = derivePartnerHandle(input.name)
+            handle = base
+            for (let i = 2; i < 52; i++) {
+                const taken = await partnerService.listPartners({ handle })
+                if (!taken?.length) break
+                handle = `${base}-${i}`
+            }
+            // Everything from -2 to -51 taken: same name created 50 times.
+            // Fall through with a unique-enough suffix rather than failing.
+            if ((await partnerService.listPartners({ handle })).length) {
+                handle = `${base}-${Date.now().toString(36)}`
+            }
+        }
+
+        const email = (input.admin_email ?? "").trim()
+        if (!email) {
+            throw new MedusaError(
+                MedusaError.Types.INVALID_DATA,
+                "Admin email is required."
+            )
+        }
+        const existingAdmin = await partnerService.listPartnerAdmins({ email })
+        if (existingAdmin?.length) {
+            throw new MedusaError(
+                MedusaError.Types.DUPLICATE_ERROR,
+                `A partner admin with email "${email}" already exists. Please use a different email.`
+            )
+        }
+
+        return new StepResponse({ handle })
+    }
+)
 
 const createPartnerAndAdminStep = createStep(
     "create-partner-and-admin-step",
@@ -145,10 +253,21 @@ const verifyPartnerAuthEmailStep = createStep(
 const createPartnerAdminWorkflow = createWorkflow(
     "create-partner-admin",
     (input: CreatePartnerAdminWorkflowInput) => {
-        const partnerWithAdmin = createPartnerAndAdminStep({
-            partner: input.partner,
-            admin: input.admin,
+        // Validation BEFORE the first insert: handle derivation + uniqueness,
+        // admin email uniqueness. A 422 here costs one read; a raw MikroORM
+        // constraint error after a partial write costs a 500 and a rollback.
+        const identity = resolvePartnerIdentityStep({
+            name: input.partner.name,
+            handle: input.partner.handle,
+            admin_email: input.admin.email,
         })
+
+        const partnerInput = transform({ input, identity }, ({ input, identity }) => ({
+            partner: { ...input.partner, handle: identity.handle },
+            admin: input.admin,
+        }))
+
+        const partnerWithAdmin = createPartnerAndAdminStep(partnerInput)
 
         setAuthAppMetadataStep({
             authIdentityId: input.authIdentityId,
@@ -202,10 +321,20 @@ const registerPartnerAdminAuthStep = createStep(
 export const createPartnerAdminWithRegistrationWorkflow = createWorkflow(
     "create-partner-admin-with-registration",
     (input: CreatePartnerAdminWithRegistrationInput) => {
-        const partnerWithAdmin = createPartnerAndAdminStep({
-            partner: input.partner,
-            admin: input.admin,
+        // Same pre-write validation as the self-registration twin: derive the
+        // handle, refuse duplicates — as 422s, never constraint-error 500s.
+        const identity = resolvePartnerIdentityStep({
+            name: input.partner.name,
+            handle: input.partner.handle,
+            admin_email: input.admin.email,
         })
+
+        const partnerInput = transform({ input, identity }, ({ input, identity }) => ({
+            partner: { ...input.partner, handle: identity.handle },
+            admin: input.admin,
+        }))
+
+        const partnerWithAdmin = createPartnerAndAdminStep(partnerInput)
 
         const registered = registerPartnerAdminAuthStep({
             email: input.admin.email,


### PR DESCRIPTION
## What happened in prod

2026-09-07 22:11–22:21 UTC, three `POST /admin/partners` answered **500** while the admin assistant created the JP Handloom partner (visible in the chat as `Error calling create_partner (/admin/partners): Route /admin/partners responded 500: HTTP 500`). The MikroORM stack in CloudWatch names the cause exactly:

```
ValidationError: Value for Partner.handle is required, 'undefined' found
  at SqlEntityManager.flush → ChangeSetPersister.executeInserts
```

- `partner.handle` is a **required, unique** column, and *nothing derived it* — the `create_partner` MCP tool advertised "auto-derived if omitted" while the workflow passed `undefined` to the flush
- The dry-run "passed" because it never touches the DB — exactly why the gap survived
- The assistant then retried twice with the same payload → same 500 each time
- `partner_admin.email` had the same latent shape: unique column, no pre-write check, raw constraint error → 500

## The fix

Both create workflows (`create-partner-admin-with-registration` for the admin route, `create-partner-admin` for self-registration) now run `resolvePartnerIdentityStep` **before any insert**:

| Condition | Behaviour |
|---|---|
| No handle / blank | Derived as `partner_<name-slug>` — accent-folded, capped at 48 chars, suffixed `-2`, `-3`, … until free; timestamp fallback for unslugable names |
| Explicit handle already taken | **422** `A partner with handle "X" already exists. Please use a unique handle.` (same message the DB path aimed at) |
| Admin email already exists | **422** `A partner admin with email "X" already exists. Please use a different email.` (was a 500) |

Because the chat route returns tool results to the model verbatim, the assistant now *sees* the duplicate message and can react (pick another handle, ask the operator) instead of relaying an opaque 500.

## Tests

- **10 unit assertions** on the slug/derivation rules (accents, runs of punctuation, 48-char cap, unslugable-name fallback)
- **3 new API integration tests**: no-handle create → 201 with `partner_jp-handloom-…`; duplicate admin email → 422; taken explicit handle → 422
- Registry description updated to state the real derivation

```
PASS workflows/partner/__tests__/create-partner-admin.unit.spec.ts   10 passed
PASS integration-tests/http/admin-partners-api.spec.ts                 5 passed
Full MCP + workflow suites                                        325 passed
```