### PR TITLE
fix(admin-graph): the inventory photo was rebuilt 7×/second, so the click never landed

### DIFF
--- a/apps/backend/src/admin/components/common/thumbnail-preview.tsx
+++ b/apps/backend/src/admin/components/common/thumbnail-preview.tsx
@@ -24,6 +24,13 @@ type ThumbnailPreviewProps = {
  *  - On a plain page (e.g. the inventory raw-material widget) there's no
  *    provider, so it falls back to a standalone `FocusModal`.
  *
+ * The context check answers "is there a provider", not "how deep am I", and
+ * that is deliberate: the same picker is rendered TWO layers down from the
+ * design graph (graph focus modal → node drawer → create modal → this), where
+ * the preview registers as a sibling in the drawer's provider and stacks above
+ * everything correctly. Depth was never the problem — see the loop documented
+ * on `StackedChromeProvider`, and the row-click note on the trigger below.
+ *
  * With no `src` it renders the placeholder thumbnail and is not interactive.
  */
 export const ThumbnailPreview = ({
@@ -48,6 +55,24 @@ export const ThumbnailPreview = ({
         "focus-visible:shadow-borders-focus hover:opacity-80"
       )}
       aria-label={alt ? `Preview image: ${alt}` : "Preview image"}
+      /*
+       * 🔴 The preview must not also be a click on the ROW.
+       *
+       * Every table this lands in puts the thumbnail in a cell, and the ones
+       * that select on row click (`onRowClick` in `DesignInventoryTable`)
+       * therefore toggled the row underneath. That is wrong on its own, and it
+       * also CLOSED the preview: the selection re-renders the table, the column
+       * definitions are rebuilt, and TanStack renders a `cell` FUNCTION as an
+       * element type — a new identity unmounts and remounts every cell, taking
+       * the modal that had just opened with it. Opening it looked like nothing
+       * happening at all.
+       *
+       * `stopPropagation` and NOT `preventDefault`: Radix composes the child's
+       * handler ahead of the Trigger's own and skips its own once the event is
+       * defaultPrevented, so preventing the default here would stop the modal
+       * from opening — the very thing this button exists to do.
+       */
+      onClick={(e) => e.stopPropagation()}
     >
       <Thumbnail src={src} alt={alt} size={size} />
     </button>

--- a/apps/backend/src/admin/components/modal/chrome/route-chrome-provider.tsx
+++ b/apps/backend/src/admin/components/modal/chrome/route-chrome-provider.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useMemo } from "react"
+import { PropsWithChildren, useMemo, useRef } from "react"
 
 import { useRouteModal } from "../use-route-modal"
 import { ModalChromeContext, type ModalChromeValue } from "./modal-chrome-context"
@@ -42,16 +42,44 @@ export const StackedChromeProvider = ({
   onClose,
   children,
 }: PropsWithChildren<{ parts: Parts; onClose: () => void }>) => {
+  /**
+   * 🔴 `onClose` is a FRESH ARROW on every render of `StackedFocusModal.Root`
+   * (`onClose={() => handleOpenChange(false)}`), so keying the memo on it
+   * re-provided this context on every render of the layer — and that turned a
+   * one-shot `register()` into an infinite remount loop:
+   *
+   *   a thumbnail mounts -> `register(useId())` -> `StackedModalProvider`
+   *   setState -> every `useStackedModal()` consumer re-renders, including the
+   *   Root above -> new `onClose` -> new chrome value -> every
+   *   `useModalChrome()` consumer re-renders, including the form inside ->
+   *   its column defs are rebuilt, and TanStack renders a `cell` FUNCTION as
+   *   the element type, so a new function identity UNMOUNTS and remounts every
+   *   cell -> the thumbnail mounts again with a new id -> round again.
+   *
+   * Measured at ~7 cycles/second in the design graph: the inventory picker's
+   * image-preview button was destroyed and rebuilt faster than a click could
+   * land on it, which read as "clicking the photo does nothing". The same table
+   * on `/designs/:id/addinv` was fine because `RouteChromeProvider` above keys
+   * its memo on values that do not churn.
+   *
+   * The ref keeps `onDone` calling the CURRENT `onClose` — the identity is what
+   * had to stop moving, not the behaviour.
+   */
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
   const value = useMemo<ModalChromeValue>(
     () => ({
       variant: "stacked",
       ...parts,
       // `path` is deliberately ignored: closing a stacked layer must not
       // navigate, or it takes its opener with it.
-      onDone: () => onClose(),
+      onDone: () => onCloseRef.current(),
     }),
+    // `parts` is a fresh object each render but its members are module-level
+    // constants — the same reasoning `RouteChromeProvider` above documents.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [onClose]
+    []
   )
 
   return (


### PR DESCRIPTION
## The symptom

From the design graph, **Inventory → Add to inventory → click an item's photo** did nothing. No console error, no dialog.

## What I actually saw

I drove a real browser at the local dev server and polled the preview button's `aria-controls` for 3 seconds on each surface:

| surface | distinct button ids in 3s |
|---|---|
| `/designs/:id/graph` (Inventory → Add to inventory) | **20** |
| `/designs/:id/addinv` (same table, its own route) | 1 |

11,160 DOM node removals in 1.5s inside the picker's `<tbody>`, with the dialog ids and the row count perfectly stable. The photo button was being destroyed and rebuilt about **7 times a second** — the click never had an element to land on.

Neither of the two hypotheses I started from was the cause. The provider's id-blind `onOpenChange` is real but cosmetic here (it only drives a background class), and `ThumbnailPreview`'s coarse context check is correct — two levels down works fine once the page stops thrashing.

## Fault 1 — a memo keyed on a value that is new every render

`StackedChromeProvider` keys its `useMemo` on `onClose`, and `StackedFocusModal.Root` passes `onClose={() => handleOpenChange(false)}` — a fresh arrow every render. So the chrome context was re-provided on every render of the layer, and a one-shot `register()` became a loop:

```
thumbnail mounts
  -> register(useId())            (StackedFocusModal.Root effect)
  -> StackedModalProvider setState
  -> every useStackedModal() consumer re-renders, incl. the Root above
  -> new onClose arrow
  -> StackedChromeProvider memo invalidated -> new chrome value
  -> every useModalChrome() consumer re-renders, incl. DesignInventoryTable
  -> useInventoryColumns() returns new inline `cell` FUNCTIONS
  -> TanStack renders `cell` as the element TYPE, so a new identity
     UNMOUNTS and remounts every cell
  -> thumbnail mounts again with a fresh useId  -> round again
```

`@addinv` escaped it because `RouteChromeProvider` above keys its memo on `[variant, handleSuccess]`, neither of which churns.

Fixed with a ref, so `onDone` still calls the current `onClose` — only the identity had to stop moving.

## Fault 2 — the photo was also a click on the row

With the loop gone the modal still didn't open: the click bubbled to `DesignInventoryTable`'s `onRowClick`, which **selected the row**. That is wrong on its own, and it also closed the preview — the selection re-renders the table and remounts every cell by the same route as above. This half broke the `@addinv` route too, where the loop never happened.

`stopPropagation`, deliberately **not** `preventDefault`: Radix composes the child's handler ahead of the Trigger's own and skips its own once the event is defaultPrevented, so preventing the default would stop the modal opening at all.

## Verified by rendering, not by reading

On the graph, after the fix:

- preview button ids: 20 distinct → **1**
- click the photo → full-size image opens in a stacked focus modal above the graph modal (`img[class*=80vh]` count 1, dialogs 3 → 4)
- close it → back on the inventory picker with all 10 rows, graph still standing, URL unchanged at `/designs/:id/graph?node=inventory`
- click a second thumbnail → opens again

Same check passes on `/designs/:id/addinv`.

## Known, pre-existing, unchanged

**Escape does not close the preview layer** (it does close the picker), on the graph and on `@addinv` alike. Focus is inside the preview dialog when the key is sent. Out of scope here — it predates this change and touching Radix's layer dismissal is a separate risk.

## Checks

- Scoped `tsc -p tsconfig.changed.json --noEmit` over both changed files: clean (temp config deleted).
- No test references either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp