### PR TITLE
fix(payments): a partner payout is priced without extra_cost — the dye job was never paid (#1891)

### DIFF
--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -1372,6 +1372,10 @@ const validateInventoryOrderLinesStep = createStep(
         "orderlines.id",
         "orderlines.quantity",
         "orderlines.price",
+        // Per-unit colour/finishing charge — part of what is owed. Must match
+        // the field list in `payable-inventory-orders.ts`, or the offer and the
+        // bill price the same order differently.
+        "orderlines.extra_cost",
         "orderlines.material_name",
         "orderlines.line_fulfillments.quantity_delta",
         /**

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/inventory-order-value.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/inventory-order-value.unit.spec.ts
@@ -89,6 +89,80 @@ describe("valueInventoryOrderByReceipts", () => {
     expect(singleLine?.amount).toBe(7980)
   })
 
+  /**
+   * Every other fixture in this file has NO `extra_cost`, which is exactly why
+   * the whole suite stayed green while a payout was computed from `price`
+   * alone. A fixture that cannot carry the charge cannot see it go missing.
+   */
+  describe("extra_cost — the per-unit colour/finishing charge is owed too", () => {
+    it("bills (price + extra_cost) per received unit, not price alone", () => {
+      const value = valueInventoryOrderByReceipts([
+        {
+          id: "l1",
+          quantity: 12,
+          price: 255,
+          extra_cost: 120,
+          line_fulfillments: [{ quantity_delta: 12 }],
+        },
+      ])
+
+      // 12 x (255 + 120). Pricing from `price` alone bills 3,060 — short by 1,440.
+      expect(value.lines[0]?.unit_price).toBe(375)
+      expect(value.lines[0]?.amount).toBe(4500)
+      expect(value.total).toBe(4500)
+    })
+
+    it("reproduces the GOF Asia order: 73 m of dyed cloth is 65,800, not 57,760", () => {
+      const gof = [
+        { id: "muslin100", quantity: 12, price: 255, extra_cost: 120 },
+        { id: "muslin150", quantity: 12, price: 285, extra_cost: 120 },
+        { id: "matka", quantity: 11, price: 1460, extra_cost: 120 },
+        { id: "mulberryDT", quantity: 13, price: 690, extra_cost: 120 },
+        { id: "mulberry3PLY", quantity: 13, price: 1230, extra_cost: 120 },
+        { id: "linen60", quantity: 12, price: 795, extra_cost: 120 },
+      ].map((l) => ({ ...l, line_fulfillments: [{ quantity_delta: l.quantity }] }))
+
+      // Dropping extra_cost bills 57,760 — 8,040 of dye work unpaid on one order.
+      expect(valueInventoryOrderByReceipts(gof).total).toBe(65800)
+    })
+
+    it("charges extra_cost only on what was RECEIVED, not on what was ordered", () => {
+      const value = valueInventoryOrderByReceipts([
+        {
+          id: "l1",
+          quantity: 20,
+          price: 100,
+          extra_cost: 50,
+          line_fulfillments: [{ quantity_delta: 8 }],
+        },
+      ])
+
+      // 8 x 150, never 20 x 150. A short delivery owes the dye it actually did.
+      expect(value.total).toBe(1200)
+      expect(value.received_quantity).toBe(8)
+    })
+
+    it("treats a null or absent extra_cost as zero rather than NaN", () => {
+      const value = valueInventoryOrderByReceipts([
+        { id: "l1", quantity: 5, price: 100, extra_cost: null, line_fulfillments: [{ quantity_delta: 5 }] },
+        { id: "l2", quantity: 5, price: 100, line_fulfillments: [{ quantity_delta: 5 }] },
+      ])
+
+      expect(value.total).toBe(1000)
+      expect(value.lines.every((l) => Number.isFinite(l.amount))).toBe(true)
+    })
+
+    it("bills a line whose whole value is the colour job", () => {
+      const value = valueInventoryOrderByReceipts([
+        { id: "l1", quantity: 10, price: 0, extra_cost: 80, line_fulfillments: [{ quantity_delta: 10 }] },
+      ])
+
+      // price 0 is not "no line" — dyeing customer-supplied cloth is real work.
+      // A `price > 0` guard anywhere in this path would pay 0 for it.
+      expect(value.total).toBe(800)
+    })
+  })
+
   it("drops lines with no receipt instead of billing them at zero", () => {
     const value = valueInventoryOrderByReceipts(PARTIAL_ORDER_LINES)
 

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/payout-orderline-fields.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/payout-orderline-fields.unit.spec.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "fs"
+import { join } from "path"
+
+/**
+ * The offer and the bill must fetch the SAME order-line fields.
+ *
+ * `list_payable_inventory_orders` (the offer a partner is shown) and
+ * `create-payment-submission` (the bill actually written) both value an order
+ * through `valueInventoryOrderByReceipts`. That function can only price what
+ * the caller's `query.graph` field list fetched — it cannot add a column the
+ * query dropped.
+ *
+ * That is how `extra_cost` came to be missing from a payout: the function, the
+ * type AND both field lists all omitted it, so no single-file fix would have
+ * changed the money. The unit specs beside this one mock `orderlines` directly
+ * and hand the valuer a well-formed line, so they cannot see a field list go
+ * wrong — only a source-level pin can.
+ *
+ * This is deliberately a SOURCE assertion rather than a behavioural one: the
+ * field lists are inline literals inside `query.graph` calls, and exporting
+ * them purely to test them would be a worse trade than reading the two files.
+ */
+
+const ROOT = join(__dirname, "..", "..")
+
+const orderlineFields = (relativePath: string): Set<string> => {
+  const source = readFileSync(join(ROOT, relativePath), "utf8")
+  const fields = new Set<string>()
+  // Matches "inventory_orders.orderlines.price" and "orderlines.price" alike,
+  // keeping only the part after `orderlines.` so the two call sites compare.
+  for (const match of source.matchAll(/["']([\w.]*\borderlines\.)([\w.]+)["']/g)) {
+    fields.add(match[2])
+  }
+  return fields
+}
+
+const PAYABLE = "lib/payable-inventory-orders.ts"
+const SUBMISSION = "create-payment-submission.ts"
+
+describe("payout order-line field lists", () => {
+  it("finds a non-trivial field list in both call sites", () => {
+    // Guards the regex itself: if a refactor moves these off string literals,
+    // every assertion below would pass vacuously on two empty sets.
+    expect(orderlineFields(PAYABLE).size).toBeGreaterThan(3)
+    expect(orderlineFields(SUBMISSION).size).toBeGreaterThan(3)
+  })
+
+  it.each([
+    ["the payable list (the offer)", PAYABLE],
+    ["the payment submission (the bill)", SUBMISSION],
+  ])("%s fetches the money fields the valuer prices from", (_label, path) => {
+    const fields = orderlineFields(path)
+
+    // Both halves of the agreed unit value. Dropping extra_cost underpays every
+    // order carrying a colour/dye/finishing charge.
+    expect(fields).toContain("price")
+    expect(fields).toContain("extra_cost")
+    // Receipts drive what is owed at all.
+    expect(fields).toContain("line_fulfillments.quantity_delta")
+  })
+
+  it("fetches identical order-line fields on both sides", () => {
+    const payable = [...orderlineFields(PAYABLE)].sort()
+    const submission = [...orderlineFields(SUBMISSION)].sort()
+
+    // Drift here does not fail loudly — it makes the number a partner is
+    // OFFERED differ from the number they are BILLED, on the same order.
+    expect(submission).toEqual(payable)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/inventory-order-value.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/inventory-order-value.ts
@@ -18,6 +18,18 @@
  * underpays by orders of magnitude. Cf. the `quantity`-is-a-rate-or-a-total
  * confusion that made a report tell operators to corrupt correct data (#1559).
  *
+ * ⚠️ That Σ check is only an identity because **every `extra_cost` on that
+ * order was null**. The real invariant is Σ((price + extra_cost) × quantity) =
+ * `total_price`; the shorter form matched because the sample could not tell the
+ * two apart. It read as proof for months while the money was wrong — if you
+ * re-verify against a live order, pick one with a colour job on it.
+ *
+ * 🔴 **`extra_cost` is owed too.** The per-unit colour/dye/finishing charge is
+ * part of the agreed unit value, so the unit price here is
+ * `price + extra_cost`. Callers must SELECT `orderlines.extra_cost`: this
+ * function cannot add a field the query never fetched, which is why the fix
+ * for this had to land in three places at once.
+ *
  * 🔴 **Receipts come from the typed `line_fulfillments` rows, NEVER from
  * `metadata.partner_delivery_history`.** `partner-complete-inventory-order`
  * dual-writes both, and on the one order examined by hand they DISAGREE: the
@@ -42,6 +54,16 @@ export type InventoryOrderLineForValue = {
   quantity?: number | null
   /** 🔴 PER UNIT. */
   price?: number | null
+  /**
+   * 🔴 ALSO PER UNIT, and it is part of what the partner is owed.
+   *
+   * The per-unit colour/dye/finishing charge (`inventory_order_line.extra_cost`).
+   * A line's agreed value is `(price + extra_cost) × quantity` — that is how
+   * `total_price` is folded at write time, and how the admin create/edit forms
+   * and `dual-write-unified-order` price it. Valuing a receipt from `price`
+   * alone silently underpays every order that carries a colour job.
+   */
+  extra_cost?: number | null
   material_name?: string | null
   line_fulfillments?: FulfillmentEvent[] | null
 }
@@ -89,7 +111,14 @@ export function valueInventoryOrderByReceipts(
 
     if (received === 0) continue
 
-    const unitPrice = num(line.price)
+    // The unit the partner is owed is the AGREED unit: goods + the per-unit
+    // colour/finishing charge. `price` alone is only the goods half, and every
+    // other pricer in the codebase folds both (`create-inventory-order`,
+    // `order-lines-payload`, `dual-write-unified-order:313`). This was the
+    // outlier, and both the offer (`list_payable_inventory_orders`) and the
+    // bill (`create-payment-submission`) read it — so they agreed with each
+    // other and understated together.
+    const unitPrice = num(line.price) + num(line.extra_cost)
 
     valued.push({
       line_id: String(line.id),

--- a/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/payable-inventory-orders.ts
@@ -136,6 +136,10 @@ export const listPayableInventoryOrders = async (
       "inventory_orders.orderlines.id",
       "inventory_orders.orderlines.quantity",
       "inventory_orders.orderlines.price",
+      // Per-unit colour/finishing charge. Owed alongside `price`, so the payable
+      // ceiling this list offers must fetch it — `valueInventoryOrderByReceipts`
+      // cannot add a field the query dropped.
+      "inventory_orders.orderlines.extra_cost",
       "inventory_orders.orderlines.material_name",
       // 🔴 The receipts. The typed rows, never `metadata.partner_delivery_history`
       // — the two disagree by INR 4,050 on a real order and these are what the

--- a/apps/docs/notes/modules/extra-cost-display-surfaces.md
+++ b/apps/docs/notes/modules/extra-cost-display-surfaces.md
@@ -1,0 +1,95 @@
+# Extra-cost display surfaces — where order-line money is shown WITHOUT `extra_cost`
+
+## Purpose
+
+`inventory_order_line.extra_cost` is a per-unit charge (colour/dye job, finishing) that a line contributes as `(price + extra_cost) × quantity` to the order total. This doc records the read/display surfaces that show inventory order-line money using `price` alone, omitting `extra_cost` — verified line-by-line against source. All four claims in the task were checked and are **CONFIRMED**. No fixes are proposed here.
+
+## Background: the model contract
+
+`apps/backend/src/modules/inventory_orders/models/orderline.ts:19` defines the field:
+
+```ts
+  extra_cost: model.bigNumber().nullable(),
+```
+
+The per-unit semantics are stated in the doc comment at `apps/backend/src/modules/inventory_orders/models/orderline.ts:13-14`:
+
+> Per-UNIT, not a line total: like `price`, a line contributes
+> `(price + extra_cost) × quantity` to the order total
+
+The same arithmetic is implemented in the write/billing paths (see Gotchas), so the omission below is a display-only divergence, not the system contract.
+
+## Entry points (the four surfaces)
+
+| # | Surface | Kind | Citation |
+|---|---------|------|----------|
+| 1 | Partner order-detail API | `GET /partners/inventory-orders/:orderId` | `apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts:GET` |
+| 2 | Partner work-order line list (UI) | React component `InventoryOrderLines` | `apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx:InventoryOrderLines` |
+| 3 | Admin inventory-orders list tooltip | Route page `InventoryOrdersPage` / `useColumns` | `apps/backend/src/admin/routes/orders/inventory/page.tsx:useColumns` |
+| 4 | Admin order-detail lines section | React component `InventoryOrderLinesSection` | `apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx:InventoryOrderLinesSection` |
+
+## Key behaviours — claim-by-claim verification
+
+### Claim 1 — Partner API response mapping omits `extra_cost`: CONFIRMED
+
+`apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts:262` maps each order line into the partner response:
+
+```ts
+        order_lines: order.orderlines?.map((line: any) => ({
+```
+
+The mapped object (lines 263–282) carries `id`, `inventory_item_id`, `quantity`, `price` (line 266: `            price: line.price,`), `metadata`, `created_at`, `updated_at`, `deleted_at`, `inventory_items`, and `line_fulfillments` — `extra_cost` is not among them. Notably the query at `apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts:171` selects `"orderlines.*"`, so `extra_cost` is fetched from the DB and then dropped by the mapping. The route's JSDoc response typedef (`apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts:8-19`) likewise documents only `price` ("The price per unit") with no `extra_cost` property.
+
+### Claim 2 — Partner UI computes displayed money from `price` only: CONFIRMED
+
+`apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx:107` reads only `price` off the line:
+
+```tsx
+        const price = Number(line?.price) || 0
+```
+
+`apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx:162` computes the line total as `price × quantity` (no `extra_cost` term):
+
+```tsx
+                  {price > 0 ? totalMoney(price * requested) : "—"}
+```
+
+The unit-price cell at `apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx:153` is likewise price-only:
+
+```tsx
+                <Text size="small">{price > 0 ? unitMoney(price) : "—"}</Text>
+```
+
+`extra_cost` does not appear anywhere in this file.
+
+### Claim 3 — Admin list tooltip renders `line.price` only: CONFIRMED
+
+`apps/backend/src/admin/routes/orders/inventory/page.tsx:67` renders the per-line tooltip content inside the Partner column:
+
+```tsx
+                            {label} — Qty {line.quantity} × ₹{line.price}
+```
+
+`extra_cost` does not appear anywhere in this file.
+
+### Claim 4 — Admin detail Price badge renders `line.price` only: CONFIRMED
+
+`apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx:118` renders the Price badge:
+
+```tsx
+                      <Badge size="small" className="text-ui-fg-subtle">Price: ₹{line.price}</Badge>
+```
+
+`extra_cost` does not appear anywhere in this file.
+
+## Gotchas / invariants
+
+- **The field is available to admin UI code but unused in display.** The admin `OrderLine` type exposes it — `apps/backend/src/admin/hooks/api/inventory-orders.ts:20`: `  extra_cost?: number | null;` — yet neither display component (claims 3 and 4) reads it.
+- **Write/edit surfaces DO include `extra_cost`**, so the omission is specific to read/display: the admin edit form seeds it (`apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx:67`: `    extra_cost: line.extra_cost ?? 0,`) and the payload builder folds it into totals (`apps/backend/src/admin/components/inventory-orders/order-lines-payload.ts:62`: `      ((Number(l.price) || 0) + (Number(l.extra_cost) || 0)) *`).
+- **Billing paths use the full `(price + extra_cost)` unit value**, so displayed line money can diverge from what is actually owed: `apps/backend/src/workflows/payment_submissions/lib/inventory-order-value.ts:121`: `    const unitPrice = num(line.price) + num(line.extra_cost)`; and the unified-order dual-write at `apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts:313`: `        const unitPrice = Number(line.price) + Number(line.extra_cost || 0)`.
+- **Partner UI cannot show it even if it wanted to**: the partner API mapping (claim 1) strips `extra_cost` before it reaches `apps/partner-ui`, so the partner-side omission is enforced server-side at `apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts:262-283`.
+- The partner UI's footer total (`apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx:197`) renders `totalPrice` passed in from the order record, which per the model comment is folded at write time (`apps/backend/src/modules/inventory_orders/models/orderline.ts:16-17`); so the order-level total can include the charge while the per-line rows beside it do not.
+
+## Open questions / (unverified)
+
+- Whether any other partner-ui or admin surface displays line money was not exhaustively audited beyond the four claims above and the grep for `extra_cost`; other read surfaces may exist that also omit it (unverified).


### PR DESCRIPTION
Closes #1891.

`valueInventoryOrderByReceipts` valued a receipt at `line.price`, dropping the per-unit colour/dye/finishing charge. **Every inventory order carrying a colour job underpaid.** On the live GOF Asia order that is 73 m × ₹120 = **₹8,760**.

## Three layers, fixed together

A one-line fix in the valuer would have moved no money — the field never arrived:

| layer | file | change |
|---|---|---|
| query (the offer) | `lib/payable-inventory-orders.ts` | `+ "inventory_orders.orderlines.extra_cost"` |
| query (the bill) | `create-payment-submission.ts` | `+ "orderlines.extra_cost"` |
| type | `lib/inventory-order-value.ts` | `extra_cost?: number \| null` |
| function | `lib/inventory-order-value.ts` | `num(line.price) + num(line.extra_cost)` |

## Why it survived — the useful half

- **The offer and the bill agreed.** `list_payable_inventory_orders` and `create-payment-submission` both call this one function, so they understated together and there was no discrepancy to spot. Agreement is not correctness.
- **Every fixture had no `extra_cost`.** Twelve green tests, not one able to see the charge go missing.
- **The docblock's proof was vacuous.** It offered Σ(quantity × price) = 88,885 = `total_price` as verification that `price` is per-unit. That identity holds *only* because every `extra_cost` on the sample order was null. Corrected in place, with a note to pick an order with a colour job when re-verifying.

## Tests

- **5 new valuer cases**, red-checked: reverting the fix fails 4 (the 5th is a null/NaN regression guard that passes either way — not claimed as a defect detector). Includes the GOF order reproduced at 65,800 rather than 57,760, and a line whose entire value is the colour job (`price: 0`) — a `price > 0` guard anywhere in this path would pay ₹0 for dyeing customer-supplied cloth.
- **New 4-case source pin** (`payout-orderline-fields.unit.spec.ts`) asserting both call sites fetch the same order-line fields. Removing `extra_cost` from one side fails 2, including the drift check that catches the offer and the bill pricing the same order differently. It is a source assertion on purpose: the specs beside it mock `orderlines` directly and so cannot see a field list go wrong, which is exactly how this got in.
- `payment_submissions` suite: **258 passed, 20 suites**. `✓ Prod-config build passed.`

## Not in this PR

Four display surfaces still show line money without the charge — audited line-by-line in `apps/docs/notes/modules/extra-cost-display-surfaces.md` (added here). They touch `apps/partner-ui`, which has its own CI shape, so they are a follow-up.

🔴 Worth knowing: the partner UI renders the order's `totalPrice` (which **includes** the charge) as a footer beneath per-line rows computed from `price` alone — **the rows visibly do not sum to the total above them.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012T4SDnsxSnBxRWLCaHKH9o