### PR TITLE
feat(admin-mcp): the MCP could record a partner order but never commission one (#1909)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/commission-vs-record-partner-order.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/commission-vs-record-partner-order.unit.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Two routes give a partner an order. Only the silent one was on the MCP (#1909).
+ *
+ * `POST /admin/inventory-orders/:id/assign-partner` (#1737) writes the
+ * `partner-inventory-order` link and NOTHING else — no event, no notification,
+ * no workflow, no status change. Its own docblock says so, and says why: it
+ * exists for backfilling work already done, where messaging a partner about a
+ * five-month-old delivery would be wrong.
+ *
+ * `POST /admin/inventory-orders/:id/send-to-partner` writes the same link AND
+ * emits `inventory_order_assigned_to_partner` — which a subscriber turns into a
+ * real message — AND parks `awaitOrderStart` / `awaitOrderCompletion`. It is
+ * the one that commissions work, and it is refused unless the order is Pending.
+ *
+ * Only `assign_inventory_order_partner` was registered. Its description sold it
+ * as "what makes the order appear in that partner's portal and in their
+ * payables" — all true, and silent about the half that matters. So an agent
+ * asked to give GOF an order used it, every view showed the order as assigned,
+ * and GOF was never told. That is the state `inv_order_01M1ZH7Y50W37WMGXYP2DM1KAF`
+ * sat in: `notified: false`, correct-looking everywhere.
+ *
+ * A capability whose only door is the inert half of a pair is worse than a
+ * missing one: it succeeds.
+ */
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { mcpToolTier } from "../../../../../lib/mcp-core/tiers"
+
+const byName = (n: string) => ADMIN_MCP_TOOLS.find((t) => t.name === n)!
+
+describe("commissioning vs recording a partner order (#1909)", () => {
+  it("registers the commissioning tool, wrapping the send-to-partner route", () => {
+    expect(byName("send_inventory_order_to_partner")).toMatchObject({
+      method: "POST",
+      path: "/admin/inventory-orders/:id/send-to-partner",
+      write: true,
+      sensitive: true,
+    })
+  })
+
+  it("forwards the route's OWN camelCase field name", () => {
+    // send-to-partner takes `partnerId`; assign-partner takes `partner_id`.
+    // The two sit next to each other and disagree, so the mismatch is a live
+    // trap: `bodyParams` is the forward list, and a name the route does not
+    // read is dropped in silence — the call would succeed and commission
+    // nobody.
+    const def = byName("send_inventory_order_to_partner")
+    expect(def.bodyParams).toEqual(["partnerId", "notes"])
+    expect(def.bodyParams).not.toContain("partner_id")
+    expect(Object.keys((def.inputSchema as any).properties)).toContain("partnerId")
+    expect(def.inputSchema.required).toEqual(["id", "partnerId"])
+  })
+
+  it("keeps the two neighbours on their own field names", () => {
+    expect(byName("assign_inventory_order_partner").bodyParams).toEqual([
+      "partner_id",
+    ])
+  })
+
+  it("is NOT demoted to write tier — it messages a third party", () => {
+    // The tool-tiers roster is explicitly limited to tools with no money, no
+    // carrier and no third-party message. This one notifies a partner, so a
+    // write-scoped credential must not reach it.
+    const def = byName("send_inventory_order_to_partner")
+    expect(def.tier).toBeUndefined()
+    expect(mcpToolTier(def)).not.toBe("write")
+  })
+
+  it("says out loud that the recording tool commissions nothing", () => {
+    const d = byName("assign_inventory_order_partner").description
+    expect(d).toMatch(/COMMISSIONS NOTHING/)
+    expect(d).toMatch(/not told/i)
+  })
+
+  it("makes each tool name the other, so the wrong one is a dead end", () => {
+    // Discoverability is the whole defect: the silent tool was reachable and
+    // the loud one was not, and nothing said they were a pair.
+    expect(byName("assign_inventory_order_partner").description).toContain(
+      "send_inventory_order_to_partner"
+    )
+    expect(byName("send_inventory_order_to_partner").description).toContain(
+      "assign_inventory_order_partner"
+    )
+  })
+
+  it("states the status gate and the irreversibility", () => {
+    const def = byName("send_inventory_order_to_partner")
+    // The workflow throws unless the order is Pending; a model that does not
+    // know this reads the failure as a broken tool.
+    expect(def.description).toMatch(/Pending/)
+    expect(def.sideEffects).toMatch(/cannot be recalled/i)
+    // Lines first: the partner is messaged about the order as it stands.
+    expect(def.description).toMatch(/update_inventory_order_lines/)
+  })
+
+  it("registers ready-for-delivery with its Partial-only gate", () => {
+    const def = byName("mark_inventory_order_ready_for_delivery")
+    expect(def).toMatchObject({
+      method: "POST",
+      path: "/admin/inventory-orders/:id/ready-for-delivery",
+      write: true,
+      sensitive: true,
+    })
+    expect(def.description).toMatch(/Partial/)
+    // A status-only route takes no body; forwarding anything would 400 or lie.
+    expect(def.bodyParams ?? []).toEqual([])
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1095,8 +1095,10 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "assign_inventory_order_partner",
     description:
-      "Assign an inventory (purchase) order to the partner supplying it — this is what makes the order appear in that partner's portal and in their payables. Sensitive: requires confirm:true. " +
-      "An order created without it is unassigned: the goods are recorded but nobody is billed for them, and list_payable_inventory_orders will not show it.",
+      "Record WHICH partner supplied an inventory order, and nothing else — the link that makes it appear in their portal and their payables. Sensitive: requires confirm:true. " +
+      "🔴 This COMMISSIONS NOTHING. No message, no event, no workflow, no status change: the partner is not told the order exists. It is for backfilling work that is already done or already agreed offline. " +
+      "🔑 To actually give a partner NEW work, use `send_inventory_order_to_partner` — that one writes the same link AND messages them AND starts the await-start/await-completion workflow. Reaching for this tool when you meant that one leaves an order that looks assigned in every view and that the partner has never heard of. " +
+      "An order with neither is unassigned outright: the goods are recorded, nobody is billed, and list_payable_inventory_orders will not show it.",
     method: "POST",
     path: "/admin/inventory-orders/:id/assign-partner",
     pathParams: ["id"],
@@ -1110,6 +1112,57 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         partner_id: STR("Partner supplying the goods, e.g. '01K77...'. Both ends are validated."),
       },
       ["id", "partner_id"]
+    ),
+    sideEffects:
+      "Writes the partner link only. The partner receives no notification and no workflow is started.",
+    nextSteps: ["list_payable_inventory_orders"],
+  },
+  {
+    name: "send_inventory_order_to_partner",
+    description:
+      "Commission an inventory order to a partner: writes the partner link, MESSAGES the partner, and starts the await-start / await-completion workflow that tracks their progress. Sensitive: requires confirm:true. " +
+      "🔴 This one reaches a REAL PERSON outside the platform — a partner is notified that they owe us these goods. It is not undoable by deleting a row. " +
+      "🔑 Only valid from status `Pending`; the workflow refuses anything else. It is the tool that moves an order into production. " +
+      "Use `assign_inventory_order_partner` instead when recording work already done or agreed offline — that one writes the same link and tells nobody. " +
+      "⚠️ Confirm the LINES are final first (update_inventory_order_lines): the partner is messaged about the order as it stands, and a later edit does not re-notify them.",
+    method: "POST",
+    path: "/admin/inventory-orders/:id/send-to-partner",
+    pathParams: ["id"],
+    previewPath: "/admin/inventory-orders/:id",
+    write: true,
+    sensitive: true,
+    // Deliberately NOT `tier: "write"`. The roster is limited to tools with no
+    // money, no carrier and no third-party message; this one messages a
+    // partner, so a write-scoped credential must not reach it.
+    bodyParams: ["partnerId", "notes"],
+    inputSchema: obj(
+      {
+        id: STR("Inventory order id, e.g. 'inv_order_...'. Must be in Pending status."),
+        partnerId: STR(
+          "Partner to commission, e.g. '01K77...'. NOTE the camelCase — this route takes `partnerId`, while assign_inventory_order_partner takes `partner_id`."
+        ),
+        notes: STR("Optional instructions included in the message to the partner."),
+      },
+      ["id", "partnerId"]
+    ),
+    sideEffects:
+      "Notifies the partner and parks a workflow awaiting their start and completion. The notification cannot be recalled.",
+    nextSteps: ["list_inventory_orders", "list_payable_inventory_orders"],
+  },
+  {
+    name: "mark_inventory_order_ready_for_delivery",
+    description:
+      "Mark an inventory order 'Ready for Delivery' — goods packed, before any shipment or AWB exists. Sensitive: requires confirm:true. " +
+      "🔑 Allowed ONLY from status `Partial`: completion must be recorded first. From `Processing` it is refused, because that means started with nothing yet fulfilled, and marking it ready would claim goods are packed before any were produced. A fully completed order goes straight to `Shipped` on its own and never passes through here.",
+    method: "POST",
+    path: "/admin/inventory-orders/:id/ready-for-delivery",
+    pathParams: ["id"],
+    previewPath: "/admin/inventory-orders/:id",
+    write: true,
+    sensitive: true,
+    inputSchema: obj(
+      { id: STR("Inventory order id, e.g. 'inv_order_...'. Must be in Partial status.") },
+      ["id"]
     ),
   },
   {


### PR DESCRIPTION
Closes #1909.

Two admin routes give a partner an inventory order. **Only the silent one was registered.**

| route | link | messages partner | workflow | gate |
|---|---|---|---|---|
| `assign-partner` (#1737) | ✅ | ❌ | ❌ | none |
| `send-to-partner` | ✅ | ✅ `inventory_order_assigned_to_partner` | ✅ `awaitOrderStart` / `awaitOrderCompletion` | **Pending only** |

`assign-partner` is inert *on purpose* — it exists for backfilling work already done, where messaging a partner about a five-month-old delivery would be wrong. Its own docblock says:

> "This route commissions NOTHING… If you are assigning work a partner has not started, use `send-to-partner` — it is the one that tells them."

**That warning never reached the MCP.** The tool description said only that assigning "makes the order appear in that partner’s portal and in their payables" — every word true, and silent about the half that matters. `send-to-partner` had no tool at all.

## What it cost

`inv_order_01M1ZH7Y50W37WMGXYP2DM1KAF` (GOF Asia, **₹69,340**) was assigned with the inert tool. It reads as assigned in every view — portal, payables, admin — and **GOF has never been told it exists**. `notified: false` sat in three handoffs looking like a loose end rather than *this order was never commissioned*.

A capability whose only door is the inert half of a pair is worse than a missing one: **it succeeds.**

## Added

- `send_inventory_order_to_partner`
- `mark_inventory_order_ready_for_delivery` — the Partial → Ready for Delivery step from #790, also unregistered

`assign_inventory_order_partner` is rewritten so the pair is discoverable from either side: the inert one now says it commissions nothing and names its counterpart; the loud one names it back.

## Two traps pinned

**The routes disagree on the field name.** `send-to-partner` takes `partnerId`; `assign-partner` takes `partner_id`. `bodyParams` is the forward list, so the wrong one is dropped **in silence** — the call succeeds and commissions nobody. That is this same bug one layer down, which is why the spec asserts the exact list rather than "contains partnerId".

**Not demoted to `tier: "write"`.** That roster is explicitly limited to tools with no money, no carrier and no third-party message. This one messages a partner, so a write-scoped credential must not reach it. The test asserts the *absence* of the demotion, not just the presence of the tool — a later "tidy-up" adding it to the roster should fail.

## Verification

Mutation: swapping the forward list to `partner_id` fails the spec.

`396/396` green in `mcp/lib/__tests__` — including #1907’s route-existence sweep, which resolves both new paths, so these are not phantoms. `check:prod-build` passed.

## Note on the live order

The GOF order is still `Pending`, so `send-to-partner` is valid for it. I have **not** sent it — that messages a real person about ₹69,340 of goods, and it is not recallable. Worth confirming the lines are final first (they were changed today: 8 lines, qty 86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp