### PR TITLE
fix(inventory-orders): the rows didn't sum to the total printed beneath them (#1894)

### DIFF
--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx
@@ -116,6 +116,11 @@ export const InventoryOrderLinesSection = ({ inventoryOrder }: { inventoryOrder:
                         </Badge>
                       )}
                       <Badge size="small" className="text-ui-fg-subtle">Price: ₹{line.price}</Badge>
+                      {/* #1894 — the finishing charge is billed per unit and was
+                          invisible here, so the badges did not explain the total. */}
+                      {Number(line.extra_cost) > 0 && (
+                        <Badge size="small" className="text-ui-fg-subtle">Finishing: ₹{line.extra_cost}</Badge>
+                      )}
                       <Badge size="small" className="text-ui-fg-subtle">Quantity: {line.quantity}</Badge>
                     </div>
                   </div>

--- a/apps/backend/src/admin/routes/orders/inventory/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/page.tsx
@@ -64,7 +64,9 @@ export const useColumns = () => {
                           "Item";
                         return (
                           <span key={line.id ?? i} className="text-ui-fg-base">
-                            {label} — Qty {line.quantity} × ₹{line.price}
+                            {label} — Qty {line.quantity} × ₹
+                            {(Number(line.price) || 0) +
+                              (Number(line.extra_cost) || 0)}
                           </span>
                         );
                       })}

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts
@@ -264,6 +264,10 @@ export async function GET(
             inventory_item_id: line.inventory_item_id,
             quantity: line.quantity,
             price: line.price,
+            // #1894 — the dye/finishing charge is part of what the partner is
+            // paid. The query already fetches it; dropping it here is what made
+            // the rows disagree with the order total rendered beneath them.
+            extra_cost: line.extra_cost ?? null,
             metadata: line.metadata ?? null,
             created_at: line.created_at,
             updated_at: line.updated_at,

--- a/apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx
+++ b/apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx
@@ -7,6 +7,7 @@ const COLLAPSED_LINE_COUNT = 6
 
 import { getLocaleAmount, getStylizedAmount } from "../../lib/money-amount-helpers"
 import { Thumbnail } from "../common/thumbnail"
+import { lineTotal, lineUnitPrice } from "./line-money"
 
 const fmt = (n: number) => {
   if (!Number.isFinite(n)) {
@@ -105,7 +106,15 @@ export const InventoryOrderLines = ({
         const fulfilled = lineFulfilled(line)
         const remaining = Math.max(0, requested - fulfilled)
         const price = Number(line?.price) || 0
-        const subtitle = [line?.color, sku ? `SKU ${sku}` : null]
+        // #1894 — extra_cost is the per-unit dye/finishing charge. The order
+        // total below these rows includes it, so the rows must too.
+        const extraCost = Number(line?.extra_cost) || 0
+        const unitPrice = lineUnitPrice(line)
+        const subtitle = [
+          line?.color,
+          sku ? `SKU ${sku}` : null,
+          extraCost > 0 ? `${unitMoney(price)} + ${unitMoney(extraCost)} finishing` : null,
+        ]
           .filter(Boolean)
           .join(" · ")
 
@@ -150,7 +159,7 @@ export const InventoryOrderLines = ({
             {/* Right: money block — mirrors core "unit  {qty}x  total" grid */}
             <div className="grid grid-cols-3 items-center gap-x-4">
               <div className="flex items-center justify-end">
-                <Text size="small">{price > 0 ? unitMoney(price) : "—"}</Text>
+                <Text size="small">{unitPrice > 0 ? unitMoney(unitPrice) : "—"}</Text>
               </div>
               <div className="flex items-center justify-end">
                 <Text size="small">
@@ -159,7 +168,7 @@ export const InventoryOrderLines = ({
               </div>
               <div className="flex items-center justify-end">
                 <Text size="small" weight="plus" className="text-ui-fg-base text-nowrap">
-                  {price > 0 ? totalMoney(price * requested) : "—"}
+                  {unitPrice > 0 ? totalMoney(lineTotal(line, requested)) : "—"}
                 </Text>
               </div>
             </div>

--- a/apps/partner-ui/src/components/work-orders/line-money.test.ts
+++ b/apps/partner-ui/src/components/work-orders/line-money.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { lineTotal, lineUnitPrice } from "./line-money"
+
+/**
+ * The six lines of inv_order_01M1ZH7Y50W37WMGXYP2DM1KAF (GOF Asia, 73 m) with
+ * the ₹120/m dye charge. The order's own total_price is 65,800 — computing
+ * these rows from `price` alone yields 57,770, the gap the partner UI showed.
+ */
+const GOF_LINES = [
+  { price: 255, extra_cost: 120, quantity: 12 },
+  { price: 285, extra_cost: 120, quantity: 12 },
+  { price: 1460, extra_cost: 120, quantity: 11 },
+  { price: 690, extra_cost: 120, quantity: 13 },
+  { price: 1230, extra_cost: 120, quantity: 13 },
+  { price: 795, extra_cost: 120, quantity: 12 },
+]
+
+describe("inventory order line money (#1894)", () => {
+  it("folds extra_cost into the per-unit price", () => {
+    expect(lineUnitPrice({ price: 255, extra_cost: 120 })).toBe(375)
+  })
+
+  it("makes the rows sum to the order total shown beneath them", () => {
+    const sum = GOF_LINES.reduce((acc, l) => acc + lineTotal(l, l.quantity), 0)
+    expect(sum).toBe(65800)
+    // and is not the price-only figure the UI used to render. 57,040 is what
+    // this same fixture yields when extra_cost is dropped — asserting against
+    // it is what makes this test fail on the old code.
+    expect(sum).not.toBe(57040)
+  })
+
+  it("treats a null or absent extra_cost as no extra charge", () => {
+    expect(lineUnitPrice({ price: 690, extra_cost: null })).toBe(690)
+    expect(lineUnitPrice({ price: 690 })).toBe(690)
+  })
+
+  it("survives a missing line rather than rendering NaN", () => {
+    expect(lineUnitPrice(null)).toBe(0)
+    expect(lineTotal(undefined, 12)).toBe(0)
+  })
+})

--- a/apps/partner-ui/src/components/work-orders/line-money.ts
+++ b/apps/partner-ui/src/components/work-orders/line-money.ts
@@ -1,0 +1,19 @@
+/**
+ * #1894 — what a partner is charged for one unit of an order line.
+ *
+ * `extra_cost` is the per-unit dye / finishing charge. The order's
+ * `total_price` already includes it, so a row computed from `price` alone does
+ * not sum to the total rendered beneath those rows — with nothing on screen
+ * explaining the gap. On the GOF Asia order that gap was ₹8,030 across 73 m.
+ *
+ * Both fields arrive untyped from the partner API, and either may be null.
+ */
+type MoneyLine = { price?: unknown; extra_cost?: unknown }
+
+export const lineUnitPrice = (line: MoneyLine | null | undefined): number =>
+  (Number(line?.price) || 0) + (Number(line?.extra_cost) || 0)
+
+export const lineTotal = (
+  line: MoneyLine | null | undefined,
+  quantity: unknown
+): number => lineUnitPrice(line) * (Number(quantity) || 0)


### PR DESCRIPTION
Closes #1894. The display half of #1891 — the money itself was fixed in #1892.

## The symptom

The partner UI renders the order's `total_price` — which **includes** the per-unit dye/finishing `extra_cost` — as a footer beneath per-line rows computed from `price` alone. On the GOF Asia order that is **₹57,040 of rows under a ₹65,800 total**, with nothing on screen explaining the ₹8,760 gap.

## The root

`apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts` fetches `orderlines.*` — so `extra_cost` is loaded — and then the response map **drops it**. Partner clients could not retrieve it at all, so the UI could not have shown it. That is why (1) is fixed first.

## The four surfaces

| # | file | change |
|---|---|---|
| 1 | `partners/inventory-orders/[orderId]/route.ts` | keep `extra_cost` in the line map |
| 2 | `partner-ui/.../inventory-order-lines.tsx` | unit + line total fold it in; subtitle shows the split when there is a finishing charge |
| 3 | `admin/routes/orders/inventory/page.tsx` | list tooltip: `Qty n × ₹(price + extra_cost)` |
| 4 | `admin/components/inventory-orders/inventory-order-lines-section.tsx` | a `Finishing` badge beside `Price` |

The four call sites the audit found already correct were left alone.

## Verification

The arithmetic moved into a pure `line-money` helper so it can actually be tested — `apps/partner-ui` had vitest configured and **zero** test files, so this is the first one.

The fixture is the real six-line GOF order. It sums to **65,800**, the order's own `total_price`, and to **57,040** when `extra_cost` is dropped.

- Reverting the helper to price-only turns **2 of 4 tests red** (`expected 255 to be 375`, `expected 57040 to be 65800`).
- That red-check is also how a bad assertion was caught: the negative case originally named **57,770** — the figure from the earlier ₹10/m dye — a value this fixture can never produce, so it could never have failed. Corrected to 57,040.
- Scoped `tsc -p` clean on both apps (whole-tree partner-ui is ~1118 pre-existing errors; `check:prod-build` bundles `src/admin` without type-checking it, so neither gate would have caught a bad edit here).

## Not done

**Not rendered.** The issue's own watch-out says every defect of this shape here was found by rendering, not reading — worth a browser pass on the partner order screen before trusting the subtitle layout, since a long `₹255 + ₹120 finishing` string sits in a `truncate` row beside the SKU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp