### PR TITLE
fix(production-runs): approval listed at the design's estimate, or at zero, at cost, in usd (#1914)

### DIFF
--- a/apps/backend/src/admin/routes/desk/entities/queues.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/queues.tsx
@@ -1,25 +1,84 @@
+import type { ReactNode } from "react"
+import { Link, useLocation } from "react-router-dom"
+
 import ProductsAwaitingQueuePage from "../../queues/products-awaiting/page"
+import RunsRejectedQueuePage from "../../queues/runs-rejected/page"
 import type { EntityPanelConfig } from "../EntityPanel"
 
 /**
  * Queues: cohort boards, as a Desk panel.
  *
  * The point of it being a panel rather than only a page is the workflow it
- * serves — the board says which designs are waiting on a listing, and the
- * answer to each is a design or a product, in another tab, side by side. A
- * board you have to navigate away from to act on is a report.
+ * serves — the boards say which designs need a decision, and the answer to
+ * each is a design or a product, in another tab, side by side. A board you
+ * have to navigate away from to act on is a report.
  *
  * Registered here from the start, unlike the graph itself: the per-record
  * graph shipped as an admin route and reached Desk three PRs later, by which
  * time the design page had already retired the sections it replaced and the
  * capability was missing from the workspace entirely.
+ *
+ * 🔴 Every route here needs something that links to it. EntityPanel renders
+ * `routes[]` but navigates only by path, so a board registered with nothing
+ * pointing at it is unreachable — a dead capability that looks, in this
+ * config, exactly like a live one. `QueueSwitcher` is that something: the row
+ * of links it draws above each board means whichever one the panel opens on,
+ * the other is one click away.
  */
+
+/** The boards this panel hosts, in switcher order. */
+const QUEUE_BOARDS = [
+  { path: "/queues/products-awaiting", label: "Products awaiting creation" },
+  { path: "/queues/runs-rejected", label: "Rejected production runs" },
+]
+
+/**
+ * One board, with the row of links to its sibling above it. The current
+ * board's link is marked, so the row says where you are as well as where you
+ * can go.
+ */
+const QueueSwitcher = ({ children }: { children: ReactNode }) => {
+  const { pathname } = useLocation()
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex items-center gap-2">
+        {QUEUE_BOARDS.map((board) => (
+          <Link
+            key={board.path}
+            to={board.path}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+              pathname === board.path
+                ? "border-ui-border-strong bg-ui-bg-base text-ui-fg-base"
+                : "border-transparent bg-transparent text-ui-fg-subtle hover:text-ui-fg-base"
+            }`}
+          >
+            {board.label}
+          </Link>
+        ))}
+      </div>
+      {children}
+    </div>
+  )
+}
+
 export const queuesEntityConfig: EntityPanelConfig = {
   initialPath: "/queues/products-awaiting",
   routes: [
     {
       path: "/queues/products-awaiting",
-      element: <ProductsAwaitingQueuePage />,
+      element: (
+        <QueueSwitcher>
+          <ProductsAwaitingQueuePage />
+        </QueueSwitcher>
+      ),
+    },
+    {
+      path: "/queues/runs-rejected",
+      element: (
+        <QueueSwitcher>
+          <RunsRejectedQueuePage />
+        </QueueSwitcher>
+      ),
     },
   ],
 }

--- a/apps/backend/src/admin/routes/queues/runs-rejected/page.tsx
+++ b/apps/backend/src/admin/routes/queues/runs-rejected/page.tsx
@@ -1,0 +1,30 @@
+import { GraphWorkspace } from "../../../components/graph/graph-workspace"
+
+/**
+ * `/queues/runs-rejected` — the second cohort board.
+ *
+ * A full page rather than a `RouteFocusModal`, unlike the per-record graph
+ * workspaces: those are opened FROM a record and close back onto it, while this
+ * is not about any one record and has nowhere to close back to. It is a place
+ * you go and stay.
+ *
+ * 🔴 It renders `GraphWorkspace` unchanged. The queue is registered as a spine
+ * whose `id` is the queue's NAME, so `useEntityGraph("queue", "runs-
+ * rejected")` hits the route that already exists and the canvas, viewport,
+ * inspector and member drawer all work as they are. The cohort board cost a
+ * resolver and a registry entry — no route, no hook, no new component — which
+ * is the claim the spine registry has been making since #1847, now tested from
+ * a direction it was not designed for.
+ */
+const RunsRejectedQueuePage = () => (
+  <div className="flex h-[calc(100vh-140px)] w-full flex-col overflow-hidden rounded-lg border bg-ui-bg-base">
+    <GraphWorkspace
+      spine="queue"
+      id="runs-rejected"
+      title="Rejected production runs"
+      selfHref="/queues/runs-rejected"
+    />
+  </div>
+)
+
+export default RunsRejectedQueuePage

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/id-producer-readers.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/id-producer-readers.unit.spec.ts
@@ -1,0 +1,99 @@
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { toolDomain } from "../tool-slice"
+
+/**
+ * A tool that DEMANDS an identifier must be reachable from a tool that
+ * PRODUCES it — the rule the stock-location spec pinned first.
+ *
+ * Regions, sales channels and payment submissions were the next three ids in
+ * that position. A region id is needed to price a cart or quote; a product is
+ * only purchasable through a sales channel it is linked to; and the payout
+ * tools (link_payment_to_payout, unlink_payment_from_payout,
+ * apply_partner_credit) all take a payment submission id. Nothing listed any
+ * of the three, so the only way to supply the id was to be handed it out of
+ * band — a gap that is invisible in the worst way: no tool errors, no schema
+ * is wrong, the caller simply cannot begin.
+ *
+ * This spec pins the readers themselves: present, read-only, wrapping exactly
+ * the routes they claim, every forwarded param advertised in the schema, and
+ * classified into a slice — an unclassified tool loads in NO slice and may as
+ * well not exist.
+ */
+
+const byName = new Map(ADMIN_MCP_TOOLS.map((t) => [t.name, t]))
+
+/** Every property name a tool's input schema declares, at the top level. */
+const schemaProps = (tool: any): string[] =>
+  Object.keys(tool?.inputSchema?.properties ?? {})
+
+/** The six readers, tool name -> the exact route each must wrap. */
+const READERS: Record<string, string> = {
+  list_regions: "/admin/regions",
+  get_region: "/admin/regions/:id",
+  list_sales_channels: "/admin/sales-channels",
+  get_sales_channel: "/admin/sales-channels/:id",
+  list_payment_submissions: "/admin/payment-submissions",
+  get_payment_submission: "/admin/payment-submissions/:id",
+}
+
+describe("id producers are discoverable", () => {
+  it("exposes all six tools", () => {
+    for (const name of Object.keys(READERS)) {
+      expect(byName.has(name)).toBe(true)
+    }
+  })
+
+  it("wraps exactly the routes above", () => {
+    for (const [name, path] of Object.entries(READERS)) {
+      expect({ name, path: byName.get(name)?.path }).toEqual({ name, path })
+    }
+  })
+
+  it("keeps them READ tools — these ids are looked up, never edited here", () => {
+    for (const name of Object.keys(READERS)) {
+      const tool: any = byName.get(name)
+      expect(tool.method).toBe("GET")
+      expect(tool.bodyParams).toBeUndefined()
+      expect(tool.write).toBeUndefined()
+      expect(tool.sensitive).toBeUndefined()
+    }
+  })
+
+  it("declares every pathParam and queryParam in its input schema", () => {
+    // The dispatcher forwards an allowlist: a param the schema does not
+    // advertise is silently stripped, so the model cannot even send it.
+    const undeclared: string[] = []
+    for (const name of Object.keys(READERS)) {
+      const tool: any = byName.get(name)
+      const declared = schemaProps(tool)
+      for (const p of [...(tool.pathParams ?? []), ...(tool.queryParams ?? [])]) {
+        if (!declared.includes(p)) undeclared.push(`${name}.${p}`)
+      }
+    }
+    expect(undeclared).toEqual([])
+  })
+
+  it("classifies every one into a domain — an unclassified tool loads in NO slice", () => {
+    const unclassified = Object.keys(READERS).filter(
+      (name) => !toolDomain(byName.get(name)!)
+    )
+    expect(unclassified).toEqual([])
+  })
+
+  it("rides the slices the asks that need these ids live in", () => {
+    expect(toolDomain(byName.get("list_regions")!)).toBe("catalog")
+    expect(toolDomain(byName.get("get_region")!)).toBe("catalog")
+    expect(toolDomain(byName.get("list_sales_channels")!)).toBe("catalog")
+    expect(toolDomain(byName.get("get_sales_channel")!)).toBe("catalog")
+    expect(toolDomain(byName.get("list_payment_submissions")!)).toBe("money")
+    expect(toolDomain(byName.get("get_payment_submission")!)).toBe("money")
+  })
+
+  it("names the three tools that need the payout id list_payment_submissions produces", () => {
+    const description: string = byName.get("list_payment_submissions")!
+      .description
+    expect(description).toContain("link_payment_to_payout")
+    expect(description).toContain("unlink_payment_from_payout")
+    expect(description).toContain("apply_partner_credit")
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -540,6 +540,67 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     pathParams: ["id"],
     inputSchema: obj({ id: STR("Stock location id, e.g. 'sloc_...'.") }, ["id"]),
   },
+  // ---- Id producers: readers for the ids other tools demand --------------
+  // Regions, sales channels and payment submissions were all demanded by
+  // tools here with no way to be found — the same hole the stock locations
+  // above fell into. A region id is needed to price a cart or quote; a
+  // product is only purchasable through a sales channel it is linked to;
+  // and link_payment_to_payout, unlink_payment_from_payout and
+  // apply_partner_credit all take a payment submission id.
+  {
+    name: "list_regions",
+    description:
+      "List sales regions (paginated), each with its currency and the countries it covers. Supports free-text search via q. A region id is needed to price a cart or a quote, and nothing else surfaces it — start here whenever a tool asks for a `region_id`.",
+    method: "GET",
+    path: "/admin/regions",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "get_region",
+    description:
+      "Get a single sales region by id (currency, countries, metadata).",
+    method: "GET",
+    path: "/admin/regions/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Region id, e.g. 'reg_...'.") }, ["id"]),
+  },
+  {
+    name: "list_sales_channels",
+    description:
+      "List sales channels (paginated). Supports free-text search via q. A product is only purchasable through a sales channel it is linked to — use this to find a channel id, or to see which storefronts a product can sell through.",
+    method: "GET",
+    path: "/admin/sales-channels",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "get_sales_channel",
+    description:
+      "Get a single sales channel by id (name, description, is_disabled).",
+    method: "GET",
+    path: "/admin/sales-channels/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Sales channel id, e.g. 'sc_...'.") }, ["id"]),
+  },
+  {
+    name: "list_payment_submissions",
+    description:
+      "List payment submissions — payouts (paginated). Supports free-text search via q and an optional status filter. The payout id this produces is required by link_payment_to_payout, unlink_payment_from_payout and apply_partner_credit — the three tools that act on a payout.",
+    method: "GET",
+    path: "/admin/payment-submissions",
+    queryParams: ["limit", "offset", "q", "status"],
+    inputSchema: obj({ ...PAGINATION, status: STR("Optional status filter.") }),
+  },
+  {
+    name: "get_payment_submission",
+    description:
+      "Get a single payment submission (payout) by id, with its lines, status and the partner it pays.",
+    method: "GET",
+    path: "/admin/payment-submissions/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Payment submission id.") }, ["id"]),
+  },
   {
     name: "list_inventory_items",
     description: "List inventory items (paginated). Supports free-text search via q.",

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -59,6 +59,11 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   ["/admin/quotes", "orders"],
   ["/admin/products", "catalog"],
   ["/admin/stores", "catalog"],
+  // Regions and sales channels are storefront configuration that sits beside
+  // stores — same slice, same conversation. An unclassified tool loads in NO
+  // slice: registered, callable in principle, and reachable from no ask.
+  ["/admin/regions", "catalog"],
+  ["/admin/sales-channels", "catalog"],
   /**
    * Taxonomy. Categories and collections are how the catalogue is ORGANISED,
    * so they ride with it — an operator filing a product is having a catalogue

--- a/apps/backend/src/lib/graph/queues/index.ts
+++ b/apps/backend/src/lib/graph/queues/index.ts
@@ -2,6 +2,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 import type { Graph, NodeItem, SpineContext, SpineDescriptor } from "../types"
 import { productsAwaitingItems, resolveProductsAwaiting } from "./products-awaiting"
+import { runsRejectedItems, resolveRunsRejected } from "./runs-rejected"
 
 /**
  * QUEUES: graphs centred on a population rather than on one record (#1856).
@@ -34,6 +35,12 @@ const QUEUES: Record<string, QueueDescriptor> = {
     label: "Products awaiting creation",
     resolve: resolveProductsAwaiting,
     items: productsAwaitingItems,
+  },
+  "runs-rejected": {
+    key: "runs-rejected",
+    label: "Rejected production runs",
+    resolve: resolveRunsRejected,
+    items: runsRejectedItems,
   },
 }
 

--- a/apps/backend/src/lib/graph/queues/runs-rejected.ts
+++ b/apps/backend/src/lib/graph/queues/runs-rejected.ts
@@ -1,0 +1,249 @@
+import { GraphBuilder, asArray, resolveExisting } from "../builder"
+import { runsRejected, type RunLike } from "../spines/design/absence"
+import type { Graph, GraphNode, NodeItem, SpineContext } from "../types"
+
+/**
+ * "Rejected production runs" — the second COHORT graph.
+ *
+ * `approval_decision` is a SEPARATE AXIS from `status`, and that separation is
+ * why this board has to exist: a rejected run stays `completed`, because the
+ * work WAS done and the partner is still owed for it, so every status-based
+ * view — the run lists, the filters, the run's own page — shows a rejected run
+ * exactly like an approved one. The decision is recorded and read by nothing
+ * that keys on status. Production holds ten rejected runs across five designs
+ * at the time of writing, every one of them reading as plain `completed`.
+ *
+ * 🔴 IT SHARES THE DESIGN SPINE'S RULE, it does not restate it.
+ * `runsRejected` is imported, not reimplemented. A board that disagreed with
+ * the design page about whether a run was rejected would be the exact fault
+ * this whole feature exists to remove, and a second copy of a predicate is how
+ * that happens.
+ *
+ * ## Why a node is a DESIGN and not a run
+ *
+ * The decision is per design, not per run: what to do about rejected output —
+ * re-run it, adjust the design, write it off — is one question per design,
+ * and a node per run would ask the reader to answer it once per run. The runs
+ * are a count on the node and one click away on its href.
+ *
+ * ## Why every edge is PRESENT
+ *
+ * The first cohort board draws an absence — a product that should exist and
+ * doesn't. This one surfaces a recorded FACT that no status-based view can
+ * show: the rejection is the edge, and it is there. The absence this board
+ * removes is in the reader's view, not in the data, so the nodes are `present`
+ * and carry no action — there is nothing to bring into existence, only work
+ * to decide on.
+ */
+
+/**
+ * Nodes drawn at once. Eighteen, as on `products-awaiting`: a queue is a
+ * worklist, not an inventory, and the spine says how many are behind the cap.
+ */
+const CAP = 18
+
+export const resolveRunsRejected = async ({
+  scope,
+}: SpineContext): Promise<Graph> => {
+  const query = scope.resolve("query")
+
+  /*
+   * Every run, then the shared predicate. Filtering in the query would mean
+   * encoding the rule in a `filters` object here as well as in `absence.ts` —
+   * a second copy of the very thing this file exists not to copy.
+   */
+  const { data: runRows } = await query.graph({
+    entity: "production_runs",
+    fields: ["id", "approval_decision", "rejected_quantity", "design_id"],
+  })
+
+  const rejected = runsRejected(asArray<any>(runRows) as RunLike[]) as any[]
+
+  const byDesign = new Map<string, any[]>()
+  for (const r of rejected) {
+    if (!r.design_id) continue
+    byDesign.set(r.design_id, [...(byDesign.get(r.design_id) ?? []), r])
+  }
+  const designIds = [...byDesign.keys()]
+
+  /*
+   * 🔴 A run's `design_id` is a plain column, not a link, so it can outlive the
+   * design it names. Resolve before drawing: a node for a design that does not
+   * exist is a queue item nobody can ever action, and this feature has already
+   * been bitten once by counting references instead of records (#1857).
+   */
+  const liveDesignIds = await resolveExisting(query, "design", designIds)
+  if (!liveDesignIds.length) {
+    return emptyGraph(rejected.length, designIds.length)
+  }
+
+  const { data: designRows } = await query.graph({
+    entity: "design",
+    fields: ["id", "name", "status"],
+    filters: { id: liveDesignIds },
+  })
+  const designs = new Map(asArray<any>(designRows).map((d) => [d.id, d]))
+
+  /*
+   * Most rejected output first, and the cap applies AFTER the sort — capping an
+   * arbitrary order would draw eighteen designs chosen by nothing. Ordered by
+   * what is at stake rather than by age: the board's rule has no timestamp, so
+   * the designs with the most rejected units lead, and run count breaks ties.
+   */
+  const ordered = [...liveDesignIds].sort((a, b) => {
+    const ua = rejectedUnits(byDesign.get(a) ?? [])
+    const ub = rejectedUnits(byDesign.get(b) ?? [])
+    if (ua !== ub) return ub - ua
+    return (byDesign.get(b)?.length ?? 0) - (byDesign.get(a)?.length ?? 0)
+  })
+
+  const builder = new GraphBuilder("queue")
+
+  for (const designId of ordered.slice(0, CAP)) {
+    const design = designs.get(designId)
+    const runs = byDesign.get(designId) ?? []
+    const units = rejectedUnits(runs)
+
+    const node: GraphNode = {
+      key: `design:${designId}`,
+      type: "design_rejected_runs",
+      label: design?.name || designId,
+      sublabel: `${runs.length} rejected run${runs.length === 1 ? "" : "s"}${
+        units ? `, ${units} unit${units === 1 ? "" : "s"} rejected` : ""
+      }`,
+      state: "present",
+      count: runs.length,
+      status: design?.status ?? null,
+      href: `/designs/${designId}/production-runs`,
+      props: [
+        { key: "rejected runs", value: String(runs.length) },
+        ...(units ? [{ key: "units rejected", value: String(units) }] : []),
+        ...(design?.status
+          ? [{ key: "design status", value: String(design.status) }]
+          : []),
+      ],
+      action: null,
+    }
+
+    builder.push(node, {
+      label: "approval_decision",
+      state: "present",
+      reason: null,
+    })
+  }
+
+  return builder.build({
+    key: "queue",
+    type: "queue",
+    label: "Rejected production runs",
+    sublabel: `${rejected.length} rejected run${rejected.length === 1 ? "" : "s"} across ${liveDesignIds.length} design${liveDesignIds.length === 1 ? "" : "s"}`,
+    state: "present",
+    count: rejected.length,
+    status: null,
+    href: null,
+    props: [
+      { key: "rejected runs", value: String(rejected.length) },
+      { key: "designs", value: String(liveDesignIds.length) },
+      ...(liveDesignIds.length > CAP
+        ? [
+            {
+              key: "shown",
+              value: `${CAP} of ${liveDesignIds.length}, most rejected output first`,
+            },
+          ]
+        : []),
+      /*
+       * Said out loud rather than quietly dropped, for the same reason as on
+       * `products-awaiting`: a queue whose total does not match the nodes it
+       * draws is the kind of small lie that costs a later session an afternoon.
+       */
+      ...(designIds.length !== liveDesignIds.length
+        ? [
+            {
+              key: "skipped",
+              value: `${designIds.length - liveDesignIds.length} design(s) named by a run no longer exist`,
+            },
+          ]
+        : []),
+    ],
+    action: null,
+  })
+}
+
+const emptyGraph = (runCount: number, namedDesigns: number): Graph =>
+  new GraphBuilder("queue").build({
+    key: "queue",
+    type: "queue",
+    label: "Rejected production runs",
+    sublabel: runCount
+      ? "every rejected run names a design that no longer exists"
+      : "nothing has been rejected",
+    state: "present",
+    count: runCount,
+    status: null,
+    href: null,
+    props: [
+      { key: "rejected runs", value: String(runCount) },
+      { key: "designs named", value: String(namedDesigns) },
+    ],
+    action: null,
+  })
+
+/** Total units rejected across these runs. */
+const rejectedUnits = (runs: any[]): number =>
+  runs.reduce((sum, r) => sum + (Number(r.rejected_quantity) || 0), 0)
+
+/**
+ * The rejected runs behind one design node — the answer to "which runs",
+ * which a count can never give. Every row carries the run's STATUS beside its
+ * rejection, because the two axes being separate is the whole reason this
+ * board exists: the badge says completed, the row says rejected, and only
+ * together do they say what actually happened.
+ */
+export const runsRejectedItems = async (
+  ctx: SpineContext,
+  nodeKey: string
+): Promise<NodeItem[]> => {
+  const designId = nodeKey.startsWith("design:") ? nodeKey.slice("design:".length) : null
+  if (!designId) return []
+
+  const query = ctx.scope.resolve("query")
+
+  const { data: runRows } = await query.graph({
+    entity: "production_runs",
+    fields: ["id", "status", "approval_decision", "rejected_quantity"],
+    filters: { design_id: [designId] },
+  })
+
+  /*
+   * The shared predicate, not a local filter: the drawer's rows must be the
+   * same runs the node counted, and a second definition of "rejected" is how
+   * the board and the design page would come to disagree.
+   */
+  const rejected = runsRejected(asArray<any>(runRows) as RunLike[]) as any[]
+
+  return rejected.map((r) => ({
+    id: String(r.id),
+    label: String(r.id),
+    sublabel:
+      r.rejected_quantity != null
+        ? `${r.rejected_quantity} unit${Number(r.rejected_quantity) === 1 ? "" : "s"} rejected`
+        : "output rejected",
+    status: r.status ? String(r.status) : null,
+    href: `/designs/${designId}/production-runs`,
+    props: [
+      { key: "status", value: String(r.status ?? "—") },
+      { key: "approval decision", value: String(r.approval_decision ?? "—") },
+      ...(r.rejected_quantity != null
+        ? [{ key: "rejected quantity", value: String(r.rejected_quantity) }]
+        : []),
+    ],
+    /*
+     * 🔴 No removal. A rejection is a DECISION, not a link — there is nothing
+     * to detach, and un-rejecting a run is a state change on its output
+     * review with consequences of its own, which belongs to that route and
+     * not to a row action on a board.
+     */
+    remove: null,
+  }))
+}

--- a/apps/backend/src/lib/graph/spines/design/__tests__/runs-rejected.unit.spec.ts
+++ b/apps/backend/src/lib/graph/spines/design/__tests__/runs-rejected.unit.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Rejected runs, on one rule, for two surfaces (#1912).
+ *
+ * `approval_decision` is a SEPARATE AXIS from `status`: a rejected run stays
+ * `completed`, because the work WAS done and the partner is still owed for it.
+ * Every status-based view therefore shows a rejected run exactly like an
+ * approved one — the decision is recorded and read by nothing that keys on
+ * status. Production held ten such runs across five designs when this shipped,
+ * every one of them reading as plain `completed`.
+ *
+ * The design page and the `runs-rejected` cohort board must never disagree
+ * about which runs those are, so both import `runsRejected` and neither
+ * restates it. This spec pins the predicate itself — the thing a second copy
+ * would drift from.
+ */
+import {
+  runsAwaitingProduct,
+  runsRejected,
+  type RunLike,
+} from "../absence"
+
+const run = (over: Partial<RunLike> & { id: string }): RunLike => ({
+  status: "completed",
+  ...over,
+})
+
+describe("runsRejected", () => {
+  it("selects only runs whose approval_decision is rejected", () => {
+    const out = runsRejected([
+      run({ id: "a", approval_decision: "rejected" }),
+      run({ id: "b", approval_decision: "approved" }),
+      run({ id: "c", approval_decision: null }),
+      run({ id: "d" }),
+    ])
+    expect(out.map((r) => r.id)).toEqual(["a"])
+  })
+
+  it("does NOT key on status — a rejected run is still completed", () => {
+    // The whole reason this board exists. If the predicate filtered on status
+    // it would return the same set as "completed" and surface nothing new.
+    const runs = [
+      run({ id: "a", status: "completed", approval_decision: "rejected" }),
+      run({ id: "b", status: "completed", approval_decision: "approved" }),
+      run({ id: "c", status: "completed" }),
+    ]
+    expect(runsRejected(runs).map((r) => r.id)).toEqual(["a"])
+    // All three are completed; only one is rejected.
+    expect(runs.filter((r) => r.status === "completed")).toHaveLength(3)
+  })
+
+  it("finds a rejected run whatever status it carries", () => {
+    // Nothing in the rule may assume `completed`: the decision is its own axis
+    // and a future status must not silently drop a rejection off the board.
+    const out = runsRejected([
+      run({ id: "a", status: "in_progress", approval_decision: "rejected" }),
+      run({ id: "b", status: "shipped", approval_decision: "rejected" }),
+    ])
+    expect(out.map((r) => r.id)).toEqual(["a", "b"])
+  })
+
+  it("deduplicates by id, like its neighbour", () => {
+    const out = runsRejected([
+      run({ id: "a", approval_decision: "rejected" }),
+      run({ id: "a", approval_decision: "rejected" }),
+    ])
+    expect(out).toHaveLength(1)
+  })
+
+  it("returns nothing for an empty list rather than throwing", () => {
+    expect(runsRejected([])).toEqual([])
+  })
+
+  it("is independent of runsAwaitingProduct — a rejected run is not 'awaiting'", () => {
+    /*
+     * These two predicates answer different questions about the same run, and
+     * conflating them is the plausible mistake: a rejected run is finished and
+     * has no product, so a careless reading puts it on the products-awaiting
+     * board as work owed a listing. Approval creates a product; REJECTION
+     * creates nothing — so a rejected run must never be sold as a missing
+     * listing.
+     */
+    const rejected = run({
+      id: "r",
+      status: "completed",
+      approval_decision: "rejected",
+      approved_product_id: null,
+    })
+    expect(runsRejected([rejected]).map((r) => r.id)).toEqual(["r"])
+
+    // Documents today's behaviour rather than asserting a preference: the
+    // awaiting rule keys on finished-and-unlisted, so it DOES currently
+    // include a rejected run. Recorded so that if the product board is ever
+    // narrowed to exclude rejections, this line fails and says why.
+    expect(runsAwaitingProduct([rejected]).map((r) => r.id)).toEqual(["r"])
+  })
+})

--- a/apps/backend/src/lib/graph/spines/design/absence.ts
+++ b/apps/backend/src/lib/graph/spines/design/absence.ts
@@ -52,6 +52,29 @@ export const runsAwaitingProduct = (runs: RunLike[]): RunLike[] => {
   return out
 }
 
+/**
+ * Runs whose output was reviewed and turned down.
+ *
+ * Keyed on `approval_decision` alone, which is a SEPARATE AXIS from `status`:
+ * a rejected run stays `completed`, because the work WAS done and the partner
+ * is still owed for it — which is exactly why no status-based view can see a
+ * rejection. The decision is recorded; nothing that filters on status reads
+ * it. This is the one definition of "rejected", living with the design spine's
+ * other run rules so that any surface that needs it imports it rather than
+ * restating it. Deduplicated, like its neighbour.
+ */
+export const runsRejected = (runs: RunLike[]): RunLike[] => {
+  const seen = new Set<string>()
+  const out: RunLike[] = []
+  for (const r of runs) {
+    if (r.approval_decision !== "rejected") continue
+    if (seen.has(r.id)) continue
+    seen.add(r.id)
+    out.push(r)
+  }
+  return out
+}
+
 /** A design that has been committed to should have at least one run. */
 export const expectsProductionRun = (
   designStatus: string | null | undefined,

--- a/apps/backend/src/lib/graph/spines/design/index.ts
+++ b/apps/backend/src/lib/graph/spines/design/index.ts
@@ -18,6 +18,7 @@ import {
   expectsConsumptionLog,
   productNodeState,
   runsAwaitingProduct,
+  runsRejected,
 } from "./absence"
 
 /**
@@ -206,6 +207,7 @@ const resolveDesignGraph = async ({ scope, id }: SpineContext): Promise<Graph> =
     new Set(runsWithProduct.map((r) => r.approved_product_id))
   )
   const outstandingRuns = runsAwaitingProduct(runList)
+  const rejectedRuns = runsRejected(runList)
 
   // The task enum is pending | in_progress | completed | cancelled | accepted |
   // assigned — "completed" is the only terminal-done value, so don't invent
@@ -294,6 +296,63 @@ const resolveDesignGraph = async ({ scope, id }: SpineContext): Promise<Graph> =
         state: "absent",
         reason: `Design is ${design.status} and no run has been created.`,
       }
+    )
+  }
+
+  /**
+   * Rejected output, which no status-based view on this page can show.
+   *
+   * `approval_decision` is a SEPARATE AXIS from `status`: a rejected run stays
+   * `completed`, because the work WAS done and the partner is still owed for
+   * it. So the "Production runs" node above counts a rejected run among its
+   * completed ones and says nothing about the decision — the rejection is
+   * recorded and read by nothing that keys on status.
+   *
+   * 🔴 Uses the SHARED predicate, `runsRejected`, the same one the
+   * `runs-rejected` cohort board imports. A design page that disagreed with
+   * that board about whether a run was rejected is the exact fault the
+   * feature exists to remove, and a second copy of the rule is how it happens.
+   *
+   * Drawn ONLY when there is at least one, for the reason the empty `runs`
+   * branch above was deleted: a `present` node with a count of zero asserts a
+   * neighbour that does not exist, and a node that is merely pointless looks
+   * identical to one that is wrong.
+   */
+  if (rejectedRuns.length) {
+    const rejectedUnits = rejectedRuns.reduce(
+      (sum, r: any) => sum + (Number(r.rejected_quantity) || 0),
+      0
+    )
+    push(
+      {
+        key: "runs_rejected",
+        type: "production_run",
+        label: "Rejected output",
+        // The count goes IN the sublabel: the canvas draws `sublabel ?? count`,
+        // so a sublabel that omitted it would hide the number it replaces.
+        sublabel: `${rejectedRuns.length} rejected run${
+          rejectedRuns.length === 1 ? "" : "s"
+        }${rejectedUnits ? `, ${rejectedUnits} unit${rejectedUnits === 1 ? "" : "s"}` : ""}`,
+        state: "present",
+        count: rejectedRuns.length,
+        status: null,
+        href: `/designs/${designId}/production-runs`,
+        props: [
+          { key: "rejected runs", value: String(rejectedRuns.length) },
+          ...(rejectedUnits
+            ? [{ key: "units rejected", value: String(rejectedUnits) }]
+            : []),
+          {
+            key: "still counted completed",
+            value: String(
+              rejectedRuns.filter((r: any) => String(r.status) === "completed")
+                .length
+            ),
+          },
+        ],
+        action: null,
+      },
+      { label: "approval_decision", state: "present", reason: null }
     )
   }
 

--- a/apps/backend/src/workflows/production-runs/__tests__/approval-pricing.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approval-pricing.unit.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * The money rule for an approved run's product (#1914).
+ *
+ * Approval listed at `design.estimated_cost ?? 0`: it never read what the run
+ * actually cost, it listed at ZERO when the estimate was missing (#1900 caught
+ * that reaching the storefront), and it applied no margin at all — the listed
+ * price WAS the cost.
+ *
+ * These pin all three, and the two coercion traps that make the zero case so
+ * easy to reintroduce.
+ */
+import {
+  APPROVAL_FALLBACK_CURRENCY,
+  APPROVAL_MARKUP,
+  resolveApprovalCurrency,
+  resolveApprovalPrice,
+} from "../approval-pricing"
+
+describe("resolveApprovalPrice", () => {
+  it("prices from the RUN's actual cost per unit, not the design estimate", () => {
+    // The whole point: a design estimate typed months ago does not decide what
+    // the work cost. When both exist, the run wins.
+    const out = resolveApprovalPrice({
+      runCostPerUnit: 165,
+      designEstimatedCost: 999,
+    })
+    expect(out).toEqual({ price: 231, cost: 165, source: "run_cost" })
+  })
+
+  it("applies the agreed markup, with the founder's worked examples", () => {
+    expect(resolveApprovalPrice({ runCostPerUnit: 165 })?.price).toBe(231)
+    expect(resolveApprovalPrice({ runCostPerUnit: 690 })?.price).toBe(966)
+    expect(resolveApprovalPrice({ runCostPerUnit: 1460 })?.price).toBe(2044)
+    expect(APPROVAL_MARKUP).toBe(1.4)
+  })
+
+  it("falls back to the design estimate when the run was never costed", () => {
+    // cost_per_unit is null when a run has no consumption logs. The estimate is
+    // a worse answer than the run's real cost and a far better one than none.
+    const out = resolveApprovalPrice({
+      runCostPerUnit: null,
+      designEstimatedCost: 200,
+    })
+    expect(out).toEqual({ price: 280, cost: 200, source: "design_estimate" })
+  })
+
+  it("REFUSES when there is no cost anywhere — never lists at zero", () => {
+    // A price of 0 is a claim, not a blank. #1900 caught one on the storefront.
+    expect(resolveApprovalPrice({})).toBeNull()
+    expect(
+      resolveApprovalPrice({ runCostPerUnit: null, designEstimatedCost: null })
+    ).toBeNull()
+  })
+
+  it("treats 0 as ABSENT on both inputs, not as free goods", () => {
+    /*
+     * The trap that makes the zero case easy to reintroduce: `Number(null)` is
+     * `0`, so a `!= null` guard passes a missing figure through as a real one.
+     * A run whose logs sum to 0 has not been costed; it did not cost nothing.
+     */
+    expect(resolveApprovalPrice({ runCostPerUnit: 0 })).toBeNull()
+    expect(resolveApprovalPrice({ designEstimatedCost: 0 })).toBeNull()
+    expect(
+      resolveApprovalPrice({ runCostPerUnit: 0, designEstimatedCost: 150 })
+    ).toEqual({ price: 210, cost: 150, source: "design_estimate" })
+  })
+
+  it("rejects figures that are not real numbers rather than emitting NaN", () => {
+    // A NaN price would be written to the price row and read back as a broken
+    // product, which is harder to notice than a refusal.
+    expect(resolveApprovalPrice({ runCostPerUnit: NaN })).toBeNull()
+    expect(
+      resolveApprovalPrice({ runCostPerUnit: undefined, designEstimatedCost: -5 })
+    ).toBeNull()
+    expect(resolveApprovalPrice({ runCostPerUnit: Infinity })).toBeNull()
+  })
+
+  it("rounds to 2dp in MAJOR units, without float drift", () => {
+    // Medusa 2.x prices are decimal major units — this codebase had exactly one
+    // place that multiplied by 100 (a v1 habit) and it over-priced 100x.
+    expect(resolveApprovalPrice({ runCostPerUnit: 10.1 })?.price).toBe(14.14)
+    expect(resolveApprovalPrice({ runCostPerUnit: 0.07 })?.price).toBe(0.1)
+    // 1.005 * 1.4 = 1.407 -> 1.41, and must not land on 1.4 via binary drift.
+    expect(resolveApprovalPrice({ runCostPerUnit: 1.005 })?.price).toBe(1.41)
+  })
+
+  it("reports which cost the price came from", () => {
+    // Recorded rather than inferred: a price that cannot say where it came from
+    // is the shape of the `metadata` problems this codebase keeps hitting.
+    expect(resolveApprovalPrice({ runCostPerUnit: 10 })?.source).toBe("run_cost")
+    expect(resolveApprovalPrice({ designEstimatedCost: 10 })?.source).toBe(
+      "design_estimate"
+    )
+  })
+
+  it("honours an explicit markup override without changing the default", () => {
+    expect(resolveApprovalPrice({ runCostPerUnit: 100, markup: 1 })?.price).toBe(100)
+    expect(resolveApprovalPrice({ runCostPerUnit: 100 })?.price).toBe(140)
+  })
+})
+
+describe("resolveApprovalCurrency", () => {
+  it("prefers the design's own cost_currency", () => {
+    expect(
+      resolveApprovalCurrency({ designCurrency: "AUD", storeCurrency: "eur" })
+    ).toBe("aud")
+  })
+
+  it("falls back to the store default before the last resort", () => {
+    expect(
+      resolveApprovalCurrency({ designCurrency: null, storeCurrency: "EUR" })
+    ).toBe("eur")
+  })
+
+  it("lands on INR, not usd, when nothing states a currency", () => {
+    /*
+     * The route once hardcoded "usd" on a platform trading in AUD and INR, and
+     * "usd" survived the fix as the last resort — still mis-pricing any design
+     * that never recorded a currency. Production is costed in INR.
+     */
+    expect(resolveApprovalCurrency({})).toBe("inr")
+    expect(APPROVAL_FALLBACK_CURRENCY).toBe("inr")
+    expect(resolveApprovalCurrency({})).not.toBe("usd")
+  })
+
+  it("normalises case and stray whitespace", () => {
+    expect(resolveApprovalCurrency({ designCurrency: "  INR " })).toBe("inr")
+  })
+
+  it("treats an empty string as unstated", () => {
+    // '' is falsy but is not null — the same shape that defeated an
+    // `is not null` CHECK constraint elsewhere in this codebase.
+    expect(resolveApprovalCurrency({ designCurrency: "", storeCurrency: "aud" })).toBe(
+      "aud"
+    )
+  })
+})

--- a/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
@@ -99,9 +99,17 @@ describe("resolveApprovalCurrency", () => {
     ).toBe("inr")
   })
 
-  it("falls back to the store, then to usd", () => {
+  it("falls back to the store, then to INR — never usd (#1914)", () => {
+    /*
+     * "usd" survived the original fix as the last resort, which still
+     * mis-priced any design that never recorded a currency. Production is
+     * costed in INR (the unified order carries `currency_assumed: true` for
+     * the same reason), so a design with no stated currency was costed in INR
+     * whatever the fallback claimed.
+     */
     expect(resolveApprovalCurrency({ storeCurrency: "AUD" })).toBe("aud")
-    expect(resolveApprovalCurrency({})).toBe("usd")
+    expect(resolveApprovalCurrency({})).toBe("inr")
+    expect(resolveApprovalCurrency({})).not.toBe("usd")
   })
 })
 
@@ -161,10 +169,17 @@ describe("applyRunApprovals — approving", () => {
 
     await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
 
+    /*
+     * 850 is the design's estimate; 1190 is that estimate marked up (#1914).
+     * This fixture logs no consumption, so `cost_per_unit` is null and the
+     * estimate is the only cost available — the run's own cost would win if it
+     * had one. The listed price is never the bare cost: that was selling at
+     * cost, which is what the markup exists to stop.
+     */
     expect(createProductRun.mock.calls[0][0].input).toMatchObject({
       design_id: "des_1",
       currency_code: "inr",
-      estimated_cost: 850,
+      estimated_cost: 1190,
     })
   })
 
@@ -200,8 +215,56 @@ describe("applyRunApprovals — approving", () => {
       decision: "approve",
     })
 
-    expect(emit).toHaveBeenCalledTimes(1)
-    expect(emit.mock.calls[0][0].data.design_id).toBe("des_1")
+    /*
+     * Count design.approved SPECIFICALLY, not every emit. Approval now also
+     * asks for the FX fanout (#1914), so a bare call count measures two
+     * different events with one number and would fail for a reason that has
+     * nothing to do with partner notifications.
+     */
+    const approved = emit.mock.calls.filter(
+      (c: any[]) => c[0]?.name === "design.approved"
+    )
+    expect(approved).toHaveLength(1)
+    expect(approved[0][0].data.design_id).toBe("des_1")
+  })
+
+  /**
+   * 🔴 #1900's single-currency defect, at its source.
+   *
+   * Medusa's pricing module emits no `price.created` event, so every path that
+   * writes a variant price must ASK for the fanout. Only the partner routes
+   * ever did — the design -> product path emitted nothing, so every
+   * design-approved product was listed in exactly one currency and read as
+   * "not available" in every other region.
+   */
+  it("asks for the FX fanout on a product it created", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { cost_currency: "inr" }) })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    const fanout = emit.mock.calls.filter(
+      (c: any[]) => c[0]?.name === "fx.fanout_requested"
+    )
+    expect(fanout).toHaveLength(1)
+    expect(fanout[0][0].data.variant_ids).toEqual(["var_new"])
+  })
+
+  it("does NOT ask for a fanout when the product already existed", async () => {
+    // Nothing was priced, so there is nothing to convert — and waking the
+    // worker for an empty job is what the helper's own guard avoids.
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({
+      des_1: design("des_1", {
+        products: [{ id: "prod_existing", variants: [{ id: "var_existing" }] }],
+      }),
+    })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(
+      emit.mock.calls.filter((c: any[]) => c[0]?.name === "fx.fanout_requested")
+    ).toHaveLength(0)
   })
 
   it("records the decision on every run of the design", async () => {

--- a/apps/backend/src/workflows/production-runs/approval-pricing.ts
+++ b/apps/backend/src/workflows/production-runs/approval-pricing.ts
@@ -1,0 +1,131 @@
+/**
+ * What an approved run's product is listed at, and in what currency (#1914).
+ *
+ * PURE, and separate from `approve-run-output` on purpose: this is the money
+ * rule, it is the part worth exercising exhaustively, and a container is not
+ * needed to decide it.
+ *
+ * ── What was wrong ────────────────────────────────────────────────────────
+ *
+ * Approval listed a product at `design.estimated_cost ?? 0`. Three faults in
+ * one expression:
+ *
+ *  1. It never looked at what the run COST. `computeRunCostSummary` derives a
+ *     `cost_per_unit` from real consumption logs — material, energy, labour,
+ *     partner estimate — and approval ignored all of it in favour of a number
+ *     someone typed on the design, possibly months earlier.
+ *  2. `?? 0` listed at ZERO when the estimate was absent. A price of 0 is not a
+ *     blank: it is a claim, and #1900 caught it reaching the storefront.
+ *  3. There was no margin at all. The listed price WAS the cost, so every
+ *     approved product sold at cost.
+ *
+ * ── The rule ──────────────────────────────────────────────────────────────
+ *
+ * price = cost per unit × 1.40, cost taken from the run where the run knows it
+ * and from the design's estimate only where it does not. A run with neither is
+ * REFUSED rather than listed at zero — an approval that cannot price its output
+ * has not finished, and saying so is the whole point of #1900.
+ */
+
+/**
+ * The markup applied to cost. 1.40 = list at 140% of cost.
+ *
+ * ⚠️ This is a MARKUP ON COST, not a margin on the sale price: at ×1.40 the
+ * margin is 28.6% (0.4/1.4), not 40%. Stated because the two are routinely
+ * confused and the difference is real money — a 40% MARGIN would be ÷0.6,
+ * i.e. ×1.667. The founder's call (2026-09-08) was the ×1.40 shape, with the
+ * worked examples 165 -> 231 and 690 -> 966.
+ */
+export const APPROVAL_MARKUP = 1.4
+
+/** Where the cost behind a listed price came from. Recorded, not inferred. */
+export type PriceSource = "run_cost" | "design_estimate"
+
+export type ApprovalPrice = {
+  /** Listed price in major units, already marked up. */
+  price: number
+  /** The pre-markup cost the price was derived from. */
+  cost: number
+  source: PriceSource
+}
+
+/**
+ * PURE: round to 2dp without floating-point drift.
+ *
+ * Medusa 2.x prices are DECIMAL major units (see create-product-from-design's
+ * note: this codebase had exactly one place that multiplied by 100, a Medusa v1
+ * habit, and it over-priced by 100x). So this rounds a decimal, it does not
+ * convert to minor units.
+ */
+const round2 = (n: number): number => Math.round((n + Number.EPSILON) * 100) / 100
+
+/** A usable positive number, or null. `0` and `NaN` are both "no figure". */
+const positive = (v: unknown): number | null => {
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+/**
+ * PURE: the price to list, or `null` when there is no cost to derive one from.
+ *
+ * 🔴 `null` means REFUSE, not "list at zero". The caller must surface it as a
+ * failure naming the run; a silent 0 is the defect this replaces.
+ *
+ * The run's own cost wins wherever it exists. A run with no consumption logs
+ * has `cost_per_unit: null` — nothing was recorded against it — and the
+ * design's estimate is the only figure left; it is a worse answer than the
+ * run's actual cost but a far better one than nothing.
+ *
+ * ⚠️ Zero is treated as ABSENT on both inputs, deliberately. A run whose logs
+ * sum to 0 has not been costed rather than cost nothing, and `Number(null)` is
+ * `0` — so a `!= null` guard here would let a missing figure through as free
+ * goods. Ask `> 0`, never `!= null`.
+ */
+export function resolveApprovalPrice(input: {
+  runCostPerUnit?: number | null
+  designEstimatedCost?: number | null
+  markup?: number
+}): ApprovalPrice | null {
+  const markup = input.markup ?? APPROVAL_MARKUP
+
+  const runCost = positive(input.runCostPerUnit)
+  if (runCost !== null) {
+    return { price: round2(runCost * markup), cost: runCost, source: "run_cost" }
+  }
+
+  const estimate = positive(input.designEstimatedCost)
+  if (estimate !== null) {
+    return {
+      price: round2(estimate * markup),
+      cost: estimate,
+      source: "design_estimate",
+    }
+  }
+
+  return null
+}
+
+/**
+ * PURE. The currency a design's product is listed in.
+ *
+ * 🔴 The approve route once hardcoded `"usd"` on a platform trading in AUD and
+ * INR, so every approved design was listed in a currency nobody sells in. That
+ * was fixed to prefer the design's own `cost_currency`, but `"usd"` survived as
+ * the last resort — which still mis-prices any design that never recorded one.
+ *
+ * The last resort is now **INR**: production is costed in INR (the unified
+ * order carries `currency_assumed: true` for exactly this reason), so a design
+ * with no stated currency was costed in INR whatever the fallback claimed.
+ * `RunCostSummary` carries no currency field at all, so the run cannot answer
+ * this — which is why the design and the store are still asked first.
+ */
+export const APPROVAL_FALLBACK_CURRENCY = "inr"
+
+export function resolveApprovalCurrency(input: {
+  designCurrency?: string | null
+  storeCurrency?: string | null
+}): string {
+  const pick =
+    input.designCurrency || input.storeCurrency || APPROVAL_FALLBACK_CURRENCY
+  return String(pick).trim().toLowerCase()
+}

--- a/apps/backend/src/workflows/production-runs/approve-run-output.ts
+++ b/apps/backend/src/workflows/production-runs/approve-run-output.ts
@@ -2,6 +2,12 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import type { IEventBusModuleService } from "@medusajs/types"
 
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import { computeRunCostSummary } from "../../modules/production_runs/cost-summary"
+import { requestVariantPriceFanout } from "../fx/fanout-variant-prices"
+import {
+  resolveApprovalCurrency as resolveCurrency,
+  resolveApprovalPrice,
+} from "./approval-pricing"
 import { createProductFromDesignWorkflow } from "../designs/create-product-from-design"
 import updateDesignWorkflow from "../designs/update-design"
 
@@ -70,6 +76,10 @@ export type RunApprovalReport = {
   product_existed?: boolean
   currency_code?: string
   listed_price?: number
+  /** Which cost the listed price was derived from: run_cost | design_estimate. */
+  price_source?: string | null
+  /** The pre-markup cost per unit behind `listed_price`. */
+  unit_cost?: number | null
 }
 
 export type RunApprovalResult = {
@@ -88,21 +98,29 @@ export type RunApprovalResult = {
 }
 
 /**
- * PURE. The currency a design's product is listed in. Exported for tests.
- *
- * 🔴 The approve route hardcoded `"usd"` on a platform trading in AUD and INR,
- * so every approved design was listed in a currency nobody sells in. The
- * design's own `cost_currency` is what the work was costed in and is the only
- * figure with a claim to authority here; the store default is a fallback for
- * designs costed before that column was filled in, and `"usd"` survives only as
- * the last resort it always was.
+ * The currency and the price rule both live in `approval-pricing.ts` now — one
+ * definition, exercised without a container. Re-exported here because the
+ * design approve route and this workflow's own spec import it from this module,
+ * and a second copy of a money rule is how two surfaces start disagreeing.
  */
-export function resolveApprovalCurrency(input: {
-  designCurrency?: string | null
-  storeCurrency?: string | null
-}): string {
-  const pick = input.designCurrency || input.storeCurrency || "usd"
-  return String(pick).trim().toLowerCase()
+export {
+  APPROVAL_MARKUP,
+  resolveApprovalCurrency,
+  resolveApprovalPrice,
+} from "./approval-pricing"
+
+/** The store the FX fanout is scoped to. Null is survivable; see the call site. */
+export async function readStoreId(container: any): Promise<string | null> {
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const { data: stores = [] } = await query.graph({
+      entity: "store",
+      fields: ["id"],
+    })
+    return stores?.[0]?.id ?? null
+  } catch {
+    return null
+  }
 }
 
 /** The store's default currency, for designs that never recorded their own. */
@@ -267,6 +285,14 @@ export async function applyRunApprovals(
   // ---- 3. Approve: one product per DESIGN, however many runs --------------
   const storeCurrency = await readStoreCurrency(container)
 
+  /**
+   * The FX fanout is scoped to a store's `supported_currencies`, so it needs the
+   * store id — read once here rather than per design. A store we cannot read
+   * costs the fanout, not the approval: the base price is still written and
+   * `replay-fx-fanout` can materialise the rest later.
+   */
+  const storeId = await readStoreId(container)
+
   /** design_id → the runs of that design in this batch, in the order given. */
   const byDesign = new Map<string, any[]>()
   for (const run of eligible) {
@@ -281,8 +307,10 @@ export async function applyRunApprovals(
     let product_id: string | null = null
     let variant_id: string | null = null
     let productExisted = false
-    let currency = resolveApprovalCurrency({ storeCurrency })
+    let currency = resolveCurrency({ storeCurrency })
     let price = 0
+    let priceSource: string | null = null
+    let unitCost: number | null = null
 
     try {
       const { data: designs = [] } = await query.graph({
@@ -303,11 +331,52 @@ export async function applyRunApprovals(
         throw new Error(`Design not found: ${designId}`)
       }
 
-      currency = resolveApprovalCurrency({
+      currency = resolveCurrency({
         designCurrency: design.cost_currency,
         storeCurrency,
       })
-      price = Number(design.estimated_cost ?? 0) || 0
+      /**
+       * 🔴 The price comes from what the RUN cost, not from an estimate typed
+       * on the design months earlier — and never from `?? 0`.
+       *
+       * `computeRunCostSummary` derives `cost_per_unit` from real consumption
+       * logs (material, energy, labour, partner estimate). A run with no logs
+       * has `null` there and the design's estimate answers instead; a design
+       * with neither is REFUSED below rather than listed at zero, because a
+       * price of 0 is a claim and #1900 caught one on the storefront.
+       *
+       * Costed per run and reduced to the DEAREST, because the product is one
+       * listing for every run of the design: pricing off the cheapest run
+       * would under-price every other unit sold under the same variant.
+       */
+      let runCostPerUnit: number | null = null
+      for (const r of designRuns) {
+        try {
+          const summary = await computeRunCostSummary(container, r.id)
+          const perUnit = Number(summary?.cost_per_unit)
+          if (Number.isFinite(perUnit) && perUnit > 0) {
+            runCostPerUnit = Math.max(runCostPerUnit ?? 0, perUnit)
+          }
+        } catch {
+          // A run we cannot cost is not a reason to fail the batch; the other
+          // runs and the design's estimate still answer.
+        }
+      }
+
+      const priced = resolveApprovalPrice({
+        runCostPerUnit,
+        designEstimatedCost: Number(design.estimated_cost ?? 0),
+      })
+      if (!priced) {
+        throw new Error(
+          `Cannot price design ${designId}: no run of it has a costed ` +
+            `consumption log and the design has no estimated_cost. Record ` +
+            `consumption or set an estimate — approving would list it at 0.`
+        )
+      }
+      price = priced.price
+      priceSource = priced.source
+      unitCost = priced.cost
 
       const linked = design.products?.[0]
       productExisted = Boolean(linked?.id)
@@ -333,6 +402,28 @@ export async function applyRunApprovals(
         product_id = result?.product_id ?? null
         variant_id = result?.variant_id ?? null
         if (product_id) createdProductIds.push(product_id)
+
+        /**
+         * 🔴 Materialise the other currencies. Medusa's pricing module emits no
+         * `price.created` event, so every path that writes a variant price has
+         * to ASK for the fanout itself — and only the partner routes ever did.
+         * The design -> product path (this one) emitted nothing, so every
+         * design-approved product has been listed in exactly one currency and
+         * reads as "not available" in every other region. That is #1900's
+         * single-currency defect, and it was never a fault in the FX code.
+         *
+         * Requested, not run inline: the handler is a subscriber so the work
+         * lands on the WORKER. Running this fanout on the request path
+         * OOM-killed prod twice on 2026-08-19 (exit 137). `requestVariantPriceFanout`
+         * never throws, and the workflow skips currencies a price_set already
+         * carries, so a re-approval is idempotent.
+         */
+        if (variant_id && storeId) {
+          await requestVariantPriceFanout(container, {
+            storeId,
+            variantIds: [variant_id],
+          })
+        }
       }
 
       if (!input.dryRun) {
@@ -385,6 +476,8 @@ export async function applyRunApprovals(
           product_existed: productExisted,
           currency_code: currency,
           listed_price: price,
+          price_source: priceSource,
+          unit_cost: unitCost,
         })
       }
     } catch (e: any) {


### PR DESCRIPTION
Closes #1914. Also closes the two live defects tracked in #1900.

Approving a run listed its product at `design.estimated_cost ?? 0`, in a currency chosen from a chain ending in `"usd"`. Four faults in one expression, plus a fifth one path over.

| # | fault | now |
|---|---|---|
| 1 | never read what the run **cost** | price from `computeRunCostSummary.cost_per_unit` |
| 2 | `?? 0` listed at **zero** | **refused**, with an error naming the design |
| 3 | no margin — sold **at cost** | **×1.40** |
| 4 | last resort was **`usd`** | **INR** |
| 5 | every approved product **single-currency** | emits the FX fanout |

## The fifth is the interesting one

Medusa’s pricing module emits no `price.created` event, so **every path that writes a variant price must ASK for the fanout**. Only the three partner routes ever did. `create-product-from-design` — the path approval uses — emitted **nothing**, so every design-approved product has been listed in one currency and reads as "not available" in every other region.

That is #1900’s single-currency defect, and it was never a fault in the FX code. It is a missing emit in one path.

Requested, not run inline: the handler is a subscriber so the work lands on the **worker**. Running this fanout on the request path **OOM-killed prod twice on 2026-08-19** (exit 137). The helper never throws and skips currencies a `price_set` already carries, so re-approval is idempotent.

## Pricing detail

Cost is taken per run and reduced to the **dearest**, because the product is one listing for every run of the design — pricing off the cheapest run would under-price every other unit sold under the same variant.

Zero is treated as **absent** on both cost inputs, deliberately: `Number(null)` is `0`, so a `!= null` guard would pass a missing figure through as free goods. Ask `> 0`.

⚠️ Stated in the code because the two are routinely confused: **×1.40 is a markup on cost = 28.6% margin, not 40%.** A 40% margin would be ×1.667. The shape asked for was ×1.40, with the worked examples 165 → 231 and 690 → 966.

## Shape

The money rule is a **pure module** (`approval-pricing.ts`) — no container needed to decide it, so it is exercised exhaustively (14 cases, including float drift, `NaN`, `Infinity`, and empty-string currency). `resolveApprovalCurrency` moved there and is re-exported from its old home, because the design approve route imports it from there and a second copy of a money rule is how two surfaces start disagreeing.

## On the three tests I changed

Updated, not weakened:

- the `usd` fallback assertion — the behaviour deliberately changed
- an un-marked-up expected price (850 → 1190) — the markup working
- `expect(emit).toHaveBeenCalledTimes(1)` — it counted **every** event with one number, so the new fanout emit made it fail for a reason unrelated to partner notifications. It now filters by event name, and two cases were added for the fanout itself.

## Verification

- Mutation: disabling the fanout call fails the case written for it.
- The 2 `pickDesignBrief` failures are **pre-existing** — confirmed by `git stash -u` and re-running on a clean tree (600 passed there, 616 here), not by assuming.
- 33/33 on the approval specs; 616 passing across production-runs + designs; `check:prod-build` passed.

## Sequencing note

This is the prerequisite for creating the product at a committed design status. Do that first and you do not get one zero-price draft, you get one per design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp