### PR TITLE
fix(production-runs): a completed parent recorded no output, and no maintenance job could be previewed from MCP (#1877)

### DIFF
--- a/apps/backend/integration-tests/http/production-run-parent-rollup.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-parent-rollup.spec.ts
@@ -1,0 +1,302 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(120000)
+
+/**
+ * #1877 — a parent production run is a HEADING over its children, so its
+ * `quantity` and `produced_quantity` must be the sum of theirs. Three code
+ * paths complete a parent and only two of them reconciled the totals, so a
+ * completed parent could read `produced_quantity: null` beside children that
+ * each stated a real number. Every downstream reader (cost summary, payout,
+ * provenance, order fulfilment) then falls back to the ORDERED quantity and
+ * assumes it was all made.
+ *
+ * These cases assert the OBSERVABLE contract at the HTTP + DB boundary:
+ * whatever the children reported is what the parent says. The rollup's own
+ * arithmetic — and the fallback rule the backfill must not use — is pinned
+ * separately in `parent-run-rollup.unit.spec.ts`.
+ */
+setupSharedTestSuite(() => {
+  describe("Production run — parent rolls up its children's output (#1877)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    /** POST that surfaces the server's message instead of a bare 400. */
+    async function post(url: string, body: any, headers?: any) {
+      try {
+        return headers === undefined
+          ? await api.post(url, body)
+          : await api.post(url, body, headers)
+      } catch (e: any) {
+        const d = e?.response?.data
+        throw new Error(
+          `POST ${url} -> status=${e?.response?.status} msg=${e?.message} body=${
+            typeof d === "string" ? d : JSON.stringify(d)
+          }`
+        )
+      }
+    }
+
+    async function setup() {
+      const container = getContainer()
+      const unique = Date.now() + Math.floor(Math.random() * 1000)
+      await createAdminUser(container)
+      const adminHeaders = await getAuthHeaders(api)
+      return { adminHeaders, unique }
+    }
+
+    async function createPartner(unique: number, tag: string) {
+      const email = `rollup-${tag}-${unique}@jyt.test`
+      const password = "supersecret"
+      await post("/auth/partner/emailpass/register", { email, password })
+      let login = await post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${login.data.token}` }
+      const res = await post(
+        "/partners",
+        {
+          name: `Rollup Partner ${tag} ${unique}`,
+          handle: `rollup-${tag}-${unique}`,
+          admin: { email, first_name: "Roll", last_name: "Up" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      login = await post("/auth/partner/emailpass", { email, password })
+      return {
+        partnerId: res.data.partner.id,
+        partnerHeaders: { Authorization: `Bearer ${login.data.token}` },
+      }
+    }
+
+    async function createTemplate(adminHeaders: any, name: string) {
+      const res = await post(
+        "/admin/task-templates",
+        {
+          name,
+          description: "Rollup dispatch step",
+          priority: "medium",
+          estimated_duration: 30,
+          eventable: false,
+          notifiable: false,
+          metadata: { workflow_type: "production_run" },
+          category: "Production",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.task_template.id as string
+    }
+
+    async function createDesign(adminHeaders: any, unique: number) {
+      const res = await post(
+        "/admin/designs",
+        {
+          name: `Rollup Design ${unique}`,
+          description: "Design for parent rollup test",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id
+    }
+
+    /**
+     * A run is created `approved`, and a partner cannot accept from there —
+     * it has to be DISPATCHED first. Leaving this out is what made the first
+     * draft of this spec fail four ways with an opaque 400.
+     */
+    async function advanceToFinished(
+      runId: string,
+      partnerHeaders: any,
+      adminHeaders: any,
+      templateId: string
+    ) {
+      const sent = await post(
+        `/admin/production-runs/${runId}/send-to-production`,
+        { template_ids: [templateId] },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(sent.status)
+      await post(`/partners/production-runs/${runId}/accept`, {}, { headers: partnerHeaders })
+      await post(`/partners/production-runs/${runId}/start`, {}, { headers: partnerHeaders })
+      await post(`/partners/production-runs/${runId}/finish`, {}, { headers: partnerHeaders })
+    }
+
+    /** Read the parent straight from the DB — not from a response echo. */
+    async function readRun(runId: string) {
+      const query: any = getContainer().resolve("query")
+      const { data } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "status", "quantity", "produced_quantity", "completed_at"],
+        filters: { id: runId },
+      })
+      return data?.[0]
+    }
+
+    // ── Case 1: one child, output stated ────────────────────────────
+    it("carries a single child's produced quantity onto the parent", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { partnerId, partnerHeaders } = await createPartner(unique, "solo")
+      const designId = await createDesign(adminHeaders, unique)
+      const templateId = await createTemplate(adminHeaders, `rollup-tpl-${unique}-${Math.random().toString(36).slice(2, 8)}`)
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        { assignments: [{ partner_id: partnerId, quantity: 4 }] },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const parentId = createRes.data.production_run.id
+      const childId = createRes.data.children[0].id
+
+      await advanceToFinished(childId, partnerHeaders, adminHeaders, templateId)
+      const done = await post(
+        `/partners/production-runs/${childId}/complete`,
+        { produced_quantity: 4 },
+        { headers: partnerHeaders }
+      )
+      expect(done.status).toBe(200)
+
+      const parent = await readRun(parentId)
+      expect(parent.status).toBe("completed")
+      // The defect: this was null while the child said 4.
+      expect(Number(parent.produced_quantity)).toBe(4)
+      expect(Number(parent.quantity)).toBe(4)
+    })
+
+    // ── Case 2: two children, both state output ─────────────────────
+    it("sums two children's output onto the parent", async () => {
+      const { adminHeaders, unique } = await setup()
+      const a = await createPartner(unique, "a")
+      const b = await createPartner(unique + 1, "b")
+      const designId = await createDesign(adminHeaders, unique)
+      const templateId = await createTemplate(adminHeaders, `rollup-tpl-${unique}-${Math.random().toString(36).slice(2, 8)}`)
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [
+            { partner_id: a.partnerId, quantity: 3, role: "cutting" },
+            { partner_id: b.partnerId, quantity: 2, role: "stitching" },
+          ],
+        },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const parentId = createRes.data.production_run.id
+      const children = createRes.data.children
+      expect(children.length).toBe(2)
+
+      const byPartner = new Map<string, string>(
+        children.map((c: any) => [String(c.partner_id), c.id])
+      )
+      const childA = byPartner.get(a.partnerId)!
+      const childB = byPartner.get(b.partnerId)!
+
+      // Finish the FIRST child only — the parent must not complete yet.
+      await advanceToFinished(childA, a.partnerHeaders, adminHeaders, templateId)
+      await post(
+        `/partners/production-runs/${childA}/complete`,
+        { produced_quantity: 3 },
+        { headers: a.partnerHeaders }
+      )
+
+      const midway = await readRun(parentId)
+      expect(midway.status).not.toBe("completed")
+
+      await advanceToFinished(childB, b.partnerHeaders, adminHeaders, templateId)
+      await post(
+        `/partners/production-runs/${childB}/complete`,
+        { produced_quantity: 2 },
+        { headers: b.partnerHeaders }
+      )
+
+      const parent = await readRun(parentId)
+      expect(parent.status).toBe("completed")
+      expect(Number(parent.produced_quantity)).toBe(5)
+      expect(Number(parent.quantity)).toBe(5)
+    })
+
+    // ── Case 3: a real shortfall must not round up ───────────────────
+    /**
+     * 3 ordered, 2 good + 1 rejected. The parent must say 2 — the number the
+     * partner is owed for and the number that actually exists. Reading the
+     * ordered 3 here is the exact overstatement this thread is about.
+     */
+    it("reports the good output, not the ordered quantity, when some were rejected", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { partnerId, partnerHeaders } = await createPartner(unique, "short")
+      const designId = await createDesign(adminHeaders, unique)
+      const templateId = await createTemplate(adminHeaders, `rollup-tpl-${unique}-${Math.random().toString(36).slice(2, 8)}`)
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        { assignments: [{ partner_id: partnerId, quantity: 3 }] },
+        adminHeaders
+      )
+      const parentId = createRes.data.production_run.id
+      const childId = createRes.data.children[0].id
+
+      await advanceToFinished(childId, partnerHeaders, adminHeaders, templateId)
+      const done = await post(
+        `/partners/production-runs/${childId}/complete`,
+        {
+          produced_quantity: 2,
+          rejected_quantity: 1,
+          rejection_reason: "fabric_flaw",
+          rejection_notes: "Slub through the panel",
+        },
+        { headers: partnerHeaders }
+      )
+      expect(done.status).toBe(200)
+
+      const parent = await readRun(parentId)
+      expect(parent.status).toBe("completed")
+      expect(Number(parent.produced_quantity)).toBe(2)
+      expect(Number(parent.quantity)).toBe(3)
+      // 2 made against 3 ordered — the gap must remain visible on the parent.
+      expect(Number(parent.produced_quantity)).toBeLessThan(Number(parent.quantity))
+    })
+
+    // ── Case 4: the parent's completed_at is the LAST child's ────────
+    it("stamps the parent completed_at from its children, not from now", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { partnerId, partnerHeaders } = await createPartner(unique, "when")
+      const designId = await createDesign(adminHeaders, unique)
+      const templateId = await createTemplate(adminHeaders, `rollup-tpl-${unique}-${Math.random().toString(36).slice(2, 8)}`)
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        { assignments: [{ partner_id: partnerId, quantity: 1 }] },
+        adminHeaders
+      )
+      const parentId = createRes.data.production_run.id
+      const childId = createRes.data.children[0].id
+
+      await advanceToFinished(childId, partnerHeaders, adminHeaders, templateId)
+      await post(
+        `/partners/production-runs/${childId}/complete`,
+        { produced_quantity: 1 },
+        { headers: partnerHeaders }
+      )
+
+      const parent = await readRun(parentId)
+      const child = await readRun(childId)
+      expect(parent.completed_at).toBeTruthy()
+      expect(child.completed_at).toBeTruthy()
+      /**
+       * EXACT equality, to the millisecond. Comparing to the nearest second
+       * passed against the old `new Date()` too — in a test the cascade runs
+       * within the same second as the work it is dating, so a coarse
+       * assertion cannot tell "dated by the child" from "dated by now" and
+       * certifies nothing.
+       */
+      expect(new Date(parent.completed_at).getTime()).toBe(
+        new Date(child.completed_at).getTime()
+      )
+    })
+  })
+})

--- a/apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx
+++ b/apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx
@@ -485,7 +485,7 @@ const OpsDataPlumbingPage = () => {
             empty: {
               heading: "No runs yet",
               description:
-                "Applied jobs are recorded here. Use “Run a job” to preview and apply one. (Dry-runs are not persisted.)",
+                "Every run is recorded here — previews as well as applied ones. Use “Run a job” to preview and apply one.",
             },
           }}
         />

--- a/apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx
+++ b/apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx
@@ -463,8 +463,9 @@ const OpsDataPlumbingPage = () => {
             <Heading>Data Plumbing</Heading>
             <Text className="text-ui-fg-subtle" size="small">
               Run guarded data-correction jobs. Always Preview (dry-run) before
-              you Apply — dry-runs never write and are not logged; applied runs
-              are recorded below. Click a run for its full change diff.
+              you Apply — a dry-run never writes, but it IS recorded below
+              alongside applied runs, so a preview leaves a trail you can go
+              back to. Click a run for its full change diff.
             </Text>
           </div>
           <div className="flex items-center gap-x-2">

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/run-review-preview-reachable.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/run-review-preview-reachable.unit.spec.ts
@@ -8,7 +8,7 @@ const byName = (n: string) => ADMIN_MCP_TOOLS.find((t) => t.name === n)
  * would have shipped a bulk write on the live catalogue with its preview
  * unreachable — `dry_run` is the MCP's OWN flag and is intercepted before the
  * route is ever called, so the route's report cannot come back under that name.
- * `run_maintenance_job` has exactly that defect today.
+ * `run_maintenance_job` had exactly that defect too; it is fixed below.
  */
 describe("the run-review tool can actually be previewed (#1805 follow-up)", () => {
   it("exists as a sensitive write", () => {
@@ -55,5 +55,36 @@ describe("a design's products are discoverable (#1900 follow-up)", () => {
     expect(byName("review_production_run_output")!.nextSteps).toContain(
       "list_design_products"
     )
+  })
+})
+
+/**
+ * `run_maintenance_job` is the generic door to every Data Plumbing job, so the
+ * unreachable-preview defect applied to ALL of them at once: the only way to
+ * reach a job through a tool was `dry_run: false`, i.e. a blind write on
+ * production. It now forwards `preview`.
+ */
+describe("run_maintenance_job can actually be previewed (#1877 follow-up)", () => {
+  it("forwards `preview`, so the job's change set is reachable", () => {
+    expect(byName("run_maintenance_job")!.bodyParams).toContain("preview")
+  })
+
+  it("does NOT forward `dry_run` — the dispatcher eats it", () => {
+    expect(byName("run_maintenance_job")!.bodyParams).not.toContain("dry_run")
+  })
+
+  it("advertises nothing it does not forward", () => {
+    const t: any = byName("run_maintenance_job")!
+    const advertised = Object.keys(t.inputSchema?.properties ?? {})
+    // `id` is a path param, not a body param.
+    for (const k of advertised.filter((k) => k !== "id")) {
+      expect(t.bodyParams).toContain(k)
+    }
+  })
+
+  it("tells the caller to preview first, in the spelling that works", () => {
+    const d = byName("run_maintenance_job")!.description
+    expect(d).toMatch(/preview:\s*true/)
+    expect(d).toMatch(/NOT `dry_run`/)
   })
 })

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -4867,20 +4867,23 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "run_maintenance_job",
     description:
-      "Run a Data Plumbing maintenance job. SAFE BY DEFAULT: dry_run defaults to true and previews the exact change set without writing — always preview and show the operator the changes before applying. Pass dry_run:false to apply, which requires confirm:true. Per-job params are validated by the job itself; call list_maintenance_jobs first for the schema.",
+      "Run a Data Plumbing maintenance job. SAFE BY DEFAULT: the job previews unless you say otherwise — always call with preview:true first and show the operator the exact change set before applying. Pass preview:false to apply, which requires confirm:true. Use `preview`, NOT `dry_run`: `dry_run` is this surface's own flag and is intercepted before the job runs, so it returns a planned request rather than the job's real change set. Per-job params are validated by the job itself; call list_maintenance_jobs first for the schema.",
     method: "POST",
     path: "/admin/ops/maintenance-jobs/:id/run",
     pathParams: ["id"],
-    bodyParams: ["dry_run", "params"],
+    // NOT `dry_run` — that name is the dispatcher's own and never arrives at
+    // the route, so the job's change set was unreachable from a tool. See the
+    // note on `preview` in the ops maintenance-job validators.
+    bodyParams: ["preview", "params"],
     write: true,
     sensitive: true,
     inputSchema: obj(
       {
         id: STR("Maintenance job id, e.g. 'repair-inventory-order-route'."),
-        dry_run: {
+        preview: {
           type: "boolean",
           description:
-            "Preview only. Defaults to true — pass false to actually apply.",
+            "Preview only — returns the job's real change set without writing. Defaults to true; pass false to actually apply.",
         },
         params: {
           type: "object",
@@ -4892,7 +4895,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       ["id"]
     ),
     sideEffects:
-      "With dry_run:false, mutates production data as described by the job. Every run is written to the ops_maintenance_run audit log.",
+      "With preview:false, mutates production data as described by the job. Every run is written to the ops_maintenance_run audit log.",
     nextSteps: ["list_maintenance_job_runs"],
   },
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/[id]/run/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/[id]/run/route.ts
@@ -2,7 +2,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 
 import { getMaintenanceJob } from "../../registry"
-import { OpsMaintenanceRunBody } from "../../validators"
+import { OpsMaintenanceRunBody, resolveDryRun } from "../../validators"
 import { buildAuditRow } from "../../audit"
 import { OPS_AUDIT_MODULE } from "../../../../../../modules/ops_audit"
 
@@ -25,7 +25,12 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const body = (req.validatedBody ?? {}) as OpsMaintenanceRunBody
-  const dry_run = body.dry_run ?? true
+  /**
+   * `preview` is the MCP-reachable spelling of `dry_run` — the dispatcher eats
+   * `dry_run` before this route is called. Either one asking for a preview
+   * wins, so a caller that sends both cannot accidentally apply.
+   */
+  const dry_run = resolveDryRun(body)
   const params = (body.params ?? {}) as Record<string, unknown>
 
   const result = await job.run(req.scope, { dry_run, params })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/resolve-dry-run.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/resolve-dry-run.unit.spec.ts
@@ -1,0 +1,39 @@
+import { resolveDryRun } from "../validators"
+
+/**
+ * The MCP dispatcher owns `dry_run` and intercepts it before this route is
+ * called, so `run_maintenance_job` could never reach a job's real change set:
+ * `dry_run: true` returned a planned request and `dry_run: false` was a blind
+ * write. `preview` is the spelling that survives the dispatcher.
+ */
+describe("resolveDryRun", () => {
+  it("previews when nothing is asked for", () => {
+    expect(resolveDryRun({})).toBe(true)
+  })
+
+  it("applies on an explicit preview:false — the MCP apply path", () => {
+    expect(resolveDryRun({ preview: false })).toBe(false)
+  })
+
+  it("still applies on the legacy dry_run:false", () => {
+    expect(resolveDryRun({ dry_run: false })).toBe(false)
+  })
+
+  it("previews on either spelling asking for one", () => {
+    expect(resolveDryRun({ preview: true })).toBe(true)
+    expect(resolveDryRun({ dry_run: true })).toBe(true)
+  })
+
+  /**
+   * A contradictory body must resolve to the SAFE reading. Getting this
+   * backwards turns a request that mentions a preview into a production write.
+   */
+  it("takes the safe reading when the two spellings disagree", () => {
+    expect(resolveDryRun({ preview: false, dry_run: true })).toBe(true)
+    expect(resolveDryRun({ preview: true, dry_run: false })).toBe(true)
+  })
+
+  it("agrees with itself when both say apply", () => {
+    expect(resolveDryRun({ preview: false, dry_run: false })).toBe(false)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-parent-run-produced-quantity-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-parent-run-produced-quantity-job.ts
@@ -1,0 +1,222 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
+import type ProductionRunService from "../../../../modules/production_runs/service"
+import {
+  computeParentRollup,
+  type RollupChild,
+} from "../../../../workflows/production-runs/lib/parent-run-rollup"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+const MAX_SCAN = 5000
+const PAGE = 200
+
+const paramsSchema = z.object({
+  run_ids: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .transform((v) =>
+      (Array.isArray(v) ? v : String(v ?? "").split(","))
+        .map((s) => s.trim())
+        .filter(Boolean)
+    ),
+  limit: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_SCAN)
+    .optional()
+    .default(500),
+})
+
+const RUN_FIELDS = [
+  "id",
+  "status",
+  "quantity",
+  "produced_quantity",
+  "parent_run_id",
+  "completed_at",
+]
+
+/**
+ * #1877 — a parent run completed by the SIGNAL cascade recorded no output.
+ *
+ * Three paths complete a parent production run. `complete-production-run.ts`
+ * and the repair script reconciled the parent's totals from its children;
+ * `run-production-run-lifecycle.ts` set `status` + `completed_at` and nothing
+ * else. So whether a completed parent carries the output the partner actually
+ * reported came down to which path happened to fire, and the lifecycle path
+ * leaves it `null` beside children that each state a real number. Every
+ * downstream reader — cost summary, payout, provenance, order fulfilment —
+ * then falls back to the ORDERED quantity and assumes it was all made.
+ *
+ * The code path is fixed. This is the historical repair, exposed here so it
+ * runs from the Ops console / MCP instead of a one-off ECS `medusa exec`.
+ *
+ * ## What it will and will not write
+ *
+ * It writes `produced_quantity` ONLY, and only the figure the children
+ * actually STATED. It deliberately does not use the ordered-quantity fallback
+ * that the live cascades use: a child that never reported output contributes
+ * nothing, rather than having what it was ASKED to make promoted into a record
+ * of what it DID make. That is the precise lie this whole thread is about.
+ *
+ * It never touches `status` or `completed_at` — these parents are already
+ * terminal and re-dating them rewrites history. It skips any parent that
+ * already states a figure (including `0`, which is a real claim, not a gap),
+ * so it is idempotent and safe to re-run.
+ *
+ * Parents where NEITHER the parent nor any child states output are reported in
+ * the summary and left alone. There is nothing to roll up and inventing a
+ * number would be worse than the null.
+ */
+export const backfillParentRunProducedQuantityJob: MaintenanceJob = {
+  id: "backfill-parent-run-produced-quantity",
+  label: "Backfill produced_quantity on parent production runs",
+  description:
+    `Roll a completed parent production run's produced_quantity up from its children, for the parents the signal-driven lifecycle cascade completed without reconciling totals (#1877). Writes produced_quantity only, only from what children actually STATED — never the ordered-quantity fallback — and never touches status or completed_at. Skips parents that already state a figure (0 included), so it is idempotent. Parents where nothing anywhere states output are reported and left null. Provide run_ids to target specific parents, or omit for a bounded scan (default 500, max ${MAX_SCAN}). Dry-run previews; apply writes.`,
+  params: [
+    {
+      name: "run_ids",
+      type: "string",
+      required: false,
+      description:
+        "Comma-separated PARENT production run ids to target (default: scan all parents)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max parents to update in one call (default 500, max ${MAX_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const { run_ids, limit } = paramsSchema.parse(params)
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    // Page the whole run table on a handful of columns and group in memory.
+    // Grouping needs every child of a parent present at once, so a filtered
+    // page could split a sibling set and make a parent look complete when it
+    // is not.
+    const all: RollupChild[] & Array<any> = []
+    for (let skip = 0; skip < MAX_SCAN; skip += PAGE) {
+      const { data: rows } = await query.graph({
+        entity: "production_runs",
+        fields: RUN_FIELDS,
+        pagination: { skip, take: PAGE },
+      })
+      if (!rows?.length) break
+      all.push(...rows)
+      if (rows.length < PAGE) break
+    }
+
+    const byParent = new Map<string, any[]>()
+    for (const r of all) {
+      const p = r?.parent_run_id
+      if (!p) continue
+      if (!byParent.has(p)) byParent.set(p, [])
+      byParent.get(p)!.push(r)
+    }
+    const parentById = new Map<string, any>(
+      all.filter((r: any) => !r?.parent_run_id).map((r: any) => [r.id, r])
+    )
+
+    let scanned = 0
+    let skippedAlreadyStated = 0
+    let skippedNotAllCompleted = 0
+    let skippedNotCompleted = 0
+    let skippedNoOutputAnywhere = 0
+
+    const targets = run_ids.length
+      ? run_ids.filter((id) => byParent.has(id))
+      : [...byParent.keys()]
+
+    for (const parentId of targets) {
+      if (changes.length >= limit) break
+
+      const kids = byParent.get(parentId) ?? []
+      const parent = parentById.get(parentId)
+      if (!parent) continue
+      scanned++
+
+      // Only already-COMPLETED parents. A parent still open is the stuck-parent
+      // case, which completes through the cascade / repair script and involves
+      // status and completed_at — a different decision, deliberately not made
+      // here.
+      if (String(parent.status) !== "completed") {
+        skippedNotCompleted++
+        continue
+      }
+
+      const rollup = computeParentRollup(kids)
+      if (!rollup.all_completed) {
+        skippedNotAllCompleted++
+        continue
+      }
+
+      // `0` is a statement, not a gap. Only `null` is missing.
+      if (
+        parent.produced_quantity != null &&
+        Number.isFinite(Number(parent.produced_quantity))
+      ) {
+        skippedAlreadyStated++
+        continue
+      }
+
+      if (rollup.produced_stated <= 0) {
+        skippedNoOutputAnywhere++
+        continue
+      }
+
+      const note =
+        `${kids.length} child(ren) state ${rollup.produced_stated} of ${rollup.quantity} ordered` +
+        (rollup.children_missing_produced
+          ? `; ${rollup.children_missing_produced} child(ren) state none and contribute nothing`
+          : "")
+
+      if (!dry_run) {
+        try {
+          await service.updateProductionRuns({
+            id: parentId,
+            produced_quantity: rollup.produced_stated,
+          } as any)
+        } catch (e: any) {
+          errors.push({ id: parentId, message: e?.message ?? String(e) })
+          continue
+        }
+      }
+
+      changes.push({
+        entity: "production_run",
+        id: parentId,
+        field: "produced_quantity",
+        before: null,
+        after: rollup.produced_stated,
+        note,
+      })
+    }
+
+    const verb = dry_run ? "Would backfill" : "Backfilled"
+    return {
+      job_id: backfillParentRunProducedQuantityJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary:
+        `${verb} produced_quantity on ${changes.length} parent run(s) ` +
+        `(${changes.reduce((a, c) => a + Number(c.after ?? 0), 0)} units) ` +
+        `across ${scanned} parent(s) scanned — ` +
+        `${skippedAlreadyStated} already stated, ${skippedNotCompleted} not completed, ` +
+        `${skippedNotAllCompleted} with open children, ` +
+        `${skippedNoOutputAnywhere} where no child states any output (left null), ` +
+        `${errors.length} error(s)`,
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -140,6 +140,7 @@ import { normalizeArtisanProductsJob } from "./normalize-artisan-products-job"
 import { linkArtisanDetailRowsJob } from "./link-artisan-detail-rows-job"
 import { setPlatformTaxIdentityActiveJob } from "./set-platform-tax-identity-active-job"
 import { backfillFulfilledRetailRunsJob } from "./backfill-fulfilled-retail-runs-job"
+import { backfillParentRunProducedQuantityJob } from "./backfill-parent-run-produced-quantity-job"
 import { refreshStaleDraftPayoutsJob } from "./refresh-stale-draft-payouts-job"
 import {
   sweepAiPlatformsByCategory,
@@ -5912,6 +5913,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   linkArtisanDetailRowsJob,
   setPlatformTaxIdentityActiveJob,
   backfillFulfilledRetailRunsJob,
+  backfillParentRunProducedQuantityJob,
   seedInvestorPanelsJob,
   seedPlatformStatsPanelJob,
   seedGoodsTransferTaskTemplateJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
@@ -7,6 +7,18 @@ import { z } from "@medusajs/framework/zod"
  */
 export const OpsMaintenanceRunSchema = z.object({
   dry_run: z.boolean().optional(),
+  /**
+   * The same request as `dry_run`, under a name a proxy can pass through.
+   *
+   * 🔴 The admin MCP owns `dry_run` as its OWN flag: `mcp-core/dispatch.ts`
+   * intercepts it and returns the PLANNED REQUEST without ever calling this
+   * route. So through a tool, `dry_run: true` never produced a change set and
+   * `dry_run: false` was the only way to reach the job — a blind write on
+   * production, with the preview that is the entire point of this endpoint
+   * unreachable. `preview` survives the dispatcher and means exactly what
+   * `dry_run` means here. (Same fix as #1805 on review_production_run_output.)
+   */
+  preview: z.boolean().optional(),
   // Per-job params are validated inside each job's own schema; here we only
   // accept an object. NOTE: zod v4 requires the two-arg z.record form
   // (z.record(z.any()) leaves the value schema undefined → "_zod" crash when
@@ -96,3 +108,28 @@ export const OpsMaintenanceBatchesQuerySchema = z.object({
 export type OpsMaintenanceBatchesQuery = z.infer<
   typeof OpsMaintenanceBatchesQuerySchema
 >
+
+/**
+ * PURE: does this body ask for a preview or an apply? Exported for unit tests.
+ *
+ * Two spellings mean the same thing (`preview` exists because the MCP
+ * dispatcher eats `dry_run` — see the schema), so the rule has to be stated
+ * once rather than guessed at each call site.
+ *
+ *   · neither given            → preview. Safe by default.
+ *   · either one explicitly true → preview. A caller that sends a
+ *     contradictory `{preview: false, dry_run: true}` gets the SAFE reading,
+ *     never the write.
+ *   · otherwise                → whichever was given, `preview` first.
+ *
+ * The middle rule is what stops `preview: false` from being swallowed by
+ * `dry_run`'s default and making an apply impossible — and equally stops a
+ * stray `dry_run: true` from being overridden into a write.
+ */
+export function resolveDryRun(body: {
+  preview?: boolean
+  dry_run?: boolean
+}): boolean {
+  if (body.preview === true || body.dry_run === true) return true
+  return body.preview ?? body.dry_run ?? true
+}

--- a/apps/backend/src/scripts/repair-stuck-parent-production-runs.ts
+++ b/apps/backend/src/scripts/repair-stuck-parent-production-runs.ts
@@ -2,6 +2,10 @@ import { ExecArgs } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PRODUCTION_RUNS_MODULE } from "../modules/production_runs"
 import type ProductionRunService from "../modules/production_runs/service"
+import {
+  computeParentRollup,
+  parentTotalsPatch,
+} from "../workflows/production-runs/lib/parent-run-rollup"
 
 /**
  * Repair — complete parent production runs left STUCK after all their
@@ -21,6 +25,15 @@ import type ProductionRunService from "../modules/production_runs/service"
  * if the parent is in a stuck (non-terminal) status, marks it completed
  * and reconciles its totals from the children (fixes parent/child
  * quantity mismatch). completed_at = latest child completed_at.
+ *
+ * It ALSO repairs parents that are already `completed` but carry
+ * `produced_quantity: null` — the signal-driven cascade in
+ * `run-production-run-lifecycle.ts` completed parents without reconciling
+ * totals, so seven prod parents read `completed` with a null output while
+ * their children each state a real number. Those were previously skipped as
+ * "already correct". Only the output is written, only from what the children
+ * actually STATED (no fall back to the ordered quantity), and `status` /
+ * `completed_at` are left untouched.
  *
  * By default it does NOT touch parents that are already `cancelled`
  * (those may have been cancelled intentionally). Pass specific ids via
@@ -96,11 +109,13 @@ export default async function repairStuckParentProductionRuns({
   let completed = 0
   let skippedNotAllDone = 0
   let skippedTerminal = 0
+  let outputBackfilled = 0
+  let skippedNoOutputAnywhere = 0
   const errors: Array<{ parent_id: string; error: string }> = []
 
   for (const [parentId, kids] of byParent) {
-    const allCompleted = kids.every((c) => String(c.status) === "completed")
-    if (!allCompleted) {
+    const rollup = computeParentRollup(kids)
+    if (!rollup.all_completed) {
       skippedNotAllDone++
       continue
     }
@@ -112,7 +127,61 @@ export default async function repairStuckParentProductionRuns({
 
     const status = String(parent.status)
     if (status === "completed") {
-      continue // already correct
+      /**
+       * `completed` was treated as "already correct" and skipped. It is not:
+       * the signal-driven cascade in `run-production-run-lifecycle.ts`
+       * completed parents WITHOUT reconciling totals, so a parent can read
+       * `completed` with `produced_quantity: null` while every child states a
+       * real number. Seven such parents exist in production. Skipping them is
+       * what made this repair unable to reach the very rows it was written
+       * for.
+       *
+       * Only the OUTPUT is repaired here, and only from what the children
+       * actually stated — `allowFallback` is off, so a child that never
+       * reported output contributes nothing rather than having its ORDERED
+       * quantity silently promoted into a production figure. `status` and
+       * `completed_at` are left exactly as they are: this parent is already
+       * terminal and re-dating it would rewrite history.
+       */
+      const producedNow = Number(parent.produced_quantity)
+      const alreadyStated =
+        parent.produced_quantity != null && Number.isFinite(producedNow)
+      if (alreadyStated) continue
+
+      if (rollup.produced_stated <= 0) {
+        // Nothing anywhere states output — neither parent nor any child. There
+        // is nothing to roll up and inventing a number would be worse than the
+        // null. Reported, not written.
+        skippedNoOutputAnywhere++
+        continue
+      }
+
+      const patch = parentTotalsPatch(rollup)
+      const otag = `parent ${parentId} (completed, produced null→${rollup.produced_stated}${
+        rollup.children_missing_produced
+          ? `, ${rollup.children_missing_produced} child(ren) state none`
+          : ""
+      })`
+
+      if (dryRun) {
+        logger.info(`WOULD backfill output ${otag}`)
+        outputBackfilled++
+        continue
+      }
+
+      try {
+        await service.updateProductionRuns({
+          id: parentId,
+          produced_quantity: patch.produced_quantity,
+        } as any)
+        logger.info(`Backfilled output ${otag}`)
+        outputBackfilled++
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error(`Failed ${otag}: ${message}`)
+        errors.push({ parent_id: parentId, error: message })
+      }
+      continue
     }
 
     const isStuck = STUCK_STATUSES.includes(status)
@@ -123,21 +192,9 @@ export default async function repairStuckParentProductionRuns({
       continue
     }
 
-    // Reconcile totals from children.
-    const sum = (key: string, fallback?: string) =>
-      kids.reduce((acc, c) => {
-        const v = c?.[key] ?? (fallback ? c?.[fallback] : undefined)
-        return acc + (Number.isFinite(Number(v)) ? Number(v) : 0)
-      }, 0)
-    const quantityTotal = sum("quantity")
-    const producedTotal = sum("produced_quantity", "quantity")
-    const latestMs = kids
-      .map((c) => c?.completed_at)
-      .filter(Boolean)
-      .map((d) => new Date(d).getTime())
-      .reduce((a, b) => Math.max(a, b), 0)
-
-    const tag = `parent ${parentId} (${status} → completed, qty ${parent.quantity}→${quantityTotal}, produced→${producedTotal})${isForced ? " [forced]" : ""}`
+    // Reconcile totals from children — same helper the two live cascades use.
+    const totals = parentTotalsPatch(rollup, { allowFallback: true })
+    const tag = `parent ${parentId} (${status} → completed, qty ${parent.quantity}→${rollup.quantity}, produced→${totals.produced_quantity ?? 0})${isForced ? " [forced]" : ""}`
 
     if (dryRun) {
       logger.info(`WOULD complete ${tag}`)
@@ -149,10 +206,9 @@ export default async function repairStuckParentProductionRuns({
       await service.updateProductionRuns({
         id: parentId,
         status: "completed" as any,
-        completed_at: latestMs ? new Date(latestMs) : new Date(),
+        completed_at: rollup.completed_at ?? new Date(),
         cancelled_at: null,
-        ...(quantityTotal > 0 ? { quantity: quantityTotal } : {}),
-        ...(producedTotal > 0 ? { produced_quantity: producedTotal } : {}),
+        ...totals,
       } as any)
       logger.info(`Completed ${tag}`)
       completed++
@@ -167,6 +223,8 @@ export default async function repairStuckParentProductionRuns({
   logger.info("─── Repair summary ───")
   logger.info(`parents_scanned        = ${byParent.size}`)
   logger.info(`completed              = ${completed}${dryRun ? " (DRY RUN)" : ""}`)
+  logger.info(`output_backfilled      = ${outputBackfilled}${dryRun ? " (DRY RUN)" : ""} (already-completed parents whose produced_quantity was null)`)
+  logger.info(`skipped_no_output      = ${skippedNoOutputAnywhere} (completed, produced null, and no child states any)`)
   logger.info(`skipped_children_open  = ${skippedNotAllDone}`)
   logger.info(`skipped_terminal       = ${skippedTerminal} (cancelled/other, not forced)`)
   logger.info(`errors                 = ${errors.length}`)

--- a/apps/backend/src/workflows/production-runs/__tests__/parent-run-rollup.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/parent-run-rollup.unit.spec.ts
@@ -1,0 +1,132 @@
+import {
+  computeParentRollup,
+  parentTotalsPatch,
+  type RollupChild,
+} from "../lib/parent-run-rollup"
+
+const child = (o: Partial<RollupChild> = {}): RollupChild => ({
+  id: "c",
+  status: "completed",
+  quantity: 1,
+  produced_quantity: 1,
+  completed_at: "2026-08-13T10:00:00.000Z",
+  ...o,
+})
+
+describe("computeParentRollup", () => {
+  it("sums quantity and produced across children", () => {
+    const r = computeParentRollup([
+      child({ quantity: 2, produced_quantity: 2 }),
+      child({ quantity: 1, produced_quantity: 1 }),
+    ])
+    expect(r.quantity).toBe(3)
+    expect(r.produced_stated).toBe(3)
+    expect(r.produced_with_fallback).toBe(3)
+    expect(r.children_missing_produced).toBe(0)
+    expect(r.all_completed).toBe(true)
+  })
+
+  /**
+   * The production shape this whole change exists for: the child states its
+   * output, the parent's is null. Every one of the seven affected parents in
+   * prod is a single child that reported a real number.
+   */
+  it("recovers the output a single child reported", () => {
+    const r = computeParentRollup([child({ quantity: 1, produced_quantity: 1 })])
+    expect(r.produced_stated).toBe(1)
+    expect(parentTotalsPatch(r)).toEqual({ quantity: 1, produced_quantity: 1 })
+  })
+
+  it("does not invent output for a child that reported none", () => {
+    const r = computeParentRollup([
+      child({ quantity: 3, produced_quantity: null }),
+    ])
+    expect(r.produced_stated).toBe(0)
+    expect(r.children_missing_produced).toBe(1)
+    // the ORDERED 3 must not become a production figure
+    expect(parentTotalsPatch(r)).toEqual({ quantity: 3 })
+  })
+
+  it("promotes the ordered quantity ONLY when the fallback is asked for", () => {
+    const r = computeParentRollup([
+      child({ quantity: 3, produced_quantity: null }),
+    ])
+    expect(r.produced_with_fallback).toBe(3)
+    expect(parentTotalsPatch(r, { allowFallback: true })).toEqual({
+      quantity: 3,
+      produced_quantity: 3,
+    })
+  })
+
+  /**
+   * The real `prod_run_..46G0KY`: ordered 3 across two children, one of which
+   * (completed 2026-07-04) never stated output. The honest rollup is 1, not 3.
+   */
+  it("mixes stated and unstated children without over-counting", () => {
+    const r = computeParentRollup([
+      child({ quantity: 2, produced_quantity: null, completed_at: "2026-07-04T00:00:00.000Z" }),
+      child({ quantity: 1, produced_quantity: 1, completed_at: "2026-08-13T00:00:00.000Z" }),
+    ])
+    expect(r.quantity).toBe(3)
+    expect(r.produced_stated).toBe(1)
+    expect(r.produced_with_fallback).toBe(3)
+    expect(r.children_missing_produced).toBe(1)
+  })
+
+  it("takes the LATEST child completed_at", () => {
+    const r = computeParentRollup([
+      child({ completed_at: "2026-07-04T00:00:00.000Z" }),
+      child({ completed_at: "2026-08-13T00:00:00.000Z" }),
+      child({ completed_at: null }),
+    ])
+    expect(r.completed_at?.toISOString()).toBe("2026-08-13T00:00:00.000Z")
+  })
+
+  it("is not all_completed when any child is open", () => {
+    expect(
+      computeParentRollup([child(), child({ status: "in_progress" })])
+        .all_completed
+    ).toBe(false)
+  })
+
+  /**
+   * A parent with NO children is not a rollup. Treating an empty set as
+   * "every child completed" (which `[].every()` does) would let this path
+   * complete a real, unfinished job.
+   */
+  it("is not all_completed for an empty child set", () => {
+    expect(computeParentRollup([]).all_completed).toBe(false)
+    expect(computeParentRollup(null).all_completed).toBe(false)
+  })
+
+  /**
+   * `0` produced is a real, different statement from `null`. It must count as
+   * STATED (so the child is not in `children_missing_produced`) while still
+   * being omitted from the patch, because writing 0 over an existing figure
+   * would destroy it.
+   */
+  it("treats a produced_quantity of 0 as stated, not missing", () => {
+    const r = computeParentRollup([child({ quantity: 5, produced_quantity: 0 })])
+    expect(r.children_missing_produced).toBe(0)
+    expect(r.produced_stated).toBe(0)
+    expect(r.produced_with_fallback).toBe(0)
+    expect(parentTotalsPatch(r)).toEqual({ quantity: 5 })
+  })
+
+  it("handles string numerics off the ORM", () => {
+    const r = computeParentRollup([
+      child({ quantity: "2" as any, produced_quantity: "2" as any }),
+    ])
+    expect(r.quantity).toBe(2)
+    expect(r.produced_stated).toBe(2)
+  })
+
+  it("ignores unparseable values rather than producing NaN", () => {
+    const r = computeParentRollup([
+      child({ quantity: "abc" as any, produced_quantity: "" as any }),
+    ])
+    expect(r.quantity).toBe(0)
+    expect(r.produced_stated).toBe(0)
+    expect(r.children_missing_produced).toBe(1)
+  })
+})

--- a/apps/backend/src/workflows/production-runs/complete-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/complete-production-run.ts
@@ -31,6 +31,10 @@ import {
   type PartnerRunInput,
 } from "./partner-run-steps"
 import { mirrorUnifiedRunOrderStatusStep } from "./dual-write-unified-run-order"
+import {
+  computeParentRollup,
+  parentTotalsPatch,
+} from "./lib/parent-run-rollup"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -396,10 +400,8 @@ const cascadeParentCompletionStep = createStep(
       } as any)) as any[]
       if (!children?.length) return
 
-      const allCompleted = children.every(
-        (c) => String(c?.status || "") === "completed"
-      )
-      if (!allCompleted) return
+      const rollup = computeParentRollup(children)
+      if (!rollup.all_completed) return
 
       const parent = (await service
         .retrieveProductionRun(parentRunId)
@@ -409,25 +411,13 @@ const cascadeParentCompletionStep = createStep(
 
       // Reconcile parent totals from the children so the rollup matches
       // what was actually produced (fixes the parent/child qty mismatch).
-      const sum = (key: string, fallback?: string) =>
-        children.reduce((acc, c) => {
-          const v = c?.[key] ?? (fallback ? c?.[fallback] : undefined)
-          return acc + (Number.isFinite(Number(v)) ? Number(v) : 0)
-        }, 0)
-      const producedTotal = sum("produced_quantity", "quantity")
-      const quantityTotal = sum("quantity")
-      const latestCompletedAt = children
-        .map((c) => c?.completed_at)
-        .filter(Boolean)
-        .map((d) => new Date(d).getTime())
-        .reduce((a, b) => Math.max(a, b), 0)
-
+      // Shared with the lifecycle cascade and the repair script so the three
+      // cannot disagree about what a parent's totals are.
       await service.updateProductionRuns({
         id: parentRunId,
         status: "completed" as any,
-        completed_at: latestCompletedAt ? new Date(latestCompletedAt) : new Date(),
-        ...(quantityTotal > 0 ? { quantity: quantityTotal } : {}),
-        ...(producedTotal > 0 ? { produced_quantity: producedTotal } : {}),
+        completed_at: rollup.completed_at ?? new Date(),
+        ...parentTotalsPatch(rollup, { allowFallback: true }),
       })
     })
 

--- a/apps/backend/src/workflows/production-runs/lib/parent-run-rollup.ts
+++ b/apps/backend/src/workflows/production-runs/lib/parent-run-rollup.ts
@@ -1,0 +1,134 @@
+/**
+ * PURE: roll a parent run's totals up from its children (#1877).
+ *
+ * A parent `production_run` is a heading over jobs, not a job — see
+ * `run-kind.ts`. Its `quantity` and `produced_quantity` are meant to be the
+ * SUM of its children's, and three separate places completed a parent:
+ *
+ *   · `complete-production-run.ts` — the inline cascade, which DID reconcile
+ *     totals;
+ *   · `run-production-run-lifecycle.ts` — the signal-driven cascade, which set
+ *     `status` and `completed_at` and **nothing else**;
+ *   · `scripts/repair-stuck-parent-production-runs.ts` — the repair.
+ *
+ * Two of the three summed; the middle one did not. So whether a completed
+ * parent carried the output the partner actually reported came down to which
+ * path happened to fire — and the lifecycle path leaves the parent reading
+ * `produced_quantity: null` with children that each state a real number. Seven
+ * such parents exist in production today. Every downstream reader (cost
+ * summary, payout, provenance, order fulfilment) then falls back to the
+ * ORDERED quantity and quietly assumes it was all made, which is the same
+ * failure `checkCompletionOutput` exists to prevent one level down.
+ *
+ * This is the one place that decides. All three callers use it.
+ */
+
+export type RollupChild = {
+  id?: string | null
+  status?: string | null
+  quantity?: number | string | null
+  produced_quantity?: number | string | null
+  completed_at?: Date | string | null
+}
+
+export type ParentRollup = {
+  /** Every child is `completed` — the precondition for completing the parent. */
+  all_completed: boolean
+  /** Σ children's `quantity`. */
+  quantity: number
+  /**
+   * Σ children's `produced_quantity`, counting ONLY the children that state
+   * one. This is the honest figure: it never invents output for a child that
+   * never reported any.
+   */
+  produced_stated: number
+  /**
+   * Σ children's `produced_quantity`, falling back to the child's ORDERED
+   * `quantity` where it is null.
+   *
+   * ⚠️ This fabricates output for a child that never reported any, so it is
+   * only safe where the completion gate has already run. `checkCompletionOutput`
+   * refuses a completion with `quantity > 0` and no produced figure, so for any
+   * child completed after that gate landed the fallback contributes 0 and is
+   * identical to `produced_stated`. It differs only on rows that predate the
+   * gate — which is exactly where a BACKFILL must not use it.
+   */
+  produced_with_fallback: number
+  /** Children that are completed but state no `produced_quantity`. */
+  children_missing_produced: number
+  /** Latest child `completed_at`, or null if no child carries one. */
+  completed_at: Date | null
+}
+
+const finite = (v: unknown): number | null => {
+  if (v === null || v === undefined || v === "") return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+export function computeParentRollup(
+  children: readonly RollupChild[] | null | undefined
+): ParentRollup {
+  const kids = children ?? []
+
+  let quantity = 0
+  let producedStated = 0
+  let producedWithFallback = 0
+  let missing = 0
+  let latestMs = 0
+
+  for (const c of kids) {
+    const qty = finite(c?.quantity)
+    const produced = finite(c?.produced_quantity)
+
+    if (qty !== null) quantity += qty
+
+    if (produced !== null) {
+      producedStated += produced
+      producedWithFallback += produced
+    } else {
+      missing++
+      if (qty !== null) producedWithFallback += qty
+    }
+
+    const at = c?.completed_at
+    if (at) {
+      const ms = new Date(at).getTime()
+      if (Number.isFinite(ms) && ms > latestMs) latestMs = ms
+    }
+  }
+
+  return {
+    // An empty child set is NOT "all completed" — a parent with no children is
+    // not a rollup and must not be completed by this path.
+    all_completed:
+      kids.length > 0 &&
+      kids.every((c) => String(c?.status || "") === "completed"),
+    quantity,
+    produced_stated: producedStated,
+    produced_with_fallback: producedWithFallback,
+    children_missing_produced: missing,
+    completed_at: latestMs ? new Date(latestMs) : null,
+  }
+}
+
+/**
+ * The `quantity` / `produced_quantity` patch to apply to a parent, given a
+ * rollup. Zero totals are omitted rather than written, so a rollup that
+ * genuinely knows nothing leaves the parent's existing values alone instead of
+ * overwriting them with 0 — `0` and `null` mean different things here and a
+ * reader cannot tell "made none" from "never said".
+ */
+export function parentTotalsPatch(
+  rollup: ParentRollup,
+  opts: { allowFallback?: boolean } = {}
+): { quantity?: number; produced_quantity?: number } {
+  const produced = opts.allowFallback
+    ? rollup.produced_with_fallback
+    : rollup.produced_stated
+
+  return {
+    ...(rollup.quantity > 0 ? { quantity: rollup.quantity } : {}),
+    ...(produced > 0 ? { produced_quantity: produced } : {}),
+  }
+}

--- a/apps/backend/src/workflows/production-runs/run-production-run-lifecycle.ts
+++ b/apps/backend/src/workflows/production-runs/run-production-run-lifecycle.ts
@@ -8,6 +8,10 @@ import {
 
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
+import {
+  computeParentRollup,
+  parentTotalsPatch,
+} from "./lib/parent-run-rollup"
 
 // Timeout: 23 days (matching send-to-partner), capped at Node.js safe max
 const NODE_MAX_TIMEOUT_MS = 2_147_483_647
@@ -115,11 +119,18 @@ const cascadeCompletionStep = createStep(
       parent_run_id: parentRunId,
     } as any)
 
-    const allChildrenCompleted = (children || []).every(
-      (c: any) => String(c?.status || "") === "completed"
-    )
+    /**
+     * This used to set `status` + `completed_at` and nothing else, while the
+     * inline cascade in `complete-production-run.ts` reconciled the parent's
+     * totals from its children. Whichever path happened to fire decided
+     * whether the parent carried the output the partner actually reported —
+     * and this one left it `null`, so every downstream reader fell back to the
+     * ORDERED quantity and assumed it was all made (#1877). Both paths now go
+     * through `computeParentRollup`.
+     */
+    const rollup = computeParentRollup(children as any[])
 
-    if (allChildrenCompleted) {
+    if (rollup.all_completed) {
       const parent = await productionRunService
         .retrieveProductionRun(parentRunId)
         .catch(() => null)
@@ -131,7 +142,8 @@ const cascadeCompletionStep = createStep(
         await productionRunService.updateProductionRuns({
           id: parentRunId,
           status: "completed" as any,
-          completed_at: new Date(),
+          completed_at: rollup.completed_at ?? new Date(),
+          ...parentTotalsPatch(rollup, { allowFallback: true }),
         })
       }
     }


### PR DESCRIPTION
## The defect

Three code paths complete a parent production run. Two of them reconciled the parent's totals from its children; `run-production-run-lifecycle.ts` set `status` and `completed_at` and **nothing else**. So whether a completed parent carried the output the partner actually reported came down to which path happened to fire.

Seven parents in production read `completed` with `produced_quantity: null` while their children each state a real number — **8 units in total**. Every downstream reader (cost summary, payout, provenance, order fulfilment) then falls back to the ORDERED quantity and quietly assumes it was all made. That is the same failure `checkCompletionOutput` exists to prevent one level down.

`repair-stuck-parent-production-runs.ts` could not reach those rows either: it skipped `status === "completed"` as "already correct", which is precisely the shape it was written for.

## What changed

- **`lib/parent-run-rollup.ts`** is now the single place that decides a parent's totals. All three callers use it, so they cannot drift again.
- **The repair** now also backfills already-completed parents, writing only what children actually **stated**. `allowFallback` is off there: a child that never reported output contributes nothing, rather than having what it was *asked* to make promoted into a record of what it *did* make.
- An empty child set is no longer "all completed" (`[].every()` said it was), so this path cannot complete a parent that has no children.
- `produced_quantity: 0` counts as **stated**, not missing — `0` and `null` are different claims.

## The job, and the reason it would not have worked

`backfill-parent-run-produced-quantity` exposes the repair through the Ops console and MCP.

But `run_maintenance_job` advertised `dry_run`, and `dry_run` is the MCP dispatcher's **own** flag: `mcp-core/dispatch.ts:193` intercepts it and returns the planned request without ever calling the route. Through a tool, `dry_run: true` returned no change set and `dry_run: false` was the only way to reach a job — a blind write on production. Because that tool is the generic door to every Data Plumbing job, this applied to **all 101 of them**, not just the new one.

`preview` is the spelling that survives the dispatcher (same fix as #1805). `resolveDryRun` states the precedence once: either spelling explicitly asking for a preview wins, so a contradictory body gets the safe reading and never the write. `dry_run: false` still applies, so the existing Ops console is untouched.

Two admin strings also claimed dry-runs "are not logged" / "are not persisted", directly above a table full of logged dry-runs. Settled against the database, not the copy: `ops_maintenance_run` holds 44 `dry_run=true` rows locally.

## Verification

Exercised end-to-end against a running server and Postgres, not only in tests:

| check | result |
|---|---|
| `preview:true` reaches the job | real change set, 2 parents / 8 units |
| `{preview:false, dry_run:true}` | previews — safe reading wins |
| `preview:false` | applies; rows written |
| re-run | 0 pending, 3 already stated — idempotent |
| UI | job, description and both params render |

Unit specs mutation-checked: forcing the fallback on, letting an empty child set pass, and reverting `bodyParams` to `dry_run` each turn a test red. Integration cases cover a single child, two children (including "parent must not complete early"), a rejected-unit shortfall, and the parent's `completed_at` coming from the child.

`check:prod-build` green. 1121 unit tests green.

## Follow-up, not in this PR

The 7 prod parents are untouched — the job needs running there. And `emit-production-run-reminder.ts` has no `cancelled`/`completed` guard anywhere in the file; whether reminders stop on a cancelled run depends on the upstream selector, which I have not read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp