### PR TITLE
fix(mcp-oauth): the authorize page treated an MFA challenge as a completed sign-in

### DIFF
--- a/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
@@ -1,3 +1,5 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import lineVariantLink from "../../src/links/inventory-order-lines-product-variants"
 import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 
@@ -413,6 +415,85 @@ setupSharedTestSuite(() => {
       )
       expect(rowsForVariant).toHaveLength(1)
       expect(rowsForVariant[0].kind).toBe("product")
+    })
+
+    it("records WHICH variant the line was ordered as, not just the item it resolved to (#1873)", async () => {
+      const marker = unique()
+      const { variantId } = await seedUntrackedVariantProduct(
+        `Traceable Greige ${marker}`,
+        `TRC-${marker}`
+      )
+
+      const order = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [{ variant_id: variantId, quantity: 12, price: 90 }],
+          quantity: 12,
+          total_price: 1080,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(order.status).toBe(201)
+
+      const lineId = order.data.inventoryOrder.orderlines[0].id
+      expect(lineId).toBeTruthy()
+
+      // Read the link through its OWN entry point. Asking the order line entity
+      // for a linked field returns no key at all rather than an error, so a
+      // traversal from the entity could not tell "no link" from "wrong query".
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: links } = await query.graph({
+        entity: lineVariantLink.entryPoint,
+        filters: { inventory_order_line_id: lineId },
+        fields: ["inventory_order_line_id", "product_variant_id"],
+      })
+
+      // The association the order used to throw away: before #1873 the line was
+      // written with a real inventory_item_id and NO record of the variant, so
+      // the order could not say which product it was for.
+      expect(links).toHaveLength(1)
+      expect(links[0].product_variant_id).toBe(variantId)
+      expect(links[0].inventory_order_line_id).toBe(lineId)
+    })
+
+    it("leaves a raw-material line with no variant link at all (#1873)", async () => {
+      const marker = unique()
+      const inventoryItemId = await seedRawMaterialItem(`Plain Cotton ${marker}`)
+
+      const order = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [{ inventory_item_id: inventoryItemId, quantity: 5, price: 20 }],
+          quantity: 5,
+          total_price: 100,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(order.status).toBe(201)
+      const lineId = order.data.inventoryOrder.orderlines[0].id
+
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: links } = await query.graph({
+        entity: lineVariantLink.entryPoint,
+        filters: { inventory_order_line_id: lineId },
+        fields: ["product_variant_id"],
+      })
+
+      // Absent, not null-valued: a raw material genuinely has no product, and a
+      // link row pointing at nothing would be a worse answer than no row.
+      expect(links || []).toHaveLength(0)
     })
 
     it("refuses a line that names both an item and a variant", async () => {

--- a/apps/backend/src/api/oauth/authorize/__tests__/login-outcome.unit.spec.ts
+++ b/apps/backend/src/api/oauth/authorize/__tests__/login-outcome.unit.spec.ts
@@ -1,0 +1,113 @@
+import { loginOutcome } from "../login-outcome"
+
+/**
+ * The bug these pin: an MFA sign-in response is HTTP 200 AND carries a token,
+ * so the page's original `if (!ok || !body.token) throw` accepted it as a
+ * completed sign-in and sent an ACTORLESS token to /oauth/authorize/consent.
+ * Consent runs authenticate("user"), so it 401'd — and the screen said
+ * "Could not authorize", never "enter your second factor".
+ */
+describe("loginOutcome (MCP authorize page)", () => {
+  const challenge = { id: "authmfachal_1", methods: ["totp"] }
+
+  it("treats an MFA response as a CHALLENGE even though it carries a token", () => {
+    const out = loginOutcome(true, {
+      mfa_required: true,
+      mfa_challenge: challenge,
+      token: "actorless.jwt",
+    })
+    expect(out.kind).toBe("mfa")
+    // The actorless token is the credential for the verify call — not for consent.
+    expect(out).toEqual({ kind: "mfa", challenge, token: "actorless.jwt" })
+  })
+
+  it("does NOT report the MFA response as a completed sign-in", () => {
+    // The precise regression: `kind: "token"` here is what sent the actorless
+    // token to consent.
+    const out = loginOutcome(true, {
+      mfa_required: true,
+      mfa_challenge: challenge,
+      token: "actorless.jwt",
+    })
+    expect(out.kind).not.toBe("token")
+  })
+
+  it("passes a normal sign-in straight through", () => {
+    expect(loginOutcome(true, { token: "real.jwt" })).toEqual({
+      kind: "token",
+      token: "real.jwt",
+    })
+  })
+
+  it("carries the server's message on a failed sign-in", () => {
+    expect(loginOutcome(false, { message: "Invalid email or password" })).toEqual({
+      kind: "error",
+      message: "Invalid email or password",
+    })
+  })
+
+  it("falls back to a generic message when the server sends none", () => {
+    expect(loginOutcome(false, {})).toEqual({
+      kind: "error",
+      message: "Sign-in failed.",
+    })
+  })
+
+  it("errors rather than proceeding when MFA is demanded without a usable challenge", () => {
+    // Would otherwise strand the page on a code prompt it cannot submit.
+    const out = loginOutcome(true, { mfa_required: true, token: "actorless.jwt" })
+    expect(out.kind).toBe("error")
+    const noId = loginOutcome(true, {
+      mfa_required: true,
+      mfa_challenge: {},
+      token: "actorless.jwt",
+    })
+    expect(noId.kind).toBe("error")
+    const noToken = loginOutcome(true, {
+      mfa_required: true,
+      mfa_challenge: challenge,
+    })
+    expect(noToken.kind).toBe("error")
+  })
+
+  it("reports verification_required distinctly from a plain failure", () => {
+    const out = loginOutcome(true, {
+      verification_required: true,
+      token: "actorless.jwt",
+    })
+    expect(out.kind).toBe("error")
+    expect((out as any).message).toMatch(/verified/i)
+  })
+
+  it("treats a 200 with no token as a failure", () => {
+    expect(loginOutcome(true, {}).kind).toBe("error")
+  })
+
+  it("tolerates a null/absent body", () => {
+    expect(loginOutcome(true, null).kind).toBe("error")
+    expect(loginOutcome(false, undefined).kind).toBe("error")
+  })
+
+  /**
+   * The page embeds this function with `toString()`. A closure reference would
+   * compile here and throw ReferenceError in the browser, so the emitted source
+   * must not mention anything from module scope.
+   */
+  it("is self-contained, so it survives being embedded in the page", () => {
+    const src = loginOutcome.toString()
+    expect(src).toMatch(/^function loginOutcome\s*\(/)
+    expect(src).not.toMatch(/\brequire\b|\bimport\b|exports\./)
+  })
+
+  /**
+   * The page is a TEMPLATE LITERAL, so a backtick or a ${...} anywhere in this
+   * function's source would terminate or interpolate the string. That is not
+   * hypothetical: two backticks in a comment inside the page's own script broke
+   * route registration outright ("Expected ',', got 'token'").
+   */
+  it("contains nothing that would break the template literal it is embedded in", () => {
+    const src = loginOutcome.toString()
+    expect(src).not.toContain("`")
+    expect(src).not.toContain("${")
+  })
+})

--- a/apps/backend/src/api/oauth/authorize/login-outcome.ts
+++ b/apps/backend/src/api/oauth/authorize/login-outcome.ts
@@ -1,0 +1,72 @@
+/**
+ * What a sign-in response on the MCP authorize page actually means.
+ *
+ * ## The trap this exists to remove
+ *
+ * `POST /auth/user/emailpass` answers an MFA-enabled account with
+ *
+ *   { mfa_required: true, mfa_challenge: {...}, token: "<ACTORLESS jwt>" }
+ *
+ * — HTTP 200, and it CARRIES A TOKEN. The page's original guard was
+ * `if (!login.ok || !body.token) throw`, which both of those pass, so the flow
+ * continued to `/oauth/authorize/consent` with a token that has no `actor_id`.
+ * Consent runs `authenticate("user")` and reads `auth.actor_id`, so it answered
+ * 401 and the page showed "Could not authorize." Nothing anywhere said "second
+ * factor". The token being present is exactly why the bug was invisible.
+ *
+ * The actorless token is not useless — it is the credential that authorizes
+ * `POST /auth/mfa/challenges/:id/verify`, and nothing else.
+ *
+ * ## Why this lives in its own module
+ *
+ * The authorize page is a self-contained HTML string with inline browser JS, so
+ * there is nothing for a test to import. Rather than keep a tested copy here and
+ * an untested copy in the template — two homes for one rule — the page embeds
+ * this function verbatim via `Function.prototype.toString()`. The function the
+ * tests exercise IS the function the browser runs.
+ *
+ * 🔴 It must therefore stay SELF-CONTAINED: no imports, no module-scope
+ * constants, no TS-only runtime constructs. A closure reference would compile
+ * fine here and throw `ReferenceError` in the browser.
+ */
+
+export type MfaChallengeLike = {
+  id: string
+  methods?: string[]
+}
+
+export type LoginOutcome =
+  /** First factor passed; a second is required before the token means anything. */
+  | { kind: "mfa"; challenge: MfaChallengeLike; token: string }
+  /** Fully authenticated: this token carries an actor and is good for consent. */
+  | { kind: "token"; token: string }
+  | { kind: "error"; message: string }
+
+export function loginOutcome(ok: boolean, body: any): LoginOutcome {
+  var b = body || {}
+  if (!ok) {
+    return { kind: "error", message: b.message || "Sign-in failed." }
+  }
+  // Checked BEFORE the token, because an MFA response has one.
+  if (b.mfa_required) {
+    if (b.mfa_challenge && b.mfa_challenge.id && b.token) {
+      return { kind: "mfa", challenge: b.mfa_challenge, token: b.token }
+    }
+    return {
+      kind: "error",
+      message:
+        "This account requires a second factor, but the server did not return a usable challenge.",
+    }
+  }
+  if (b.verification_required) {
+    return {
+      kind: "error",
+      message:
+        "This account needs to be verified before it can authorize a client.",
+    }
+  }
+  if (!b.token) {
+    return { kind: "error", message: b.message || "Sign-in failed." }
+  }
+  return { kind: "token", token: b.token }
+}

--- a/apps/backend/src/api/oauth/authorize/route.ts
+++ b/apps/backend/src/api/oauth/authorize/route.ts
@@ -33,6 +33,7 @@ import {
 import { MCP_OAUTH_MODULE } from "../../../modules/mcp_oauth"
 import type McpOauthService from "../../../modules/mcp_oauth/service"
 import { redirectUriRegistered } from "../../../lib/mcp-oauth"
+import { loginOutcome } from "./login-outcome"
 
 const esc = (value: unknown): string =>
   String(value ?? "")
@@ -192,7 +193,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   label.opt{display:flex;gap:.6rem;align-items:flex-start;border:1px solid #d4d4d8;border-radius:.5rem;padding:.6rem .75rem;margin:.4rem 0;cursor:pointer}
   label.opt.sel{border-color:#111}
   label.opt small{color:#666}
-  input[type=email],input[type=password]{width:100%;box-sizing:border-box;padding:.55rem .6rem;border:1px solid #d4d4d8;border-radius:.4rem;font-size:1rem;background:transparent;color:inherit}
+  select,input[type=email],input[type=password],input#mfaCode{width:100%;box-sizing:border-box;padding:.55rem .6rem;border:1px solid #d4d4d8;border-radius:.4rem;font-size:1rem;background:transparent;color:inherit}
   .field{margin:.6rem 0}
   button{width:100%;padding:.7rem;border:0;border-radius:.45rem;background:#111;color:#fff;font-size:1rem;cursor:pointer;margin-top:1rem}
   @media(prefers-color-scheme:dark){button{background:#eee;color:#111}}
@@ -210,11 +211,26 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 </div>
 
 <form id="f">
-  <div class="field"><input type="email" id="email" placeholder="Admin email" autocomplete="username" required></div>
-  <div class="field"><input type="password" id="password" placeholder="Password" autocomplete="current-password" required></div>
+  <div id="credentials">
+    <div class="field"><input type="email" id="email" placeholder="Admin email" autocomplete="username" required></div>
+    <div class="field"><input type="password" id="password" placeholder="Password" autocomplete="current-password" required></div>
 
-  <p style="margin:1.25rem 0 .25rem"><strong>Access level</strong></p>
-  ${options}
+    <p style="margin:1.25rem 0 .25rem"><strong>Access level</strong></p>
+    ${options}
+  </div>
+
+  <!-- Second factor. Hidden until the sign-in response asks for one; the access
+       level chosen above is kept and re-sent after verification. -->
+  <div id="mfa" hidden>
+    <p class="sub" id="mfaHint">Enter the 6-digit code from your authenticator app.</p>
+    <div class="field" id="mfaMethodField" hidden>
+      <select id="mfaMethod"></select>
+    </div>
+    <div class="field">
+      <input id="mfaCode" placeholder="Verification code" inputmode="numeric"
+             autocomplete="one-time-code" autocapitalize="off" spellcheck="false">
+    </div>
+  </div>
 
   <button type="submit" id="go">Approve</button>
   <div class="err" id="err"></div>
@@ -224,6 +240,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
 <script>
   var P = ${JSON.stringify(params)};
+  // Embedded verbatim from src/api/oauth/authorize/login-outcome.ts so the rule
+  // the unit tests exercise is the rule the browser runs — see that file.
+  ${loginOutcome.toString()}
   var f = document.getElementById('f'), err = document.getElementById('err'), go = document.getElementById('go');
   document.addEventListener('change', function (e) {
     if (e.target.name !== 'level') return;
@@ -238,24 +257,122 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     if (P.state) u.searchParams.set('state', P.state);
     location.href = u.toString();
   });
+  // Set once the first factor passes and a second is required. Its 'token' is
+  // ACTORLESS token from the sign-in response: it carries no actor_id, so it is
+  // useless to /oauth/authorize/consent (which runs authenticate("user")) and is
+  // good for exactly one thing — authorizing the challenge verification.
+  var pending = null;
+
+  var mfaBox = document.getElementById('mfa');
+  var mfaCode = document.getElementById('mfaCode');
+  var mfaMethod = document.getElementById('mfaMethod');
+  var mfaMethodField = document.getElementById('mfaMethodField');
+  var mfaHint = document.getElementById('mfaHint');
+  var credentials = document.getElementById('credentials');
+
+  var METHOD_LABEL = { totp: 'Authenticator app', recovery_code: 'Recovery code' };
+  var label = function (m) { return METHOD_LABEL[m] || m; };
+
+  var hintFor = function (m) {
+    return m === 'recovery_code'
+      ? 'Enter one of your unused recovery codes.'
+      : 'Enter the 6-digit code from your authenticator app.';
+  };
+
+  // Show the second-factor step. The access-level radios are hidden but NOT
+  // removed, so the choice made before the code prompt is still what gets sent.
+  function enterMfa(challenge, token) {
+    pending = { challenge: challenge, token: token };
+    var methods = (challenge && challenge.methods) || [];
+    credentials.hidden = true;
+    mfaBox.hidden = false;
+
+    mfaMethod.innerHTML = '';
+    methods.forEach(function (m) {
+      var o = document.createElement('option');
+      o.value = m; o.textContent = label(m);
+      mfaMethod.appendChild(o);
+    });
+    // Only worth a control when there is a genuine choice to make.
+    mfaMethodField.hidden = methods.length < 2;
+    mfaHint.textContent = hintFor(methods[0]);
+    go.textContent = 'Verify';
+    mfaCode.value = '';
+    mfaCode.focus();
+  }
+
+  // Drop back to the credential step: a challenge is single-use and time-boxed,
+  // so once it is spent or expired the only way forward is a fresh sign-in.
+  function resetToCredentials(message) {
+    pending = null;
+    mfaBox.hidden = true;
+    credentials.hidden = false;
+    go.textContent = 'Approve';
+    err.textContent = message || '';
+  }
+
+  mfaMethod.addEventListener('change', function () {
+    mfaHint.textContent = hintFor(mfaMethod.value);
+    mfaCode.value = '';
+    mfaCode.focus();
+  });
+
   f.addEventListener('submit', async function (e) {
     e.preventDefault();
-    err.textContent = ''; go.disabled = true; go.textContent = 'Authorizing…';
+    err.textContent = ''; go.disabled = true;
+    go.textContent = pending ? 'Verifying…' : 'Authorizing…';
     try {
-      var login = await fetch('/auth/user/emailpass', {
-        method: 'POST', headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          email: document.getElementById('email').value,
-          password: document.getElementById('password').value
-        })
-      });
-      var loginBody = await login.json().catch(function () { return {}; });
-      if (!login.ok || !loginBody.token) throw new Error(loginBody.message || 'Sign-in failed.');
+      var token;
+
+      if (pending) {
+        // Second factor. 'method' is required by the API even when the challenge
+        // offers only one.
+        var code = (mfaCode.value || '').trim();
+        if (!code) throw new Error('Enter your verification code.');
+        var method = mfaMethodField.hidden
+          ? ((pending.challenge.methods || [])[0] || 'totp')
+          : mfaMethod.value;
+
+        var verify = await fetch('/auth/mfa/challenges/' + encodeURIComponent(pending.challenge.id) + '/verify', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', authorization: 'Bearer ' + pending.token },
+          body: JSON.stringify({ method: method, code: code })
+        });
+        var verifyBody = await verify.json().catch(function () { return {}; });
+        if (!verify.ok || !verifyBody.token) {
+          var msg = verifyBody.message || 'That code was not accepted.';
+          // A spent or expired challenge cannot be retried in place.
+          if (verify.status === 404 || /expired|not found/i.test(msg)) {
+            resetToCredentials(msg + ' Please sign in again.');
+            go.disabled = false;
+            return;
+          }
+          throw new Error(msg);
+        }
+        token = verifyBody.token;
+      } else {
+        var login = await fetch('/auth/user/emailpass', {
+          method: 'POST', headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            email: document.getElementById('email').value,
+            password: document.getElementById('password').value
+          })
+        });
+        var loginBody = await login.json().catch(function () { return {}; });
+        var outcome = loginOutcome(login.ok, loginBody);
+        if (outcome.kind === 'error') throw new Error(outcome.message);
+        if (outcome.kind === 'mfa') {
+          enterMfa(outcome.challenge, outcome.token);
+          go.disabled = false;
+          return;
+        }
+        token = outcome.token;
+      }
 
       var level = (document.querySelector('input[name=level]:checked') || {}).value || 'read';
       var consent = await fetch('/oauth/authorize/consent', {
         method: 'POST',
-        headers: { 'content-type': 'application/json', authorization: 'Bearer ' + loginBody.token },
+        headers: { 'content-type': 'application/json', authorization: 'Bearer ' + token },
         body: JSON.stringify({
           client_id: P.client_id, redirect_uri: P.redirect_uri,
           code_challenge: P.code_challenge, code_challenge_method: P.code_challenge_method,
@@ -267,7 +384,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       location.href = out.redirect_to;
     } catch (e2) {
       err.textContent = e2.message || String(e2);
-      go.disabled = false; go.textContent = 'Approve';
+      go.disabled = false;
+      go.textContent = pending ? 'Verify' : 'Approve';
     }
   });
 </script>`)

--- a/apps/backend/src/links/inventory-order-lines-product-variants.ts
+++ b/apps/backend/src/links/inventory-order-lines-product-variants.ts
@@ -1,0 +1,34 @@
+/**
+ * Inventory order line ↔ product variant (#1873).
+ *
+ * An inventory order line may be placed by naming a partner's product VARIANT
+ * rather than an inventory item. `ensureLineInventoryItems` (#1662) resolves
+ * that variant to an inventory item — creating the item and enabling tracking
+ * at our end when the variant was `manage_inventory: false` — and until this
+ * link existed the variant was then thrown away. The order could no longer say
+ * which product it was for; prod had 65 of 65 lines item-backed and 0
+ * product-backed.
+ *
+ * The line model's own comment ("We are linking module links to order line with
+ * inventory and product") always intended this; only the inventory half was
+ * ever built (`inventory-orders-inventory-items.ts`).
+ *
+ * A line has AT MOST one variant, and a variant may appear on many lines over
+ * time — one order line is one thing ordered once, but the same variant is
+ * reorderable. Raw-material lines have no link row at all: they genuinely have
+ * no product, and an absent row says that more honestly than a null column.
+ */
+import { defineLink } from "@medusajs/framework/utils";
+import InventoryOrdersModule from "../modules/inventory_orders";
+import ProductModule from "@medusajs/medusa/product";
+
+export default defineLink(
+  {
+    linkable: InventoryOrdersModule.linkable.inventoryOrderLine,
+    isList: true,
+  },
+  {
+    linkable: ProductModule.linkable.productVariant,
+    isList: false,
+  }
+);

--- a/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   buildOrderLinePayloads,
   buildInventoryLineLinkPairs,
+  buildInventoryLineVariantPairs,
   sumLineTotals,
   buildMaterialLookupByInventoryId,
   enrichOrderLinesWithMaterial,
@@ -290,5 +291,77 @@ describe("planMaterialBackfill (#1613 scope item 4)", () => {
       { line_id: "ol_2", inventory_item_id: "iitem_2", field: "material_name", after: "Muga Silk" },
       { line_id: "ol_2", inventory_item_id: "iitem_2", field: "raw_material_id", after: "rm_2" },
     ])
+  })
+})
+
+describe("buildInventoryLineVariantPairs (#1873)", () => {
+  const line = (id: string) => ({ id })
+  const input = (inventory_id: string, variant_id?: string | null) => ({
+    inventory_id,
+    quantity: 1,
+    price: 10,
+    ...(variant_id !== undefined ? { variant_id } : {}),
+  })
+
+  it("pairs a line to the variant it was ordered as", () => {
+    expect(
+      buildInventoryLineVariantPairs([line("ol_1")], [input("iitem_1", "variant_1")])
+    ).toEqual([{ order_line_id: "ol_1", variant_id: "variant_1" }])
+  })
+
+  it("DROPS a line with no variant rather than pairing it to null", () => {
+    // A raw-material line genuinely has no product. An absent link row says
+    // that; a row pointing at null would be a link to nothing.
+    expect(
+      buildInventoryLineVariantPairs([line("ol_1")], [input("iitem_1")])
+    ).toEqual([])
+    expect(
+      buildInventoryLineVariantPairs([line("ol_1")], [input("iitem_1", null)])
+    ).toEqual([])
+  })
+
+  it("keeps each line with its OWN variant when only some lines have one", () => {
+    // The regression this guards: dropping unpaired lines by filtering the
+    // INPUT first would shift every later line onto the wrong variant.
+    const pairs = buildInventoryLineVariantPairs(
+      [line("ol_1"), line("ol_2"), line("ol_3")],
+      [input("iitem_1"), input("iitem_2", "variant_2"), input("iitem_3", "variant_3")]
+    )
+    expect(pairs).toEqual([
+      { order_line_id: "ol_2", variant_id: "variant_2" },
+      { order_line_id: "ol_3", variant_id: "variant_3" },
+    ])
+  })
+
+  it("throws on a length mismatch instead of silently mis-pairing", () => {
+    expect(() =>
+      buildInventoryLineVariantPairs(
+        [line("ol_1")],
+        [input("iitem_1", "variant_1"), input("iitem_2", "variant_2")]
+      )
+    ).toThrow(/line count mismatch/i)
+  })
+
+  it("is empty for an order where no line named a variant", () => {
+    expect(
+      buildInventoryLineVariantPairs(
+        [line("ol_1"), line("ol_2")],
+        [input("iitem_1"), input("iitem_2")]
+      )
+    ).toEqual([])
+  })
+})
+
+describe("buildOrderLinePayloads x variant_id (#1873)", () => {
+  it("does NOT persist variant_id on the line — it has no such column", () => {
+    // The whole reason variant_id can ride along on the service input safely:
+    // this allowlist is the persistence boundary. If it ever started passing
+    // unknown keys through, the create would fail on an unknown field.
+    const [payload] = buildOrderLinePayloads(
+      [{ inventory_id: "iitem_1", quantity: 2, price: 5, variant_id: "variant_1" }],
+      "order_1"
+    )
+    expect(payload).not.toHaveProperty("variant_id")
+    expect(payload).toMatchObject({ quantity: 2, price: 5, inventory_orders: "order_1" })
   })
 })

--- a/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
@@ -21,6 +21,17 @@ export type CreateOrderLineInput = {
   raw_material_id?: string | null
   // Per-unit extra charge on top of `price` (colour job, finishing, …).
   extra_cost?: number | null
+  /**
+   * #1873 — the product variant this line was ordered as, when the caller named
+   * one instead of an inventory item. `ensureLineInventoryItems` resolves it to
+   * `inventory_id`; this keeps WHICH variant that was, so the order can still
+   * answer "what product was this for" afterwards.
+   *
+   * Never persisted on the line: `buildOrderLinePayloads` is an allowlist and
+   * does not pass it through. It exists to build the line↔variant link.
+   * Raw-material lines leave it null, which is honest — they have no product.
+   */
+  variant_id?: string | null
 }
 
 export type OrderLinePayload = {
@@ -169,6 +180,38 @@ export const buildInventoryLineLinkPairs = (
     order_line_id: line.id,
     inventory_item_id: order_lines[i].inventory_id,
   }))
+}
+
+/** One line paired with the product variant it was ordered as (#1873). */
+export type LineVariantPair = {
+  order_line_id: string
+  variant_id: string
+}
+
+/**
+ * #1873 — pair created lines with the variant each was ordered as.
+ *
+ * Same contract as `buildInventoryLineLinkPairs`: positional, but only behind
+ * the count guard that makes the position meaningful (#778 C3). Lines with no
+ * variant are DROPPED rather than paired to null — a link row must mean "this
+ * line is that variant", and a raw-material line genuinely is not one.
+ */
+export const buildInventoryLineVariantPairs = (
+  createdLines: { id: string }[],
+  order_lines: CreateOrderLineInput[]
+): LineVariantPair[] => {
+  if (createdLines.length !== order_lines.length) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Inventory order line count mismatch: created ${createdLines.length} lines for ${order_lines.length} inputs`
+    )
+  }
+  return createdLines.flatMap((line, i) => {
+    const variantId = order_lines[i].variant_id
+    return variantId
+      ? [{ order_line_id: line.id, variant_id: String(variantId) }]
+      : []
+  })
 }
 
 /** One order line as the material backfill sees it (#1613 scope item 4). */

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -15,6 +15,7 @@ import { InferTypeOf, Context } from "@medusajs/framework/types"
 import {
   buildOrderLinePayloads,
   buildInventoryLineLinkPairs,
+  buildInventoryLineVariantPairs,
 } from "./lib/create-helpers";
 export type OrderLinesResponse = InferTypeOf<typeof OrderLine>[]
 
@@ -156,8 +157,12 @@ class InventoryOrderService extends MedusaService({
     }
 
     const lineItemPairs = buildInventoryLineLinkPairs(orderLines, order_lines);
+    // #1873 — computed here for the same reason as the item pairing: the
+    // correspondence between an input line and the row it became is only known
+    // at creation time. Empty when no line named a variant (raw materials).
+    const lineVariantPairs = buildInventoryLineVariantPairs(orderLines, order_lines);
 
-    return { order, orderLines, lineItemPairs };
+    return { order, orderLines, lineItemPairs, lineVariantPairs };
   }
 } 
 

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -93,6 +93,11 @@ export const createInventoryOrderWithLinesStep = createStep(
       price: line.price,
       extra_cost: line.extra_cost ?? null,
       batch_number: line.batch_number ?? null,
+      // #1873 — the SECOND place the variant was lost. This mapping builds the
+      // service input field by field, so keeping `variant_id` on the ensured
+      // line upstream achieves nothing unless it is named here too. Null for a
+      // raw-material line, which has no product.
+      variant_id: (line as any).variant_id ?? null,
       metadata: line.metadata
     };
     });
@@ -205,6 +210,53 @@ export const linkInventoryItemsWithLinesStep = createStep(
   }
 );
 
+/**
+ * #1873 — link each line to the product variant it was ordered as.
+ *
+ * Separate from `linkInventoryItemsWithLinesStep` rather than folded into it:
+ * the two links answer different questions (what to stock vs what it was for),
+ * and only some lines have a variant at all. Pairs come from the create step,
+ * never from re-zipping arrays by index (#778 C3).
+ */
+export const linkVariantsWithLinesStep = createStep(
+  "link-variants-with-lines-step",
+  async (
+    input: { order_id: string; variant_pairs: { order_line_id: string; variant_id: string }[] },
+    { container }
+  ) => {
+    const pairs = input.variant_pairs ?? [];
+    if (!pairs.length) {
+      // No line named a variant — a pure raw-material order. Nothing to link,
+      // and an empty `create` call is not worth making.
+      return new StepResponse([], []);
+    }
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
+    const links: LinkDefinition[] = pairs.map(({ order_line_id, variant_id }) => ({
+      [ORDER_INVENTORY_MODULE]: {
+        inventory_order_line_id: order_line_id,
+      },
+      [Modules.PRODUCT]: {
+        product_variant_id: variant_id,
+      },
+      data: {
+        order_line_id,
+        variant_id,
+      },
+    }));
+    await remoteLink.create(links);
+    return new StepResponse(links, links);
+  },
+  async (links, { container }) => {
+    if (!links?.length) return;
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
+    try {
+      await remoteLink.dismiss(links as any);
+    } catch {
+      /* best-effort link cleanup */
+    }
+  }
+);
+
 export const linkInventoryOrderWithStockLocation = createStep(
   "link-inventory-order-with-stock-location",
   async (input: { order_id: string; stock_location_id: string }, { container }) => {
@@ -285,7 +337,13 @@ export const ensureOrderLineInventoryItemsStep = createStep(
     );
 
     return new StepResponse({
-      order_lines: lines.map(({ enabled_variant_id, actions, variant_id, ...line }) => ({
+      // #1873 — `variant_id` is KEPT. It used to be destructured out here, which
+      // is where the association died: the line was written with a real item id
+      // and no record of the variant it was ordered as, so the order could never
+      // say which product it was for. It is not a line column and cannot become
+      // one by accident — `buildOrderLinePayloads` is an allowlist — it rides
+      // along only far enough to build the line↔variant link.
+      order_lines: lines.map(({ enabled_variant_id, actions, ...line }) => ({
         ...line,
         inventory_item_id: line.inventory_item_id,
       })),
@@ -331,12 +389,22 @@ export const createInventoryOrderWorkflow = createWorkflow(
           // Explicit line→item pairing from the create step (#778 C3) — not a
           // positional zip of separately-derived id arrays.
           line_pairs: created.lineItemPairs ?? [],
+          // #1873 — same provenance, for the line→variant link. Empty unless a
+          // line was ordered by naming a variant.
+          variant_pairs: created.lineVariantPairs ?? [],
           order: created.order,
           orderLines: created.orderLines,
         }
       }
     );
     const links = linkInventoryItemsWithLinesStep(linkInput);
+
+    // #1873 — record WHICH product variant each line was ordered as, alongside
+    // the inventory item it resolved to.
+    linkVariantsWithLinesStep({
+      order_id: linkInput.order_id,
+      variant_pairs: linkInput.variant_pairs,
+    });
 
     // Determine the to-location id from alias or stock_location_id
     const toLocationId = transform({ input }, ({ input }) => (

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -267,7 +267,7 @@ export const updateOrderLinesStep = createStep(
       );
     }
 
-    const created: Array<{ id: string; inventory_item_id?: string }> = [];
+    const created: Array<{ id: string; inventory_item_id?: string; variant_id?: string | null }> = [];
     const updated: Array<{ id: string; prevQuantity: number; prevPrice: any; prevExtraCost: any }> = [];
     const removed: Array<{ id: string; inventory_item_id?: string; quantity: number; price: any }> = [];
 
@@ -339,7 +339,29 @@ export const updateOrderLinesStep = createStep(
             }
           });
         }
-        created.push({ id: created_line.id, inventory_item_id: line.inventory_item_id });
+        // #1873 — a line added through UPDATE resolves a variant the same way
+        // create does (above, via ensureLineInventoryItems), so it must record
+        // the variant the same way too. Without this the association survives
+        // one door and dies at the other.
+        if (line.variant_id) {
+          await remoteLink.create({
+            [ORDER_INVENTORY_MODULE]: {
+              inventory_order_line_id: created_line.id
+            },
+            [Modules.PRODUCT]: {
+              product_variant_id: line.variant_id
+            },
+            data: {
+              order_line_id: created_line.id,
+              variant_id: line.variant_id
+            }
+          });
+        }
+        created.push({
+          id: created_line.id,
+          inventory_item_id: line.inventory_item_id,
+          variant_id: line.variant_id,
+        });
       }
     }
     // Return new state and save the precise per-line ops for compensation
@@ -352,7 +374,7 @@ export const updateOrderLinesStep = createStep(
   //   - lines we REMOVED → restore them by id + recreate their links (stable ids)
   async (
     compensationData: {
-      created: Array<{ id: string; inventory_item_id?: string }>;
+      created: Array<{ id: string; inventory_item_id?: string; variant_id?: string | null }>;
       updated: Array<{ id: string; prevQuantity: number; prevPrice: any; prevExtraCost: any }>;
       removed: Array<{ id: string; inventory_item_id?: string; quantity: number; price: any }>;
       order_id: string;
@@ -369,6 +391,15 @@ export const updateOrderLinesStep = createStep(
         await remoteLink.dismiss({
           [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: c.id },
           [Modules.INVENTORY]: { inventory_item_id: c.inventory_item_id },
+        });
+      }
+      // #1873 — a link this step created must be dismissed by this step's
+      // compensation, or a rolled-back update leaves a variant link pointing at
+      // a soft-deleted line.
+      if (c.variant_id) {
+        await remoteLink.dismiss({
+          [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: c.id },
+          [Modules.PRODUCT]: { product_variant_id: c.variant_id },
         });
       }
     }


### PR DESCRIPTION
With MFA enabled on an admin account, authorizing an MCP client was impossible — and the page never said why.

## The bug

`POST /auth/user/emailpass` answers an MFA-enabled account with:

```json
{ "mfa_required": true, "mfa_challenge": {...}, "token": "<ACTORLESS jwt>" }
```

HTTP 200, **and it carries a token**. The page's guard was `if (!login.ok || !loginBody.token) throw`. Both halves pass, so the flow continued to `/oauth/authorize/consent` with a token that has no `actor_id`. Consent runs `authenticate("user")` and reads `auth.actor_id`, so it answered 401 and the page showed *"Could not authorize."* — with nothing anywhere mentioning a second factor.

**The token being present is exactly why this looked like a generic failure rather than a missing step.** That actorless token isn't useless, though: it's the credential for `POST /auth/mfa/challenges/:id/verify`, and nothing else.

## The flow now

`emailpass → mfa_required? → code prompt → challenges/:id/verify → consent`

- The **access-level radios are hidden but not removed** at the code step, so the level chosen before the prompt is what gets sent after it.
- A **method picker appears only when there's a real choice** — `totp`, plus `recovery_code` when recovery codes exist — and the hint follows the selection. `method` is sent even when there's one option, because the API requires it.
- An **empty code is refused client-side** without calling the API. The input is deliberately **not** `required`: a hidden `required` field bars submission with an unfocusable-control error and no visible cause.
- A **spent or expired challenge** (404 / "expired") drops back to the credential step with the reason — a challenge is single-use and time-boxed.
- `verification_required` gets its own message instead of "Sign-in failed."

## One rule, one home

The decision lives in `login-outcome.ts` as a pure function, and the page embeds **that same function** via `toString()`. The page is a self-contained HTML string with inline browser JS, so there's nothing for a test to import — a tested copy here plus an untested copy in the template would be two homes for the rule carrying the entire bug.

That embedding constrains the function: no imports, no module-scope references (a closure compiles fine and then throws `ReferenceError` in the browser), and no backticks or `${...}` — the page is a **template literal**.

That last constraint is not hypothetical. Two backticks in a comment I added inside the page's script broke route registration outright (`Expected ',', got 'token'`) and the dev server refused to boot. Both constraints are now pinned by tests.

## Verified

- **11 unit cases**, mutation-checked: restoring the original ordering (trust the token before checking `mfa_required`) fails 3, including both cases aimed at the bug.
- **The function was extracted from the rendered page and executed** — MFA response → `mfa`, normal login → `token`, bad password → `error`. Not just the TS module: the shipped bytes.
- **Driven in a real browser** against the dev server with auth calls intercepted:

  | check | result |
  |---|---|
  | code prompt shown / credentials hidden | ✓ / ✓ |
  | picker options | Authenticator app, Recovery code |
  | empty code | no request made, inline error |
  | verify URL | `/auth/mfa/challenges/authmfachal_TEST/verify` |
  | verify auth + body | `Bearer ACTORLESS.JWT`, `{"method":"totp","code":"123456"}` |
  | **consent auth** | **`Bearer REAL.JWT`** ← the fix |
  | call order | login → verify → consent |

- `check:prod-build` green.

## Note

The browser run above was a scratch Playwright script, not checked in — the repo's e2e harness would need its own wiring for a page like this, and the DOM logic it covers is thin around the unit-tested core. Worth adding if this page grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4