### PR TITLE
fix(admin-mcp): three body shapes the unit tests could not have caught (#1907)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/option-value-and-variant-shapes.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/option-value-and-variant-shapes.unit.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Three shapes that only a REAL call against prod revealed (#1907 follow-up).
+ *
+ * #1906 repointed `update_product_option` at the batch route and shipped with
+ * every unit test green — including a new guard proving the route exists. The
+ * route did exist. The BODY was still wrong, and no amount of registry
+ * introspection could have said so, because a description is prose until
+ * something on the other end disagrees with it.
+ *
+ * Running the two variants owed on `inv_order_01M1ZH7Y50W37WMGXYP2DM1KAF`
+ * disagreed three times:
+ *
+ *  1. `add: ["33s"]` — a bare string in `add` is read as the ID of an
+ *     ALREADY-EXISTING option value. Core answered:
+ *       "You tried to set relationship product_option_value_id: 33s,
+ *        but such entity does not exist"
+ *     An error naming a relationship the caller never mentioned, which reads
+ *     like a data problem and sends you looking for a missing row. The correct
+ *     shape is `add: [{ value: "33s" }]`.
+ *
+ *  2. `manage_inventory` is `.optional().default(true)` in core. The old
+ *     docblock said "leave it off", which was read — by me — as "omit it".
+ *     Omitting it turns tracking ON. The 33s variant was created tracked while
+ *     all five of its siblings are untracked, and a tracked variant with no
+ *     stock is refused at checkout while its siblings sell freely.
+ *
+ *  3. `prices` is REQUIRED on variant create — `z.array(...)` with no
+ *     `.optional()`. A genuinely unpriced variant (the 1 m Linen sample) must
+ *     send `[]`. Omitting the key is a 400: "Field 'prices' is required".
+ *     There is no `.min(1)`, so `[]` is accepted.
+ *
+ * These pin the DESCRIPTIONS, because the description is the only thing a model
+ * reads before it builds the body. A wrong one is a defect with no stack trace.
+ */
+import { ADMIN_MCP_TOOLS } from "../registry"
+
+const byName = (n: string) => ADMIN_MCP_TOOLS.find((t) => t.name === n)!
+
+describe("option-value and variant body shapes (#1907 follow-up)", () => {
+  describe("update_product_option: `add` takes objects, not strings", () => {
+    const def = () => byName("update_product_option")
+
+    it("declares add[] items as objects requiring `value`", () => {
+      const add = (def().inputSchema as any).properties.update.items.properties
+        .add
+      expect(add.items.type).toBe("object")
+      expect(add.items.required).toEqual(["value"])
+      // The bare-string form is what fails, so it must not be offered.
+      expect(add.items.type).not.toBe("string")
+    })
+
+    it("says so in the description, where a model actually looks", () => {
+      const d = def().description
+      expect(d).toMatch(/OBJECTS/)
+      expect(d).toContain("{ value: '33s' }")
+      // Quote the real error, so the next caller recognises it instantly
+      // instead of hunting for a missing option-value row.
+      expect(d).toContain("product_option_value_id")
+    })
+
+    it("still distinguishes remove, which really does take ids", () => {
+      const d = def().description
+      expect(d).toMatch(/optval_/)
+    })
+  })
+
+  describe("create_product_variant: the two defaults that bite", () => {
+    const def = () => byName("create_product_variant")
+
+    it("says manage_inventory must be passed explicitly, not omitted", () => {
+      const d = def().description
+      // "Leave it off" was the old wording and is exactly the misreading:
+      // core's default is true, so omission is the opposite of off.
+      expect(d).toMatch(/EXPLICITLY/)
+      expect(d).toMatch(/defaults it to TRUE/i)
+      expect(d).not.toMatch(/Leave `manage_inventory` off/)
+    })
+
+    it("explains the consequence, not just the flag", () => {
+      // A rule without its consequence gets overridden by a plausible-looking
+      // shortcut the next time someone is in a hurry.
+      expect(def().description).toMatch(/refused at checkout/i)
+    })
+
+    it("says prices is required, and that [] is the way to send none", () => {
+      const prices = (def().inputSchema as any).properties.prices
+      expect(prices.description).toMatch(/REQUIRED/)
+      expect(prices.description).toMatch(/\[\]/)
+      expect(prices.description).toContain("Field 'prices' is required")
+    })
+
+    it("keeps prices forwarded — an unsent [] is not the same as an empty one", () => {
+      expect(def().bodyParams).toContain("prices")
+      expect(def().bodyParams).toContain("manage_inventory")
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1639,7 +1639,8 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     description: [
       "Add or remove the values a product option allows — the '33s', '60lea Colour' choices a variant is matched to. Sensitive: requires confirm:true.",
       "🔑 This is the tool that unblocks `create_product_variant`. That tool matches a variant to option values that ALREADY EXIST and core will not invent one, so a variant naming a new value cannot be created until the value is added here first.",
-      "✅ ADDITIVE, not a rewrite: `add` appends and `remove` deletes by VALUE ID. Values you do not mention are untouched, so there is no need to resend the existing list and no way to drop one by omission.",
+      "✅ ADDITIVE, not a rewrite: `add` appends and `remove` deletes. Values you do not mention are untouched, so there is no need to resend the existing list and no way to drop one by omission.",
+      "🔴 `add` entries must be OBJECTS — `add: [{ value: '33s' }]`. A bare string is read as the id of an ALREADY-EXISTING value, so `add: ['33s']` fails with \"you tried to set relationship product_option_value_id: 33s, but such entity does not exist\": an error naming a relationship the caller never mentioned, which reads like a data problem rather than a shape problem.",
       "⚠️ `remove` takes option-value IDs (`optval_...`), not the value strings. Removing a value that a variant is matched to leaves that variant without its option.",
       "Find the option id under `product.options[].id` and the value ids under `product.options[].values[].id`, both from `get_product`.",
     ].join("\n"),
@@ -1661,15 +1662,21 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         update: {
           type: "array",
           description:
-            "One entry per option being edited. Each is { product_option_id: 'opt_...', add?: ['33s'], remove?: ['optval_...'] } — `add` takes value STRINGS, `remove` takes value IDS.",
+            "One entry per option being edited. Each is { product_option_id: 'opt_...', add?: [{ value: '33s' }], remove?: ['optval_...'] }. `add` entries are OBJECTS carrying the new value string; a bare string there means an existing value ID and fails. `remove` takes value IDs.",
           items: {
             type: "object",
             properties: {
               product_option_id: STR("Option id, e.g. 'opt_...'."),
               add: {
                 type: "array",
-                description: "Value strings to add, e.g. ['33s'].",
-                items: { type: "string" },
+                description:
+                  "New values to add, each as an OBJECT: [{ value: '33s' }]. A bare string is interpreted as an existing option-value id, not as a new value.",
+                items: {
+                  type: "object",
+                  properties: { value: STR("The new option value, e.g. '33s'.") },
+                  required: ["value"],
+                  additionalProperties: false,
+                },
               },
               remove: {
                 type: "array",
@@ -2133,7 +2140,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "Add a NEW variant to an existing product (title, options, prices, sku, inventory flags). Sensitive: requires confirm:true. " +
       "Use this when a product needs another colourway/count/size — `create_product` makes a whole new product, and `update_product_variant` can only change one that already exists. " +
       "🔑 `options` must name values the product's options ALREADY have: core matches the variant to existing option values and will not invent one, so add the value to the product option first if it is new. " +
-      "Leave `manage_inventory` off for a variant a partner supplies — an inventory order line naming that variant is what creates its inventory item at our end.",
+      "🔴 Pass `manage_inventory: false` EXPLICITLY for a variant a partner supplies. Core defaults it to TRUE, so omitting the flag does NOT leave it off — and a tracked variant with no stock is refused at checkout, where its untracked siblings sell freely. An inventory order line naming the variant is what creates its inventory item at our end.",
     method: "POST",
     path: "/admin/products/:product_id/variants",
     pathParams: ["product_id"],
@@ -2164,7 +2171,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         prices: {
           type: "array",
           description:
-            "Prices per currency, e.g. [{ amount: 165, currency_code: \'inr\' }]. A variant with no price cannot be sold, but can still be ordered on an inventory order (the line carries its own price).",
+            "Prices per currency, e.g. [{ amount: 165, currency_code: \'inr\' }]. REQUIRED by core even when the variant has no price: send [] rather than omitting the key, or the call is refused with \"Field 'prices' is required\". A variant with no price cannot be sold, but can still be ordered on an inventory order (the line carries its own price).",
           items: {
             type: "object",
             properties: {


### PR DESCRIPTION
Follow-up to #1906. Re-opens nothing — #1907 is closed, this corrects what running it taught.

#1906 repointed `update_product_option` at the batch route and shipped with every test green, **including a new guard proving that route exists**. The route did exist. The *body* was still wrong.

That is the honest limit of the guard I added: it proves something is listening, not that you are speaking its language. A tool description is prose until something on the other end disagrees with it. Running the two variants owed on `inv_order_01M1ZH7Y50W37WMGXYP2DM1KAF` disagreed three times.

## 1. `add` takes objects, not strings

```
add: ["33s"]
-> You tried to set relationship product_option_value_id: 33s,
   but such entity does not exist
```

A bare string in `add` is the **ID of an already-existing value**. The error names a relationship the caller never mentioned, so it reads like a missing row rather than a wrong shape — I went looking for the row first.

Correct form: `add: [{ value: "33s" }]`. The schema now offers only the object form, and the description quotes the real error verbatim.

## 2. `manage_inventory` omitted is not `manage_inventory` off

Core: `.optional().default(true)`. The old docblock said *"Leave `manage_inventory` off"* — which I read as "omit it". So **33s Kala Cotton was created tracked** while all five siblings are untracked.

That is a live sales difference, not tidiness: a tracked variant with no stock is **refused at checkout** where its untracked siblings sell freely.

Corrected in prod on the same variant and verified by re-read — `manage_inventory: false`, and the ₹165 price survived **with the same price id**, so omitting `prices` on an update does not trigger #1857’s whole-set replacement. Worth knowing independently.

## 3. `prices` is required even when there is no price

`z.array(...)`, no `.optional()` — omitting it is a 400 (`Field prices is required`). No `.min(1)`, so a genuinely unpriced variant (the 1 m Linen sample) sends `[]`. The old description said an unpriced variant was possible, which was true and unusable.

## The test

Pins the **descriptions**, not only the schemas — the description is the only thing a model reads before building a body, so a wrong one is a defect with no stack trace. It also asserts the old wording is *gone*, since "leave it off" is the exact phrasing that produced the misreading.

Verified by mutation: reverting `add[]` to string items fails the spec.

`388/388` green in `mcp/lib/__tests__`; `check:prod-build` passed.

## Prod state (already applied, by API)

| what | id |
|---|---|
| `33s` option value | `optval_01M207S9HC2W0N6B0VKXGKWWEH` |
| `40 lea` option value | `optval_01M207SS7C1Z9MVPEG1CKXXEF3` |
| 33s Kala Cotton variant | `variant_01M207T9DVXFPADK32EEZ1Y3V9` — ₹165, untracked |
| Linen 40 lea variant | `variant_01M207ZBTKGEPPKKKZGB1ZJX7A` — unpriced, untracked |

Both option updates were additive: Kala Cotton kept all five prior values, Linen both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp