### PR TITLE
fix(production-runs): 28 completed runs could never be reviewed, and the design page offered the wrong approval (#1898)

### DIFF
--- a/apps/backend/src/admin/components/designs/design-production-runs-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-production-runs-section.tsx
@@ -1,9 +1,12 @@
 import { Container, Heading, Skeleton, Text, Badge, Button, toast, usePrompt } from "@medusajs/ui"
 import { Plus } from "@medusajs/icons"
+import { useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
 
 import { AdminDesign, useApproveDesign } from "../../hooks/api/designs"
 import { useProductionRuns, useCancelProductionRun } from "../../hooks/api/production-runs"
+import { RunOutputReviewPanel } from "../production-runs/run-output-review-panel"
+import { runsAwaitingOutputReview } from "../../lib/run-review"
 import { productionRunStatusColor as statusColor } from "../../lib/status-colors"
 
 interface DesignProductionRunsSectionProps {
@@ -26,6 +29,24 @@ export const DesignProductionRunsSection = ({ design }: DesignProductionRunsSect
   }
 
   const isInReview = design.status === "Technical_Review"
+
+  /*
+    #1898 — two DIFFERENT approvals were being conflated here.
+
+    The button below is the DESIGN approve (POST /admin/designs/:id/approve):
+    it sets the design's status and creates the product listing. Reviewing what
+    a completed run PRODUCED is a separate axis — `run.approval_decision`,
+    added by #1805 — and this page had no control for it at all.
+
+    So a design already `Approved` showed no button (correct for the design
+    approve, whose skip list in complete-production-run.ts deliberately leaves
+    the status alone) while its completed runs sat undecided with nowhere to
+    decide them. The global queue was no help either: it hid child runs.
+
+    Gate this on the runs themselves, never on design.status.
+  */
+  const runsAwaitingReview = runsAwaitingOutputReview(runs as any[])
+  const [reviewDecision, setReviewDecision] = useState<"approve" | "reject" | null>(null)
   const prompt = usePrompt()
   const approveMutation = useApproveDesign(design.id)
 
@@ -64,6 +85,46 @@ export const DesignProductionRunsSection = ({ design }: DesignProductionRunsSect
           </Button>
         </Link>
       </div>
+
+      {/* #1898 — output review, gated on the runs and not on design.status. */}
+      {runsAwaitingReview.length > 0 && (
+        <div className="mx-3 mb-3 rounded-md border border-ui-border-base bg-ui-bg-subtle px-4 py-3">
+          <div className="flex items-center justify-between gap-x-4">
+            <div>
+              <Text size="small" weight="plus" className="text-ui-fg-base">
+                {runsAwaitingReview.length === 1
+                  ? "1 run awaiting output review"
+                  : `${runsAwaitingReview.length} runs awaiting output review`}
+              </Text>
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                Completed, but nobody has decided whether what they produced is
+                acceptable. Approving lists the design as a product; rejecting
+                records the decision and still leaves the partner owed for the
+                work.
+              </Text>
+            </div>
+            <div className="flex shrink-0 items-center gap-x-2">
+              <Button
+                size="small"
+                variant="secondary"
+                onClick={() => setReviewDecision("reject")}
+              >
+                Reject
+              </Button>
+              <Button size="small" onClick={() => setReviewDecision("approve")}>
+                Review output
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <RunOutputReviewPanel
+        decision={reviewDecision}
+        runIds={runsAwaitingReview.map((r) => String(r.id))}
+        onClose={() => setReviewDecision(null)}
+        onApplied={() => setReviewDecision(null)}
+      />
 
       {/* Review banner */}
       {isInReview && (

--- a/apps/backend/src/admin/lib/__tests__/run-review.unit.spec.ts
+++ b/apps/backend/src/admin/lib/__tests__/run-review.unit.spec.ts
@@ -1,0 +1,68 @@
+import {
+  runsAwaitingOutputReview,
+  shouldExcludeChildRuns,
+} from "../run-review"
+
+describe("child runs are reachable in the review queue (#1898)", () => {
+  it("INCLUDES children when the review queue is asked for", () => {
+    // The defect: 28 of 70 completed runs on prod were children, and the page
+    // hid them unconditionally, so the queue could never reach zero.
+    expect(shouldExcludeChildRuns({ reviewFilter: "none" })).toBe(false)
+  })
+
+  it("stays parents-only for every other view, as before", () => {
+    expect(shouldExcludeChildRuns({})).toBe(true)
+    expect(shouldExcludeChildRuns({ reviewFilter: "approved" })).toBe(true)
+    expect(shouldExcludeChildRuns({ reviewFilter: "rejected" })).toBe(true)
+  })
+
+  it("lets an explicit Scope choice win over the review filter, both ways", () => {
+    expect(shouldExcludeChildRuns({ scopeFilter: "all" })).toBe(false)
+    expect(
+      shouldExcludeChildRuns({ scopeFilter: "parents", reviewFilter: "none" })
+    ).toBe(true)
+    expect(
+      shouldExcludeChildRuns({ scopeFilter: "all", reviewFilter: "approved" })
+    ).toBe(false)
+  })
+})
+
+describe("which runs await output review (#1898)", () => {
+  // The real pair from design 01KKP0RHEW57DSCSRSQQW0SAN2 — one parent, one
+  // child, both completed 2026-07-25, both undecided since.
+  const JACKET_RUNS = [
+    { id: "prod_run_01KW74KBC1XZ5724G1XWY73XZK", status: "completed", parent_run_id: null, approval_decision: null },
+    { id: "prod_run_01KW74KC1J431DBMG5MCG0Q43K", status: "completed", parent_run_id: "prod_run_01KW74KBC1XZ5724G1XWY73XZK", approval_decision: null },
+  ]
+
+  it("finds both runs on the design whose page offered no way to review them", () => {
+    expect(runsAwaitingOutputReview(JACKET_RUNS).map((r) => r.id)).toEqual([
+      "prod_run_01KW74KBC1XZ5724G1XWY73XZK",
+      "prod_run_01KW74KC1J431DBMG5MCG0Q43K",
+    ])
+  })
+
+  it("does NOT re-offer a run that was already decided", () => {
+    // A rejected run stays `completed` (#1805), so status alone cannot tell
+    // "decided" from "nobody has looked".
+    const decided = [
+      { status: "completed", approval_decision: "rejected" },
+      { status: "completed", approval_decision: "approved" },
+    ]
+    expect(runsAwaitingOutputReview(decided)).toHaveLength(0)
+  })
+
+  it("ignores runs that are not completed", () => {
+    const open = [
+      { status: "in_progress", approval_decision: null },
+      { status: "cancelled", approval_decision: null },
+    ]
+    expect(runsAwaitingOutputReview(open)).toHaveLength(0)
+  })
+
+  it("treats undefined like null, and survives no runs at all", () => {
+    expect(runsAwaitingOutputReview([{ status: "completed" }])).toHaveLength(1)
+    expect(runsAwaitingOutputReview(null)).toHaveLength(0)
+    expect(runsAwaitingOutputReview(undefined)).toHaveLength(0)
+  })
+})

--- a/apps/backend/src/admin/lib/run-review.ts
+++ b/apps/backend/src/admin/lib/run-review.ts
@@ -1,0 +1,47 @@
+/**
+ * #1898 — the two rules that decide whether a run awaiting review can be SEEN.
+ *
+ * Extracted from JSX so they can be exercised. Both were previously inline
+ * expressions, and both were wrong in a way no test could reach.
+ */
+
+/**
+ * Whether the production-run list should hide child runs.
+ *
+ * The list hardcoded `true`. A child run carries its own `approval_decision`,
+ * and on production 28 of 70 completed runs were children — so the review queue
+ * could never be emptied from that page: `applyRunApprovals` writes the
+ * decision onto the runs in the SELECTION, and a run that is never listed is
+ * never selected.
+ *
+ * Parents-only stays the default, because a parent is the aggregator an
+ * operator normally wants. But asking for the review queue must show every run
+ * awaiting review, children included, or the filter is lying about its name.
+ */
+export const shouldExcludeChildRuns = (input: {
+  /** The explicit Scope filter, when the operator has set one. */
+  scopeFilter?: string
+  /** The Review filter. `"none"` is the review queue. */
+  reviewFilter?: string
+}): boolean => {
+  if (input.scopeFilter === "all") return false
+  if (input.scopeFilter === "parents") return true
+  return input.reviewFilter !== "none"
+}
+
+/**
+ * The runs on a design that nobody has decided about yet.
+ *
+ * `approval_decision` is a separate axis from `status` (#1805): a rejected run
+ * stays `completed`, so "completed" alone does not mean "needs a decision", and
+ * `null` is the only value meaning nobody has looked.
+ *
+ * Uses `== null` deliberately — it must catch both `null` and `undefined`, and
+ * must NOT treat a decided run as undecided.
+ */
+export const runsAwaitingOutputReview = <T extends { status?: unknown; approval_decision?: unknown }>(
+  runs: readonly T[] | null | undefined
+): T[] =>
+  (runs ?? []).filter(
+    (r) => r?.status === "completed" && r?.approval_decision == null
+  )

--- a/apps/backend/src/admin/routes/production-runs/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/page.tsx
@@ -21,6 +21,7 @@ import { useProductionRuns, type AdminProductionRun } from "../../hooks/api/prod
 import { usePartners } from "../../hooks/api/partners"
 import { productionRunStatusColor } from "../../lib/status-colors"
 import { RunOutputReviewPanel } from "../../components/production-runs/run-output-review-panel"
+import { shouldExcludeChildRuns } from "../../lib/run-review"
 
 const PAGE_SIZE = 20
 
@@ -109,6 +110,23 @@ const ProductionRunsListPage = () => {
       : (filtering.partner_id as string)
     : undefined
 
+  /*
+    #1898 — this list hid child runs unconditionally, and a child run carries
+    its own `approval_decision`. 28 of 70 completed runs on prod were children,
+    so the review queue could never be emptied from here: approval writes the
+    decision onto the runs in the SELECTION, and an invisible run is never in
+    one. Default stays parents-only — a parent is the aggregator an operator
+    normally wants — but it is now a choice, and asking for the review queue
+    turns it off, because "awaiting review" must mean every run awaiting review.
+  */
+  const scopeFilter = filtering.run_scope
+    ? Array.isArray(filtering.run_scope)
+      ? (filtering.run_scope[0] as string)
+      : (filtering.run_scope as string)
+    : undefined
+
+  const excludeChildren = shouldExcludeChildRuns({ scopeFilter, reviewFilter })
+
   const { production_runs, count, isLoading, isError, error } = useProductionRuns({
     limit: pagination.pageSize,
     offset,
@@ -117,7 +135,7 @@ const ProductionRunsListPage = () => {
     run_type: runTypeFilter,
     partner_id: partnerFilter,
     approval_decision: reviewFilter,
-    exclude_children: true,
+    exclude_children: excludeChildren,
   })
 
   const { partners = [] } = usePartners({ limit: 100, offset: 0 })
@@ -304,6 +322,19 @@ const ProductionRunsListPage = () => {
           { label: "Awaiting review", value: "none" },
           { label: "Approved", value: "approved" },
           { label: "Rejected", value: "rejected" },
+        ],
+      }),
+      /*
+        #1898 — child runs were unreachable. Left unset this follows the review
+        filter, so the queue shows everything awaiting a decision and every
+        other view stays parents-only, as before.
+      */
+      filterHelper.accessor("run_scope", {
+        type: "select",
+        label: "Scope",
+        options: [
+          { label: "Parent runs only", value: "parents" },
+          { label: "Include child runs", value: "all" },
         ],
       }),
     ],


### PR DESCRIPTION
Closes #1898. Two surfaces, one miss: a run awaiting output review could not be reached from **either** place an operator would look.

## 1. The queue page hid the runs

`production-runs/page.tsx:120` hardcoded `exclude_children: true`, which `route.ts:262-264` turns into `parent_run_id = null`. There was no toggle.

A child run carries its own `approval_decision`, and `complete-production-run.ts:387-408` rolls children up so **both** parent and child end `completed`. Measured on production:

| completed runs | |
|---|---|
| total, all with `approval_decision: null` | **70** |
| parents | 42 |
| **children — invisible here** | **28** |

`applyRunApprovals` writes the decision onto the runs in the *selection* (`approve-run-output.ts:335-345`), so a run that is never listed is never decided. The queue could not reach zero, and the graph's `runsAwaitingProduct` disagreed with the page by 28.

Adds a **Scope** filter. Parents-only stays the default — a parent is the aggregator an operator normally wants — but asking for the review queue now includes children.

## 2. The design page offered a different approval entirely

`design-production-runs-section.tsx:28` gated its only button on `design.status === "Technical_Review"`. That button is `POST /admin/designs/:id/approve` — the **design** approve, which sets status and creates the product listing. Reviewing what a run **produced** is a separate axis (`approval_decision`, added by #1805), and this page had **no control for it at all**. `ProductionRunRow` has none either.

Design `01KKP0RHEW57DSCSRSQQW0SAN2` is the worked example: status `Approved`, so the design-approve button correctly hides — `complete-production-run.ts:339` deliberately skips the `Technical_Review` transition for an already-approved design. Meanwhile its two runs, both completed 2026-07-25, sat undecided with nowhere to decide them. The global queue was no help: one of the two is a child.

Adds a second banner gated on the **runs**, reusing `RunOutputReviewPanel` unchanged. The section already calls `useProductionRuns({ design_id })`, so no new query. `useRunApprovals` spreads `...options` *before* `onSuccess` and invalidates `productionRunQueryKeys.lists()`, so the banner clears itself — checked, since that ordering silently kills invalidation in this codebase.

## Verification

Both rules move into `lib/run-review.ts` so they can be exercised at all — they were inline JSX expressions no test could reach. Fixture is the real Jacket With Embroidery pair, one parent and one child.

**Red-checked** by restoring the old behaviour — 3 of 7 fail:
- the queue excluding children,
- an explicit Scope choice being ignored,
- a *rejected* run being re-offered for review. A rejected run stays `completed` by design, so `status` alone cannot tell "decided" from "nobody has looked" — that one is easy to get wrong and silently re-approves work someone already rejected.

Scoped `tsc -p` clean; `check:prod-build` passed.

## Not done

**Not rendered.** Both changes are UI and this repo's record on that is unambiguous — the dead button, the badge overflow, the Radix select stuck on its placeholder were all found by rendering, not reading. Worth a pass on the design page in particular: the new banner sits directly above the existing design-approve banner, and when a design is in `Technical_Review` **with** undecided runs, both render at once. That stack is the thing to look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp