### PR TITLE
fix(inventory-orders): an order line resolves a partner variant, then discards it (#1873)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
@@ -1,3 +1,5 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import lineVariantLink from "../../src/links/inventory-order-lines-product-variants"
 import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 
@@ -413,6 +415,85 @@ setupSharedTestSuite(() => {
       )
       expect(rowsForVariant).toHaveLength(1)
       expect(rowsForVariant[0].kind).toBe("product")
+    })
+
+    it("records WHICH variant the line was ordered as, not just the item it resolved to (#1873)", async () => {
+      const marker = unique()
+      const { variantId } = await seedUntrackedVariantProduct(
+        `Traceable Greige ${marker}`,
+        `TRC-${marker}`
+      )
+
+      const order = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [{ variant_id: variantId, quantity: 12, price: 90 }],
+          quantity: 12,
+          total_price: 1080,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(order.status).toBe(201)
+
+      const lineId = order.data.inventoryOrder.orderlines[0].id
+      expect(lineId).toBeTruthy()
+
+      // Read the link through its OWN entry point. Asking the order line entity
+      // for a linked field returns no key at all rather than an error, so a
+      // traversal from the entity could not tell "no link" from "wrong query".
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: links } = await query.graph({
+        entity: lineVariantLink.entryPoint,
+        filters: { inventory_order_line_id: lineId },
+        fields: ["inventory_order_line_id", "product_variant_id"],
+      })
+
+      // The association the order used to throw away: before #1873 the line was
+      // written with a real inventory_item_id and NO record of the variant, so
+      // the order could not say which product it was for.
+      expect(links).toHaveLength(1)
+      expect(links[0].product_variant_id).toBe(variantId)
+      expect(links[0].inventory_order_line_id).toBe(lineId)
+    })
+
+    it("leaves a raw-material line with no variant link at all (#1873)", async () => {
+      const marker = unique()
+      const inventoryItemId = await seedRawMaterialItem(`Plain Cotton ${marker}`)
+
+      const order = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [{ inventory_item_id: inventoryItemId, quantity: 5, price: 20 }],
+          quantity: 5,
+          total_price: 100,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(order.status).toBe(201)
+      const lineId = order.data.inventoryOrder.orderlines[0].id
+
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: links } = await query.graph({
+        entity: lineVariantLink.entryPoint,
+        filters: { inventory_order_line_id: lineId },
+        fields: ["product_variant_id"],
+      })
+
+      // Absent, not null-valued: a raw material genuinely has no product, and a
+      // link row pointing at nothing would be a worse answer than no row.
+      expect(links || []).toHaveLength(0)
     })
 
     it("refuses a line that names both an item and a variant", async () => {

--- a/apps/backend/src/links/inventory-order-lines-product-variants.ts
+++ b/apps/backend/src/links/inventory-order-lines-product-variants.ts
@@ -1,0 +1,34 @@
+/**
+ * Inventory order line ↔ product variant (#1873).
+ *
+ * An inventory order line may be placed by naming a partner's product VARIANT
+ * rather than an inventory item. `ensureLineInventoryItems` (#1662) resolves
+ * that variant to an inventory item — creating the item and enabling tracking
+ * at our end when the variant was `manage_inventory: false` — and until this
+ * link existed the variant was then thrown away. The order could no longer say
+ * which product it was for; prod had 65 of 65 lines item-backed and 0
+ * product-backed.
+ *
+ * The line model's own comment ("We are linking module links to order line with
+ * inventory and product") always intended this; only the inventory half was
+ * ever built (`inventory-orders-inventory-items.ts`).
+ *
+ * A line has AT MOST one variant, and a variant may appear on many lines over
+ * time — one order line is one thing ordered once, but the same variant is
+ * reorderable. Raw-material lines have no link row at all: they genuinely have
+ * no product, and an absent row says that more honestly than a null column.
+ */
+import { defineLink } from "@medusajs/framework/utils";
+import InventoryOrdersModule from "../modules/inventory_orders";
+import ProductModule from "@medusajs/medusa/product";
+
+export default defineLink(
+  {
+    linkable: InventoryOrdersModule.linkable.inventoryOrderLine,
+    isList: true,
+  },
+  {
+    linkable: ProductModule.linkable.productVariant,
+    isList: false,
+  }
+);

--- a/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   buildOrderLinePayloads,
   buildInventoryLineLinkPairs,
+  buildInventoryLineVariantPairs,
   sumLineTotals,
   buildMaterialLookupByInventoryId,
   enrichOrderLinesWithMaterial,
@@ -290,5 +291,77 @@ describe("planMaterialBackfill (#1613 scope item 4)", () => {
       { line_id: "ol_2", inventory_item_id: "iitem_2", field: "material_name", after: "Muga Silk" },
       { line_id: "ol_2", inventory_item_id: "iitem_2", field: "raw_material_id", after: "rm_2" },
     ])
+  })
+})
+
+describe("buildInventoryLineVariantPairs (#1873)", () => {
+  const line = (id: string) => ({ id })
+  const input = (inventory_id: string, variant_id?: string | null) => ({
+    inventory_id,
+    quantity: 1,
+    price: 10,
+    ...(variant_id !== undefined ? { variant_id } : {}),
+  })
+
+  it("pairs a line to the variant it was ordered as", () => {
+    expect(
+      buildInventoryLineVariantPairs([line("ol_1")], [input("iitem_1", "variant_1")])
+    ).toEqual([{ order_line_id: "ol_1", variant_id: "variant_1" }])
+  })
+
+  it("DROPS a line with no variant rather than pairing it to null", () => {
+    // A raw-material line genuinely has no product. An absent link row says
+    // that; a row pointing at null would be a link to nothing.
+    expect(
+      buildInventoryLineVariantPairs([line("ol_1")], [input("iitem_1")])
+    ).toEqual([])
+    expect(
+      buildInventoryLineVariantPairs([line("ol_1")], [input("iitem_1", null)])
+    ).toEqual([])
+  })
+
+  it("keeps each line with its OWN variant when only some lines have one", () => {
+    // The regression this guards: dropping unpaired lines by filtering the
+    // INPUT first would shift every later line onto the wrong variant.
+    const pairs = buildInventoryLineVariantPairs(
+      [line("ol_1"), line("ol_2"), line("ol_3")],
+      [input("iitem_1"), input("iitem_2", "variant_2"), input("iitem_3", "variant_3")]
+    )
+    expect(pairs).toEqual([
+      { order_line_id: "ol_2", variant_id: "variant_2" },
+      { order_line_id: "ol_3", variant_id: "variant_3" },
+    ])
+  })
+
+  it("throws on a length mismatch instead of silently mis-pairing", () => {
+    expect(() =>
+      buildInventoryLineVariantPairs(
+        [line("ol_1")],
+        [input("iitem_1", "variant_1"), input("iitem_2", "variant_2")]
+      )
+    ).toThrow(/line count mismatch/i)
+  })
+
+  it("is empty for an order where no line named a variant", () => {
+    expect(
+      buildInventoryLineVariantPairs(
+        [line("ol_1"), line("ol_2")],
+        [input("iitem_1"), input("iitem_2")]
+      )
+    ).toEqual([])
+  })
+})
+
+describe("buildOrderLinePayloads x variant_id (#1873)", () => {
+  it("does NOT persist variant_id on the line — it has no such column", () => {
+    // The whole reason variant_id can ride along on the service input safely:
+    // this allowlist is the persistence boundary. If it ever started passing
+    // unknown keys through, the create would fail on an unknown field.
+    const [payload] = buildOrderLinePayloads(
+      [{ inventory_id: "iitem_1", quantity: 2, price: 5, variant_id: "variant_1" }],
+      "order_1"
+    )
+    expect(payload).not.toHaveProperty("variant_id")
+    expect(payload).toMatchObject({ quantity: 2, price: 5, inventory_orders: "order_1" })
   })
 })

--- a/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
@@ -21,6 +21,17 @@ export type CreateOrderLineInput = {
   raw_material_id?: string | null
   // Per-unit extra charge on top of `price` (colour job, finishing, …).
   extra_cost?: number | null
+  /**
+   * #1873 — the product variant this line was ordered as, when the caller named
+   * one instead of an inventory item. `ensureLineInventoryItems` resolves it to
+   * `inventory_id`; this keeps WHICH variant that was, so the order can still
+   * answer "what product was this for" afterwards.
+   *
+   * Never persisted on the line: `buildOrderLinePayloads` is an allowlist and
+   * does not pass it through. It exists to build the line↔variant link.
+   * Raw-material lines leave it null, which is honest — they have no product.
+   */
+  variant_id?: string | null
 }
 
 export type OrderLinePayload = {
@@ -169,6 +180,38 @@ export const buildInventoryLineLinkPairs = (
     order_line_id: line.id,
     inventory_item_id: order_lines[i].inventory_id,
   }))
+}
+
+/** One line paired with the product variant it was ordered as (#1873). */
+export type LineVariantPair = {
+  order_line_id: string
+  variant_id: string
+}
+
+/**
+ * #1873 — pair created lines with the variant each was ordered as.
+ *
+ * Same contract as `buildInventoryLineLinkPairs`: positional, but only behind
+ * the count guard that makes the position meaningful (#778 C3). Lines with no
+ * variant are DROPPED rather than paired to null — a link row must mean "this
+ * line is that variant", and a raw-material line genuinely is not one.
+ */
+export const buildInventoryLineVariantPairs = (
+  createdLines: { id: string }[],
+  order_lines: CreateOrderLineInput[]
+): LineVariantPair[] => {
+  if (createdLines.length !== order_lines.length) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Inventory order line count mismatch: created ${createdLines.length} lines for ${order_lines.length} inputs`
+    )
+  }
+  return createdLines.flatMap((line, i) => {
+    const variantId = order_lines[i].variant_id
+    return variantId
+      ? [{ order_line_id: line.id, variant_id: String(variantId) }]
+      : []
+  })
 }
 
 /** One order line as the material backfill sees it (#1613 scope item 4). */

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -15,6 +15,7 @@ import { InferTypeOf, Context } from "@medusajs/framework/types"
 import {
   buildOrderLinePayloads,
   buildInventoryLineLinkPairs,
+  buildInventoryLineVariantPairs,
 } from "./lib/create-helpers";
 export type OrderLinesResponse = InferTypeOf<typeof OrderLine>[]
 
@@ -156,8 +157,12 @@ class InventoryOrderService extends MedusaService({
     }
 
     const lineItemPairs = buildInventoryLineLinkPairs(orderLines, order_lines);
+    // #1873 — computed here for the same reason as the item pairing: the
+    // correspondence between an input line and the row it became is only known
+    // at creation time. Empty when no line named a variant (raw materials).
+    const lineVariantPairs = buildInventoryLineVariantPairs(orderLines, order_lines);
 
-    return { order, orderLines, lineItemPairs };
+    return { order, orderLines, lineItemPairs, lineVariantPairs };
   }
 } 
 

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -93,6 +93,11 @@ export const createInventoryOrderWithLinesStep = createStep(
       price: line.price,
       extra_cost: line.extra_cost ?? null,
       batch_number: line.batch_number ?? null,
+      // #1873 — the SECOND place the variant was lost. This mapping builds the
+      // service input field by field, so keeping `variant_id` on the ensured
+      // line upstream achieves nothing unless it is named here too. Null for a
+      // raw-material line, which has no product.
+      variant_id: (line as any).variant_id ?? null,
       metadata: line.metadata
     };
     });
@@ -205,6 +210,53 @@ export const linkInventoryItemsWithLinesStep = createStep(
   }
 );
 
+/**
+ * #1873 — link each line to the product variant it was ordered as.
+ *
+ * Separate from `linkInventoryItemsWithLinesStep` rather than folded into it:
+ * the two links answer different questions (what to stock vs what it was for),
+ * and only some lines have a variant at all. Pairs come from the create step,
+ * never from re-zipping arrays by index (#778 C3).
+ */
+export const linkVariantsWithLinesStep = createStep(
+  "link-variants-with-lines-step",
+  async (
+    input: { order_id: string; variant_pairs: { order_line_id: string; variant_id: string }[] },
+    { container }
+  ) => {
+    const pairs = input.variant_pairs ?? [];
+    if (!pairs.length) {
+      // No line named a variant — a pure raw-material order. Nothing to link,
+      // and an empty `create` call is not worth making.
+      return new StepResponse([], []);
+    }
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
+    const links: LinkDefinition[] = pairs.map(({ order_line_id, variant_id }) => ({
+      [ORDER_INVENTORY_MODULE]: {
+        inventory_order_line_id: order_line_id,
+      },
+      [Modules.PRODUCT]: {
+        product_variant_id: variant_id,
+      },
+      data: {
+        order_line_id,
+        variant_id,
+      },
+    }));
+    await remoteLink.create(links);
+    return new StepResponse(links, links);
+  },
+  async (links, { container }) => {
+    if (!links?.length) return;
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
+    try {
+      await remoteLink.dismiss(links as any);
+    } catch {
+      /* best-effort link cleanup */
+    }
+  }
+);
+
 export const linkInventoryOrderWithStockLocation = createStep(
   "link-inventory-order-with-stock-location",
   async (input: { order_id: string; stock_location_id: string }, { container }) => {
@@ -285,7 +337,13 @@ export const ensureOrderLineInventoryItemsStep = createStep(
     );
 
     return new StepResponse({
-      order_lines: lines.map(({ enabled_variant_id, actions, variant_id, ...line }) => ({
+      // #1873 — `variant_id` is KEPT. It used to be destructured out here, which
+      // is where the association died: the line was written with a real item id
+      // and no record of the variant it was ordered as, so the order could never
+      // say which product it was for. It is not a line column and cannot become
+      // one by accident — `buildOrderLinePayloads` is an allowlist — it rides
+      // along only far enough to build the line↔variant link.
+      order_lines: lines.map(({ enabled_variant_id, actions, ...line }) => ({
         ...line,
         inventory_item_id: line.inventory_item_id,
       })),
@@ -331,12 +389,22 @@ export const createInventoryOrderWorkflow = createWorkflow(
           // Explicit line→item pairing from the create step (#778 C3) — not a
           // positional zip of separately-derived id arrays.
           line_pairs: created.lineItemPairs ?? [],
+          // #1873 — same provenance, for the line→variant link. Empty unless a
+          // line was ordered by naming a variant.
+          variant_pairs: created.lineVariantPairs ?? [],
           order: created.order,
           orderLines: created.orderLines,
         }
       }
     );
     const links = linkInventoryItemsWithLinesStep(linkInput);
+
+    // #1873 — record WHICH product variant each line was ordered as, alongside
+    // the inventory item it resolved to.
+    linkVariantsWithLinesStep({
+      order_id: linkInput.order_id,
+      variant_pairs: linkInput.variant_pairs,
+    });
 
     // Determine the to-location id from alias or stock_location_id
     const toLocationId = transform({ input }, ({ input }) => (

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -267,7 +267,7 @@ export const updateOrderLinesStep = createStep(
       );
     }
 
-    const created: Array<{ id: string; inventory_item_id?: string }> = [];
+    const created: Array<{ id: string; inventory_item_id?: string; variant_id?: string | null }> = [];
     const updated: Array<{ id: string; prevQuantity: number; prevPrice: any; prevExtraCost: any }> = [];
     const removed: Array<{ id: string; inventory_item_id?: string; quantity: number; price: any }> = [];
 
@@ -339,7 +339,29 @@ export const updateOrderLinesStep = createStep(
             }
           });
         }
-        created.push({ id: created_line.id, inventory_item_id: line.inventory_item_id });
+        // #1873 — a line added through UPDATE resolves a variant the same way
+        // create does (above, via ensureLineInventoryItems), so it must record
+        // the variant the same way too. Without this the association survives
+        // one door and dies at the other.
+        if (line.variant_id) {
+          await remoteLink.create({
+            [ORDER_INVENTORY_MODULE]: {
+              inventory_order_line_id: created_line.id
+            },
+            [Modules.PRODUCT]: {
+              product_variant_id: line.variant_id
+            },
+            data: {
+              order_line_id: created_line.id,
+              variant_id: line.variant_id
+            }
+          });
+        }
+        created.push({
+          id: created_line.id,
+          inventory_item_id: line.inventory_item_id,
+          variant_id: line.variant_id,
+        });
       }
     }
     // Return new state and save the precise per-line ops for compensation
@@ -352,7 +374,7 @@ export const updateOrderLinesStep = createStep(
   //   - lines we REMOVED → restore them by id + recreate their links (stable ids)
   async (
     compensationData: {
-      created: Array<{ id: string; inventory_item_id?: string }>;
+      created: Array<{ id: string; inventory_item_id?: string; variant_id?: string | null }>;
       updated: Array<{ id: string; prevQuantity: number; prevPrice: any; prevExtraCost: any }>;
       removed: Array<{ id: string; inventory_item_id?: string; quantity: number; price: any }>;
       order_id: string;
@@ -369,6 +391,15 @@ export const updateOrderLinesStep = createStep(
         await remoteLink.dismiss({
           [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: c.id },
           [Modules.INVENTORY]: { inventory_item_id: c.inventory_item_id },
+        });
+      }
+      // #1873 — a link this step created must be dismissed by this step's
+      // compensation, or a rolled-back update leaves a variant link pointing at
+      // a soft-deleted line.
+      if (c.variant_id) {
+        await remoteLink.dismiss({
+          [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: c.id },
+          [Modules.PRODUCT]: { product_variant_id: c.variant_id },
         });
       }
     }


### PR DESCRIPTION
Closes #1873.

An inventory order line may name a partner's product **variant** instead of an inventory item — the admin validator allows it as an XOR. `ensureLineInventoryItems` (#1662) resolves that variant to an inventory item, creating the item and enabling tracking at our end when the variant was `manage_inventory: false`. Then the variant was thrown away.

The order could no longer say **which product it was for**. On prod: 65 of 65 lines item-backed, 0 product-backed. It also feeds #342's mapping — the projected core order carries title-only lines because no `variant_id` survives to put on them.

The line model's own comment (*"We are linking module links to order line with inventory and product"*) always intended both halves. Only the inventory half was ever built.

## It was dropped in TWO places

The obvious one is the destructure at `create-inventory-orders.ts:288`. **Fixing only that changes nothing** — the workflow→service mapping below it builds the service input field by field and simply never named `variant_id`. Both are fixed; the second is the one that would have made this a silent no-op.

## Persisted as a link, not a column

`inventoryOrderLine ↔ productVariant`, mirroring the existing `inventory-orders-inventory-items` link. A line has at most one variant; a variant may appear on many lines — a line is one thing ordered once, a variant is reorderable.

Raw-material lines get **no link row** rather than one pointing at null. They genuinely have no product, and an absent row states that more honestly than a null column. `buildInventoryLineVariantPairs` therefore drops unpaired lines *after* pairing, never by filtering the input first — that would shift every later line onto the wrong variant. Same count guard as `buildInventoryLineLinkPairs` (#778 C3).

`variant_id` rides on the service input but can never reach the model: `buildOrderLinePayloads` is an allowlist, and there's now a test pinning exactly that.

## Both doors, not just create

`update-inventory-orders` resolves variants through the same helper but creates lines through a separate inline path, and had the identical gap — a line added by UPDATE would have lost the variant a line added by CREATE now keeps. Its compensation dismisses the new link too, or a rolled-back update leaves a variant link pointing at a soft-deleted line.

## Tests

- **6 unit cases** on the pairing helper and the allowlist guarantee (33/33 in the file).
- **2 integration cases**: a variant-ordered line records which variant; a raw-material line has no link at all.
- The link is read through `Link.entryPoint`, **not** by traversing from the order line entity — an entity-side traversal returns no key rather than an error, so it couldn't tell "no link" from "wrong query".

**Red-checked properly.** With the link step neutralised: the variant case **fails** (1 failed / 8 passed), and the raw-material case still passes — as it must, since it asserts an absence that holds under both behaviours.

Worth flagging: my first attempt at that red-check silently ran against the *fixed* code, because a `cd` short-circuited the edit and the suite came back 9/9 green. A check that never ran reads exactly like a check that passed. The neutralisation is confirmed reverted — 0 occurrences in the tree.

`check:prod-build` green, re-run after the last edit.

## Not in scope

No read surface exposes the variant yet — this makes the association exist and durable. Surfacing "which product was this order for" in the admin is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4