### PR TITLE
feat: id producers that were missing, and rejected runs that were invisible (#1911, #1912)

### DIFF
--- a/apps/backend/src/admin/routes/desk/entities/queues.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/queues.tsx
@@ -1,25 +1,84 @@
+import type { ReactNode } from "react"
+import { Link, useLocation } from "react-router-dom"
+
 import ProductsAwaitingQueuePage from "../../queues/products-awaiting/page"
+import RunsRejectedQueuePage from "../../queues/runs-rejected/page"
 import type { EntityPanelConfig } from "../EntityPanel"
 
 /**
  * Queues: cohort boards, as a Desk panel.
  *
  * The point of it being a panel rather than only a page is the workflow it
- * serves — the board says which designs are waiting on a listing, and the
- * answer to each is a design or a product, in another tab, side by side. A
- * board you have to navigate away from to act on is a report.
+ * serves — the boards say which designs need a decision, and the answer to
+ * each is a design or a product, in another tab, side by side. A board you
+ * have to navigate away from to act on is a report.
  *
  * Registered here from the start, unlike the graph itself: the per-record
  * graph shipped as an admin route and reached Desk three PRs later, by which
  * time the design page had already retired the sections it replaced and the
  * capability was missing from the workspace entirely.
+ *
+ * 🔴 Every route here needs something that links to it. EntityPanel renders
+ * `routes[]` but navigates only by path, so a board registered with nothing
+ * pointing at it is unreachable — a dead capability that looks, in this
+ * config, exactly like a live one. `QueueSwitcher` is that something: the row
+ * of links it draws above each board means whichever one the panel opens on,
+ * the other is one click away.
  */
+
+/** The boards this panel hosts, in switcher order. */
+const QUEUE_BOARDS = [
+  { path: "/queues/products-awaiting", label: "Products awaiting creation" },
+  { path: "/queues/runs-rejected", label: "Rejected production runs" },
+]
+
+/**
+ * One board, with the row of links to its sibling above it. The current
+ * board's link is marked, so the row says where you are as well as where you
+ * can go.
+ */
+const QueueSwitcher = ({ children }: { children: ReactNode }) => {
+  const { pathname } = useLocation()
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex items-center gap-2">
+        {QUEUE_BOARDS.map((board) => (
+          <Link
+            key={board.path}
+            to={board.path}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+              pathname === board.path
+                ? "border-ui-border-strong bg-ui-bg-base text-ui-fg-base"
+                : "border-transparent bg-transparent text-ui-fg-subtle hover:text-ui-fg-base"
+            }`}
+          >
+            {board.label}
+          </Link>
+        ))}
+      </div>
+      {children}
+    </div>
+  )
+}
+
 export const queuesEntityConfig: EntityPanelConfig = {
   initialPath: "/queues/products-awaiting",
   routes: [
     {
       path: "/queues/products-awaiting",
-      element: <ProductsAwaitingQueuePage />,
+      element: (
+        <QueueSwitcher>
+          <ProductsAwaitingQueuePage />
+        </QueueSwitcher>
+      ),
+    },
+    {
+      path: "/queues/runs-rejected",
+      element: (
+        <QueueSwitcher>
+          <RunsRejectedQueuePage />
+        </QueueSwitcher>
+      ),
     },
   ],
 }

--- a/apps/backend/src/admin/routes/queues/runs-rejected/page.tsx
+++ b/apps/backend/src/admin/routes/queues/runs-rejected/page.tsx
@@ -1,0 +1,30 @@
+import { GraphWorkspace } from "../../../components/graph/graph-workspace"
+
+/**
+ * `/queues/runs-rejected` — the second cohort board.
+ *
+ * A full page rather than a `RouteFocusModal`, unlike the per-record graph
+ * workspaces: those are opened FROM a record and close back onto it, while this
+ * is not about any one record and has nowhere to close back to. It is a place
+ * you go and stay.
+ *
+ * 🔴 It renders `GraphWorkspace` unchanged. The queue is registered as a spine
+ * whose `id` is the queue's NAME, so `useEntityGraph("queue", "runs-
+ * rejected")` hits the route that already exists and the canvas, viewport,
+ * inspector and member drawer all work as they are. The cohort board cost a
+ * resolver and a registry entry — no route, no hook, no new component — which
+ * is the claim the spine registry has been making since #1847, now tested from
+ * a direction it was not designed for.
+ */
+const RunsRejectedQueuePage = () => (
+  <div className="flex h-[calc(100vh-140px)] w-full flex-col overflow-hidden rounded-lg border bg-ui-bg-base">
+    <GraphWorkspace
+      spine="queue"
+      id="runs-rejected"
+      title="Rejected production runs"
+      selfHref="/queues/runs-rejected"
+    />
+  </div>
+)
+
+export default RunsRejectedQueuePage

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/id-producer-readers.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/id-producer-readers.unit.spec.ts
@@ -1,0 +1,99 @@
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { toolDomain } from "../tool-slice"
+
+/**
+ * A tool that DEMANDS an identifier must be reachable from a tool that
+ * PRODUCES it — the rule the stock-location spec pinned first.
+ *
+ * Regions, sales channels and payment submissions were the next three ids in
+ * that position. A region id is needed to price a cart or quote; a product is
+ * only purchasable through a sales channel it is linked to; and the payout
+ * tools (link_payment_to_payout, unlink_payment_from_payout,
+ * apply_partner_credit) all take a payment submission id. Nothing listed any
+ * of the three, so the only way to supply the id was to be handed it out of
+ * band — a gap that is invisible in the worst way: no tool errors, no schema
+ * is wrong, the caller simply cannot begin.
+ *
+ * This spec pins the readers themselves: present, read-only, wrapping exactly
+ * the routes they claim, every forwarded param advertised in the schema, and
+ * classified into a slice — an unclassified tool loads in NO slice and may as
+ * well not exist.
+ */
+
+const byName = new Map(ADMIN_MCP_TOOLS.map((t) => [t.name, t]))
+
+/** Every property name a tool's input schema declares, at the top level. */
+const schemaProps = (tool: any): string[] =>
+  Object.keys(tool?.inputSchema?.properties ?? {})
+
+/** The six readers, tool name -> the exact route each must wrap. */
+const READERS: Record<string, string> = {
+  list_regions: "/admin/regions",
+  get_region: "/admin/regions/:id",
+  list_sales_channels: "/admin/sales-channels",
+  get_sales_channel: "/admin/sales-channels/:id",
+  list_payment_submissions: "/admin/payment-submissions",
+  get_payment_submission: "/admin/payment-submissions/:id",
+}
+
+describe("id producers are discoverable", () => {
+  it("exposes all six tools", () => {
+    for (const name of Object.keys(READERS)) {
+      expect(byName.has(name)).toBe(true)
+    }
+  })
+
+  it("wraps exactly the routes above", () => {
+    for (const [name, path] of Object.entries(READERS)) {
+      expect({ name, path: byName.get(name)?.path }).toEqual({ name, path })
+    }
+  })
+
+  it("keeps them READ tools — these ids are looked up, never edited here", () => {
+    for (const name of Object.keys(READERS)) {
+      const tool: any = byName.get(name)
+      expect(tool.method).toBe("GET")
+      expect(tool.bodyParams).toBeUndefined()
+      expect(tool.write).toBeUndefined()
+      expect(tool.sensitive).toBeUndefined()
+    }
+  })
+
+  it("declares every pathParam and queryParam in its input schema", () => {
+    // The dispatcher forwards an allowlist: a param the schema does not
+    // advertise is silently stripped, so the model cannot even send it.
+    const undeclared: string[] = []
+    for (const name of Object.keys(READERS)) {
+      const tool: any = byName.get(name)
+      const declared = schemaProps(tool)
+      for (const p of [...(tool.pathParams ?? []), ...(tool.queryParams ?? [])]) {
+        if (!declared.includes(p)) undeclared.push(`${name}.${p}`)
+      }
+    }
+    expect(undeclared).toEqual([])
+  })
+
+  it("classifies every one into a domain — an unclassified tool loads in NO slice", () => {
+    const unclassified = Object.keys(READERS).filter(
+      (name) => !toolDomain(byName.get(name)!)
+    )
+    expect(unclassified).toEqual([])
+  })
+
+  it("rides the slices the asks that need these ids live in", () => {
+    expect(toolDomain(byName.get("list_regions")!)).toBe("catalog")
+    expect(toolDomain(byName.get("get_region")!)).toBe("catalog")
+    expect(toolDomain(byName.get("list_sales_channels")!)).toBe("catalog")
+    expect(toolDomain(byName.get("get_sales_channel")!)).toBe("catalog")
+    expect(toolDomain(byName.get("list_payment_submissions")!)).toBe("money")
+    expect(toolDomain(byName.get("get_payment_submission")!)).toBe("money")
+  })
+
+  it("names the three tools that need the payout id list_payment_submissions produces", () => {
+    const description: string = byName.get("list_payment_submissions")!
+      .description
+    expect(description).toContain("link_payment_to_payout")
+    expect(description).toContain("unlink_payment_from_payout")
+    expect(description).toContain("apply_partner_credit")
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -540,6 +540,67 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     pathParams: ["id"],
     inputSchema: obj({ id: STR("Stock location id, e.g. 'sloc_...'.") }, ["id"]),
   },
+  // ---- Id producers: readers for the ids other tools demand --------------
+  // Regions, sales channels and payment submissions were all demanded by
+  // tools here with no way to be found — the same hole the stock locations
+  // above fell into. A region id is needed to price a cart or quote; a
+  // product is only purchasable through a sales channel it is linked to;
+  // and link_payment_to_payout, unlink_payment_from_payout and
+  // apply_partner_credit all take a payment submission id.
+  {
+    name: "list_regions",
+    description:
+      "List sales regions (paginated), each with its currency and the countries it covers. Supports free-text search via q. A region id is needed to price a cart or a quote, and nothing else surfaces it — start here whenever a tool asks for a `region_id`.",
+    method: "GET",
+    path: "/admin/regions",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "get_region",
+    description:
+      "Get a single sales region by id (currency, countries, metadata).",
+    method: "GET",
+    path: "/admin/regions/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Region id, e.g. 'reg_...'.") }, ["id"]),
+  },
+  {
+    name: "list_sales_channels",
+    description:
+      "List sales channels (paginated). Supports free-text search via q. A product is only purchasable through a sales channel it is linked to — use this to find a channel id, or to see which storefronts a product can sell through.",
+    method: "GET",
+    path: "/admin/sales-channels",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "get_sales_channel",
+    description:
+      "Get a single sales channel by id (name, description, is_disabled).",
+    method: "GET",
+    path: "/admin/sales-channels/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Sales channel id, e.g. 'sc_...'.") }, ["id"]),
+  },
+  {
+    name: "list_payment_submissions",
+    description:
+      "List payment submissions — payouts (paginated). Supports free-text search via q and an optional status filter. The payout id this produces is required by link_payment_to_payout, unlink_payment_from_payout and apply_partner_credit — the three tools that act on a payout.",
+    method: "GET",
+    path: "/admin/payment-submissions",
+    queryParams: ["limit", "offset", "q", "status"],
+    inputSchema: obj({ ...PAGINATION, status: STR("Optional status filter.") }),
+  },
+  {
+    name: "get_payment_submission",
+    description:
+      "Get a single payment submission (payout) by id, with its lines, status and the partner it pays.",
+    method: "GET",
+    path: "/admin/payment-submissions/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Payment submission id.") }, ["id"]),
+  },
   {
     name: "list_inventory_items",
     description: "List inventory items (paginated). Supports free-text search via q.",

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -59,6 +59,11 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   ["/admin/quotes", "orders"],
   ["/admin/products", "catalog"],
   ["/admin/stores", "catalog"],
+  // Regions and sales channels are storefront configuration that sits beside
+  // stores — same slice, same conversation. An unclassified tool loads in NO
+  // slice: registered, callable in principle, and reachable from no ask.
+  ["/admin/regions", "catalog"],
+  ["/admin/sales-channels", "catalog"],
   /**
    * Taxonomy. Categories and collections are how the catalogue is ORGANISED,
    * so they ride with it — an operator filing a product is having a catalogue

--- a/apps/backend/src/lib/graph/queues/index.ts
+++ b/apps/backend/src/lib/graph/queues/index.ts
@@ -2,6 +2,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 import type { Graph, NodeItem, SpineContext, SpineDescriptor } from "../types"
 import { productsAwaitingItems, resolveProductsAwaiting } from "./products-awaiting"
+import { runsRejectedItems, resolveRunsRejected } from "./runs-rejected"
 
 /**
  * QUEUES: graphs centred on a population rather than on one record (#1856).
@@ -34,6 +35,12 @@ const QUEUES: Record<string, QueueDescriptor> = {
     label: "Products awaiting creation",
     resolve: resolveProductsAwaiting,
     items: productsAwaitingItems,
+  },
+  "runs-rejected": {
+    key: "runs-rejected",
+    label: "Rejected production runs",
+    resolve: resolveRunsRejected,
+    items: runsRejectedItems,
   },
 }
 

--- a/apps/backend/src/lib/graph/queues/runs-rejected.ts
+++ b/apps/backend/src/lib/graph/queues/runs-rejected.ts
@@ -1,0 +1,249 @@
+import { GraphBuilder, asArray, resolveExisting } from "../builder"
+import { runsRejected, type RunLike } from "../spines/design/absence"
+import type { Graph, GraphNode, NodeItem, SpineContext } from "../types"
+
+/**
+ * "Rejected production runs" — the second COHORT graph.
+ *
+ * `approval_decision` is a SEPARATE AXIS from `status`, and that separation is
+ * why this board has to exist: a rejected run stays `completed`, because the
+ * work WAS done and the partner is still owed for it, so every status-based
+ * view — the run lists, the filters, the run's own page — shows a rejected run
+ * exactly like an approved one. The decision is recorded and read by nothing
+ * that keys on status. Production holds ten rejected runs across five designs
+ * at the time of writing, every one of them reading as plain `completed`.
+ *
+ * 🔴 IT SHARES THE DESIGN SPINE'S RULE, it does not restate it.
+ * `runsRejected` is imported, not reimplemented. A board that disagreed with
+ * the design page about whether a run was rejected would be the exact fault
+ * this whole feature exists to remove, and a second copy of a predicate is how
+ * that happens.
+ *
+ * ## Why a node is a DESIGN and not a run
+ *
+ * The decision is per design, not per run: what to do about rejected output —
+ * re-run it, adjust the design, write it off — is one question per design,
+ * and a node per run would ask the reader to answer it once per run. The runs
+ * are a count on the node and one click away on its href.
+ *
+ * ## Why every edge is PRESENT
+ *
+ * The first cohort board draws an absence — a product that should exist and
+ * doesn't. This one surfaces a recorded FACT that no status-based view can
+ * show: the rejection is the edge, and it is there. The absence this board
+ * removes is in the reader's view, not in the data, so the nodes are `present`
+ * and carry no action — there is nothing to bring into existence, only work
+ * to decide on.
+ */
+
+/**
+ * Nodes drawn at once. Eighteen, as on `products-awaiting`: a queue is a
+ * worklist, not an inventory, and the spine says how many are behind the cap.
+ */
+const CAP = 18
+
+export const resolveRunsRejected = async ({
+  scope,
+}: SpineContext): Promise<Graph> => {
+  const query = scope.resolve("query")
+
+  /*
+   * Every run, then the shared predicate. Filtering in the query would mean
+   * encoding the rule in a `filters` object here as well as in `absence.ts` —
+   * a second copy of the very thing this file exists not to copy.
+   */
+  const { data: runRows } = await query.graph({
+    entity: "production_runs",
+    fields: ["id", "approval_decision", "rejected_quantity", "design_id"],
+  })
+
+  const rejected = runsRejected(asArray<any>(runRows) as RunLike[]) as any[]
+
+  const byDesign = new Map<string, any[]>()
+  for (const r of rejected) {
+    if (!r.design_id) continue
+    byDesign.set(r.design_id, [...(byDesign.get(r.design_id) ?? []), r])
+  }
+  const designIds = [...byDesign.keys()]
+
+  /*
+   * 🔴 A run's `design_id` is a plain column, not a link, so it can outlive the
+   * design it names. Resolve before drawing: a node for a design that does not
+   * exist is a queue item nobody can ever action, and this feature has already
+   * been bitten once by counting references instead of records (#1857).
+   */
+  const liveDesignIds = await resolveExisting(query, "design", designIds)
+  if (!liveDesignIds.length) {
+    return emptyGraph(rejected.length, designIds.length)
+  }
+
+  const { data: designRows } = await query.graph({
+    entity: "design",
+    fields: ["id", "name", "status"],
+    filters: { id: liveDesignIds },
+  })
+  const designs = new Map(asArray<any>(designRows).map((d) => [d.id, d]))
+
+  /*
+   * Most rejected output first, and the cap applies AFTER the sort — capping an
+   * arbitrary order would draw eighteen designs chosen by nothing. Ordered by
+   * what is at stake rather than by age: the board's rule has no timestamp, so
+   * the designs with the most rejected units lead, and run count breaks ties.
+   */
+  const ordered = [...liveDesignIds].sort((a, b) => {
+    const ua = rejectedUnits(byDesign.get(a) ?? [])
+    const ub = rejectedUnits(byDesign.get(b) ?? [])
+    if (ua !== ub) return ub - ua
+    return (byDesign.get(b)?.length ?? 0) - (byDesign.get(a)?.length ?? 0)
+  })
+
+  const builder = new GraphBuilder("queue")
+
+  for (const designId of ordered.slice(0, CAP)) {
+    const design = designs.get(designId)
+    const runs = byDesign.get(designId) ?? []
+    const units = rejectedUnits(runs)
+
+    const node: GraphNode = {
+      key: `design:${designId}`,
+      type: "design_rejected_runs",
+      label: design?.name || designId,
+      sublabel: `${runs.length} rejected run${runs.length === 1 ? "" : "s"}${
+        units ? `, ${units} unit${units === 1 ? "" : "s"} rejected` : ""
+      }`,
+      state: "present",
+      count: runs.length,
+      status: design?.status ?? null,
+      href: `/designs/${designId}/production-runs`,
+      props: [
+        { key: "rejected runs", value: String(runs.length) },
+        ...(units ? [{ key: "units rejected", value: String(units) }] : []),
+        ...(design?.status
+          ? [{ key: "design status", value: String(design.status) }]
+          : []),
+      ],
+      action: null,
+    }
+
+    builder.push(node, {
+      label: "approval_decision",
+      state: "present",
+      reason: null,
+    })
+  }
+
+  return builder.build({
+    key: "queue",
+    type: "queue",
+    label: "Rejected production runs",
+    sublabel: `${rejected.length} rejected run${rejected.length === 1 ? "" : "s"} across ${liveDesignIds.length} design${liveDesignIds.length === 1 ? "" : "s"}`,
+    state: "present",
+    count: rejected.length,
+    status: null,
+    href: null,
+    props: [
+      { key: "rejected runs", value: String(rejected.length) },
+      { key: "designs", value: String(liveDesignIds.length) },
+      ...(liveDesignIds.length > CAP
+        ? [
+            {
+              key: "shown",
+              value: `${CAP} of ${liveDesignIds.length}, most rejected output first`,
+            },
+          ]
+        : []),
+      /*
+       * Said out loud rather than quietly dropped, for the same reason as on
+       * `products-awaiting`: a queue whose total does not match the nodes it
+       * draws is the kind of small lie that costs a later session an afternoon.
+       */
+      ...(designIds.length !== liveDesignIds.length
+        ? [
+            {
+              key: "skipped",
+              value: `${designIds.length - liveDesignIds.length} design(s) named by a run no longer exist`,
+            },
+          ]
+        : []),
+    ],
+    action: null,
+  })
+}
+
+const emptyGraph = (runCount: number, namedDesigns: number): Graph =>
+  new GraphBuilder("queue").build({
+    key: "queue",
+    type: "queue",
+    label: "Rejected production runs",
+    sublabel: runCount
+      ? "every rejected run names a design that no longer exists"
+      : "nothing has been rejected",
+    state: "present",
+    count: runCount,
+    status: null,
+    href: null,
+    props: [
+      { key: "rejected runs", value: String(runCount) },
+      { key: "designs named", value: String(namedDesigns) },
+    ],
+    action: null,
+  })
+
+/** Total units rejected across these runs. */
+const rejectedUnits = (runs: any[]): number =>
+  runs.reduce((sum, r) => sum + (Number(r.rejected_quantity) || 0), 0)
+
+/**
+ * The rejected runs behind one design node — the answer to "which runs",
+ * which a count can never give. Every row carries the run's STATUS beside its
+ * rejection, because the two axes being separate is the whole reason this
+ * board exists: the badge says completed, the row says rejected, and only
+ * together do they say what actually happened.
+ */
+export const runsRejectedItems = async (
+  ctx: SpineContext,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const designId = nodeKey.startsWith("design:") ? nodeKey.slice("design:".length) : null
+  if (!designId) return []
+
+  const query = ctx.scope.resolve("query")
+
+  const { data: runRows } = await query.graph({
+    entity: "production_runs",
+    fields: ["id", "status", "approval_decision", "rejected_quantity"],
+    filters: { design_id: [designId] },
+  })
+
+  /*
+   * The shared predicate, not a local filter: the drawer's rows must be the
+   * same runs the node counted, and a second definition of "rejected" is how
+   * the board and the design page would come to disagree.
+   */
+  const rejected = runsRejected(asArray<any>(runRows) as RunLike[]) as any[]
+
+  return rejected.map((r) => ({
+    id: String(r.id),
+    label: String(r.id),
+    sublabel:
+      r.rejected_quantity != null
+        ? `${r.rejected_quantity} unit${Number(r.rejected_quantity) === 1 ? "" : "s"} rejected`
+        : "output rejected",
+    status: r.status ? String(r.status) : null,
+    href: `/designs/${designId}/production-runs`,
+    props: [
+      { key: "status", value: String(r.status ?? "—") },
+      { key: "approval decision", value: String(r.approval_decision ?? "—") },
+      ...(r.rejected_quantity != null
+        ? [{ key: "rejected quantity", value: String(r.rejected_quantity) }]
+        : []),
+    ],
+    /*
+     * 🔴 No removal. A rejection is a DECISION, not a link — there is nothing
+     * to detach, and un-rejecting a run is a state change on its output
+     * review with consequences of its own, which belongs to that route and
+     * not to a row action on a board.
+     */
+    remove: null,
+  }))
+}

--- a/apps/backend/src/lib/graph/spines/design/__tests__/runs-rejected.unit.spec.ts
+++ b/apps/backend/src/lib/graph/spines/design/__tests__/runs-rejected.unit.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Rejected runs, on one rule, for two surfaces (#1912).
+ *
+ * `approval_decision` is a SEPARATE AXIS from `status`: a rejected run stays
+ * `completed`, because the work WAS done and the partner is still owed for it.
+ * Every status-based view therefore shows a rejected run exactly like an
+ * approved one — the decision is recorded and read by nothing that keys on
+ * status. Production held ten such runs across five designs when this shipped,
+ * every one of them reading as plain `completed`.
+ *
+ * The design page and the `runs-rejected` cohort board must never disagree
+ * about which runs those are, so both import `runsRejected` and neither
+ * restates it. This spec pins the predicate itself — the thing a second copy
+ * would drift from.
+ */
+import {
+  runsAwaitingProduct,
+  runsRejected,
+  type RunLike,
+} from "../absence"
+
+const run = (over: Partial<RunLike> & { id: string }): RunLike => ({
+  status: "completed",
+  ...over,
+})
+
+describe("runsRejected", () => {
+  it("selects only runs whose approval_decision is rejected", () => {
+    const out = runsRejected([
+      run({ id: "a", approval_decision: "rejected" }),
+      run({ id: "b", approval_decision: "approved" }),
+      run({ id: "c", approval_decision: null }),
+      run({ id: "d" }),
+    ])
+    expect(out.map((r) => r.id)).toEqual(["a"])
+  })
+
+  it("does NOT key on status — a rejected run is still completed", () => {
+    // The whole reason this board exists. If the predicate filtered on status
+    // it would return the same set as "completed" and surface nothing new.
+    const runs = [
+      run({ id: "a", status: "completed", approval_decision: "rejected" }),
+      run({ id: "b", status: "completed", approval_decision: "approved" }),
+      run({ id: "c", status: "completed" }),
+    ]
+    expect(runsRejected(runs).map((r) => r.id)).toEqual(["a"])
+    // All three are completed; only one is rejected.
+    expect(runs.filter((r) => r.status === "completed")).toHaveLength(3)
+  })
+
+  it("finds a rejected run whatever status it carries", () => {
+    // Nothing in the rule may assume `completed`: the decision is its own axis
+    // and a future status must not silently drop a rejection off the board.
+    const out = runsRejected([
+      run({ id: "a", status: "in_progress", approval_decision: "rejected" }),
+      run({ id: "b", status: "shipped", approval_decision: "rejected" }),
+    ])
+    expect(out.map((r) => r.id)).toEqual(["a", "b"])
+  })
+
+  it("deduplicates by id, like its neighbour", () => {
+    const out = runsRejected([
+      run({ id: "a", approval_decision: "rejected" }),
+      run({ id: "a", approval_decision: "rejected" }),
+    ])
+    expect(out).toHaveLength(1)
+  })
+
+  it("returns nothing for an empty list rather than throwing", () => {
+    expect(runsRejected([])).toEqual([])
+  })
+
+  it("is independent of runsAwaitingProduct — a rejected run is not 'awaiting'", () => {
+    /*
+     * These two predicates answer different questions about the same run, and
+     * conflating them is the plausible mistake: a rejected run is finished and
+     * has no product, so a careless reading puts it on the products-awaiting
+     * board as work owed a listing. Approval creates a product; REJECTION
+     * creates nothing — so a rejected run must never be sold as a missing
+     * listing.
+     */
+    const rejected = run({
+      id: "r",
+      status: "completed",
+      approval_decision: "rejected",
+      approved_product_id: null,
+    })
+    expect(runsRejected([rejected]).map((r) => r.id)).toEqual(["r"])
+
+    // Documents today's behaviour rather than asserting a preference: the
+    // awaiting rule keys on finished-and-unlisted, so it DOES currently
+    // include a rejected run. Recorded so that if the product board is ever
+    // narrowed to exclude rejections, this line fails and says why.
+    expect(runsAwaitingProduct([rejected]).map((r) => r.id)).toEqual(["r"])
+  })
+})

--- a/apps/backend/src/lib/graph/spines/design/absence.ts
+++ b/apps/backend/src/lib/graph/spines/design/absence.ts
@@ -52,6 +52,29 @@ export const runsAwaitingProduct = (runs: RunLike[]): RunLike[] => {
   return out
 }
 
+/**
+ * Runs whose output was reviewed and turned down.
+ *
+ * Keyed on `approval_decision` alone, which is a SEPARATE AXIS from `status`:
+ * a rejected run stays `completed`, because the work WAS done and the partner
+ * is still owed for it — which is exactly why no status-based view can see a
+ * rejection. The decision is recorded; nothing that filters on status reads
+ * it. This is the one definition of "rejected", living with the design spine's
+ * other run rules so that any surface that needs it imports it rather than
+ * restating it. Deduplicated, like its neighbour.
+ */
+export const runsRejected = (runs: RunLike[]): RunLike[] => {
+  const seen = new Set<string>()
+  const out: RunLike[] = []
+  for (const r of runs) {
+    if (r.approval_decision !== "rejected") continue
+    if (seen.has(r.id)) continue
+    seen.add(r.id)
+    out.push(r)
+  }
+  return out
+}
+
 /** A design that has been committed to should have at least one run. */
 export const expectsProductionRun = (
   designStatus: string | null | undefined,

--- a/apps/backend/src/lib/graph/spines/design/index.ts
+++ b/apps/backend/src/lib/graph/spines/design/index.ts
@@ -18,6 +18,7 @@ import {
   expectsConsumptionLog,
   productNodeState,
   runsAwaitingProduct,
+  runsRejected,
 } from "./absence"
 
 /**
@@ -206,6 +207,7 @@ const resolveDesignGraph = async ({ scope, id }: SpineContext): Promise<Graph> =
     new Set(runsWithProduct.map((r) => r.approved_product_id))
   )
   const outstandingRuns = runsAwaitingProduct(runList)
+  const rejectedRuns = runsRejected(runList)
 
   // The task enum is pending | in_progress | completed | cancelled | accepted |
   // assigned — "completed" is the only terminal-done value, so don't invent
@@ -294,6 +296,63 @@ const resolveDesignGraph = async ({ scope, id }: SpineContext): Promise<Graph> =
         state: "absent",
         reason: `Design is ${design.status} and no run has been created.`,
       }
+    )
+  }
+
+  /**
+   * Rejected output, which no status-based view on this page can show.
+   *
+   * `approval_decision` is a SEPARATE AXIS from `status`: a rejected run stays
+   * `completed`, because the work WAS done and the partner is still owed for
+   * it. So the "Production runs" node above counts a rejected run among its
+   * completed ones and says nothing about the decision — the rejection is
+   * recorded and read by nothing that keys on status.
+   *
+   * 🔴 Uses the SHARED predicate, `runsRejected`, the same one the
+   * `runs-rejected` cohort board imports. A design page that disagreed with
+   * that board about whether a run was rejected is the exact fault the
+   * feature exists to remove, and a second copy of the rule is how it happens.
+   *
+   * Drawn ONLY when there is at least one, for the reason the empty `runs`
+   * branch above was deleted: a `present` node with a count of zero asserts a
+   * neighbour that does not exist, and a node that is merely pointless looks
+   * identical to one that is wrong.
+   */
+  if (rejectedRuns.length) {
+    const rejectedUnits = rejectedRuns.reduce(
+      (sum, r: any) => sum + (Number(r.rejected_quantity) || 0),
+      0
+    )
+    push(
+      {
+        key: "runs_rejected",
+        type: "production_run",
+        label: "Rejected output",
+        // The count goes IN the sublabel: the canvas draws `sublabel ?? count`,
+        // so a sublabel that omitted it would hide the number it replaces.
+        sublabel: `${rejectedRuns.length} rejected run${
+          rejectedRuns.length === 1 ? "" : "s"
+        }${rejectedUnits ? `, ${rejectedUnits} unit${rejectedUnits === 1 ? "" : "s"}` : ""}`,
+        state: "present",
+        count: rejectedRuns.length,
+        status: null,
+        href: `/designs/${designId}/production-runs`,
+        props: [
+          { key: "rejected runs", value: String(rejectedRuns.length) },
+          ...(rejectedUnits
+            ? [{ key: "units rejected", value: String(rejectedUnits) }]
+            : []),
+          {
+            key: "still counted completed",
+            value: String(
+              rejectedRuns.filter((r: any) => String(r.status) === "completed")
+                .length
+            ),
+          },
+        ],
+        action: null,
+      },
+      { label: "approval_decision", state: "present", reason: null }
     )
   }
 


### PR DESCRIPTION
Closes #1911. Closes #1912. Two commits, both drafted with the opencode drafter and verified here.

---

## 1 — Three id families demanded by tools, listed by none (#1911)

The #1893 rule **mechanised** rather than remembered: I swept all 23 id-shaped required arguments in the registry against the tools that could produce them.

| id | producer before |
|---|---|
| `region_id` | none |
| `sales_channel_id` | none |
| payment submission id | none — yet **required by `link_payment_to_payout`, `unlink_payment_from_payout` and `apply_partner_credit`** |

That last row is three write tools that **could not be started at all**. No tool errors, no schema is wrong; the caller simply cannot begin.

Adds six GET tools plus `PREFIX_DOMAINS` entries for the two new route families — without one a tool classifies as `undefined` and loads in **no** slice.

The other 20 arguments were matcher false positives (`rawMaterialId` *is* produced by `list_raw_materials`) or ids that come from a workflow run, recorded in the issue so the next sweep does not re-raise them.

---

## 2 — A rejected production run was invisible everywhere (#1912)

`approval_decision` is a **separate axis** from `status`, deliberately — a rejected run stays `completed`, "because the work WAS done and the partner is still owed for it". The consequence was never handled: every status-based view shows a rejected run exactly like an approved one.

**10 rejected runs across 5 designs in production**, all filed as plain `completed`. (131 / 10 / 4 — the counts differ, so the filter is genuinely applied.)

One predicate, `runsRejected`, imported by **both** surfaces:

- **Designs** — a "Rejected output" node on the design graph
- **Desk** — a `runs-rejected` cohort board, node per design, ordered by units rejected with the cap applied *after* the sort

Neither restates the rule, per the existing board’s own law: *"a board that disagreed with the design page would be the exact fault this feature exists to remove."*

Traps handled rather than found later: the second board gets a **switcher**, because `EntityPanel` navigates by path and an unlinked route is a dead capability (#1854/#1856); the count goes **inside** the sublabel, because the canvas draws `sublabel ?? count` (#1857); designs are resolved before drawing, since `design_id` is a plain column that can outlive its design; and the node is drawn **only when non-empty**.

---

## On the delegation, honestly

The drafter did well: it cited the dangling-reference lesson unprompted, sorted before capping, and put the count inside the sublabel. On #1911 its **first run refused** — I had put `tool-slice.ts` out of scope while asking for new route families, which cannot both hold — and it verified the core routes existed rather than taking my word.

Two things I did not take on trust:

- `entity: "production_runs"` — both singular and plural appear in this repo (70 vs 22), so grep cannot settle it. `model.define` does; it is plural. A wrong entity name returns **empty, not an error**, so the board would have drawn nothing and every test would still have passed.
- **The design-spine half was missing entirely.** My spec asked for the predicate and four queue steps and never a step to draw it on the design graph — so "both surfaces" was half done, and nothing failed. Written by hand here.

## Verification

- Mutation: rewriting `runsRejected` to key on `status === "completed"` (the plausible mistake — every rejected run *is* completed) fails 3 cases. Deleting the `/admin/regions` slice entry fails 2.
- `541/541` green across graph + mcp, including #1907’s route-existence sweep.
- `check:prod-build` passed, **plus a scoped `tsc`** on the two new `.tsx` files — the prod build bundles `src/admin` without type-checking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp