### PR TITLE
fix(analytics): the tracker dies silently in three places, and discards the 400 from #1884

### DIFF
--- a/.github/workflows/deploy-analytics.yml
+++ b/.github/workflows/deploy-analytics.yml
@@ -43,6 +43,11 @@ jobs:
         # (terser), so it needs none of the backend's native deps.
         run: pnpm install --frozen-lockfile --filter @jyt/analytics
 
+      - name: Verify tracker behaviour
+        # This artifact goes straight to the CDN and runs on customers' pages,
+        # so the gate has to be here — nothing else in CI looks at it.
+        run: pnpm --filter @jyt/analytics test
+
       - name: Build analytics script
         run: pnpm --filter @jyt/analytics build
 

--- a/apps/analytics/__tests__/analytics.behaviour.mjs
+++ b/apps/analytics/__tests__/analytics.behaviour.mjs
@@ -1,0 +1,112 @@
+/**
+ * Behaviour tests for the CDN tracking script.
+ *
+ * This file exists because `deploy-analytics.yml` builds `src/analytics.js` and
+ * uploads it straight to R2 on every merge to main — it lands on customers'
+ * pages with nothing standing between the edit and the CDN. The cases below are
+ * the ones that cannot be caught by looking at the file: each one FAILED on the
+ * tracker as it shipped before #1884's follow-up.
+ *
+ * No framework and no dependencies on purpose — the deploy job installs only
+ * terser, so this has to run on bare node.
+ *
+ *   node __tests__/analytics.behaviour.mjs [path-to-src]
+ */
+import vm from 'node:vm';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const target = process.argv[2] || path.join(here, '..', 'src', 'analytics.js');
+const SRC = fs.readFileSync(target, 'utf8');
+
+function makeEnv({ storageThrows = false, beaconResult = true, hasBeacon = true,
+                   currentScriptNull = false, fetchStatus = 200 } = {}) {
+  const sent = [], warns = [], errors = [], fetches = [];
+  const mkStore = () => {
+    const m = new Map();
+    return {
+      getItem: k => { if (storageThrows) throw new Error('SecurityError'); return m.has(k) ? m.get(k) : null; },
+      setItem: (k, v) => { if (storageThrows) throw new Error('SecurityError'); m.set(k, String(v)); },
+      removeItem: k => { if (storageThrows) throw new Error('SecurityError'); m.delete(k); },
+    };
+  };
+  const tag = { getAttribute: n => (n === 'data-website-id' ? 'web_TEST' : null) };
+  const doc = {
+    currentScript: currentScriptNull ? null : tag,
+    querySelector: sel => (sel.includes('data-website-id') ? tag : null),
+    title: 't', referrer: '', body: { textContent: '' },
+    addEventListener() {}, querySelectorAll: () => [],
+    documentElement: { scrollHeight: 1000 }, visibilityState: 'visible',
+  };
+  const sandbox = {
+    document: doc,
+    navigator: {
+      ...(hasBeacon ? { sendBeacon: (ep, b) => { if (beaconResult) sent.push(ep); return beaconResult; } } : {}),
+      language: 'en-AU', languages: ['en-AU'], userAgent: 'test',
+    },
+    window: {
+      location: { pathname: '/p', search: '', href: 'https://x/p' },
+      addEventListener() {}, innerHeight: 800, scrollY: 0,
+    },
+    history: { pushState() {}, replaceState() {}, back() {} },
+    localStorage: mkStore(), sessionStorage: mkStore(),
+    Blob: class { constructor(p) { this.parts = p; } },
+    fetch: (ep, opts) => { fetches.push(ep); return Promise.resolve({ ok: fetchStatus < 400, status: fetchStatus }); },
+    console: { log() {}, warn: (...a) => warns.push(a.join(' ')), error: (...a) => errors.push(a.join(' ')) },
+    setInterval: () => 0, clearInterval() {}, setTimeout: () => 0,
+    URLSearchParams, Intl, Date, Math, JSON, parseInt, Object, Array, String, Promise, Error,
+  };
+  sandbox.window.localStorage = sandbox.localStorage;
+  sandbox.window.sessionStorage = sandbox.sessionStorage;
+  sandbox.globalThis = sandbox;
+  return { sandbox, sent, warns, errors, fetches };
+}
+
+function run(name, opts, check) {
+  const env = makeEnv(opts);
+  let threw = null;
+  try { vm.createContext(env.sandbox); vm.runInContext(SRC, env.sandbox); }
+  catch (e) { threw = e; }
+  return Promise.resolve().then(() => {
+    const r = check({ ...env, threw, api: env.sandbox.window.jytAnalytics });
+    console.log((r === true ? 'PASS  ' : 'FAIL  ') + name + (r === true ? '' : '  -> ' + r));
+    return r === true;
+  });
+}
+
+const results = [];
+results.push(run('storage throws -> tracker still sends pageview', { storageThrows: true },
+  e => e.threw ? 'threw: ' + e.threw.message : (e.sent.length > 0 ? true : 'nothing sent')));
+
+results.push(run('storage throws -> one stable visitor id per page', { storageThrows: true },
+  e => { if (!e.api) return 'no api'; const a = e.api.getVisitorId(), b = e.api.getVisitorId();
+         return a === b ? true : 'ids differ: ' + a + ' vs ' + b; }));
+
+results.push(run('storage throws -> one stable session id per page', { storageThrows: true },
+  e => { if (!e.api) return 'no api'; const a = e.api.getSessionId(), b = e.api.getSessionId();
+         return a === b ? true : 'ids differ: ' + a + ' vs ' + b; }));
+
+results.push(run('currentScript null -> falls back to querySelector, still sends', { currentScriptNull: true },
+  e => e.threw ? 'threw: ' + e.threw.message : (e.sent.length > 0 ? true : 'nothing sent')));
+
+results.push(run('sendBeacon refuses (false) -> retried via fetch', { beaconResult: false },
+  e => e.fetches.length > 0 ? true : 'no fetch fallback; event dropped'));
+
+results.push(run('sendBeacon ok -> fetch NOT also called (no double-send)', { beaconResult: true },
+  e => e.fetches.length === 0 ? true : 'double-sent via fetch'));
+
+results.push(run('400 on fetch path -> warns', { hasBeacon: false, fetchStatus: 400 },
+  e => e.warns.some(w => w.includes('rejected') && w.includes('400')) ? true : 'no warn; warns=' + JSON.stringify(e.warns)));
+
+results.push(run('200 on fetch path -> no warn', { hasBeacon: false, fetchStatus: 200 },
+  e => e.warns.some(w => w.includes('rejected')) ? 'warned on success' : true));
+
+Promise.all(results).then(rs => {
+  const bad = rs.filter(r => !r).length;
+  console.log(
+    '\n' + (rs.length - bad) + '/' + rs.length + ' passed  (' + target + ')'
+  );
+  process.exit(bad ? 1 : 0);
+});

--- a/apps/analytics/package.json
+++ b/apps/analytics/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@jyt/analytics",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "JYT client-side analytics tracking script. CDN-deployed.",
   "license": "MIT",
   "scripts": {
     "build": "node scripts/build.js",
+    "test": "node __tests__/analytics.behaviour.mjs",
     "clean": "rimraf dist"
   },
   "devDependencies": {

--- a/apps/analytics/src/analytics.js
+++ b/apps/analytics/src/analytics.js
@@ -19,7 +19,23 @@
   'use strict';
 
   // Configuration
-  const script = document.currentScript;
+  //
+  // `document.currentScript` is null inside a module script and in any deferred
+  // callback. Reading an attribute off null throws, which kills the tracker
+  // before it sends anything — the silent-death case that looks identical to
+  // "analytics is fine, this page just had no traffic". Fall back to locating
+  // our own tag by the attribute only we set.
+  const script =
+    document.currentScript ||
+    document.querySelector('script[data-website-id]');
+
+  if (!script) {
+    if (console && console.warn) {
+      console.warn('[Analytics] Could not locate the tracking script tag');
+    }
+    return;
+  }
+
   const websiteId = script.getAttribute('data-website-id');
   const apiUrl = script.getAttribute('data-api-url') || 'https://v3.jaalyantra.com';
   const enableJourney = script.getAttribute('data-enable-journey') !== 'false';
@@ -38,16 +54,52 @@
     return;
   }
 
+  // localStorage and sessionStorage do not merely return null when they are
+  // unavailable — they THROW: Safari private mode, a sandboxed iframe, and any
+  // browser where the user has blocked site data. Every read below is evaluated
+  // inside the object literal being sent, so an unguarded throw does not
+  // degrade one field, it destroys the whole event.
+  function storageGet(store, key) {
+    try {
+      return window[store].getItem(key);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function storageSet(store, key, value) {
+    try {
+      window[store].setItem(key, value);
+    } catch (e) {
+      // An id we cannot persist is still perfectly usable for this page load.
+    }
+  }
+
+  function storageRemove(store, key) {
+    try {
+      window[store].removeItem(key);
+    } catch (e) {
+      // Nothing to remove if the store is unreachable.
+    }
+  }
+
+  // When storage is unreachable these keep one id for the life of the page.
+  // Without them every call would mint a fresh id and a single pageview would
+  // report as several unrelated visitors — worse data than the crash.
+  let cachedVisitorId = null;
+  let cachedSessionId = null;
+
   // Generate or retrieve visitor ID (persistent across sessions)
   function getVisitorId() {
     const key = 'jyt_visitor_id';
-    let visitorId = localStorage.getItem(key);
+    let visitorId = storageGet('localStorage', key) || cachedVisitorId;
 
     if (!visitorId) {
       visitorId = 'visitor_' + Math.random().toString(36).substring(2) + Date.now().toString(36);
-      localStorage.setItem(key, visitorId);
+      storageSet('localStorage', key, visitorId);
     }
 
+    cachedVisitorId = visitorId;
     return visitorId;
   }
 
@@ -58,22 +110,27 @@
     const sessionTimeout = 30 * 60 * 1000; // 30 minutes
 
     const now = Date.now();
-    const lastActivity = parseInt(sessionStorage.getItem(timestampKey) || '0');
+    const storedActivity = storageGet('sessionStorage', timestampKey);
 
-    // Check if session expired
-    if (now - lastActivity > sessionTimeout) {
-      sessionStorage.removeItem(key);
+    // Only expire on a timestamp we actually read. Treating an ABSENT one as 0
+    // would expire the session on every single call once storage is
+    // unreachable, which is exactly when the cache below is holding the id.
+    if (storedActivity && now - parseInt(storedActivity) > sessionTimeout) {
+      storageRemove('sessionStorage', key);
+      cachedSessionId = null;
     }
 
-    let sessionId = sessionStorage.getItem(key);
+    let sessionId = storageGet('sessionStorage', key) || cachedSessionId;
 
     if (!sessionId) {
       sessionId = 'session_' + Math.random().toString(36).substring(2) + Date.now().toString(36);
-      sessionStorage.setItem(key, sessionId);
+      storageSet('sessionStorage', key, sessionId);
     }
 
+    cachedSessionId = sessionId;
+
     // Update last activity timestamp
-    sessionStorage.setItem(timestampKey, now.toString());
+    storageSet('sessionStorage', timestampKey, now.toString());
 
     return sessionId;
   }
@@ -93,7 +150,7 @@
 
     // Store UTM params for later use (for conversions)
     if (Object.keys(utm).length > 0) {
-      sessionStorage.setItem('jyt_utm', JSON.stringify(utm));
+      storageSet('sessionStorage', 'jyt_utm', JSON.stringify(utm));
     }
 
     return Object.keys(utm).length > 0 ? utm : undefined;
@@ -102,7 +159,7 @@
   // Get stored UTM params (for conversions that happen after initial landing)
   function getStoredUTMParams() {
     try {
-      const stored = sessionStorage.getItem('jyt_utm');
+      const stored = storageGet('sessionStorage', 'jyt_utm');
       return stored ? JSON.parse(stored) : {};
     } catch (e) {
       return {};
@@ -152,25 +209,49 @@
 
   // Send data to endpoint
   function sendData(endpoint, data) {
-    // Use sendBeacon for reliability (works even when page is closing)
+    const body = JSON.stringify(data);
+
+    // Use sendBeacon for reliability (works even when page is closing).
+    // It returns FALSE when the user agent refuses the payload — over the queue
+    // limit, or the queue is full — and the event is then dropped on the floor.
+    // Treat that as "not sent" and fall through to fetch rather than assuming it
+    // went. sendBeacon can never see the response, so a rejected request is
+    // invisible on this path by design.
     if (navigator.sendBeacon) {
-      const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
-      navigator.sendBeacon(endpoint, blob);
-    } else {
-      // Fallback to fetch
-      fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-        keepalive: true,
-      }).catch(function(err) {
+      const blob = new Blob([body], { type: 'application/json' });
+      if (navigator.sendBeacon(endpoint, blob)) {
+        return;
+      }
+    }
+
+    // fetch: the fallback for old browsers AND the retry when sendBeacon
+    // refused the payload above.
+    fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: body,
+      keepalive: true,
+    })
+      .then(function(res) {
+        // The server answers 400 only when the REQUEST was wrong (#1884); its
+        // own failures still come back 200 so that our outage never surfaces as
+        // an error on a customer's page. So a 4xx here is always our tracking
+        // setup at fault and is worth one line — `fetch` does not reject on it,
+        // which is why this went unnoticed.
+        if (!res.ok && console && console.warn) {
+          console.warn(
+            '[Analytics] Event rejected (' + res.status + '), dropped:',
+            endpoint
+          );
+        }
+      })
+      .catch(function(err) {
         if (console && console.error) {
           console.error('[Analytics] Failed to send data:', err);
         }
       });
-    }
   }
 
   // Track pageview
@@ -565,7 +646,7 @@
   // Identify user (for logged-in users)
   function identify(personId, traits = {}) {
     // Store person ID for journey tracking
-    sessionStorage.setItem('jyt_person_id', personId);
+    storageSet('sessionStorage', 'jyt_person_id', personId);
 
     trackEvent('identify', {
       person_id: personId,
@@ -587,7 +668,7 @@
 
   // Get stored person ID
   function getPersonId() {
-    return sessionStorage.getItem('jyt_person_id') || null;
+    return storageGet('sessionStorage', 'jyt_person_id') || null;
   }
 
   // Expose API for custom tracking


### PR DESCRIPTION
Follow-up to #1884, which asked one question and was never answered: **would a deployed tracker retrying on 4xx amplify the new 400s?**

## The answer is no — and the handoff's premise was wrong

#1884 recorded that "the trackers live elsewhere; grep finds only tests calling these endpoints." They don't. The tracker is `apps/analytics/src/analytics.js`, in this repo. A fresh `node scripts/build.js` is **byte-identical** (sha256) to what `automatic.jaalyantra.com/analytics.min.js` serves right now, so this is the deployed tracker, not a stand-in for it.

No amplification risk, for three independent reasons:

1. `sendBeacon` is the primary transport and cannot see a response by spec.
2. The `fetch` fallback has `.catch()` only — and `fetch` does not reject on 4xx. Zero occurrences of `.ok`, `.status` or `retry` in source or the live minified file.
3. No retry logic exists anywhere in the tracker.

Prod was probed after the #1884 deploy landed: `POST /web/analytics/track` with `{}` returns **400** on five consecutive requests. The contract is live and safe.

## What reading it for that turned up

Three ways the tracker loses events in silence — the same failure #1884 was about: something is broken and nothing says so.

| # | fault | consequence |
|---|---|---|
| 1 | `document.currentScript` is null in a module script / deferred callback | `script.getAttribute` throws, whole IIFE dies, **sends nothing** — looks exactly like a page with no traffic |
| 2 | `localStorage`/`sessionStorage` **throw** when blocked (Safari private, sandboxed iframe, blocked site data) | `getVisitorId()`/`getSessionId()` were unguarded *while their neighbours already had try/catch*, and are evaluated **inside the object literal being sent** — so the throw destroyed the entire pageview, not one field |
| 3 | `sendBeacon` returns `false` when the UA refuses the payload | return value discarded; the event went **nowhere** |

Plus: the fetch path never inspected the response, so the signal #1884 created was thrown away by the only client that could see it.

### On the storage fix specifically

Guarded reads *alone* would have made things worse — with storage dead, every call mints a fresh id and one pageview reports as several unrelated visitors. Hence the per-page cache. Relatedly, the session-expiry check now only fires on a timestamp actually read: treating an absent one as `0` would expire the session on every call, in precisely the case the cache exists for.

### On the 400 warn

This keeps #1884's deliberate asymmetry intact. The server still answers 200 for **its own** failures so that our outage never surfaces as an error on a customer's page — which means a 4xx here is always our tracking setup at fault, and worth one line. Reach is limited and I won't oversell it: `sendBeacon` handles nearly all traffic and can never see a response.

## Tests

`__tests__/analytics.behaviour.mjs` — 8 cases in a `vm` sandbox. No framework, no dependencies, because the deploy job installs only terser.

- **Red-checked against the pre-fix source: 6 of 8 fail** (`SecurityError`, `Cannot read properties of null`, event dropped, no warn). The 2 passing on both are negative controls — no double-send, no warn on success.
- They also pass against `dist/analytics.min.js`, so the assertions hold on the artifact that actually ships.

`deploy-analytics.yml` gains a verify step **before** the R2 upload. That workflow builds and publishes to the CDN on every merge to main with nothing checking the result, and this artifact runs on customers' pages. Drop the step if you'd rather not gate the deploy — it's one block.

Version `1.0.0` → `1.1.0` per the README's release note.

## Not fixed, deliberately

`missing_website_id` — the branch #1884 singled out as *"THE alertable one"* — **cannot be produced by any embed we ship**. The tracker early-returns on a falsy `websiteId`, and the admin's generated snippet always interpolates one. The branch isn't wrong, but nothing exercises it; it's only reachable via a hand-rolled third-party embed. Noted on #1884 rather than papered over here.

## Deploy note

🔴 Merging this **publishes to the CDN automatically** (R2 upload + cache purge) — it goes live on customer pages without a further step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4