### PR TITLE
feat(admin-mcp): the review queue had no tool, a design's products had no reader, and the product was called "Custom"

### DIFF
--- a/apps/backend/src/api/admin/designs/[id]/products/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/products/route.ts
@@ -1,0 +1,57 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import productDesignLink from "../../../../../links/product-design-link"
+
+/**
+ * GET /admin/designs/:id/products — which products came from this design.
+ *
+ * There was no way to ask this. `create-product-from-design` writes a
+ * product↔design link row and stamps `metadata.design_id` on the product, but
+ * nothing read either direction: `get_design` returns no products and
+ * `/admin/products` cannot filter on metadata. Finding the product for a design
+ * meant free-text searching titles — which, when it was tried on production,
+ * happened to work only because the generated `custom-design-…` handle matched;
+ * two of the twelve had titles that did not contain the search string at all.
+ *
+ * 🔑 Queried through the LINK's `entryPoint`, not from the design entity. A
+ * `query.graph` from an entity to a linked field returns no key at all rather
+ * than erroring, so reading it the obvious way looks exactly like "this design
+ * has no products".
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: productDesignLink.entryPoint,
+    fields: [
+      "product.id",
+      "product.title",
+      "product.handle",
+      "product.status",
+      "product.thumbnail",
+      "product.created_at",
+      "product.metadata",
+      "product.variants.id",
+      "product.variants.title",
+      "product.variants.sku",
+      "product.variants.prices.amount",
+      "product.variants.prices.currency_code",
+    ],
+    filters: { design_id: req.params.id },
+  })
+
+  // A link row whose product was hard-deleted resolves to a null `product`.
+  // Reporting it as a product with no id would be worse than omitting it.
+  const products = (data || [])
+    .map((row: any) => row?.product)
+    .filter((p: any) => p && p.id)
+
+  res.status(200).json({ products, count: products.length })
+}

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/run-review-preview-reachable.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/run-review-preview-reachable.unit.spec.ts
@@ -1,0 +1,59 @@
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { toolDomain } from "../tool-slice"
+
+const byName = (n: string) => ADMIN_MCP_TOOLS.find((t) => t.name === n)
+
+/**
+ * The output-review queue had no tool at all, and the obvious way to add one
+ * would have shipped a bulk write on the live catalogue with its preview
+ * unreachable — `dry_run` is the MCP's OWN flag and is intercepted before the
+ * route is ever called, so the route's report cannot come back under that name.
+ * `run_maintenance_job` has exactly that defect today.
+ */
+describe("the run-review tool can actually be previewed (#1805 follow-up)", () => {
+  it("exists as a sensitive write", () => {
+    const t = byName("review_production_run_output")
+    expect(t).toBeDefined()
+    expect(t!.write).toBe(true)
+    expect(t!.sensitive).toBe(true)
+  })
+
+  it("forwards `preview`, so the route's report is reachable", () => {
+    expect(byName("review_production_run_output")!.bodyParams).toContain("preview")
+  })
+
+  it("does NOT forward `dry_run` — that name is the dispatcher's and never arrives", () => {
+    expect(byName("review_production_run_output")!.bodyParams).not.toContain("dry_run")
+  })
+
+  it("advertises nothing it does not forward", () => {
+    const t: any = byName("review_production_run_output")!
+    const advertised = Object.keys(t.inputSchema?.properties ?? {})
+    for (const k of advertised) expect(t.bodyParams).toContain(k)
+  })
+
+  it("tells the caller to preview first and warns that approval reuses a product", () => {
+    const d = byName("review_production_run_output")!.description
+    expect(d).toMatch(/preview: true/)
+    expect(d).toMatch(/reuses/i)
+  })
+})
+
+describe("a design's products are discoverable (#1900 follow-up)", () => {
+  it("exists as a read tool", () => {
+    const t = byName("list_design_products")
+    expect(t).toBeDefined()
+    expect(t!.method).toBe("GET")
+    expect(t!.write).toBeUndefined()
+  })
+
+  it("shares a slice with the review tool that depends on it", () => {
+    // Approval reuses the design's existing product, so the tool that reveals
+    // that product must surface in the same ask as the tool that blesses it.
+    const a = toolDomain(byName("list_design_products")!)
+    expect(a).toBeTruthy()
+    expect(byName("review_production_run_output")!.nextSteps).toContain(
+      "list_design_products"
+    )
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -717,7 +717,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     name: "update_inventory_order_lines",
     description:
       "Change an existing inventory order's lines — quantity, per-unit price, per-unit extra_cost (the colour/dye job), batch tag — add new lines, or remove one. Sensitive: requires confirm:true. ALWAYS dry_run first. " +
-      "🔑 The `order_lines` array is the DESIRED FINAL STATE of the lines you send: keep an existing line by sending its `id`, add one by omitting `id` (naming an inventory_item_id or an untracked variant_id), and remove one with `{ id, remove: true }`. " +
+      "🔑 The `order_lines` array is the DESIRED FINAL STATE of the lines you send: keep an existing line by sending its `id`, add one by omitting `id`, and remove one with `{ id, remove: true }`. ⚠️ EVERY line you keep or add must ALSO carry its `inventory_item_id` (or `variant_id`) — the validator rejects the whole request without it, `id` alone is not enough. Read the ids off get_order/list_inventory_orders and send them back. Do NOT respond to that 400 by dropping the `id`: that stops being an edit and becomes a delete-and-recreate of the line. " +
       "⚠️ `data.quantity` and `data.total_price` are NOT recomputed for you — send the new totals, where total_price is Σ (price + extra_cost) × quantity across the lines you are left with. " +
       "Use get_order/list_inventory_orders first to read the current line ids.",
     method: "PUT",
@@ -1265,6 +1265,59 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     ),
     sideEffects: "Publishing a product makes it live on the storefront.",
     nextSteps: ["get_product", "list_product_categories", "set_category_products"],
+  },
+  {
+    name: "list_design_products",
+    description: [
+      "Which products were created FROM a design — the reverse lookup that did not exist.",
+      "`create_product_from_design` writes a product↔design link and stamps `metadata.design_id`, but nothing read either direction: get_design returns no products and list_products cannot filter on metadata. Finding a design's product meant free-text searching titles, which silently misses any product whose title was edited.",
+      "Use it before approving a run: approval REUSES an existing product for the design rather than creating another, so what this returns is what the approval will bless — including its price.",
+    ].join("\n"),
+    method: "GET",
+    path: "/admin/designs/:id/products",
+    pathParams: ["id"],
+    inputSchema: obj(
+      { id: STR("Design id, e.g. '01KWKHSQ8FDGSKNW4FNY3K5FF0'.") },
+      ["id"]
+    ),
+    nextSteps: ["get_product", "get_design", "list_production_runs"],
+  },
+  {
+    name: "review_production_run_output",
+    description: [
+      "Decide whether what a COMPLETED production run produced is acceptable — the output review queue (#1805). Sensitive: requires confirm:true.",
+      "🔑 ALWAYS pass `preview: true` first. The preview resolves which runs map to which designs, which designs ALREADY have a product and so will be skipped, and what each would be listed at — and creates nothing. Approving blind is a bulk write on the live catalogue.",
+      "⚠️ `preview`, NOT `dry_run`: `dry_run` is this MCP's own flag and never reaches the route, so it returns the planned request instead of the report.",
+      "Approve creates the catalogue product ONCE PER DESIGN however many of its runs are selected, and reuses the design's existing product if it has one — so a design whose product is mispriced is blessed, not corrected. Check list_design_products first.",
+      "Reject records the refusal and creates nothing. A rejected run STAYS `completed`: the partner made the goods and is still owed for `produced_quantity`. A reason is required to reject.",
+      "Runs with no `design_id` can only be rejected, never approved — they come back `skipped`.",
+      "Answers with a PER-RUN report, not a bare success: read it rather than assuming the whole batch landed.",
+    ].join("\n"),
+    method: "POST",
+    path: "/admin/production-runs/approvals",
+    write: true,
+    sensitive: true,
+    bodyParams: ["run_ids", "decision", "reason", "preview"],
+    inputSchema: obj(
+      {
+        run_ids: {
+          type: "array",
+          description: "Production run ids to decide on, 1-200.",
+          items: { type: "string" },
+        },
+        decision: STR("'approve' | 'reject'."),
+        reason: STR(
+          "Why the output was refused. REQUIRED to reject (unless previewing) — it is the only record the partner who made the goods can be shown."
+        ),
+        preview: BOOL(
+          "Resolve and report what the decision would do, changing nothing. Do this first."
+        ),
+      },
+      ["run_ids", "decision"]
+    ),
+    sideEffects:
+      "Approve creates a product per design (reusing an existing one) and stamps approval_decision on every selected run. Reject stamps the refusal only. Neither changes run status, and neither affects payout — billing keys on `completed`.",
+    nextSteps: ["list_production_runs", "list_design_products", "get_product"],
   },
   {
     name: "update_product_option",

--- a/apps/backend/src/api/admin/production-runs/approvals/route.ts
+++ b/apps/backend/src/api/admin/production-runs/approvals/route.ts
@@ -34,7 +34,10 @@ export const POST = async (
     // Who decided. `auth_context` is the admin acting; "system" only when a
     // job ever calls this.
     actorId: req.auth_context?.actor_id ?? null,
-    dryRun: Boolean(body.dry_run),
+    // Either flag means preview. `||` and not `??`: an explicit
+    // `dry_run: false` beside `preview: true` must still preview, and a
+    // nullish check would let the false win.
+    dryRun: Boolean(body.dry_run) || Boolean(body.preview),
   })
 
   res.status(200).json({ run_approvals: result })

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -194,6 +194,17 @@ export const AdminRunApprovalsReq = z
      * the batch before it happens.
      */
     dry_run: z.boolean().optional(),
+    /**
+     * The same request as `dry_run`, under a name a proxy can pass through.
+     *
+     * 🔴 The admin MCP owns `dry_run` as its OWN flag: it intercepts and
+     * returns the planned request without ever calling this route, so the
+     * report `dry_run` produces here — which runs map to which designs, which
+     * already have a product, what each would list at — was unreachable from a
+     * tool. A bulk approve you cannot preview is a blind write on production,
+     * and the preview is the point of this endpoint, not a courtesy.
+     */
+    preview: z.boolean().optional(),
   })
   .refine(
     // A PREVIEW is not a decision, so it does not need the reason a decision
@@ -201,6 +212,7 @@ export const AdminRunApprovalsReq = z
     // sentence that explains it.
     (b) =>
       b.dry_run === true ||
+      b.preview === true ||
       b.decision !== "reject" ||
       Boolean(b.reason && b.reason.trim()),
     {

--- a/apps/backend/src/workflows/designs/__tests__/create-product-from-design.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/create-product-from-design.unit.spec.ts
@@ -1,4 +1,4 @@
-import { designOptionValue, resolveListedPrice } from "../create-product-from-design"
+import { designOptionValue, designProductNaming, resolveListedPrice } from "../create-product-from-design"
 
 /**
  * The price a design is listed at. Medusa 2.x amounts are DECIMAL major units —
@@ -78,5 +78,47 @@ describe("designOptionValue — #1874", () => {
 
   it("does not reuse the legacy literal that caused the collision", () => {
     expect(designOptionValue({ id: "des_a", name: "Kalamkari" }, ["Custom"])).not.toBe("Custom")
+  })
+})
+
+describe("designProductNaming — the product stops being called 'Custom'", () => {
+  const design = {
+    id: "01KWKHSQ8FDGSKNW4FNY3K5FF0",
+    name: "Embroidered jacket",
+    design_type: "Original",
+  }
+
+  it("titles the product after the design, with no 'Custom Design - ' prefix", () => {
+    // The real product this replaced was titled "Custom Design - Embroidered jacket".
+    expect(designProductNaming(design).title).toBe("Embroidered jacket")
+    expect(designProductNaming(design).title).not.toMatch(/Custom Design/)
+  })
+
+  it("uses design_type as the option title instead of the generic 'Type'", () => {
+    expect(designProductNaming(design).optionTitle).toBe("Original")
+  })
+
+  it("never claims the literal 'Custom' as an option value (#1874)", () => {
+    // The value the appended branch already avoids: two designs on one product
+    // resolved to an identical option tuple.
+    const n = designProductNaming(design)
+    expect(n.optionValue).toBe("Embroidered jacket")
+    expect(n.optionValue).not.toBe("Custom")
+    expect(n.variantTitle).not.toBe("Custom Design")
+  })
+
+  it("agrees with designOptionValue, so the two branches cannot drift apart", () => {
+    expect(designProductNaming(design).optionValue).toBe(designOptionValue(design))
+  })
+
+  it("falls back to 'Type' for an unclassified design rather than an empty option title", () => {
+    expect(designProductNaming({ id: "d1", name: "Stole" }).optionTitle).toBe("Type")
+    expect(
+      designProductNaming({ id: "d1", name: "Stole", design_type: "  " }).optionTitle
+    ).toBe("Type")
+  })
+
+  it("still names a design with no name at all", () => {
+    expect(designProductNaming({ id: "des_x" }).title).toBe("Design des_x")
   })
 })

--- a/apps/backend/src/workflows/designs/create-product-from-design.ts
+++ b/apps/backend/src/workflows/designs/create-product-from-design.ts
@@ -112,6 +112,48 @@ export const designOptionValue = (
 }
 
 /**
+ * PURE: how a design-created product is NAMED. Exported for tests.
+ *
+ * 🔴 This branch hardcoded `title: "Custom Design - <name>"`, an option `Type`
+ * whose only value was the literal `"Custom"`, and a variant titled
+ * `"Custom Design"`. Three problems:
+ *
+ *  - The `Custom Design - ` prefix said nothing the `is_custom_design` metadata
+ *    does not, and it is what shows in the catalogue, the order line and the
+ *    partner portal.
+ *  - `design_type` (Original / Derivative / Custom / Collaboration) was already
+ *    on the design and went unused, while the option was called "Type".
+ *  - The literal `"Custom"` is the exact value #1874 removed from the APPENDED
+ *    branch, because two designs on one product then resolved to an identical
+ *    option tuple. This branch kept writing it, so a product created here and
+ *    appended to later carried `["Custom", "<other design>"]` — the first
+ *    variant named after nothing in particular.
+ *
+ * The design's own name is the value in both branches now, via the same helper.
+ */
+export const designProductNaming = (design: {
+  id: string
+  name?: string | null
+  design_type?: string | null
+}): {
+  title: string
+  optionTitle: string
+  optionValue: string
+  variantTitle: string
+} => {
+  const optionValue = designOptionValue(design)
+  return {
+    title: optionValue,
+    // The design's own classification, when it has one. "Type" is the fallback
+    // rather than the default, so an unclassified design still gets a sane
+    // option rather than an empty title.
+    optionTitle: String(design.design_type ?? "").trim() || "Type",
+    optionValue,
+    variantTitle: optionValue,
+  }
+}
+
+/**
  * PURE: the amount written to `variant.prices[].amount`. Exported for tests.
  *
  * Medusa 2.x prices are DECIMAL major units — the seed lists a €10 shirt as
@@ -293,8 +335,18 @@ const createProductAndVariantStep = createStep(
 
       // Create new product for this custom design
       // Medusa 2.0 requires options for products with variants
+      // #1874's rule applies here too: the option value a variant claims must
+      // be the DESIGN's, not the literal "Custom". This branch still hardcoded
+      // it, so a product created here and then appended to by a second design
+      // ended up with an option list of ["Custom", "<other design>"] — the
+      // first variant named after nothing in particular.
+      const naming = designProductNaming(design)
+
       const productInput = {
-        title: `Custom Design - ${design.name}`,
+        // The design's own name, not "Custom Design - <name>". The prefix said
+        // nothing the `is_custom_design` metadata does not, and it read badly
+        // everywhere the title is shown. `design_type` rides in metadata below.
+        title: naming.title,
         description: design.description || `Custom design: ${design.name}`,
         // Draft is not purchasable. A made-to-order product has to be live for
         // the cart an accepted quote builds to be completable at all.
@@ -313,17 +365,17 @@ const createProductAndVariantStep = createStep(
         sales_channels: [{ id: salesChannelId }],
         options: [
           {
-            title: "Type",
-            values: ["Custom"],
+            title: naming.optionTitle,
+            values: [naming.optionValue],
           },
         ],
         variants: [
           {
-            title: "Custom Design",
+            title: naming.variantTitle,
             sku: `CUSTOM-${design.id}`,
             manage_inventory: manageInventory,
             options: {
-              Type: "Custom",
+              [naming.optionTitle]: naming.optionValue,
             },
             prices: [
               {


### PR DESCRIPTION
Three gaps found while working the 70-run output-review queue, plus the tool description that sent me into a 400 on a live order.

## 1. `review_production_run_output`

`POST /admin/production-runs/approvals` has existed since #1805 and nothing exposed it, so clearing the queue was dashboard-only.

**The obvious registry entry would have shipped a blind bulk write.** This MCP owns `dry_run` as its *own* flag — it returns the planned request and never calls the route — so the route's report (which runs map to which designs, which designs already have a product and will be skipped, what each would list at) could not come back under that name. `run_maintenance_job` has exactly that defect today: its preview is unreachable, and a real run differs from a preview only by `confirm`.

So the route gains a `preview` alias. `Boolean(dry_run) || Boolean(preview)`, deliberately **not** `??` — an explicit `dry_run: false` beside `preview: true` must still preview, and a nullish check would let the `false` win. The reject-needs-a-reason refinement honours it too, since a preview is not a decision.

## 2. `list_design_products` — new `GET /admin/designs/:id/products`

`create-product-from-design` writes a product↔design link **and** stamps `metadata.design_id`, and nothing read either direction. Finding a design's product meant free-text searching titles — which on production worked only because the generated `custom-design-…` handle happened to match, and **two of the twelve** products had titles not containing the search string at all.

Queried through the link's `entryPoint`, not from the design entity: a `query.graph` from an entity to a linked field returns no key rather than erroring, which reads exactly like "this design has no products".

This is load-bearing before approving anything — approval **reuses** the design's existing product, so a design whose product is mispriced (#1900: one is listed at `187500 usd`, two at `0`) gets *blessed*, not corrected. The tool says so and names the reader as its previous step.

## 3. The product stops being called "Custom"

| | before | after |
|---|---|---|
| product title | `Custom Design - Embroidered jacket` | `Embroidered jacket` |
| option title | `Type` | `Original` (the design's `design_type`) |
| option value | `Custom` | `Embroidered jacket` |
| variant title | `Custom Design` | `Embroidered jacket` |

That option value is the one **#1874 already removed from the appended branch**, because two designs on one product resolved to an identical option tuple. This branch kept writing it — so a product created here and appended to later carried `["Custom", "<other design>"]`, the first variant named after nothing in particular. Both branches now go through `designOptionValue`.

`design_type` was sitting unused on the design while the option was literally called "Type". It falls back to `"Type"` when blank, so an unclassified design doesn't get an empty option title.

Naming extracted to `designProductNaming`, matching this file's existing pure-helper pattern (`designOptionValue`, `resolveListedPrice`).

## 4. `update_inventory_order_lines`' description was wrong

It said an existing line is kept by sending its `id`. The validator requires `inventory_item_id` or `variant_id` on **every** line and 400s without it — hit while correcting the GOF order. The real danger is the obvious recovery: dropping the `id` clears the error and turns an edit into a **delete-and-recreate** of the line. Now said outright.

## Verification

- **Red-checked** the naming: restoring the three literals fails **5 of 17**.
- New MCP spec pins that `preview` is forwarded and `dry_run` is **not**, that nothing advertised is unforwarded, and that the products reader shares a slice with the tool depending on it.
- Admin MCP **243 / 14 suites**; designs + production-runs + mcp **672 / 48 suites**; `check:prod-build` passed.

## Not done

The new route is **not rendered or called against a live server** — it's covered by the registry contract tests, not an integration test. Worth one call against `01KWKHSQ8FDGSKNW4FNY3K5FF0`, which should return `prod_01M0XY2A2900JY867RVY957ERK`.

Separately: `.claude/CLAUDE.md` says `yarn dev`, which the repo's `packageManager` field makes yarn refuse — it should be `pnpm dev`. Fixed locally, but `.claude/` is gitignored and untracked, so it cannot be committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp