### PR TITLE
fix(web): a bot's empty POST is not an incident, and a broken tracker is not a success

### DIFF
--- a/apps/backend/integration-tests/http/analytics/track-analytics-event.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/track-analytics-event.spec.ts
@@ -352,16 +352,32 @@ setupSharedTestSuite(({ api, getContainer }) => {
           expect(response.data.success).toBe(true);
         });
 
-        it("should validate required fields", async () => {
+        it("should reject missing required fields with a 400", async () => {
           const incompleteData = {
             website_id: websiteId,
             // Missing required fields
           };
 
-          const response = await api.post("/web/analytics/track", incompleteData);
+          const response = await api.post(
+            "/web/analytics/track",
+            incompleteData,
+            { validateStatus: () => true } as any
+          );
 
-          // Validation should fail but still return 200 for security
-          expect(response.status).toBe(200);
+          /**
+           * Was 200 "for security". That conflated a malformed request with a
+           * successful one, so a storefront with a broken tracker looked
+           * identical to a bot and nobody could tell. The caller's mistake is
+           * now the caller's 400; only OUR failures are still swallowed into a
+           * 200 (see tracking-error-contract.spec.ts).
+           */
+          expect(response.status).toBe(400);
+          expect(response.data.success).toBe(false);
+          // event_type/channel carry schema defaults, so they are NOT reported
+          // missing — only the genuinely absent fields are.
+          expect(response.data.fields).toEqual(
+            expect.arrayContaining(["pathname", "visitor_id", "session_id"])
+          );
         });
       });
 

--- a/apps/backend/integration-tests/http/analytics/tracking-error-contract.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/tracking-error-contract.spec.ts
@@ -1,0 +1,135 @@
+import { setupSharedTestSuite } from "../shared-test-setup";
+
+jest.setTimeout(100000);
+
+/**
+ * The contract for a tracking request that cannot be honoured.
+ *
+ * Replicates the prod log noise — ~175/week of error-level entries produced by
+ * bots POSTing an empty body to the three public tracking endpoints — and pins
+ * the behaviour that replaced it:
+ *
+ *   malformed request  → 400, one warn line, no stack, no zod dump
+ *   unexpected failure → 200 + error level (unchanged; a broken write path must
+ *                        never surface on a customer's storefront)
+ *
+ * 🔴 These endpoints are called by trackers that DO NOT live in this repo, so
+ * this spec is the only place the wire contract is written down. Changing a
+ * status code here changes it for clients we cannot grep.
+ */
+setupSharedTestSuite(({ api, getContainer }) => {
+  describe("Web tracking endpoints — the malformed-request contract", () => {
+    const ENDPOINTS = [
+      { path: "/web/analytics/track", label: "analytics" },
+      { path: "/web/ad-planning/track-journey", label: "journey" },
+      { path: "/web/ad-planning/track-conversion", label: "conversion" },
+    ];
+
+    // A 400 must reach us as a response, not as a thrown axios error.
+    const post = (path: string, body?: unknown) =>
+      api.post(path, body, { validateStatus: () => true } as any);
+
+    describe.each(ENDPOINTS)("$label", ({ path }) => {
+      it("answers an empty body with 400 rather than a cheerful 200", async () => {
+        const res = await post(path, {});
+
+        expect(res.status).toBe(400);
+        expect(res.data.success).toBe(false);
+        expect(res.data.message).toBe("Invalid tracking payload");
+      });
+
+      it("answers a bodiless POST the same way", async () => {
+        const res = await post(path);
+        expect(res.status).toBe(400);
+        expect(res.data.success).toBe(false);
+      });
+
+      it("names the missing fields so a tracker can be fixed", async () => {
+        const res = await post(path, {});
+
+        expect(Array.isArray(res.data.fields)).toBe(true);
+        expect(res.data.fields).toContain("website_id");
+      });
+
+      it("does not leak a zod dump or a stack to the client", async () => {
+        const res = await post(path, {});
+        const body = JSON.stringify(res.data);
+
+        expect(body).not.toContain("ZodError");
+        expect(body).not.toContain("invalid_type");
+        expect(body).not.toContain("at Object.");
+        expect(res.data.issues).toBeUndefined();
+        expect(res.data.stack).toBeUndefined();
+      });
+
+      it("rejects a non-object body without throwing", async () => {
+        const res = await post(path, "not-an-object");
+        expect(res.status).toBe(400);
+      });
+    });
+
+    /**
+     * The case the old code hid: a REAL storefront whose tracker booted before
+     * `website_id` resolved got `success: true` and was indistinguishable from
+     * a bot. It must now be told.
+     */
+    it("tells a tracker that lost its website_id, instead of claiming success", async () => {
+      const res = await post("/web/analytics/track", {
+        event_type: "pageview",
+        pathname: "/shop",
+        visitor_id: "visitor_real_client",
+        session_id: "session_real_client",
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.data.fields).toContain("website_id");
+    });
+  });
+
+  /**
+   * The half that must NOT change. A valid payload still tracks, and a website
+   * id that simply does not exist is OUR problem to absorb, not the caller's —
+   * it passes validation and fails downstream, so it keeps the 200 swallow.
+   */
+  describe("Web tracking endpoints — the happy path is unaffected", () => {
+    it("still tracks a well-formed event", async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const website = await websiteService.createWebsites({
+        domain: "test-tracking-contract.example.com",
+        name: "Tracking Contract Site",
+        status: "Active",
+        primary_language: "en",
+      });
+
+      const res = await api.post("/web/analytics/track", {
+        website_id: website.id,
+        event_type: "pageview",
+        pathname: "/still-works",
+        visitor_id: "visitor_contract",
+        session_id: "session_contract",
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.data.success).toBe(true);
+    });
+
+    it("absorbs a well-formed event for an unknown website as OURS (200, not 400)", async () => {
+      const res = await api.post(
+        "/web/analytics/track",
+        {
+          website_id: "web_does_not_exist_at_all",
+          event_type: "pageview",
+          pathname: "/unknown-site",
+          visitor_id: "visitor_unknown",
+          session_id: "session_unknown",
+        },
+        { validateStatus: () => true } as any
+      );
+
+      // Passes validation, fails downstream — the swallow branch, unchanged.
+      expect(res.status).toBe(200);
+      expect(res.data.success).toBe(true);
+    });
+  });
+});

--- a/apps/backend/src/api/web/ad-planning/track-conversion/route.ts
+++ b/apps/backend/src/api/web/ad-planning/track-conversion/route.ts
@@ -7,6 +7,7 @@ import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { z } from "@medusajs/framework/zod";
 import { AD_PLANNING_MODULE } from "../../../../modules/ad-planning";
+import { handleTrackingError } from "../../lib/tracking-error-response";
 
 // Validator for conversion tracking request
 export const TrackConversionSchema = z.object({
@@ -90,8 +91,22 @@ export const POST = async (
     });
   } catch (error) {
     const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+
+    // Malformed input → one warn line + 400. Ours → error level + 200 swallow.
+    if (
+      handleTrackingError({
+        error,
+        body: req.body,
+        logger,
+        label: "track-conversion",
+        res,
+      })
+    ) {
+      return;
+    }
+
     logger.error("Conversion tracking error:", error as Error);
-    // Don't expose errors to client for security
+    // Don't expose OUR failures to the client.
     res.status(200).json({
       success: true,
       message: "Conversion received",

--- a/apps/backend/src/api/web/ad-planning/track-journey/route.ts
+++ b/apps/backend/src/api/web/ad-planning/track-journey/route.ts
@@ -7,6 +7,7 @@ import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { z } from "@medusajs/framework/zod";
 import { AD_PLANNING_MODULE } from "../../../../modules/ad-planning";
+import { handleTrackingError } from "../../lib/tracking-error-response";
 
 // Validator for journey tracking request
 export const TrackJourneySchema = z.object({
@@ -128,8 +129,22 @@ export const POST = async (
     });
   } catch (error) {
     const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+
+    // Malformed input → one warn line + 400. Ours → error level + 200 swallow.
+    if (
+      handleTrackingError({
+        error,
+        body: req.body,
+        logger,
+        label: "track-journey",
+        res,
+      })
+    ) {
+      return;
+    }
+
     logger.error("Journey tracking error:", error as Error);
-    // Don't expose errors to client for security
+    // Don't expose OUR failures to the client.
     res.status(200).json({
       success: true,
       message: "Journey event received",

--- a/apps/backend/src/api/web/analytics/track/route.ts
+++ b/apps/backend/src/api/web/analytics/track/route.ts
@@ -80,6 +80,7 @@ import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { z } from "@medusajs/framework/zod";
 import { trackAnalyticsEventWorkflow } from "../../../../workflows/analytics/track-analytics-event";
+import { handleTrackingError } from "../../lib/tracking-error-response";
 import {
   getIngestRedis,
   isBatchIngestEnabled,
@@ -245,8 +246,27 @@ export const POST = async (
       message: "Event tracked",
     });
   } catch (error) {
+    /**
+     * A malformed body is the CALLER's problem: one warn line and a 400 (#1877
+     * follow-on). Only an unexpected failure — our database or buffer down —
+     * keeps the error-level log and the 200 swallow, because this endpoint runs
+     * inside a <script> on someone else's page.
+     */
+    if (
+      handleTrackingError({
+        error,
+        body: req.body,
+        logger,
+        label: "analytics-track",
+        res,
+      })
+    ) {
+      return;
+    }
+
     logger.error("Analytics tracking error:", error as Error);
-    // Don't expose errors to client for security
+    // Don't expose OUR failures to the client — a broken write path must not
+    // surface as a console error on a customer's storefront.
     res.status(200).json({
       success: true,
       message: "Event received",

--- a/apps/backend/src/api/web/lib/__tests__/tracking-error-response.unit.spec.ts
+++ b/apps/backend/src/api/web/lib/__tests__/tracking-error-response.unit.spec.ts
@@ -1,0 +1,139 @@
+import {
+  classifyTrackingRejection,
+  formatTrackingWarn,
+  handleTrackingError,
+  isValidationError,
+} from "../tracking-error-response"
+
+/** A zod-shaped error without importing zod — mirrors what `.parse()` throws. */
+const zodErr = (paths: string[][]) => ({
+  name: "ZodError",
+  issues: paths.map((path) => ({ code: "invalid_type", path })),
+})
+
+describe("isValidationError", () => {
+  it("recognises a zod error by shape, not by instanceof", () => {
+    expect(isValidationError(zodErr([["website_id"]]))).toBe(true)
+    expect(isValidationError({ issues: [] })).toBe(true)
+  })
+
+  it("does NOT claim an ordinary failure is a validation error", () => {
+    // The whole point: a DB outage must reach the error-level branch.
+    expect(isValidationError(new Error("connect ECONNREFUSED redis:6379"))).toBe(false)
+    expect(isValidationError(null)).toBe(false)
+    expect(isValidationError("boom")).toBe(false)
+  })
+})
+
+describe("classifyTrackingRejection", () => {
+  const err = zodErr([["website_id"], ["pathname"], ["visitor_id"], ["session_id"]])
+
+  it("calls an empty object background noise, not a broken client", () => {
+    // The bot case: ~175/week of these. `req.body` is {} for a bodiless POST.
+    expect(classifyTrackingRejection({}, err).kind).toBe("not_an_object")
+    expect(classifyTrackingRejection(undefined, err).kind).toBe("not_an_object")
+    expect(classifyTrackingRejection(null, err).kind).toBe("not_an_object")
+    expect(classifyTrackingRejection("nonsense", err).kind).toBe("not_an_object")
+    expect(classifyTrackingRejection([], err).kind).toBe("not_an_object")
+  })
+
+  it("singles out a real request that lost its website_id", () => {
+    // A storefront whose tracker booted before website_id resolved: it HAS
+    // something to say and says it about nobody. This is the alertable one.
+    const r = classifyTrackingRejection(
+      { pathname: "/shop", visitor_id: "v1", session_id: "s1" },
+      zodErr([["website_id"]])
+    )
+    expect(r.kind).toBe("missing_website_id")
+    expect(r.fields).toEqual(["website_id"])
+  })
+
+  it("calls a populated body with wrong details malformed", () => {
+    const r = classifyTrackingRejection(
+      { website_id: "web_1", event_type: "not_a_real_enum_value" },
+      zodErr([["event_type"]])
+    )
+    expect(r.kind).toBe("malformed")
+    expect(r.fields).toEqual(["event_type"])
+  })
+
+  it("de-duplicates field paths and joins nested ones", () => {
+    const r = classifyTrackingRejection(
+      { website_id: "web_1", metadata: {} },
+      zodErr([["metadata", "utm"], ["metadata", "utm"], ["event_data", "id"]])
+    )
+    expect(r.fields).toEqual(["metadata.utm", "event_data.id"])
+  })
+})
+
+describe("formatTrackingWarn", () => {
+  it("is one line with no stack and no zod dump", () => {
+    const line = formatTrackingWarn("analytics-track", {
+      kind: "missing_website_id",
+      fields: ["website_id"],
+    })
+    expect(line).toBe("[analytics-track] rejected (missing_website_id): website_id")
+    expect(line.split("\n")).toHaveLength(1)
+  })
+})
+
+describe("handleTrackingError", () => {
+  const makeRes = () => {
+    const json = jest.fn()
+    return { res: { status: jest.fn(() => ({ json })) } as any, json }
+  }
+  const makeLogger = () => ({ warn: jest.fn(), error: jest.fn() })
+
+  it("answers a malformed body with 400 and ONE warn line, never an error", () => {
+    const { res, json } = makeRes()
+    const logger = makeLogger()
+
+    const handled = handleTrackingError({
+      error: zodErr([["website_id"]]),
+      body: {},
+      logger,
+      label: "analytics-track",
+      res,
+    })
+
+    expect(handled).toBe(true)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(json.mock.calls[0][0]).toEqual({
+      success: false,
+      message: "Invalid tracking payload",
+      fields: ["website_id"],
+    })
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    // The regression this whole change exists to prevent.
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it("declines an unexpected failure so the caller keeps error-level + 200", () => {
+    const { res } = makeRes()
+    const logger = makeLogger()
+
+    const handled = handleTrackingError({
+      error: new Error("connect ECONNREFUSED redis:6379"),
+      body: { website_id: "web_1" },
+      logger,
+      label: "analytics-track",
+      res,
+    })
+
+    expect(handled).toBe(false)
+    expect(res.status).not.toHaveBeenCalled()
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it("never echoes the submitted values back — field names only", () => {
+    const { res, json } = makeRes()
+    handleTrackingError({
+      error: zodErr([["visitor_id"]]),
+      body: { website_id: "web_1", visitor_id: { evil: "<script>" } },
+      logger: makeLogger(),
+      label: "analytics-track",
+      res,
+    })
+    expect(JSON.stringify(json.mock.calls[0][0])).not.toContain("script")
+  })
+})

--- a/apps/backend/src/api/web/lib/tracking-error-response.ts
+++ b/apps/backend/src/api/web/lib/tracking-error-response.ts
@@ -1,0 +1,142 @@
+/**
+ * One answer to "what do I do with a failed tracking request", shared by the
+ * three public `/web` tracking endpoints.
+ *
+ * ## The problem this replaces
+ *
+ * All three routes had the same chain: `schema.parse()` inside the handler →
+ * an empty body throws → `catch` logs the full zod dump and stack at ERROR
+ * level → responds `200 {success: true}`. Two things were wrong with it, and
+ * they pull in opposite directions:
+ *
+ * 1. **A non-event was logged as an incident.** A bot POSTing `{}` got the same
+ *    error-level treatment as a real pipeline failure — ~175/week of it, drowning
+ *    genuine errors in CloudWatch.
+ * 2. **The client was told it succeeded.** A real storefront whose tracker booted
+ *    without a resolved `website_id` was indistinguishable from that bot, because
+ *    both received `success: true`.
+ *
+ * So the fix is not "log less" or "fail louder" — it is to stop treating two
+ * different situations as one:
+ *
+ * | situation | log | status |
+ * |---|---|---|
+ * | malformed request (the caller's fault) | ONE warn line, no stack | **400** |
+ * | unexpected failure (ours — DB/Redis down) | error + stack, as before | 200 |
+ *
+ * 🔑 The 200-swallow is KEPT for our own failures on purpose. These endpoints are
+ * called from a `<script>` on someone else's page; an outage in our write path
+ * must never surface as a console error on a customer's storefront.
+ */
+
+/**
+ * Why a body was rejected. Split three ways rather than two because the middle
+ * case is the ONLY one worth waking someone for.
+ */
+export type TrackingRejectionKind =
+  /** Not an object at all, or an empty one: a bot, a probe, a health check. Background radiation. */
+  | "not_an_object"
+  /**
+   * A real request that forgot who it is about. This is the shape a genuine
+   * storefront produces when its tracker booted before `website_id` resolved —
+   * the case the old code hid by answering `success: true`. Given its own kind
+   * so a log filter can alert on it WITHOUT drowning in bot noise.
+   */
+  | "missing_website_id"
+  /** Well-formed intent, wrong details (bad enum, wrong type). */
+  | "malformed"
+
+export type TrackingRejection = {
+  kind: TrackingRejectionKind
+  /** Field paths zod complained about — names only, never values. */
+  fields: string[]
+}
+
+/**
+ * Duck-typed rather than `instanceof ZodError`: the schemas come from
+ * `@medusajs/framework/zod`, and an `instanceof` across a re-exported module
+ * copy is a silent false — it would send every validation failure down the
+ * "unexpected failure" branch and restore the noise this exists to remove.
+ */
+export const isValidationError = (error: unknown): boolean => {
+  const e = error as any
+  return !!e && (e.name === "ZodError" || Array.isArray(e?.issues))
+}
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === "object" && !Array.isArray(v)
+
+/**
+ * Which of the three situations this is. Pure, so it can be tested without a
+ * server — the classification is the part with the actual judgement in it.
+ */
+export const classifyTrackingRejection = (
+  body: unknown,
+  error: unknown
+): TrackingRejection => {
+  const issues = ((error as any)?.issues ?? []) as Array<{ path?: unknown[] }>
+  const fields = Array.from(
+    new Set(
+      issues
+        .map((i) => (Array.isArray(i?.path) ? i.path.join(".") : ""))
+        .filter(Boolean)
+    )
+  ) as string[]
+
+  // An absent body and `{}` are the same event: somebody hit the URL with
+  // nothing to say. `req.body` is `{}` for a bodiless POST, so both land here.
+  if (!isPlainObject(body) || Object.keys(body).length === 0) {
+    return { kind: "not_an_object", fields }
+  }
+
+  if (fields.includes("website_id")) {
+    return { kind: "missing_website_id", fields }
+  }
+
+  return { kind: "malformed", fields }
+}
+
+/** One line, no stack, no zod dump — the whole point. */
+export const formatTrackingWarn = (
+  label: string,
+  rejection: TrackingRejection
+): string =>
+  `[${label}] rejected (${rejection.kind})` +
+  (rejection.fields.length ? `: ${rejection.fields.join(", ")}` : "")
+
+/**
+ * The shared catch body for all three routes.
+ *
+ * Returns `true` when it handled the error as a client-side rejection, so the
+ * caller can `return`. Returns `false` when the error is OURS — the caller then
+ * logs at error level and swallows into a 200, exactly as before.
+ */
+export const handleTrackingError = (opts: {
+  error: unknown
+  body: unknown
+  logger: { warn: (m: string) => void; error: (m: string, e?: any) => void }
+  /** Log prefix, e.g. "analytics-track". */
+  label: string
+  res: {
+    status: (code: number) => { json: (payload: unknown) => unknown }
+  }
+}): boolean => {
+  const { error, body, logger, label, res } = opts
+
+  if (!isValidationError(error)) {
+    return false
+  }
+
+  const rejection = classifyTrackingRejection(body, error)
+  logger.warn(formatTrackingWarn(label, rejection))
+
+  // Field NAMES only. Enough for a storefront developer to fix their tracker,
+  // nothing about what was sent and no internal shape.
+  res.status(400).json({
+    success: false,
+    message: "Invalid tracking payload",
+    fields: rejection.fields,
+  })
+
+  return true
+}


### PR DESCRIPTION
Option **C** from the triage: split malformed input from infrastructure failure.

## The problem

All three public tracking endpoints shared one chain — `schema.parse()` in the handler → empty body throws → `catch` logs the full zod dump + stack at **error** level → responds `200 {success: true}`. Two things were wrong, pulling in opposite directions:

1. **A non-event was logged as an incident.** A bot POSTing `{}` got the same treatment as a real pipeline failure — ~175/week, drowning genuine errors in CloudWatch.
2. **The client was lied to.** A real storefront whose tracker booted before `website_id` resolved was indistinguishable from that bot — both were told they succeeded.

## The change

| situation | log | status |
|---|---|---|
| malformed request (theirs) | one warn line, no stack, no zod dump | **400** |
| unexpected failure (ours — DB/Redis down) | error + stack | 200, unchanged |

The **200-swallow is kept for our own failures deliberately**: these endpoints run inside a `<script>` on someone else's page, and an outage in our write path must never surface as a console error on a customer's storefront.

### Three kinds, not two
`classifyTrackingRejection` splits malformed further, because only the middle case is worth alerting on:

- `not_an_object` — `{}` or a bodiless POST. Bots, probes, background radiation.
- `missing_website_id` — **a real request that forgot who it is about.** The storefront-with-a-broken-tracker case the old code hid.
- `malformed` — right intent, wrong details.

Collapsing them would cut the noise and keep the blindness.

`isValidationError` is duck-typed rather than `instanceof ZodError` — schemas come from `@medusajs/framework/zod`, and an `instanceof` across a re-exported copy is a silent false that would send every validation failure down the "unexpected" branch and restore the exact noise this removes.

The 400 body carries **field names only**.

## ⚠️ Wire-contract change for clients that aren't in this repo

Grep finds only tests calling these endpoints — the trackers live elsewhere, so `tracking-error-contract.spec.ts` is now the only written record of the contract. `navigator.sendBeacon` ignores the response entirely, but **a fetch-based tracker that retries on 4xx would amplify**. Worth confirming against the deployed tracker before this reaches prod.

## Related finding: there is nothing to delete

The suspicion that junk analytics rows needed wiping doesn't hold. `parse` runs at `route.ts:180`, the workflow at `:233` — a malformed body throws **before any write**, so this noise created zero rows. `analytics_event` (84) and `analytics_session` (33) have no null `website_id`/`visitor_id` at all, and the 4 `conversion` rows with a null `website_id` are legitimate: the column is `nullable()` by design and each carries a real `anon_order_*` visitor id from an order path. **No cleanup should run.**

## Tests

- **10 unit** on the classifier (pure — the part with the judgement in it)
- **18 integration** across all three endpoints, including the bodiless POST that reproduces the prod noise
- **Red-checked**: neutralising the branch fails 13 of 18 (the 5 survivors are the two happy-path cases and the three "no leak" assertions, which hold under both behaviours by nature)
- One existing assertion moved from 200 → 400; it stated the old belief outright ("Validation should fail but still return 200 for security")
- ad-planning-conversions **22/22**, track-analytics-event **12/12**, `check:prod-build` **green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4