### PR TITLE
fix(admin-mcp): a phantom route, and an inventory item that could be listed and nothing else (#1905, #1907)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/inventory-lifecycle-tools.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/inventory-lifecycle-tools.unit.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * The inventory item's own lifecycle over MCP (#1905).
+ *
+ * `list_inventory_items` shipped alone: a reader with no way to open one row,
+ * create one, place it at a warehouse, count it, hold it or divide it. The
+ * routes all existed — core's location-levels and reservations, this repo's
+ * split and raw-material update — so the gap was nine missing registry rows,
+ * and a gap of that shape is invisible: nothing errors, the caller simply
+ * cannot start.
+ *
+ * What is pinned here:
+ *
+ *  1. `bodyParams` and the input schema agree BOTH ways. The global invariant
+ *     in `dispatch.unit.spec` only checks params -> schema; the direction that
+ *     actually bites is schema -> params, because a field the schema advertises
+ *     and the forward list omits is stripped in SILENCE — the call succeeds and
+ *     changes nothing.
+ *  2. Every wrapped core route is `.strict()`, so an extra forwarded key is a
+ *     400 rather than a no-op. The lists must be exactly the routes' fields.
+ *  3. The writes that overwrite an absolute count carry the warning that says
+ *     so. `stocked_quantity` is not a delta, and a model that assumes it is
+ *     destroys stock silently.
+ *  4. A tool demanding an id is reachable from one that produces it.
+ */
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { toolDomain } from "../tool-slice"
+
+const byName = (name: string) => ADMIN_MCP_TOOLS.find((t) => t.name === name)
+
+/** The rows this issue added, plus the create tool they complete. */
+const NEW_TOOLS = [
+  "get_inventory_item",
+  "create_inventory_item",
+  "list_inventory_levels",
+  "set_inventory_level",
+  "update_inventory_level",
+  "list_reservations",
+  "create_reservation",
+  "delete_reservation",
+  "split_inventory_item",
+  "get_raw_material",
+  "update_inventory_raw_material",
+]
+
+describe("inventory lifecycle tools (#1905)", () => {
+  it("registers every tool", () => {
+    for (const name of NEW_TOOLS) {
+      expect(`${name}:${byName(name) ? "present" : "MISSING"}`).toBe(`${name}:present`)
+    }
+  })
+
+  it("forwards exactly what each schema advertises — neither stripped nor 400", () => {
+    for (const name of NEW_TOOLS) {
+      const def = byName(name)!
+      if (def.method === "GET" || def.method === "DELETE") {
+        expect(`${name}:${JSON.stringify(def.bodyParams ?? [])}`).toBe(`${name}:[]`)
+        continue
+      }
+      const props = Object.keys(def.inputSchema.properties ?? {})
+      const pathAndQuery = new Set([
+        ...(def.pathParams ?? []),
+        ...(def.queryParams ?? []),
+      ])
+      // Everything the schema offers that is not a path/query param has to be
+      // on the forward list, or the model can fill it in and nothing happens.
+      const shouldForward = props.filter((p) => !pathAndQuery.has(p)).sort()
+      expect(`${name}:${[...(def.bodyParams ?? [])].sort().join(",")}`).toBe(
+        `${name}:${shouldForward.join(",")}`
+      )
+    }
+  })
+
+  it("wraps the real routes with the real methods", () => {
+    expect(byName("get_inventory_item")).toMatchObject({
+      method: "GET",
+      path: "/admin/inventory-items/:id",
+    })
+    expect(byName("create_inventory_item")).toMatchObject({
+      method: "POST",
+      path: "/admin/inventory-items",
+    })
+    expect(byName("list_inventory_levels")).toMatchObject({
+      method: "GET",
+      path: "/admin/inventory-items/:id/location-levels",
+    })
+    expect(byName("set_inventory_level")).toMatchObject({
+      method: "POST",
+      path: "/admin/inventory-items/:id/location-levels",
+    })
+    // Core updates a single level with POST, not PUT/PATCH.
+    expect(byName("update_inventory_level")).toMatchObject({
+      method: "POST",
+      path: "/admin/inventory-items/:id/location-levels/:location_id",
+    })
+    expect(byName("list_reservations")).toMatchObject({
+      method: "GET",
+      path: "/admin/reservations",
+    })
+    expect(byName("create_reservation")).toMatchObject({
+      method: "POST",
+      path: "/admin/reservations",
+    })
+    expect(byName("delete_reservation")).toMatchObject({
+      method: "DELETE",
+      path: "/admin/reservations/:id",
+    })
+    expect(byName("split_inventory_item")).toMatchObject({
+      method: "POST",
+      path: "/admin/inventory-items/:id/split",
+    })
+    // This repo's raw-material update is PUT; the create beside it is POST.
+    expect(byName("update_inventory_raw_material")).toMatchObject({
+      method: "PUT",
+      path: "/admin/inventory-items/:id/rawmaterials/:rawMaterialId",
+    })
+  })
+
+  it("sends only the fields the core validators accept (every one is .strict())", () => {
+    expect(byName("set_inventory_level")!.bodyParams).toEqual([
+      "location_id",
+      "stocked_quantity",
+      "incoming_quantity",
+    ])
+    // The single-level update takes the location from the PATH; sending
+    // `location_id` in the body is rejected outright by the strict schema.
+    expect(byName("update_inventory_level")!.bodyParams).toEqual([
+      "stocked_quantity",
+      "incoming_quantity",
+    ])
+    expect(byName("update_inventory_level")!.bodyParams).not.toContain("location_id")
+    expect(byName("create_reservation")!.bodyParams).toEqual([
+      "inventory_item_id",
+      "location_id",
+      "quantity",
+      "line_item_id",
+      "description",
+      "metadata",
+    ])
+    expect(byName("split_inventory_item")!.bodyParams).toEqual([
+      "quantity",
+      "new_title",
+      "location_id",
+      "raw_material_overrides",
+    ])
+  })
+
+  it("says that a stocked quantity is absolute, not a delta", () => {
+    for (const name of ["set_inventory_level", "update_inventory_level"]) {
+      expect(`${name}:${/ABSOLUTE|absolute/.test(byName(name)!.description)}`).toBe(
+        `${name}:true`
+      )
+    }
+    // The update is the destructive one: it overwrites a count that already
+    // exists, so it also has to say what is lost.
+    expect(byName("update_inventory_level")!.description).toMatch(/loses 30 units/)
+    expect(byName("update_inventory_level")!.sideEffects).toBeTruthy()
+  })
+
+  it("warns that specifications and media REPLACE rather than merge", () => {
+    const d = byName("update_inventory_raw_material")!
+    expect(d.description).toMatch(/REPLACES/)
+    expect(d.sideEffects).toMatch(/Replaces/)
+  })
+
+  it("teaches the media shape, and that an empty files array is not a photo", () => {
+    for (const name of ["add_inventory_raw_material", "update_inventory_raw_material"]) {
+      const d = byName(name)!.description
+      expect(`${name}:${d.includes('"files"')}`).toBe(`${name}:true`)
+    }
+    // 12 of the first 50 raw materials in production carry `{files: []}` —
+    // present, non-null, and showing nothing. The create tool is where that
+    // gets prevented, so that is where the warning belongs.
+    expect(byName("add_inventory_raw_material")!.description).toContain('"files": []')
+  })
+
+  it("points every id-demanding tool at one that produces the id", () => {
+    // A stock location id is not guessable and nothing else surfaces it.
+    for (const name of ["set_inventory_level", "create_inventory_item"]) {
+      expect(`${name}:${byName(name)!.description.includes("list_stock_locations")}`).toBe(
+        `${name}:true`
+      )
+    }
+    expect(byName("get_raw_material")!.description).toMatch(/list_raw_materials/)
+  })
+
+  it("names the ordinary door to an inventory item, which is not create", () => {
+    // A partner-supplied variant has no inventory item until an order line
+    // names it; an item created directly is linked to nothing.
+    const d = byName("create_inventory_item")!.description
+    expect(d).toMatch(/inventory-order line|inventory_order line|order line/i)
+    expect(d).toMatch(/create_inventory_order|update_inventory_order_lines/)
+  })
+
+  it("gates every mutation behind confirm, and none of them are dangerous", () => {
+    const writes = NEW_TOOLS.map(byName).filter((d) => d!.method !== "GET")
+    expect(writes.length).toBe(7)
+    for (const d of writes) {
+      expect(`${d!.name}:${d!.write === true}`).toBe(`${d!.name}:true`)
+      expect(`${d!.name}:${d!.sensitive === true}`).toBe(`${d!.name}:true`)
+      // Reversible platform edits: reachable by a write-scoped credential,
+      // still confirm-gated in the admin UI.
+      expect(`${d!.name}:${d!.tier}`).toBe(`${d!.name}:write`)
+      expect(`${d!.name}:${d!.dangerous ?? false}`).toBe(`${d!.name}:false`)
+    }
+  })
+
+  it("classifies every new tool into the inventory slice", () => {
+    // An unclassified tool loads in NO slice — registered and unreachable.
+    for (const name of NEW_TOOLS) {
+      expect(`${name}:${toolDomain(byName(name)!)}`).toBe(`${name}:inventory`)
+    }
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/product-option-value-discoverability.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/product-option-value-discoverability.unit.spec.ts
@@ -50,9 +50,25 @@ describe("product option values are reachable (#1894)", () => {
     )
   })
 
-  it("warns that values REPLACES rather than appends — the trap that destroys existing variants' options", () => {
+  /**
+   * #1907. This assertion used to demand the opposite — that the description
+   * warn `values` REPLACES the whole list. That warning described
+   * `POST /admin/products/:id/options/:option_id`, a route that never existed
+   * in core or in this repo, so the tool 404'd on every real call while this
+   * spec stayed green. Core's only door to an option's values is the batch
+   * endpoint, and it is ADDITIVE: `add` appends, `remove` deletes by value id,
+   * and anything unmentioned is left alone.
+   *
+   * The destructive-rewrite footgun is therefore gone, not merely documented.
+   * `registry-routes-exist.unit.spec` now pins the route's existence, which is
+   * the check whose absence let this ship.
+   */
+  it("is additive — values are added, not rewritten by omission", () => {
     const d = byName("update_product_option")!.description
-    expect(d).toMatch(/REPLACES/)
-    expect(d).toMatch(/not an append/i)
+    expect(d).toMatch(/ADDITIVE/)
+    expect(d).not.toMatch(/REPLACES/)
+    // `remove` takes ids, and saying so is the whole guard against a model
+    // sending the value string and silently removing nothing.
+    expect(d).toMatch(/optval_/)
   })
 })

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/registry-routes-exist.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/registry-routes-exist.unit.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Every proxy tool must wrap a route that actually EXISTS (#1907).
+ *
+ * `update_product_option` shipped in #1896 pointing at
+ * `POST /admin/products/:id/options/:option_id`. No such route exists — not in
+ * this repo, not in core. Core only ever exposed the values through
+ * `/admin/products/:id/options/batch`.
+ *
+ * Every registry test stayed green the whole time, because every one of them
+ * asked about the registry's own internal consistency: is the tool present, is
+ * it `write`, does its schema agree with its forward list, is it in a slice,
+ * does its prose carry the right warning. Not one asked the only question that
+ * mattered — is anything listening on the other end. So the tool advertised
+ * itself, passed review, deployed, and 404'd on the first real call, weeks
+ * later, against a live inventory order.
+ *
+ * A check that never ran reads as a pass. This is the check.
+ *
+ * ── How the match works ───────────────────────────────────────────────────
+ *
+ * Routes are files: `/admin/orders/:id` lives at `admin/orders/[id]/route.ts`.
+ * Two things stop that from being a plain string comparison:
+ *
+ *  - Parameter NAMES need not agree. The registry says `:product_id` where
+ *    core's directory is `[id]`. That is not a defect — the dispatcher
+ *    substitutes positionally — so a `:param` segment matches ANY `[...]`
+ *    directory at that depth.
+ *  - A path can exist in BOTH trees with different verbs. `/admin/stores` is
+ *    POST in this repo and GET in core. So a root that has the file but not
+ *    the method is not a failure; the search continues into the next root.
+ *    (Getting this wrong is what made my first pass report five phantoms that
+ *    were not phantoms.)
+ */
+import fs from "fs"
+import path from "path"
+import { ADMIN_MCP_TOOLS } from "../registry"
+
+/**
+ * Repo routes take precedence, then core's compiled ones.
+ *
+ * Core's location is resolved through Node, not by counting `..` segments:
+ * this is a pnpm workspace, so `@medusajs/medusa` is hoisted to the REPO root
+ * rather than sitting under `apps/backend`, and a hand-counted relative path
+ * silently resolves to nothing — which would make this guard pass every core
+ * route by finding no file to disagree with.
+ */
+const CORE_API = path.join(
+  path.dirname(require.resolve("@medusajs/medusa/package.json")),
+  "dist/api"
+)
+
+const ROOTS = [
+  path.resolve(__dirname, "../../../../"), // src/api
+  CORE_API,
+]
+
+/** Directories a `:param` segment is allowed to match. */
+const dynamicDirs = (dir: string): string[] => {
+  if (!fs.existsSync(dir)) return []
+  return fs
+    .readdirSync(dir)
+    .filter(
+      (e) => e.startsWith("[") && fs.statSync(path.join(dir, e)).isDirectory()
+    )
+    .map((e) => path.join(dir, e))
+}
+
+/** Every route file a path could resolve to under one root. */
+const resolveRouteFiles = (root: string, routePath: string): string[] => {
+  let cursor = [root]
+  for (const seg of routePath.replace(/^\//, "").split("/")) {
+    const next: string[] = []
+    for (const dir of cursor) {
+      if (seg.startsWith(":")) next.push(...dynamicDirs(dir))
+      else if (fs.existsSync(path.join(dir, seg))) next.push(path.join(dir, seg))
+    }
+    if (!next.length) return []
+    cursor = next
+  }
+  return cursor
+    .flatMap((d) => ["route.ts", "route.js"].map((f) => path.join(d, f)))
+    .filter((f) => fs.existsSync(f))
+}
+
+const exportsMethod = (file: string, method: string): boolean => {
+  const src = fs.readFileSync(file, "utf8")
+  return new RegExp(
+    `(export\\s+const\\s+${method}\\b|export\\s+async\\s+function\\s+${method}\\b|export\\s+function\\s+${method}\\b|exports\\.${method}\\s*=)`
+  ).test(src)
+}
+
+describe("every admin MCP tool wraps a route that exists (#1907)", () => {
+  // Native tools run in-process and wrap no route at all.
+  const proxyTools = ADMIN_MCP_TOOLS.filter((t) => !t.native && t.path)
+
+  it("has proxy tools to check (a vacuous pass is not a pass)", () => {
+    expect(proxyTools.length).toBeGreaterThan(150)
+  })
+
+  it("actually found both route trees", () => {
+    // If a root resolves to nothing, every path under it reports as missing
+    // and the suite becomes noise. Fail on the root, not on 50 tools.
+    for (const root of ROOTS) {
+      expect(`${root}:${fs.existsSync(root)}`).toBe(`${root}:true`)
+    }
+    expect(fs.existsSync(path.join(CORE_API, "admin/products/route.js"))).toBe(true)
+  })
+
+  it("resolves every tool's path to a real route file exporting its method", () => {
+    const broken: string[] = []
+
+    for (const def of proxyTools) {
+      const method = def.method ?? "GET"
+      const files = ROOTS.flatMap((r) => resolveRouteFiles(r, def.path!))
+
+      if (!files.length) {
+        broken.push(`${def.name}: NO ROUTE FILE for ${method} ${def.path}`)
+        continue
+      }
+      if (!files.some((f) => exportsMethod(f, method))) {
+        broken.push(
+          `${def.name}: ${def.path} exists but exports no ${method} (${files
+            .map((f) => path.relative(process.cwd(), f))
+            .join(", ")})`
+        )
+      }
+    }
+
+    // Named, not counted: a failure here should say which tool is a phantom.
+    expect(broken).toEqual([])
+  })
+
+  it("still catches a phantom when one is introduced", () => {
+    // The guard is only worth having if it fails on the thing it exists for.
+    // This is #1896's exact broken path.
+    const files = ROOTS.flatMap((r) =>
+      resolveRouteFiles(r, "/admin/products/:id/options/:option_id")
+    )
+    expect(files).toEqual([])
+  })
+
+  it("does not mistake a differently-named path param for a missing route", () => {
+    // The registry says `:product_id`; core's directory is `[id]`.
+    const def = ADMIN_MCP_TOOLS.find((t) => t.name === "create_product_variant")!
+    expect(def.path).toBe("/admin/products/:product_id/variants")
+    const files = ROOTS.flatMap((r) => resolveRouteFiles(r, def.path!))
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it("does not fail a path whose method lives in the OTHER root", () => {
+    // `/admin/stores` is POST here and GET in core. Searching only the first
+    // root that has the file would report list_stores as broken.
+    const def = ADMIN_MCP_TOOLS.find((t) => t.name === "list_stores")
+    if (!def?.path || def.native) return
+    const files = ROOTS.flatMap((r) => resolveRouteFiles(r, def.path!))
+    expect(files.some((f) => exportsMethod(f, "GET"))).toBe(true)
+  })
+
+  it("points update_product_option at the batch route that actually exists", () => {
+    const def = ADMIN_MCP_TOOLS.find((t) => t.name === "update_product_option")!
+    expect(def.path).toBe("/admin/products/:id/options/batch")
+    // Additive now, not a whole-list rewrite: the destructive `values` shape
+    // belonged to the route that was never there.
+    expect(def.bodyParams).toEqual(["update"])
+    expect(def.description).toMatch(/ADDITIVE/)
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
@@ -102,7 +102,21 @@ describe("admin MCP tool tiers", () => {
         "create_crm_opportunity",
         "create_crm_task",
         "create_design",
+        // The inventory item's own lifecycle (#1905). All seven move stock
+        // figures inside the platform: no money leaves, no carrier is booked,
+        // nobody outside is messaged. They stay `sensitive`, and two of them
+        // need that gate badly — `update_inventory_level` writes an ABSOLUTE
+        // count over an existing one, and `split_inventory_item` divides a lot
+        // in two with no link back. A write-scoped credential may reach them;
+        // a model still cannot fire one without confirm:true.
+        "create_inventory_item",
         "create_raw_material_group",
+        "create_reservation",
+        "delete_reservation",
+        "set_inventory_level",
+        "split_inventory_item",
+        "update_inventory_level",
+        "update_inventory_raw_material",
         "log_crm_activity",
         "log_crm_note",
         "link_design_inventory",

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -548,6 +548,321 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     queryParams: ["limit", "offset", "q"],
     inputSchema: obj({ ...PAGINATION }),
   },
+  /**
+   * The inventory item's own lifecycle — #1905.
+   *
+   * `list_inventory_items` existed alone: a reader with no way to open one row,
+   * create one, place it at a location, count it, hold it, or divide it. Every
+   * one of those is a real route, and the raw-material tools below demand an
+   * `iitem_` id that only these produce for a good we did not buy on an order.
+   *
+   * ⚠️ The ordinary path to an inventory item is NOT `create_inventory_item`.
+   * A partner-supplied variant carries `manage_inventory: false` and has no
+   * item row at all; adding an inventory-order line that names the variant is
+   * what creates it (`ensureLineInventoryItems`, #1662 — idempotent, and
+   * deliberately not compensated). Reach for `create_inventory_item` only for
+   * stock that arrives outside an order.
+   */
+  {
+    name: "get_inventory_item",
+    description:
+      "Get one inventory item by id, with its location levels and raw-material data. Read. Call it before any level, reservation or split write — the stocked quantity you are about to change is only visible here.",
+    method: "GET",
+    path: "/admin/inventory-items/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Inventory item id, e.g. 'iitem_...'.") }, ["id"]),
+  },
+  {
+    name: "create_inventory_item",
+    description:
+      "Create a standalone inventory item — stock that exists at our end without a product variant or a purchase order behind it. Sensitive: requires confirm:true. " +
+      "🔑 This is the UNUSUAL door. A partner-supplied variant has no inventory item until an inventory-order line names it, and that path also links the item to the variant; an item created here is linked to NOTHING and will not appear against any product. Prefer create_inventory_order / update_inventory_order_lines with a `variant_id` unless the stock genuinely arrived outside an order. " +
+      "`location_levels` places it and counts it in the same call, using a `sloc_` id from list_stock_locations — otherwise the item exists in no warehouse and every consumption read returns zero.",
+    method: "POST",
+    path: "/admin/inventory-items",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: [
+      "title",
+      "sku",
+      "description",
+      "unit_of_measure",
+      "requires_shipping",
+      "hs_code",
+      "origin_country",
+      "mid_code",
+      "material",
+      "weight",
+      "length",
+      "height",
+      "width",
+      "thumbnail",
+      "metadata",
+      "location_levels",
+    ],
+    inputSchema: obj(
+      {
+        title: STR("What the item is called, e.g. '33s Kala Cotton'."),
+        sku: STR("Optional SKU."),
+        description: STR("Optional longer description."),
+        unit_of_measure: STR("Unit the quantity is counted in, e.g. 'Meter'."),
+        requires_shipping: BOOL("Whether the item physically ships."),
+        hs_code: STR("HS/HSN customs code."),
+        origin_country: STR("ISO-2 country of origin, e.g. 'IN'."),
+        mid_code: STR("Manufacturer Identification (MID) code."),
+        material: STR("Material description for customs."),
+        weight: INT("Weight in grams."),
+        length: INT("Length in centimetres."),
+        height: INT("Height in centimetres."),
+        width: INT("Width in centimetres."),
+        thumbnail: STR("Thumbnail image URL."),
+        metadata: { type: "object", description: "Free-form metadata." },
+        location_levels: {
+          type: "array",
+          description:
+            "Where this stock sits and how much of it, created with the item. Each entry is { location_id (sloc_..., from list_stock_locations), stocked_quantity?, incoming_quantity? }. An item with no level is held nowhere.",
+          items: {
+            type: "object",
+            properties: {
+              location_id: STR("Stock location id, e.g. 'sloc_...'."),
+              stocked_quantity: INT("Units physically on hand at this location."),
+              incoming_quantity: INT("Units expected but not yet received."),
+            },
+            required: ["location_id"],
+            additionalProperties: false,
+          },
+        },
+      },
+      []
+    ),
+    nextSteps: ["set_inventory_level", "add_inventory_raw_material"],
+  },
+  {
+    name: "list_inventory_levels",
+    description:
+      "List an inventory item's location levels — which warehouses hold it, and the stocked / reserved / incoming counts at each. Read. This is the only place the per-location split is visible: `list_inventory_items` shows the item, not where it is.",
+    method: "GET",
+    path: "/admin/inventory-items/:id/location-levels",
+    pathParams: ["id"],
+    queryParams: ["limit", "offset"],
+    inputSchema: obj(
+      {
+        id: STR("Inventory item id, e.g. 'iitem_...'."),
+        limit: INT("Max results (default 20)."),
+        offset: INT("Pagination offset."),
+      },
+      ["id"]
+    ),
+  },
+  {
+    name: "set_inventory_level",
+    description:
+      "Associate an inventory item with a stock location and set its opening counts — the level row that makes the item exist AT a warehouse. Sensitive: requires confirm:true. " +
+      "Read the `sloc_` id from list_stock_locations first: it is not guessable, and a level written at the wrong end reads as a delivery that never arrived. " +
+      "Use this to place stock somewhere for the FIRST time; `update_inventory_level` changes a location it already sits at, and re-creating an existing level is refused. " +
+      "🔑 `stocked_quantity` is an ABSOLUTE count, not a delta.",
+    method: "POST",
+    path: "/admin/inventory-items/:id/location-levels",
+    pathParams: ["id"],
+    previewPath: "/admin/inventory-items/:id/location-levels",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: ["location_id", "stocked_quantity", "incoming_quantity"],
+    inputSchema: obj(
+      {
+        id: STR("Inventory item id, e.g. 'iitem_...'."),
+        location_id: STR(
+          "Stock location id, e.g. 'sloc_...'. Read it from list_stock_locations — it is not guessable, and a level written at the wrong end reads as a delivery that never arrived."
+        ),
+        stocked_quantity: INT("Units physically on hand. ABSOLUTE, not a delta."),
+        incoming_quantity: INT("Units expected but not yet received."),
+      },
+      ["id", "location_id"]
+    ),
+    nextSteps: ["list_inventory_levels"],
+  },
+  {
+    name: "update_inventory_level",
+    description:
+      "Change the counts on a location an inventory item ALREADY sits at. Sensitive: requires confirm:true. " +
+      "🔑 `stocked_quantity` is an ABSOLUTE count, not a delta — sending 10 against a level of 40 sets it to 10 and loses 30 units of stock. Read list_inventory_levels first and send the number you want to end up with. " +
+      "It cannot move stock between locations: that is a split, or a level at each end.",
+    method: "POST",
+    path: "/admin/inventory-items/:id/location-levels/:location_id",
+    pathParams: ["id", "location_id"],
+    previewPath: "/admin/inventory-items/:id/location-levels",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: ["stocked_quantity", "incoming_quantity"],
+    inputSchema: obj(
+      {
+        id: STR("Inventory item id, e.g. 'iitem_...'."),
+        location_id: STR("Stock location id the level is held at, e.g. 'sloc_...'."),
+        stocked_quantity: INT("Units on hand AFTER this write. Absolute, not a delta."),
+        incoming_quantity: INT("Units expected but not yet received. Absolute."),
+      },
+      ["id", "location_id"]
+    ),
+    sideEffects:
+      "Overwrites the stored count outright. A wrong number here is indistinguishable from a real stock movement afterwards.",
+    nextSteps: ["list_inventory_levels"],
+  },
+  {
+    name: "list_reservations",
+    description:
+      "List stock reservations — quantities held at a location against an order line or held manually, so they cannot be sold twice. Read. Filter by inventory_item_id, location_id or line_item_id. A level's `reserved_quantity` is the sum of these; this is where you see WHO holds it.",
+    method: "GET",
+    path: "/admin/reservations",
+    queryParams: [
+      "limit",
+      "offset",
+      "inventory_item_id",
+      "location_id",
+      "line_item_id",
+    ],
+    inputSchema: obj({
+      limit: INT("Max results (default 20)."),
+      offset: INT("Pagination offset."),
+      inventory_item_id: STR("Filter to one inventory item, e.g. 'iitem_...'."),
+      location_id: STR("Filter to one stock location, e.g. 'sloc_...'."),
+      line_item_id: STR("Filter to the order line the stock is held for."),
+    }),
+  },
+  {
+    name: "create_reservation",
+    description:
+      "Hold a quantity of an inventory item at a location so it cannot be sold or consumed elsewhere. Sensitive: requires confirm:true. " +
+      "The stock stays where it is — a reservation moves nothing and changes no stocked_quantity; it raises `reserved_quantity`, which is what makes the rest unavailable. " +
+      "Leave `line_item_id` unset for a manual hold (a sample pulled for a buyer, cloth set aside for a run); set it to bind the hold to an order line.",
+    method: "POST",
+    path: "/admin/reservations",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: [
+      "inventory_item_id",
+      "location_id",
+      "quantity",
+      "line_item_id",
+      "description",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        inventory_item_id: STR("Inventory item to hold, e.g. 'iitem_...'."),
+        location_id: STR("Stock location the hold is taken at, e.g. 'sloc_...'."),
+        quantity: INT("Units to hold. Must not exceed what is available at that location."),
+        line_item_id: STR(
+          "Order line this hold is for. Omit for a manual hold with no order behind it."
+        ),
+        description: STR("Why the stock is held — the only record a later reader gets."),
+        metadata: { type: "object", description: "Free-form metadata." },
+      },
+      ["inventory_item_id", "location_id", "quantity"]
+    ),
+    nextSteps: ["list_reservations"],
+  },
+  {
+    name: "delete_reservation",
+    description:
+      "Release a reservation, returning the held quantity to available stock. DELETE, so sensitive: requires confirm:true. Deleting the hold does NOT change stocked_quantity — nothing is consumed, the stock simply stops being spoken for.",
+    method: "DELETE",
+    path: "/admin/reservations/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/reservations/:id",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    inputSchema: obj({ id: STR("Reservation id, e.g. 'res_...'.") }, ["id"]),
+    nextSteps: ["list_reservations"],
+  },
+  {
+    name: "split_inventory_item",
+    description:
+      "Divide an inventory item in two: `quantity` units leave the source and become a NEW item titled `new_title`, carrying a copy of the source's raw-material record. Sensitive: requires confirm:true. " +
+      "This is how one bolt of greige becomes 'dyed' and 'undyed', or how a partner's delivery is separated into gradings — the two halves then price, move and get consumed independently. " +
+      "🔑 `location_id` takes the whole split from that ONE location; omit it and the split is taken proportionally across every location the item sits at. " +
+      "`raw_material_overrides` is what makes the new half a different material (its colour, grade or name) rather than a second row of the same thing — without it the copy is indistinguishable from its source.",
+    method: "POST",
+    path: "/admin/inventory-items/:id/split",
+    pathParams: ["id"],
+    previewPath: "/admin/inventory-items/:id",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: ["quantity", "new_title", "location_id", "raw_material_overrides"],
+    inputSchema: obj(
+      {
+        id: STR("Inventory item to split, e.g. 'iitem_...'."),
+        quantity: INT(
+          "Units to move OUT of the source into the new item. Positive, and no more than the source holds."
+        ),
+        new_title: STR("Title of the item created by the split."),
+        location_id: STR(
+          "Take the whole split from this location only. Omit to split proportionally across every location."
+        ),
+        raw_material_overrides: {
+          type: "object",
+          description:
+            "What differs about the new half: { name?, color?, composition?, grade?, description?, extra? } — `extra` is a flat string map merged into the copied specifications. Anything omitted is inherited from the source.",
+        },
+      },
+      ["id", "quantity", "new_title"]
+    ),
+    sideEffects:
+      "Creates a second inventory item and decrements the source. The two are not linked afterwards — nothing records that they were once one lot beyond the titles you give them.",
+    nextSteps: ["list_inventory_levels", "get_inventory_item"],
+  },
+  {
+    name: "get_raw_material",
+    description:
+      "Get one raw material by id, with its material type. Read. The id comes from list_raw_materials or get_inventory_item. Call this before update_inventory_raw_material — the update is a partial, but `specifications` and `media` REPLACE wholesale, so you cannot write a correct partial without seeing what is stored.",
+    method: "GET",
+    path: "/admin/inventory-items/:id/rawmaterials/:rawMaterialId",
+    pathParams: ["id", "rawMaterialId"],
+    inputSchema: obj(
+      {
+        id: STR("Inventory item id, e.g. 'iitem_...'."),
+        rawMaterialId: STR("Raw material id (from list_raw_materials / get_inventory_item)."),
+      },
+      ["id", "rawMaterialId"]
+    ),
+    nextSteps: ["update_inventory_raw_material"],
+  },
+  {
+    name: "update_inventory_raw_material",
+    description:
+      "Update an existing raw material — its attributes (colour, grade, width, weight, composition), its specifications, its cost, and its photos. Sensitive: requires confirm:true. " +
+      "A PARTIAL update: fields you omit are left alone. But `specifications` and `media` are whole values, so passing either REPLACES what is stored — read get_raw_material first and send the merged object, or you will delete the keys you did not resend. " +
+      "🔑 Photos live at `media.files`, an array of URLs: `{ \"files\": [\"https://...jpg\"] }`. `{ \"files\": [] }` is the shape a material gets when someone opened the media form and saved nothing — it is NOT a photographed material, though it passes any `media != null` check. " +
+      "🔑 The free-form attribute store is `specifications` (the fabrics here use gi_status / technique / weave_type, and often comb, loom, pick, artist, weight). The `attributes` column is unused — do not reach for it.",
+    method: "PUT",
+    path: "/admin/inventory-items/:id/rawmaterials/:rawMaterialId",
+    pathParams: ["id", "rawMaterialId"],
+    previewPath: "/admin/inventory-items/:id/rawmaterials/:rawMaterialId",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: ["rawMaterialData"],
+    inputSchema: obj(
+      {
+        id: STR("Inventory item id, e.g. 'iitem_...'."),
+        rawMaterialId: STR("Raw material id to update."),
+        rawMaterialData: {
+          type: "object",
+          description:
+            "The fields to change. Any of: name, description, composition, color, grade, width, weight, unit_of_measure (Meter|Yard|Kilogram|Gram|Piece|Roll|Other), unit_cost, cost_currency, minimum_order_quantity, lead_time_days, certification, usage_guidelines, storage_requirements, status (Active|Discontinued|Under_Review|Development), material_type or material_type_id, metadata, specifications (REPLACES), media (REPLACES; { files: [url] }).",
+        },
+      },
+      ["id", "rawMaterialId", "rawMaterialData"]
+    ),
+    sideEffects:
+      "Replaces `specifications` and `media` outright when either is passed. Omit a key to leave it untouched.",
+    nextSteps: ["get_raw_material"],
+  },
   {
     name: "list_inventory_orders",
     description:
@@ -4104,7 +4419,10 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "add_inventory_raw_material",
     description:
-      "Attach raw-material data (composition, unit of measure, cost, material type) to an existing inventory item. Sensitive: requires confirm:true.",
+      "Attach raw-material data (composition, unit of measure, cost, material type) to an existing inventory item. Sensitive: requires confirm:true. " +
+      "🔑 Give it PHOTOS at the same time: `media` is `{ \"files\": [\"https://...jpg\"] }`. When the stock is a partner's product, reuse that product's own image URLs (get_product -> images[].url) rather than leaving it unphotographed — a material with no picture cannot be told apart from another grading of the same cloth. " +
+      "⚠️ `{ \"files\": [] }` is what a material gets when the media form is saved empty; it satisfies any `media != null` check while showing nothing, so send real URLs or omit the key. " +
+      "🔑 The free-form attribute store is `specifications` (the fabrics here use gi_status / technique / weave_type, often with comb, loom, pick, artist, weight). The `attributes` column is unused.",
     method: "POST",
     path: "/admin/inventory-items/:id/rawmaterials",
     pathParams: ["id"],
@@ -4119,11 +4437,12 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         rawMaterialData: {
           type: "object",
           description:
-            "{ name, composition, unit_of_measure?, unit_cost?, material_type? (a category NAME, find-or-create) or material_type_id?, specifications?, media? }.",
+            "Required: name, composition. Optional: description, color, grade, width, weight, unit_of_measure (Meter|Yard|Kilogram|Gram|Piece|Roll|Other), unit_cost, cost_currency, minimum_order_quantity, lead_time_days, certification, usage_guidelines, storage_requirements, status (Active|Discontinued|Under_Review|Development), material_type (a category NAME, find-or-create) or material_type_id, metadata, specifications (the attribute store), media ({ files: [url] }).",
         },
       },
       ["id", "rawMaterialData"]
     ),
+    nextSteps: ["get_raw_material", "update_inventory_raw_material"],
   },
   {
     name: "list_raw_material_groups",

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1637,34 +1637,56 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "update_product_option",
     description: [
-      "Rewrite a product option's list of allowed values — the '33s', '60lea Colour' choices a variant is matched to. Sensitive: requires confirm:true.",
+      "Add or remove the values a product option allows — the '33s', '60lea Colour' choices a variant is matched to. Sensitive: requires confirm:true.",
       "🔑 This is the tool that unblocks `create_product_variant`. That tool matches a variant to option values that ALREADY EXIST and core will not invent one, so a variant naming a new value cannot be created until the value is added here first.",
-      "⚠️ `values` REPLACES the option's entire value list — it is not an append. Call `get_product` first and send every existing value PLUS the new one. Sending only the new value drops the rest, and any variant matched to a dropped value loses its option.",
-      "Find the option id and its current values under `product.options[]` from `get_product`.",
+      "✅ ADDITIVE, not a rewrite: `add` appends and `remove` deletes by VALUE ID. Values you do not mention are untouched, so there is no need to resend the existing list and no way to drop one by omission.",
+      "⚠️ `remove` takes option-value IDs (`optval_...`), not the value strings. Removing a value that a variant is matched to leaves that variant without its option.",
+      "Find the option id under `product.options[].id` and the value ids under `product.options[].values[].id`, both from `get_product`.",
     ].join("\n"),
     method: "POST",
-    path: "/admin/products/:id/options/:option_id",
-    pathParams: ["id", "option_id"],
+    // The batch endpoint is the ONLY route core exposes for editing an
+    // option's values. There is no `/admin/products/:id/options/:option_id`
+    // — this row pointed at one until #1907, which is why every call 404'd
+    // while every registry test stayed green: they check the registry's own
+    // consistency and its prose, never that the route on the other end exists.
+    path: "/admin/products/:id/options/batch",
+    pathParams: ["id"],
     previewPath: "/admin/products/:id",
     write: true,
     sensitive: true,
-    bodyParams: ["title", "values"],
+    bodyParams: ["update"],
     inputSchema: obj(
       {
         id: STR("Product id, e.g. 'prod_...'."),
-        option_id: STR("Option id, e.g. 'opt_...'. Read it from product.options[].id."),
-        title: STR("Option title. Omit to leave it unchanged."),
-        values: {
+        update: {
           type: "array",
           description:
-            "The option's COMPLETE resulting value list, e.g. ['0s','10s','20s','30s','33s','60s']. Every value you want to keep must appear — omitted values are removed.",
-          items: { type: "string" },
+            "One entry per option being edited. Each is { product_option_id: 'opt_...', add?: ['33s'], remove?: ['optval_...'] } — `add` takes value STRINGS, `remove` takes value IDS.",
+          items: {
+            type: "object",
+            properties: {
+              product_option_id: STR("Option id, e.g. 'opt_...'."),
+              add: {
+                type: "array",
+                description: "Value strings to add, e.g. ['33s'].",
+                items: { type: "string" },
+              },
+              remove: {
+                type: "array",
+                description:
+                  "Option-value IDs to delete, e.g. ['optval_...']. NOT the value strings.",
+                items: { type: "string" },
+              },
+            },
+            required: ["product_option_id"],
+            additionalProperties: false,
+          },
         },
       },
-      ["id", "option_id", "values"]
+      ["id", "update"]
     ),
     sideEffects:
-      "Replaces the option's value list. Values omitted from `values` are removed, and a variant matched to a removed value loses that option. Adding a value is inert on its own until a variant claims it.",
+      "Adds or deletes option values in place. Adding one is inert until a variant claims it; deleting one strips that option from any variant matched to it.",
     nextSteps: ["create_product_variant", "get_product"],
   },
   {

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -94,6 +94,11 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   // that needs a location id — "order 40 m to the Dharamshala warehouse",
   // "this order's route is reversed" — is already an inventory conversation.
   ["/admin/stock-locations", "inventory"],
+  // Held-but-not-consumed stock (#1905). A reservation is only ever discussed
+  // alongside the level it draws down, so it rides the same slice — split out,
+  // an ask about "why can't I sell these 40 m" would reach the level tools and
+  // not the thing actually holding them.
+  ["/admin/reservations", "inventory"],
   ["/admin/raw-material-groups", "inventory"],
   // Photo -> raw materials + inventory. Classified as inventory because that is
   // what it CREATES; the image is just the input format.


### PR DESCRIPTION
Closes #1905. Closes #1907.

Two commits. The second was found by trying to use the first.

---

## 1 — `update_product_option` 404'd on every call (#1907)

#1896 shipped it pointing at `POST /admin/products/:id/options/:option_id`. **There is no such route** — not in this repo (`src/api/admin/products/[id]/` has no `options` directory), not in core (`products/[id]/options/` holds only `route.js` GET and `batch/`).

Found by running the tool against the two variants owed on `inv_order_01M1ZH7Y50W37WMGXYP2DM1KAF` — the exact work #1896 was written to unblock.

Core's only door to an option's values is the batch endpoint, and it is **additive**:

```
POST /admin/products/:id/options/batch
{ update: [ { product_option_id, add: ["33s"], remove: ["optval_..."] } ] }
```

So the destructive footgun the old description warned about at length — *"`values` REPLACES the entire list, send every existing value plus the new one"* — described a route that was never there. It's now **gone rather than documented**: `add` appends, `remove` deletes by value ID, and a value cannot be dropped by omission.

### Why every test passed

That tool's spec has five cases. All five ask about the registry's own internal consistency — present? `write`? schema agrees with forward list? in a slice? prose contains "REPLACES"? **None asks whether anything is listening on the other end.** It advertised itself, passed review, deployed, and 404'd weeks later against a live order.

### The guard

`registry-routes-exist.unit.spec` resolves **every** proxy row's path to a real route file exporting its method, across both trees. All 205 swept — `update_product_option` was the only phantom; 204 already resolved.

Two false-alarm shapes it had to learn, both of which made my first pass over-report by five:

| shape | example |
|---|---|
| parameter names need not agree | registry `:product_id` vs core's `[id]` — dispatcher substitutes positionally |
| a path exists in both trees with different verbs | `/admin/stores` is POST here, GET in core — must fall through, not fail |

Core's tree is located via `require.resolve`, not by counting `..`: this is a pnpm workspace and `@medusajs/medusa` is hoisted to the repo root, so a hand-counted path silently resolves to nothing — which would make the guard pass every core route by finding no file to disagree with. A test pins that both roots exist, so the sweep cannot go vacuously green.

---

## 2 — An inventory item could be listed and nothing else (#1905)

`list_inventory_items` shipped alone: no way to open one row, create one, place it at a warehouse, count it, hold stock against it, split a lot, or update a raw material's attributes and photos. Every route already existed; the gap was eleven registry rows.

| | tools |
|---|---|
| reads | `get_inventory_item`, `list_inventory_levels`, `list_reservations`, `get_raw_material` |
| writes | `create_inventory_item`, `set_inventory_level`, `update_inventory_level`, `create_reservation`, `delete_reservation`, `split_inventory_item`, `update_inventory_raw_material` |

All in the `inventory` slice — an unclassified tool loads in **no** slice. All seven writes `sensitive` at `tier: "write"`, named explicitly in the tool-tiers roster so the permission decision is a visible line in this diff.

### Three things the descriptions now say

- **`stocked_quantity` is ABSOLUTE, not a delta.** Sending 10 against a level of 40 sets it to 10 and loses 30 units, indistinguishable from a real movement afterwards.
- **`create_inventory_item` is the UNUSUAL door.** A partner-supplied variant carries `manage_inventory: false` and has no item row until an inventory-order line names it (`ensureLineInventoryItems`, #1662) — and *that* path also links item to variant. An item created directly is linked to nothing.
- **Photos live at `media.files`.** Twelve of the first fifty raw materials in production carry `{"files": []}` — an empty shell that satisfies any `media != null` check while showing nothing. **Kala Cotton and Linen are both in that twelve.** `add_inventory_raw_material` now says so, and says to reuse the partner product's own image URLs. It also names `specifications` as the attribute store; `attributes` is unused and null on every row.

The spec pins `bodyParams` and the input schema in agreement **both ways**. The global invariant only checks params → schema; the direction that bites is schema → params, because an advertised field the forward list omits is **stripped in silence**. Every wrapped core validator is `.strict()`, so the opposite error is a 400 — `update_inventory_level` deliberately does *not* forward `location_id`, which it takes from the path.

---

## Verified by mutation, not just by green

| mutation | result |
|---|---|
| restore the old `update_product_option` path | sweep fails, naming the tool |
| drop `location_id` from `set_inventory_level`'s forward list | 2 tests fail |
| add `location_id` to `update_inventory_level`'s forward list | 2 tests fail |
| remove the `/admin/reservations` slice entry | 1 test fails |

Writing the tests also found three real gaps in my own descriptions: `list_stock_locations` and `list_raw_materials` were named only in nested field descriptions, not where the model reads first.

`381/381` green in `mcp/lib/__tests__`; `check:prod-build` passed (`✓ Prod-config build passed.`), `workflow-schemas.json` unchanged.

---

## Still blocked after this merges

The two variants (33s Kala Cotton at ₹165, `Linen 40 lea` unpriced) need this deployed — the MCP client only sees prod's advertised tools, so the fix must land and deploy before the option value can be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp