### PR TITLE
feat(admin-mcp): create_product_variant demanded an option value nothing could create

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/product-option-value-discoverability.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/product-option-value-discoverability.unit.spec.ts
@@ -1,0 +1,58 @@
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { toolDomain } from "../tool-slice"
+
+/**
+ * #1894 follow-up — `create_product_variant` matches a variant to option values
+ * that already exist and core will not invent one, so a variant naming a new
+ * value cannot be created at all unless some tool can add that value first.
+ *
+ * That gap has the same shape as the stock-location one in #1893: nothing
+ * errors and no schema is wrong, the caller simply cannot begin. It cost two
+ * live order lines — a 33s Kala Cotton and a 40 lea Linen — that could not be
+ * added to a pending inventory order through the MCP at all.
+ *
+ * These pin the RULE, so the next tool that depends on an option value inherits
+ * the guarantee instead of re-finding the hole.
+ */
+const byName = (n: string) => ADMIN_MCP_TOOLS.find((t) => t.name === n)
+
+describe("product option values are reachable (#1894)", () => {
+  it("a tool exists that can add a value to a product option", () => {
+    const tool = byName("update_product_option")
+    expect(tool).toBeDefined()
+    expect(tool!.write).toBe(true)
+    expect(tool!.sensitive).toBe(true)
+  })
+
+  it("forwards `values` — a body param the schema advertises but the forward list omits is stripped in silence", () => {
+    const tool = byName("update_product_option")!
+    const advertised = Object.keys(
+      (tool.inputSchema as any).properties ?? {}
+    ).filter((k) => !(tool.pathParams ?? []).includes(k))
+
+    for (const key of advertised) {
+      expect(tool.bodyParams).toContain(key)
+    }
+  })
+
+  it("shares a slice with the variant tool it unblocks, or it loads in no slice", () => {
+    const creator = byName("create_product_variant")!
+    const option = byName("update_product_option")!
+
+    const optionDomain = toolDomain(option)
+    expect(optionDomain).toBeTruthy()
+    expect(optionDomain).toBe(toolDomain(creator))
+  })
+
+  it("names create_product_variant as the next step, so the blocked caller is told where to go", () => {
+    expect(byName("update_product_option")!.nextSteps).toContain(
+      "create_product_variant"
+    )
+  })
+
+  it("warns that values REPLACES rather than appends — the trap that destroys existing variants' options", () => {
+    const d = byName("update_product_option")!.description
+    expect(d).toMatch(/REPLACES/)
+    expect(d).toMatch(/not an append/i)
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1267,6 +1267,39 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     nextSteps: ["get_product", "list_product_categories", "set_category_products"],
   },
   {
+    name: "update_product_option",
+    description: [
+      "Rewrite a product option's list of allowed values — the '33s', '60lea Colour' choices a variant is matched to. Sensitive: requires confirm:true.",
+      "🔑 This is the tool that unblocks `create_product_variant`. That tool matches a variant to option values that ALREADY EXIST and core will not invent one, so a variant naming a new value cannot be created until the value is added here first.",
+      "⚠️ `values` REPLACES the option's entire value list — it is not an append. Call `get_product` first and send every existing value PLUS the new one. Sending only the new value drops the rest, and any variant matched to a dropped value loses its option.",
+      "Find the option id and its current values under `product.options[]` from `get_product`.",
+    ].join("\n"),
+    method: "POST",
+    path: "/admin/products/:id/options/:option_id",
+    pathParams: ["id", "option_id"],
+    previewPath: "/admin/products/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["title", "values"],
+    inputSchema: obj(
+      {
+        id: STR("Product id, e.g. 'prod_...'."),
+        option_id: STR("Option id, e.g. 'opt_...'. Read it from product.options[].id."),
+        title: STR("Option title. Omit to leave it unchanged."),
+        values: {
+          type: "array",
+          description:
+            "The option's COMPLETE resulting value list, e.g. ['0s','10s','20s','30s','33s','60s']. Every value you want to keep must appear — omitted values are removed.",
+          items: { type: "string" },
+        },
+      },
+      ["id", "option_id", "values"]
+    ),
+    sideEffects:
+      "Replaces the option's value list. Values omitted from `values` are removed, and a variant matched to a removed value loses that option. Adding a value is inert on its own until a variant claims it.",
+    nextSteps: ["create_product_variant", "get_product"],
+  },
+  {
     name: "bulk_update_products",
     description: [
       "Update MANY products, their variants and their stock levels in one call. Sensitive: requires confirm:true. ALWAYS dry_run first — the plan names every product and variant it would touch, with the before/after quantity at each location, and there is no undo once it fires.",


### PR DESCRIPTION
Unblocks the two order lines still owed on `inv_order_01M1ZH7Y50W37WMGXYP2DM1KAF`.

## The gap

`create_product_variant` matches a variant to option values that **already exist** — core will not invent one — and nothing in the registry could add a value. `update_product`'s `bodyParams` has no `options`, and the dispatcher is a thin loopback proxy with no read-modify-write hook. There was no way in.

Same shape as the stock-location gap in #1893: nothing errors, no schema is wrong, the caller simply cannot begin.

It cost two lines on a live pending inventory order:

| line | product option | has | needs |
|---|---|---|---|
| 33s Kala Cotton | `HandSpun HandWoven` | 0s / 10s / 20s / 30s / 60s | **33s** |
| Linen 40 lea | `HandWoven Linen` | 60lea White / 60lea Colour | **40 lea** |

Worse than blocked: the Linen product's own "Default variant" carries `options: []`, which is evidence core creates an **unmatched** variant rather than refusing. Attempting it blind would have left a half-formed record on prod — which is why it wasn't attempted.

## The tool

`update_product_option` over core's existing `POST /admin/products/:id/options/:option_id`. It rides the `/admin/products` prefix, so tool-slice classifies it into `catalog` with no new entry needed.

### ⚠️ Replace, not append

`values` **replaces** the option's whole list. The endpoint has no append and the proxy cannot synthesise one, so the caller must `get_product` first and send every existing value plus the new one. The description says so three times and the spec asserts the wording — this is the same family as the price-set replace that hard-deleted 11 prices in #1857, and here a variant matched to a dropped value loses its option.

If that trade is not acceptable, the alternative is a real handler with read-modify-write rather than a registry row; that is a larger change and is not what this PR does.

## Verification

Spec pins the **rule**, not the row — including that every property the schema advertises appears in `bodyParams`, since a field the forward list omits is stripped in silence and the call succeeds changing nothing.

- Red-checked: all **5 fail** with the registry row removed.
- Admin MCP suite **236 passing across 13 suites**.
- `check:prod-build` passed.

Needs a deploy and a session restart before the variants can be created — MCP servers load at session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp