### PR TITLE
feat(admin): assistant history + media picker as route modals over the chat

### DIFF
--- a/apps/backend/src/admin/routes/assistant/@history/page.tsx
+++ b/apps/backend/src/admin/routes/assistant/@history/page.tsx
@@ -1,0 +1,19 @@
+/**
+ * Chat history as a route modal over the assistant page.
+ *
+ * The `@` prefix makes this a CHILD route of /assistant (the `@` is stripped
+ * from the URL), so it renders inside the page's <Outlet /> — the chat, its
+ * useChat thread and any pending attachments stay mounted underneath.
+ */
+import { RouteFocusModal } from "../../../components/modal/route-focus-modal"
+import { HistoryListModal } from "../_components/history-modal"
+
+const AssistantHistoryPage = () => (
+  <RouteFocusModal>
+    <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto px-6 py-8 md:px-8">
+      <HistoryListModal />
+    </RouteFocusModal.Body>
+  </RouteFocusModal>
+)
+
+export default AssistantHistoryPage

--- a/apps/backend/src/admin/routes/assistant/@media/page.tsx
+++ b/apps/backend/src/admin/routes/assistant/@media/page.tsx
@@ -1,0 +1,18 @@
+/**
+ * Media picker as a route modal over the assistant page.
+ *
+ * The `@` prefix makes this a CHILD route of /assistant (the `@` is stripped
+ * from the URL), so it renders inside the page's <Outlet /> — the chat stays
+ * mounted underneath, and the picker adds its selection straight into the
+ * composer's pending attachments through the shared page context.
+ */
+import { RouteFocusModal } from "../../../components/modal/route-focus-modal"
+import { MediaPickerModal } from "../_components/media-picker"
+
+const AssistantMediaPage = () => (
+  <RouteFocusModal>
+    <MediaPickerModal />
+  </RouteFocusModal>
+)
+
+export default AssistantMediaPage

--- a/apps/backend/src/admin/routes/assistant/_components/assistant-page-context.tsx
+++ b/apps/backend/src/admin/routes/assistant/_components/assistant-page-context.tsx
@@ -1,0 +1,74 @@
+/**
+ * Shared state between the assistant page and its route modals.
+ *
+ * History and the media picker live on child routes (`@history`, `@media`) so
+ * they render as `RouteFocusModal`s over the chat — which keeps the thread
+ * (and `useChat`) mounted while they are open. The `@`-prefixed segments are
+ * registered as children of `/assistant`, so both modals render inside this
+ * page's `<Outlet />` and share its React tree — this context is the bridge
+ * they use to act on the page's state: attachments for the media picker,
+ * conversation actions for the history list.
+ */
+import { createContext, useContext } from "react"
+import { API_BASE_URL } from "../../../lib/config"
+
+/** An image the operator attached to the next message — uploaded or from the media library. */
+export type AssistantAttachment = {
+  url: string
+  name: string
+  mime_type: string
+}
+
+export type ConversationSummary = {
+  id: string
+  title: string
+  created_at?: string
+  updated_at?: string
+}
+
+export type StoredMessage = { id: string; role: string; parts: any[] }
+
+/**
+ * Matches the server validator (`attachments` on POST /admin/assistant/chat)
+ * and the `useChat` files part — see the composer in page.tsx.
+ */
+export const MAX_ATTACHMENTS = 4
+
+export const CONVERSATIONS_URL = `${API_BASE_URL.replace(/\/$/, "")}/admin/assistant/conversations`
+
+/** Admin session cookie authenticates; small typed fetch wrapper. */
+export async function apiFetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    ...init,
+  })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return (await res.json()) as T
+}
+
+export type AssistantPageContextValue = {
+  // ── Attachments shared between the composer and the media picker ──
+  attachments: AssistantAttachment[]
+  addAttachments: (files: AssistantAttachment[]) => void
+  removeAttachment: (url: string) => void
+  clearAttachments: () => void
+  maxAttachments: number
+
+  // ── Conversation actions, used by the history route modal ──
+  activeId: string | null
+  openConversation: (id: string) => void
+  /** Rejects after toasting, so a caller can undo an optimistic removal. */
+  deleteConversation: (id: string) => Promise<void>
+  startNew: () => void
+}
+
+export const AssistantPageContext = createContext<AssistantPageContextValue | null>(null)
+
+export const useAssistantPage = (): AssistantPageContextValue => {
+  const ctx = useContext(AssistantPageContext)
+  if (!ctx) {
+    throw new Error("useAssistantPage must be used within the assistant page")
+  }
+  return ctx
+}

--- a/apps/backend/src/admin/routes/assistant/_components/history-modal.tsx
+++ b/apps/backend/src/admin/routes/assistant/_components/history-modal.tsx
@@ -1,0 +1,145 @@
+/**
+ * Chat history, shown in the route modal at /assistant/history.
+ *
+ * The assistant page no longer carries a sidebar: history lives here, opened
+ * from the header, and the list is fetched fresh on every open so it reflects
+ * conversations created or deleted anywhere since the page loaded. Selecting a
+ * conversation calls back into the page (via AssistantPageContext) to load its
+ * messages, then the modal closes — the page never unmounted, so the switch is
+ * instant.
+ */
+import { useCallback, useEffect, useState } from "react"
+import { Plus, Spinner, Trash } from "@medusajs/icons"
+import { Badge, Button, Container, Text, toast } from "@medusajs/ui"
+import { useRouteModal } from "@/components/modal/use-route-modal"
+import {
+  CONVERSATIONS_URL,
+  apiFetch,
+  useAssistantPage,
+  type ConversationSummary,
+} from "./assistant-page-context"
+
+const HistoryList = () => {
+  const { activeId, openConversation, deleteConversation, startNew } = useAssistantPage()
+  const { handleSuccess } = useRouteModal()
+  const [conversations, setConversations] = useState<ConversationSummary[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const { conversations } = await apiFetch<{ conversations: ConversationSummary[] }>(
+          CONVERSATIONS_URL
+        )
+        if (!cancelled) setConversations(conversations)
+      } catch {
+        if (!cancelled) toast.error("Could not load your conversations.")
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const select = useCallback(
+    (id: string) => {
+      if (id !== activeId) openConversation(id)
+      handleSuccess()
+    },
+    [activeId, openConversation, handleSuccess]
+  )
+
+  const remove = useCallback(
+    async (id: string) => {
+      const previous = conversations
+      // Optimistic: the row disappearing is the confirmation the delete landed.
+      setConversations((prev) => prev.filter((c) => c.id !== id))
+      try {
+        await deleteConversation(id)
+      } catch {
+        // The page already surfaced the failure; put the row back.
+        setConversations(previous)
+      }
+    },
+    [conversations, deleteConversation]
+  )
+
+  return (
+    <div className="flex w-full flex-col gap-y-3">
+      <div className="flex items-center justify-between">
+        <Text size="small" className="text-ui-fg-subtle">
+          Pick up a past conversation, or start a new one.
+        </Text>
+        <Button
+          size="small"
+          variant="secondary"
+          onClick={() => {
+            startNew()
+            handleSuccess()
+          }}
+        >
+          <Plus /> New chat
+        </Button>
+      </div>
+
+      <Container className="p-0">
+        {loading ? (
+          <div className="text-ui-fg-muted flex items-center gap-2 px-6 py-6">
+            <Spinner className="animate-spin" />
+            <Text size="small">Loading…</Text>
+          </div>
+        ) : conversations.length === 0 ? (
+          <Text size="small" className="text-ui-fg-muted px-6 py-6">
+            No conversations yet — they appear here after your first exchange.
+          </Text>
+        ) : (
+          conversations.map((c) => (
+            <div
+              key={c.id}
+              className={`group flex items-center gap-3 border-b px-6 py-3 last:border-b-0 ${
+                c.id === activeId ? "bg-ui-bg-base-pressed" : "hover:bg-ui-bg-base-hover"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => select(c.id)}
+                className="flex min-w-0 flex-1 flex-col items-start gap-1 text-left"
+                title={c.title}
+              >
+                <span className="text-ui-fg-base w-full truncate text-sm">{c.title}</span>
+                <span className="text-ui-fg-subtle text-xs">
+                  {c.updated_at || c.created_at
+                    ? new Date(c.updated_at || (c.created_at as string)).toLocaleString()
+                    : ""}
+                </span>
+              </button>
+              {c.id === activeId ? (
+                <Badge size="2xsmall" color="green">
+                  Current
+                </Badge>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => void remove(c.id)}
+                className="text-ui-fg-muted hover:text-ui-fg-error opacity-0 transition-opacity group-hover:opacity-100"
+                aria-label="Delete conversation"
+              >
+                <Trash className="h-4 w-4" />
+              </button>
+            </div>
+          ))
+        )}
+      </Container>
+    </div>
+  )
+}
+
+export const HistoryListModal = () => (
+  <div className="flex w-full max-w-[720px] flex-col">
+    <HistoryList />
+  </div>
+)

--- a/apps/backend/src/admin/routes/assistant/_components/media-picker.tsx
+++ b/apps/backend/src/admin/routes/assistant/_components/media-picker.tsx
@@ -1,0 +1,255 @@
+/**
+ * Media picker for the chat, shown in the route modal at /assistant/media.
+ *
+ * Finds an already-hosted image in the media library and attaches its URL to
+ * the next chat message — the same `attachments` array a direct upload feeds,
+ * so the server-side contract (POST /admin/assistant/chat) is untouched: the
+ * picker just produces `{ url, name, mime_type }` references instead of bytes.
+ *
+ * Selection is capped by the room left under the composer's attachment limit;
+ * adding beyond that is refused here, at the UI, rather than silently dropped
+ * by the page's backstop slice.
+ */
+import { useEffect, useMemo, useState } from "react"
+import { CheckCircleSolid, Photo } from "@medusajs/icons"
+import { Button, Input, Select, Text, Tooltip, toast } from "@medusajs/ui"
+import { RouteFocusModal } from "@/components/modal/route-focus-modal"
+import { useRouteModal } from "@/components/modal/use-route-modal"
+import {
+  useMediaFiles,
+  useFolders,
+  type MediaFile,
+} from "@/hooks/api/media"
+import { getThumbUrl } from "@/lib/media"
+import { useAssistantPage } from "./assistant-page-context"
+
+/** Absolute URL for a library file, matching how MediaUpload builds them. */
+const mediaFileUrl = (file: MediaFile): string =>
+  file.file_path?.startsWith("http")
+    ? file.file_path
+    : `${process.env.NEXT_PUBLIC_AWS_S3 || ""}${file.file_path}`
+
+const MediaTile = ({
+  file,
+  isSelected,
+  onToggle,
+}: {
+  file: MediaFile
+  isSelected: boolean
+  onToggle: () => void
+}) => {
+  const url = mediaFileUrl(file)
+  const displayName = file.original_name || file.file_name
+
+  return (
+    <Tooltip content={displayName}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={`relative h-20 w-20 cursor-pointer overflow-hidden rounded border shadow-sm transition-colors ${
+          isSelected
+            ? "border-ui-border-interactive"
+            : "border-ui-border-base hover:border-ui-border-strong"
+        }`}
+      >
+        {isSelected ? (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/50">
+            <CheckCircleSolid className="text-ui-fg-on-color" />
+          </div>
+        ) : null}
+        <img
+          src={getThumbUrl(url, { width: 160, quality: 70, fit: "cover" })}
+          alt={displayName}
+          className="h-full w-full object-cover"
+          loading="lazy"
+          decoding="async"
+        />
+      </button>
+    </Tooltip>
+  )
+}
+
+export const MediaPickerModal = () => {
+  const { attachments, addAttachments, maxAttachments } = useAssistantPage()
+  const { handleSuccess } = useRouteModal()
+
+  const [folderId, setFolderId] = useState<string | undefined>(undefined)
+  const [search, setSearch] = useState("")
+  const [debouncedSearch, setDebouncedSearch] = useState("")
+  const [selected, setSelected] = useState<MediaFile[]>([])
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 300)
+    return () => clearTimeout(t)
+  }, [search])
+
+  const { data: foldersData } = useFolders()
+  const folders = foldersData?.folders || []
+
+  const room = maxAttachments - attachments.length
+  const roomLeft = Math.max(0, room - selected.length)
+
+  const {
+    files,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useMediaFiles({
+    file_type: "image",
+    folder_id: folderId,
+    search: debouncedSearch || undefined,
+    limit: 40,
+  })
+
+  const toggle = (file: MediaFile) => {
+    if (selected.find((f) => f.id === file.id)) {
+      setSelected(selected.filter((f) => f.id !== file.id))
+      return
+    }
+    if (room <= 0) {
+      toast.error(
+        `Attachment limit reached — remove one from the composer first (max ${maxAttachments} per message)`
+      )
+      return
+    }
+    if (selected.length >= room) {
+      toast.error(`You can select at most ${room} more image${room === 1 ? "" : "s"}`)
+      return
+    }
+    setSelected([...selected, file])
+  }
+
+  const confirm = () => {
+    if (!selected.length) return
+    addAttachments(
+      selected.map((f) => ({
+        url: mediaFileUrl(f),
+        name: f.original_name || f.file_name,
+        mime_type: f.mime_type || "image/*",
+      }))
+    )
+    handleSuccess()
+  }
+
+  const folderSelect = useMemo(
+    () => (
+      <div className="w-full max-w-[260px]">
+        <Text size="xsmall" className="text-ui-fg-subtle mb-1">
+          Folder
+        </Text>
+        <Select
+          value={folderId || "all"}
+          onValueChange={(val) => setFolderId(val === "all" ? undefined : val)}
+          disabled={isLoading}
+        >
+          <Select.Trigger>
+            <Select.Value placeholder="All Folders" />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="all">All Folders</Select.Item>
+            {folders.map((folder) => (
+              <Select.Item key={folder.id} value={folder.id}>
+                {folder.path}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+      </div>
+    ),
+    [folderId, folders, isLoading]
+  )
+
+  return (
+    <>
+      <RouteFocusModal.Header>
+        <RouteFocusModal.Title asChild>
+          <span className="text-xl md:text-2xl">Attach media</span>
+        </RouteFocusModal.Title>
+        <RouteFocusModal.Description asChild>
+          <span className="text-ui-fg-subtle mt-1 text-small">
+            Pick images from the media library to send with your next message —
+            the assistant reads them on request.
+          </span>
+        </RouteFocusModal.Description>
+      </RouteFocusModal.Header>
+
+      <RouteFocusModal.Body className="flex flex-1 flex-col overflow-y-auto">
+        <div className="flex w-full flex-col gap-y-4 px-6 py-8 md:px-8">
+          <div className="flex flex-wrap items-end gap-x-4 gap-y-2">
+            {folderSelect}
+            <div className="w-full max-w-[260px]">
+              <Text size="xsmall" className="text-ui-fg-subtle mb-1">
+                Search
+              </Text>
+              <Input
+                type="text"
+                placeholder="Search images…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                size="small"
+                disabled={isLoading}
+              />
+            </div>
+            <Text size="xsmall" className="text-ui-fg-muted ml-auto">
+              {selected.length
+                ? `${selected.length} selected · ${roomLeft} slot${roomLeft === 1 ? "" : "s"} left`
+                : `${room > 0 ? `${room} slot${room === 1 ? "" : "s"} left` : "Attachment limit reached"}`}
+            </Text>
+          </div>
+
+          {isError ? (
+            <Text className="text-ui-fg-error">Failed to load files.</Text>
+          ) : files.length === 0 && !isLoading ? (
+            <div className="flex flex-col items-center justify-center py-12">
+              <Photo className="text-ui-fg-muted mb-2" />
+              <Text size="small" className="text-ui-fg-subtle">
+                {search || folderId ? "No images match your filters" : "No images found"}
+              </Text>
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-4 gap-3 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10">
+                {files.map((file) => (
+                  <MediaTile
+                    key={file.id}
+                    file={file}
+                    isSelected={!!selected.find((f) => f.id === file.id)}
+                    onToggle={() => toggle(file)}
+                  />
+                ))}
+              </div>
+              {hasNextPage && !isLoading ? (
+                <Button
+                  variant="secondary"
+                  size="small"
+                  disabled={isFetchingNextPage}
+                  onClick={() => fetchNextPage()}
+                  className="self-center"
+                >
+                  {isFetchingNextPage ? "Loading…" : "Load more"}
+                </Button>
+              ) : null}
+            </>
+          )}
+        </div>
+      </RouteFocusModal.Body>
+
+      <RouteFocusModal.Footer className="px-6 py-3 md:px-8 md:py-4">
+        <div className="flex w-full items-center justify-end gap-x-2">
+          <RouteFocusModal.Close asChild>
+            <Button variant="secondary">Cancel</Button>
+          </RouteFocusModal.Close>
+          <Button
+            variant="primary"
+            disabled={!selected.length}
+            onClick={confirm}
+          >
+            Add to chat{selected.length ? ` (${selected.length})` : ""}
+          </Button>
+        </div>
+      </RouteFocusModal.Footer>
+    </>
+  )
+}

--- a/apps/backend/src/admin/routes/assistant/page.tsx
+++ b/apps/backend/src/admin/routes/assistant/page.tsx
@@ -10,16 +10,31 @@
  *
  * This lives alongside the legacy V4 hybrid-resolver chat (routes/chats) rather
  * than replacing it, per the epic's one-release deprecation window.
+ *
+ * History is NOT a sidebar any more: it opens as a route modal over the chat
+ * (`/assistant/history`), and the media picker rides the same mechanism
+ * (`assistant/media`) so picking library images does not disturb the thread.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { defineRouteConfig } from "@medusajs/admin-sdk"
-import { ChatBubbleLeftRight, Sparkles, ArrowUpMini, Spinner, Check, ExclamationCircle, ArrowPathMini, SquareTwoStack, Plus, Trash, Photo, TriangleDownMini, TriangleRightMini } from "@medusajs/icons"
+import { ChatBubbleLeftRight, Sparkles, ArrowUpMini, Spinner, Check, ExclamationCircle, ArrowPathMini, SquareTwoStack, Plus, Trash, Photo, SquaresPlus, Clock, TriangleDownMini, TriangleRightMini } from "@medusajs/icons"
 import { Container, Heading, Text, Button, Textarea, IconButton, Badge, Table, toast } from "@medusajs/ui"
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport } from "ai"
+import { Outlet, useNavigate } from "react-router-dom"
 import { API_BASE_URL } from "../../lib/config"
 import { runAdminMcpTool, type AdminToolResult } from "../../lib/assistant-mcp"
 import { Markdown } from "../../components/markdown"
+import { getThumbUrl } from "../../lib/media"
+import {
+  MAX_ATTACHMENTS,
+  CONVERSATIONS_URL,
+  apiFetch,
+  useAssistantPage,
+  AssistantPageContext,
+  type AssistantAttachment,
+  type StoredMessage,
+} from "./_components/assistant-page-context"
 
 const SUGGESTIONS = [
   "Give me a snapshot of the platform",
@@ -28,18 +43,9 @@ const SUGGESTIONS = [
   "What production runs are open?",
 ]
 
-/** An uploaded image the operator attached to the next message. */
-type Attachment = {
-  url: string
-  name: string
-  mime_type: string
-}
-
 /** Images only, and small enough that a vision model can actually read it. */
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
 import { describeChatError } from "./chat-error"
-
-const MAX_ATTACHMENTS = 4
 
 /**
  * Upload one image and return the reference the chat route stores.
@@ -48,7 +54,7 @@ const MAX_ATTACHMENTS = 4
  * the path that must never regress to latin1, or every image ≥ 0x80 arrives
  * corrupted and unreadable by any vision model (#769/#789).
  */
-async function uploadAttachment(file: File): Promise<Attachment> {
+async function uploadAttachment(file: File): Promise<AssistantAttachment> {
   const form = new FormData()
   form.append("files", file)
 
@@ -418,6 +424,40 @@ const getText = (parts: any[] | undefined): string =>
     .map((p) => p.text)
     .join("")
 
+/**
+ * Thumbnails for the files a user message carried — uploaded or picked from
+ * the media library. The file parts ride on the message itself (sent via
+ * `sendMessage({ files })`), so they render here immediately, persist with the
+ * conversation, and are stripped server-side before the model sees anything.
+ */
+const AttachmentThumbs = ({ parts }: { parts: any[] | undefined }) => {
+  const files = (parts || []).filter(
+    (p) => p?.type === "file" && typeof p.url === "string"
+  )
+  if (!files.length) return null
+  return (
+    <div className="mt-1 flex flex-wrap gap-1.5">
+      {files.map((f: any, i: number) =>
+        String(f.mediaType || "").startsWith("image/") ? (
+          <img
+            key={`${f.url}-${i}`}
+            src={getThumbUrl(f.url, { width: 320, quality: 70, fit: "cover" })}
+            alt={f.filename || "attachment"}
+            className="h-16 w-16 rounded-md object-cover"
+          />
+        ) : (
+          <span
+            key={`${f.url}-${i}`}
+            className="bg-ui-bg-base-pressed max-w-[160px] truncate rounded-md px-2 py-1 text-xs"
+          >
+            {f.filename || f.url}
+          </span>
+        )
+      )}
+    </div>
+  )
+}
+
 /** Copy-to-clipboard affordance for an assistant answer. */
 const CopyButton = ({ text }: { text: string }) => {
   const [copied, setCopied] = useState(false)
@@ -444,28 +484,6 @@ const CopyButton = ({ text }: { text: string }) => {
 }
 
 // ─── Conversation persistence (history) ──────────────────────────────────────
-
-type ConversationSummary = {
-  id: string
-  title: string
-  created_at?: string
-  updated_at?: string
-}
-
-type StoredMessage = { id: string; role: string; parts: any[] }
-
-const CONVERSATIONS_URL = `${API_BASE_URL.replace(/\/$/, "")}/admin/assistant/conversations`
-
-/** Admin session cookie authenticates; small typed fetch wrapper. */
-async function apiFetch<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
-    credentials: "include",
-    headers: { "content-type": "application/json" },
-    ...init,
-  })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return (await res.json()) as T
-}
 
 /** First user message → conversation title (trimmed to a sane length). */
 function deriveTitle(messages: any[]): string {
@@ -571,10 +589,20 @@ const AssistantChat = ({
     JSON.stringify(initialMessages.map((m) => [m.id, m.parts?.length]))
   )
 
-  // Attachments for the turn currently being sent. A ref, not state, because
-  // the transport closure is built once and must read the value at send time —
-  // and because clearing it must not race the re-render that follows send.
-  const pendingAttachmentsRef = useRef<Attachment[]>([])
+  // Attachments live on the page (shared context) rather than here, because
+  // the media picker on /assistant/media must be able to add to them while
+  // this component stays the one that SENDS them. A ref, not state, for the
+  // pending copy, because the transport closure is built once and must read
+  // the value at send time — and because clearing it must not race the
+  // re-render that follows send.
+  const {
+    attachments,
+    addAttachments,
+    removeAttachment,
+    clearAttachments,
+  } = useAssistantPage()
+  const pendingAttachmentsRef = useRef<AssistantAttachment[]>([])
+  const navigate = useNavigate()
 
   const transport = useMemo(
     () =>
@@ -616,7 +644,6 @@ const AssistantChat = ({
 
   const [autoScroll, setAutoScroll] = useState(true)
   const [queued, setQueued] = useState<string[]>([])
-  const [attachments, setAttachments] = useState<Attachment[]>([])
   const [uploading, setUploading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [compacting, setCompacting] = useState(false)
@@ -715,9 +742,22 @@ const AssistantChat = ({
 
     if (attachments.length) {
       pendingAttachmentsRef.current = attachments
-      setAttachments([])
+      clearAttachments()
+      // File parts ride on the message so thumbnails render in the thread and
+      // persist with it — the server strips them before the model sees
+      // anything; the top-level `attachments` field is what it reads.
+      sendMessage({
+        text: t || "(see attached)",
+        files: attachments.map((a) => ({
+          type: "file" as const,
+          mediaType: a.mime_type,
+          filename: a.name,
+          url: a.url,
+        })),
+      })
+      return
     }
-    sendMessage({ text: t || "(see attached)" })
+    sendMessage({ text: t })
   }
 
   /** Validate, upload, and hold images for the next send. */
@@ -754,19 +794,19 @@ const AssistantChat = ({
       try {
         const settled = await Promise.allSettled(accepted.map(uploadAttachment))
         const ok = settled
-          .filter((s): s is PromiseFulfilledResult<Attachment> => s.status === "fulfilled")
+          .filter((s): s is PromiseFulfilledResult<AssistantAttachment> => s.status === "fulfilled")
           .map((s) => s.value)
         settled
           .filter((s): s is PromiseRejectedResult => s.status === "rejected")
           .forEach((s) =>
             toast.error(`Could not attach: ${s.reason?.message ?? "upload failed"}`)
           )
-        if (ok.length) setAttachments((a) => [...a, ...ok])
+        if (ok.length) addAttachments(ok)
       } finally {
         setUploading(false)
       }
     },
-    [attachments.length]
+    [attachments.length, addAttachments]
   )
 
   useEffect(() => {
@@ -870,11 +910,14 @@ const AssistantChat = ({
                 }
               >
                 {m.role === "user" ? (
-                  text ? (
-                    <Text size="small" className="whitespace-pre-wrap">
-                      {text}
-                    </Text>
-                  ) : null
+                  <>
+                    {text ? (
+                      <Text size="small" className="whitespace-pre-wrap">
+                        {text}
+                      </Text>
+                    ) : null}
+                    <AttachmentThumbs parts={m.parts} />
+                  </>
                 ) : (
                   <>
                     {/*
@@ -999,9 +1042,7 @@ const AssistantChat = ({
                 <IconButton
                   size="2xsmall"
                   variant="transparent"
-                  onClick={() =>
-                    setAttachments((list) => list.filter((_, idx) => idx !== i))
-                  }
+                  onClick={() => removeAttachment(a.url)}
                 >
                   <Trash />
                 </IconButton>
@@ -1032,6 +1073,14 @@ const AssistantChat = ({
             onClick={() => fileInputRef.current?.click()}
           >
             <Photo />
+          </IconButton>
+          <IconButton
+            variant="transparent"
+            disabled={attachments.length >= MAX_ATTACHMENTS}
+            onClick={() => navigate("/assistant/media")}
+            title="Pick from the media library"
+          >
+            <SquaresPlus />
           </IconButton>
           <Textarea
             placeholder={
@@ -1084,100 +1133,23 @@ const AssistantChat = ({
   )
 }
 
-// ─── History sidebar ─────────────────────────────────────────────────────────
-
-const HistorySidebar = ({
-  conversations,
-  activeId,
-  loading,
-  onNew,
-  onSelect,
-  onDelete,
-}: {
-  conversations: ConversationSummary[]
-  activeId: string | null
-  loading: boolean
-  onNew: () => void
-  onSelect: (id: string) => void
-  onDelete: (id: string) => void
-}) => (
-  <div className="border-ui-border-base flex w-64 shrink-0 flex-col border-r">
-    <div className="border-ui-border-base border-b p-3">
-      <Button variant="secondary" size="small" className="w-full" onClick={onNew}>
-        <Plus /> New chat
-      </Button>
-    </div>
-    <div className="min-h-0 flex-1 overflow-y-auto p-2">
-      {loading ? (
-        <Text size="xsmall" className="text-ui-fg-muted px-2 py-1">
-          Loading…
-        </Text>
-      ) : conversations.length === 0 ? (
-        <Text size="xsmall" className="text-ui-fg-muted px-2 py-1">
-          No conversations yet.
-        </Text>
-      ) : (
-        conversations.map((c) => (
-          <div
-            key={c.id}
-            className={`group flex items-center gap-1 rounded-md px-2 py-1.5 ${
-              c.id === activeId ? "bg-ui-bg-base-pressed" : "hover:bg-ui-bg-base-hover"
-            }`}
-          >
-            <button
-              type="button"
-              onClick={() => onSelect(c.id)}
-              className="text-ui-fg-subtle hover:text-ui-fg-base flex-1 truncate text-left text-sm"
-              title={c.title}
-            >
-              {c.title}
-            </button>
-            <button
-              type="button"
-              onClick={() => onDelete(c.id)}
-              className="text-ui-fg-muted hover:text-ui-fg-error opacity-0 transition-opacity group-hover:opacity-100"
-              aria-label="Delete conversation"
-            >
-              <Trash className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        ))
-      )}
-    </div>
-  </div>
-)
-
-// ─── Page (two-pane: history + chat) ─────────────────────────────────────────
+// ─── Page (chat; history + media picker open as route modals) ────────────────
 
 const AssistantPage = () => {
-  const [conversations, setConversations] = useState<ConversationSummary[]>([])
-  const [loading, setLoading] = useState(true)
+  const navigate = useNavigate()
   const [activeId, setActiveId] = useState<string | null>(null)
   const [initialMessages, setInitialMessages] = useState<StoredMessage[]>([])
   // Bumping this remounts <AssistantChat>, resetting useChat for a fresh thread
   // or a freshly-loaded conversation.
   const [threadKey, setThreadKey] = useState(0)
-
-  const refreshList = useCallback(async () => {
-    try {
-      const { conversations } = await apiFetch<{
-        conversations: ConversationSummary[]
-      }>(CONVERSATIONS_URL)
-      setConversations(conversations)
-    } catch {
-      // Non-fatal: the chat still works without the history list.
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    void refreshList()
-  }, [refreshList])
+  // Pending attachments for the next send — held here (not inside the chat) so
+  // the media picker route modal can add to them; see _components/context.
+  const [attachments, setAttachments] = useState<AssistantAttachment[]>([])
 
   const startNew = useCallback(() => {
     setActiveId(null)
     setInitialMessages([])
+    setAttachments([])
     setThreadKey((k) => k + 1)
   }, [])
 
@@ -1188,6 +1160,7 @@ const AssistantPage = () => {
       }>(`${CONVERSATIONS_URL}/${id}`)
       setActiveId(id)
       setInitialMessages(conversation.messages || [])
+      setAttachments([])
       setThreadKey((k) => k + 1)
     } catch {
       toast.error("Could not open that conversation.")
@@ -1198,24 +1171,55 @@ const AssistantPage = () => {
     async (id: string) => {
       try {
         await apiFetch(`${CONVERSATIONS_URL}/${id}`, { method: "DELETE" })
-        setConversations((prev) => prev.filter((c) => c.id !== id))
         if (id === activeId) startNew()
-      } catch {
+      } catch (e) {
         toast.error("Could not delete that conversation.")
+        // Let the caller (the history modal) undo its optimistic removal.
+        throw e
       }
     },
     [activeId, startNew]
   )
 
-  const onCreated = useCallback(
-    (id: string, title: string) => {
-      setActiveId(id)
-      setConversations((prev) => [
-        { id, title },
-        ...prev.filter((c) => c.id !== id),
-      ])
-    },
-    []
+  const onCreated = useCallback((id: string) => {
+    setActiveId(id)
+  }, [])
+
+  const addAttachments = useCallback((files: AssistantAttachment[]) => {
+    // The picker enforces the cap in the UI; the slice is a backstop so the
+    // promise the server validator sees (max 8, max 4 here) can never be broken.
+    if (!files.length) return
+    setAttachments((prev) => [...prev, ...files].slice(0, MAX_ATTACHMENTS))
+  }, [])
+
+  const removeAttachment = useCallback((url: string) => {
+    setAttachments((prev) => prev.filter((a) => a.url !== url))
+  }, [])
+
+  const clearAttachments = useCallback(() => setAttachments([]), [])
+
+  const pageValue = useMemo(
+    () => ({
+      attachments,
+      addAttachments,
+      removeAttachment,
+      clearAttachments,
+      maxAttachments: MAX_ATTACHMENTS,
+      activeId,
+      openConversation,
+      deleteConversation,
+      startNew,
+    }),
+    [
+      attachments,
+      addAttachments,
+      removeAttachment,
+      clearAttachments,
+      activeId,
+      openConversation,
+      deleteConversation,
+      startNew,
+    ]
   )
 
   return (
@@ -1228,23 +1232,35 @@ const AssistantPage = () => {
             Ask about orders, partners, production and more — it reads the Admin API for you.
           </Text>
         </div>
+        <div className="ml-auto flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => navigate("/assistant/history")}
+          >
+            <Clock /> History
+          </Button>
+          <Button variant="secondary" size="small" onClick={startNew}>
+            <Plus /> New chat
+          </Button>
+        </div>
       </div>
-      <div className="flex min-h-0 flex-1">
-        <HistorySidebar
-          conversations={conversations}
-          activeId={activeId}
-          loading={loading}
-          onNew={startNew}
-          onSelect={openConversation}
-          onDelete={deleteConversation}
-        />
+      <AssistantPageContext.Provider value={pageValue}>
         <AssistantChat
           key={threadKey}
           conversationId={activeId}
           initialMessages={initialMessages}
           onCreated={onCreated}
         />
-      </div>
+        {/*
+          History (/assistant/history) and the media picker (/assistant/media)
+          are @-child routes, so they render here — inside this provider — as
+          route focus modals OVER the chat. Rendering the Outlet after the chat
+          is what keeps the thread mounted (useChat state included) while a
+          modal is open.
+        */}
+        <Outlet />
+      </AssistantPageContext.Provider>
     </Container>
   )
 }


### PR DESCRIPTION
## What

- **History sidebar removed** from the admin chat assistant. History now opens from a **History** button in the header as a **RouteFocusModal** at `/assistant/history` — fresh conversation list on every open, select/delete/new-chat inline, active conversation highlighted.
- **Media modal added** at `/assistant/media` (SquaresPlus button in the composer): browse the media library with folder + search filters, multi-select images, and attach their URLs to the next chat request — same `attachments` contract as direct uploads, no backend change.
- **Thumbnails in chat**: attached images now ride the message as AI-SDK `file` parts (`sendMessage({ files })`), so they render as thumbnails in the user's bubble immediately, **persist with the conversation** (reloads show them), and are stripped server-side before the model sees anything (`normaliseUiMessages` already does this). The top-level `attachments` field the route reads is unchanged.

## How

- `@history` and `@media` are `@`-prefixed child routes of `/assistant`, so they render inside the page's `<Outlet />` — the chat and its `useChat` thread stay mounted while a modal is open (no state loss mid-stream).
- A shared page context (`_components/assistant-page-context.tsx`) bridges the modals and the page: pending-attachment state (picker adds, composer sends) and conversation actions (history modal selects/deletes).
- The media picker reuses the existing media hooks (`useMediaFiles` with `file_type: image`, `useFolders`) and Cloudflare thumb URLs (`getThumbUrl`); selection is capped at the remaining attachment slots (max 4/message).

## Verification

- `tsc` clean for all touched files (remaining repo errors are pre-existing integration-test ones, untouched by this PR).
- Route generation verified against the admin vite plugin: parent `assistant/page.tsx` registers before `@`-children, so both modals attach correctly; React Router matches `/assistant` exactly with child routes present.

## Manual test checklist

1. Open **Assistant** — no sidebar; header shows **History** and **New chat**.
2. Chat a turn → click **History** → conversation listed; reopen to switch threads instantly (modal over the page).
3. Click the **SquaresPlus** button in the composer → pick images from the library → they appear as pending chips → send → thumbnails visible in your message bubble; reload the conversation from History → thumbnails persist.
4. Attachment cap (4) enforced in the picker and composer; direct upload (Photo button) still works alongside.