### PR TITLE
feat(admin-mcp): the registry asked for a stock_location_id it gave no way to find

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/stock-location-discoverability.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/stock-location-discoverability.unit.spec.ts
@@ -1,0 +1,67 @@
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { toolDomain } from "../tool-slice"
+
+/**
+ * A tool that DEMANDS an identifier must be reachable from a tool that
+ * PRODUCES it.
+ *
+ * Five admin tools took a `stock_location_id` and nothing in the registry
+ * listed one. That gap is invisible in the worst way: no tool errors, no
+ * schema is wrong, the caller simply cannot begin — the only way to supply the
+ * id was to be handed it out of band. It surfaced when an inventory order was
+ * created with its supplier's warehouse as the DESTINATION and the correction
+ * could not be made through the MCP at all.
+ *
+ * This spec pins the general rule rather than the two new rows, so the next
+ * tool that asks for a location id inherits the guarantee instead of
+ * re-discovering the hole.
+ */
+
+const byName = new Map(ADMIN_MCP_TOOLS.map((t) => [t.name, t]))
+
+/** Every property name a tool's input schema declares, at the top level. */
+const schemaProps = (tool: any): string[] =>
+  Object.keys(tool?.inputSchema?.properties ?? {})
+
+describe("stock locations are discoverable", () => {
+  it("exposes a list tool and a get tool", () => {
+    expect(byName.has("list_stock_locations")).toBe(true)
+    expect(byName.has("get_stock_location")).toBe(true)
+  })
+
+  it("keeps them READ tools — a location is looked up, never edited here", () => {
+    for (const name of ["list_stock_locations", "get_stock_location"]) {
+      const tool: any = byName.get(name)
+      expect(tool.method).toBe("GET")
+      expect(tool.write).toBeUndefined()
+      expect(tool.sensitive).toBeUndefined()
+    }
+  })
+
+  it("classifies both into the inventory slice", () => {
+    // An unclassified tool loads in NO slice, so it may as well not exist —
+    // it would be present in the registry and unreachable from every ask.
+    expect(toolDomain(byName.get("list_stock_locations")!)).toBe("inventory")
+    expect(toolDomain(byName.get("get_stock_location")!)).toBe("inventory")
+  })
+
+  it("THE RULE: every tool asking for a stock_location_id has a discovery tool beside it", () => {
+    const askers = ADMIN_MCP_TOOLS.filter((t) =>
+      schemaProps(t).some((p) => /(^|_)stock_location_id$/.test(p))
+    ).map((t) => t.name)
+
+    // Guards the guard: if this ever finds nothing, the regex has drifted and
+    // every assertion below would pass over an empty list.
+    expect(askers.length).toBeGreaterThan(0)
+    expect(askers).toContain("create_inventory_order")
+
+    // The discovery tool must be in the SAME domain as each asker, or a sliced
+    // ask that surfaces the asker will not surface the way to answer it.
+    const discoveryDomain = toolDomain(byName.get("list_stock_locations")!)
+    const unreachable = askers.filter(
+      (name) => toolDomain(byName.get(name)!) !== discoveryDomain
+    )
+
+    expect({ askers, unreachable }).toEqual({ askers, unreachable: [] })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -509,6 +509,37 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   },
 
   // ===== Inventory =========================================================
+  /**
+   * Stock locations were the one id this registry ASKED FOR and gave no way to
+   * find. `create_inventory_order` requires `stock_location_id`;
+   * `extract_inventory_from_image` and the repair jobs take one too — five
+   * call sites, and nothing that lists them. An agent could only supply an id
+   * it had been handed out of band, which in practice meant the work stopped.
+   *
+   * A tool that demands an identifier must be reachable from a tool that
+   * produces it. When it isn't, the gap is invisible: nothing errors, the
+   * caller simply cannot start.
+   */
+  {
+    name: "list_stock_locations",
+    description:
+      "List stock locations — our own warehouses AND partner-held locations, with their addresses. Read. " +
+      "Start here whenever a tool needs a `stock_location_id` (create_inventory_order, the route-repair jobs, inventory extraction): the id is not guessable and nothing else surfaces it. " +
+      "🔑 The name is the only thing that distinguishes ours from a partner's here — use `set-location-ownership` (Data Plumbing) to read which are core, since consumption is only ever deducted from a core location.",
+    method: "GET",
+    path: "/admin/stock-locations",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "get_stock_location",
+    description:
+      "Get one stock location by id, with its address and metadata. Read. Use it to confirm a location is the one you meant before pointing an inventory order at it — a reversed route posts stock at the wrong end and reads as a delivery that never arrived.",
+    method: "GET",
+    path: "/admin/stock-locations/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Stock location id, e.g. 'sloc_...'.") }, ["id"]),
+  },
   {
     name: "list_inventory_items",
     description: "List inventory items (paginated). Supports free-text search via q.",

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -90,6 +90,10 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   ["/admin/task-templates", "production"],
   ["/admin/inventory-items", "inventory"],
   ["/admin/inventory-orders", "inventory"],
+  // Where stock physically sits. Rides the inventory slice because every ask
+  // that needs a location id — "order 40 m to the Dharamshala warehouse",
+  // "this order's route is reversed" — is already an inventory conversation.
+  ["/admin/stock-locations", "inventory"],
   ["/admin/raw-material-groups", "inventory"],
   // Photo -> raw materials + inventory. Classified as inventory because that is
   // what it CREATES; the image is just the input format.


### PR DESCRIPTION
## The gap

`create_inventory_order` **requires** `stock_location_id`. `extract_inventory_from_image` and the route-repair maintenance jobs take one too. **Nothing in the registry listed a stock location** — so the id could only ever arrive out of band.

This is invisible in the worst way: no tool errors, no schema is wrong. The caller simply cannot begin.

It surfaced on a live inventory order created with the **supplier's own warehouse as its destination** and no source at all. `repair-inventory-order-route` already exists and handles exactly that, but it needs both location ids — and nothing could produce either, so the correction was unreachable through the MCP.

## The change

Two read-only rows, thin proxies over core's existing `/admin/stock-locations` routes — no backend surface added:

| tool | route |
|---|---|
| `list_stock_locations` | `GET /admin/stock-locations` |
| `get_stock_location` | `GET /admin/stock-locations/:id` |

Plus one line in `tool-slice.ts` classifying `/admin/stock-locations` into the `inventory` domain. **That line is not bookkeeping** — an unclassified tool loads in NO slice, so it would sit in the registry unreachable from every ask. The registry's own docblock records twelve rows that were silently lost this way before.

## The test pins the rule, not the rows

`stock-location-discoverability.unit.spec.ts` asserts the general property:

> **a tool that DEMANDS an identifier must be reachable from a tool that PRODUCES it**

— every tool whose schema asks for a `stock_location_id` must share a domain with a tool that lists them. The next tool to want a location inherits the guarantee instead of re-discovering the hole. It also guards its own matcher: if the regex drifts and finds no askers, every later assertion would otherwise pass over an empty list.

## Verification

- **Red-checked both layers independently.** All 4 fail with the registry rows removed. 4 fail with the rows present but the domain entry deleted — the existing orphan invariant catches that half.
- Admin MCP suite: **231 passing, 12 suites**.
- `✓ Prod-config build passed.`

## Deliberately not in scope

An audit of every `*_id` the registry asks for found two more families with **no read tool at all**: `region_id` and `sales_channel_id`. Neither blocks work today, and each deserves its own decision about what an agent should be able to see, so they are left for a follow-up rather than bundled here.

(`collection_id`, `category_id`, `company_id` and the person ids looked like gaps under a naive name match but are covered by readers under different names — `list_product_collections`, `list_product_categories`, `list_crm_companies`, `list_partner_people`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp