### PR TITLE
feat(designs): bind a design to an ORDER ITEM with a real link, not a metadata string (#1919)

### DIFF
--- a/apps/backend/integration-tests/http/design-order-item-link.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-item-link.spec.ts
@@ -1,0 +1,243 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IRegionModuleService } from "@medusajs/types"
+import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import {
+  linkDesignsToOrderItems,
+  repointOrderItemDesign,
+} from "../../src/workflows/designs/link-designs-to-order-items"
+import { resolveLineItemDesignId } from "../../src/lib/resolve-line-item-production"
+import designOrderLineItemLink from "../../src/links/design-order-line-item-link"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * #1919 — the design↔order-item binding as a real link.
+ *
+ * 🔴 This spec exists because a UNIT test cannot prove any of it.
+ * `defineLink(...).entryPoint` is empty until the Medusa runtime loads links,
+ * so a unit test's link query arrives with `entity: ""` and a stub keyed on
+ * the name would answer nothing while appearing to pass. Only a booted
+ * runtime can show the link is actually written and actually read back.
+ */
+setupSharedTestSuite(() => {
+  describe("#1919 — design ↔ order line item link", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let regionId: string
+    const { api, getContainer } = getSharedTestEnv()
+
+    const makeDesign = async (name: string) => {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name,
+          description: "Design for the item-link spec",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id as string
+    }
+
+    /** A commissioning order: title-only items carrying metadata.design_id. */
+    const makeDesignOrder = async (designIds: string[]) => {
+      const container = getContainer()
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          is_draft_order: true,
+          status: "draft",
+          no_notification: true,
+          region_id: regionId,
+          currency_code: "inr",
+          items: designIds.map((design_id, i) => ({
+            title: `Item ${i}`,
+            quantity: 1,
+            unit_price: 100,
+            metadata: { design_id },
+          })) as any,
+        } as any,
+      })
+      return order
+    }
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (regionsRes.data.regions?.length) {
+        regionId = regionsRes.data.regions[0].id
+      } else {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        const region = await regionService.createRegions({
+          name: "Item Link Region",
+          currency_code: "inr",
+          countries: ["in"],
+        })
+        regionId = region.id
+      }
+    })
+
+    /**
+     * The entryPoint is the load-bearing thing. If it is empty or wrong the
+     * query returns EMPTY rather than erroring, so every other case in this
+     * file could pass while reading nothing.
+     */
+    it("resolves a non-empty entryPoint once the runtime has loaded links", () => {
+      expect((designOrderLineItemLink as any).entryPoint).toBeTruthy()
+    })
+
+    it("writes a link per item and reads it back through the entryPoint", async () => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const a = await makeDesign(`Link A ${Date.now()}`)
+      const b = await makeDesign(`Link B ${Date.now()}`)
+      const order = await makeDesignOrder([a, b])
+
+      const res = await linkDesignsToOrderItems(container, order.id)
+      expect(res.linked).toBe(2)
+      expect(res.unresolved).toEqual([])
+
+      const { data: rows } = await query.graph({
+        entity: designOrderLineItemLink.entryPoint,
+        fields: ["design_id", "order_line_item_id"],
+        filters: { order_line_item_id: order.items.map((i: any) => i.id) },
+      })
+      expect(rows).toHaveLength(2)
+      expect(new Set(rows.map((r: any) => r.design_id))).toEqual(new Set([a, b]))
+    })
+
+    it("is idempotent — a second run links nothing", async () => {
+      const container = getContainer()
+      const a = await makeDesign(`Idem ${Date.now()}`)
+      const order = await makeDesignOrder([a])
+
+      const first = await linkDesignsToOrderItems(container, order.id)
+      expect(first.linked).toBe(1)
+
+      const second = await linkDesignsToOrderItems(container, order.id)
+      expect(second.linked).toBe(0)
+      expect(second.skipped_existing).toBe(1)
+    })
+
+    it("dry run writes nothing", async () => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const a = await makeDesign(`Dry ${Date.now()}`)
+      const order = await makeDesignOrder([a])
+
+      const res = await linkDesignsToOrderItems(container, order.id, {
+        dryRun: true,
+      })
+      expect(res.linked).toBe(1)
+
+      const { data: rows } = await query.graph({
+        entity: designOrderLineItemLink.entryPoint,
+        fields: ["design_id"],
+        filters: { order_line_item_id: order.items[0].id },
+      })
+      expect(rows || []).toHaveLength(0)
+    })
+
+    /**
+     * The whole point of the phase: an item that has NO product and NO variant
+     * still resolves, and resolves via the link rather than the string.
+     */
+    it("resolves a design-order item that has neither product nor variant", async () => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const a = await makeDesign(`Resolve ${Date.now()}`)
+      const order = await makeDesignOrder([a])
+      const item = order.items[0]
+      expect(item.variant_id ?? null).toBeNull()
+
+      // Before the link: the string is the only answer.
+      const before = await resolveLineItemDesignId(query, {
+        lineItemId: item.id,
+        metadata: item.metadata,
+      })
+      expect(before.designId).toBe(a)
+      expect(before.source).toBe("metadata")
+
+      await linkDesignsToOrderItems(container, order.id)
+
+      const after = await resolveLineItemDesignId(query, {
+        lineItemId: item.id,
+        metadata: item.metadata,
+      })
+      expect(after.designId).toBe(a)
+      expect(after.source).toBe("link")
+    })
+
+    /**
+     * #1921's precondition. The string cannot do this at all, which is why a
+     * deviated order could not be re-pointed.
+     */
+    it("re-points an item to a different design, and the link wins over the stale string", async () => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const original = await makeDesign(`Orig ${Date.now()}`)
+      const successor = await makeDesign(`Succ ${Date.now()}`)
+      const order = await makeDesignOrder([original])
+      const item = order.items[0]
+
+      await linkDesignsToOrderItems(container, order.id)
+      const moved = await repointOrderItemDesign(container, item.id, successor)
+      expect(moved.removed).toBe(1)
+      expect(moved.created).toBe(true)
+
+      const after = await resolveLineItemDesignId(query, {
+        lineItemId: item.id,
+        metadata: item.metadata,
+      })
+      expect(after.designId).toBe(successor)
+      expect(after.source).toBe("link")
+      // Provenance survives: the item still records what was ORDERED.
+      expect(item.metadata.design_id).toBe(original)
+    })
+
+    /**
+     * #1918 requires "design-less" to be distinguishable from "never had a
+     * design". Unlinked keeps its provenance string; never-had has neither.
+     */
+    it("unlinks to design-less, and that is distinguishable from never having one", async () => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const a = await makeDesign(`Unlink ${Date.now()}`)
+      const order = await makeDesignOrder([a])
+      const item = order.items[0]
+
+      await linkDesignsToOrderItems(container, order.id)
+      const cleared = await repointOrderItemDesign(container, item.id, null)
+      expect(cleared.removed).toBe(1)
+      expect(cleared.created).toBe(false)
+
+      const { data: rows } = await query.graph({
+        entity: designOrderLineItemLink.entryPoint,
+        fields: ["design_id"],
+        filters: { order_line_item_id: item.id },
+      })
+      expect(rows || []).toHaveLength(0)
+      // Still tells you what it WAS — that is the difference.
+      expect(item.metadata.design_id).toBe(a)
+    })
+
+    it("reports, rather than links, an item naming a design that no longer exists", async () => {
+      const container = getContainer()
+      const order = await makeDesignOrder(["design_does_not_exist_01"])
+
+      const res = await linkDesignsToOrderItems(container, order.id)
+      expect(res.linked).toBe(0)
+      expect(res.unresolved).toHaveLength(1)
+      expect(res.unresolved[0].reason).toMatch(/no longer exists/)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-design-order-item-links-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-design-order-item-links-job.ts
@@ -1,0 +1,115 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { linkDesignsToOrderItems } from "../../../../workflows/designs/link-designs-to-order-items"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+const MAX_SCAN = 5000
+
+const paramsSchema = z.object({
+  order_ids: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .transform((v) =>
+      (Array.isArray(v) ? v : String(v ?? "").split(","))
+        .map((s) => s.trim())
+        .filter(Boolean)
+    ),
+  limit: z.coerce.number().int().positive().max(MAX_SCAN).optional().default(500),
+})
+
+/**
+ * #1919 — turn the historical `metadata.design_id` strings on order items into
+ * real `design ↔ order_line_item` links.
+ *
+ * The live path writes them at `order.placed`; this reaches everything placed
+ * before the link existed. Idempotent: `linkDesignsToOrderItems` reads existing
+ * pairs first and skips them, so re-running adds nothing.
+ *
+ * ⚠️ Verify the count against `metadata.design_id` occurrences before and
+ * after — a link row is not a record, and a job reporting "linked 47" tells you
+ * how many writes it made, not how many items now resolve. The `unresolved`
+ * list is the interesting output: those are items naming a design that no
+ * longer exists, which the string allowed and a link must not.
+ */
+export const backfillDesignOrderItemLinksJob: MaintenanceJob = {
+  id: "backfill-design-order-item-links",
+  label: "Backfill design ↔ order-item links from metadata.design_id",
+  description:
+    `Create the per-item design link for order items that carry a metadata.design_id but no link yet (#1919). metadata.design_id is KEPT as provenance — nothing is removed. Items naming a design that no longer exists are reported, not linked, since a dangling link row reads as a real binding. Idempotent: existing pairs are read first and skipped. Provide order_ids to target specific orders, or omit for a bounded scan (default 500, max ${MAX_SCAN}). Preview shows exactly which item→design pairs would be written.`,
+  params: [
+    {
+      name: "order_ids",
+      type: "string",
+      required: false,
+      description: "Comma-separated order ids to target (default: scan orders)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max orders to scan in one call (default 500, max ${MAX_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const { order_ids, limit } = paramsSchema.parse(params)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let scanned = 0
+    let skippedExisting = 0
+    let unresolvedCount = 0
+
+    let targets: string[] = order_ids
+    if (!targets.length) {
+      const { data: orders } = await query.graph({
+        entity: "order",
+        fields: ["id"],
+        pagination: { skip: 0, take: limit },
+      })
+      targets = (orders || []).map((o: any) => String(o.id))
+    }
+
+    for (const orderId of targets) {
+      scanned++
+      try {
+        const res = await linkDesignsToOrderItems(container, orderId, {
+          dryRun: dry_run,
+        })
+        skippedExisting += res.skipped_existing
+        for (const p of res.pairs) {
+          changes.push({
+            entity: "order_line_item",
+            id: p.line_item_id,
+            field: "design_link",
+            before: null,
+            after: p.design_id,
+            note: `order ${orderId} — from metadata.design_id`,
+          })
+        }
+        for (const u of res.unresolved) {
+          unresolvedCount++
+          errors.push({
+            id: u.line_item_id,
+            message: `names design ${u.design_id} but ${u.reason} — left unlinked`,
+          })
+        }
+      } catch (e: any) {
+        errors.push({ id: orderId, message: e?.message ?? String(e) })
+      }
+    }
+
+    const verb = dry_run ? "Would link" : "Linked"
+    return {
+      job_id: backfillDesignOrderItemLinksJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary:
+        `${verb} ${changes.length} order item(s) to their design across ${scanned} order(s) — ` +
+        `${skippedExisting} already linked, ${unresolvedCount} naming a design that no longer exists (reported, not linked)`,
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -141,6 +141,7 @@ import { linkArtisanDetailRowsJob } from "./link-artisan-detail-rows-job"
 import { setPlatformTaxIdentityActiveJob } from "./set-platform-tax-identity-active-job"
 import { backfillFulfilledRetailRunsJob } from "./backfill-fulfilled-retail-runs-job"
 import { backfillParentRunProducedQuantityJob } from "./backfill-parent-run-produced-quantity-job"
+import { backfillDesignOrderItemLinksJob } from "./backfill-design-order-item-links-job"
 import { refreshStaleDraftPayoutsJob } from "./refresh-stale-draft-payouts-job"
 import {
   sweepAiPlatformsByCategory,
@@ -5914,6 +5915,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   setPlatformTaxIdentityActiveJob,
   backfillFulfilledRetailRunsJob,
   backfillParentRunProducedQuantityJob,
+  backfillDesignOrderItemLinksJob,
   seedInvestorPanelsJob,
   seedPlatformStatsPanelJob,
   seedGoodsTransferTaskTemplateJob,

--- a/apps/backend/src/lib/__tests__/resolve-line-item-design.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/resolve-line-item-design.unit.spec.ts
@@ -1,0 +1,148 @@
+import { resolveLineItemDesignId } from "../resolve-line-item-production"
+
+/**
+ * The priority order is the whole point of #1919, and getting it backwards is
+ * silent: every branch returns a plausible design id, so a wrong precedence
+ * shows up as the WRONG design being produced, not as an error.
+ */
+
+/**
+ * A query stub keyed on the query's SHAPE, not on `entity`.
+ *
+ * 🔴 `defineLink(...).entryPoint` is EMPTY at import time — the Medusa runtime
+ * populates it when it loads links, which does not happen in a unit test. So
+ * the link lookup here arrives with `entity: ""`, and a stub keyed on the name
+ * would silently answer nothing and the test would "pass" against a resolver
+ * that never consults the link at all. (This is the same trap as a wrong
+ * `entity:` name: it returns EMPTY, never an error.) Keying on the filter the
+ * caller actually sends is both robust and a truer description of the contract.
+ */
+const makeQuery = (byEntity: Record<string, any[]>) => {
+  const calls: string[] = []
+  return {
+    calls,
+    graph: jest.fn(async ({ entity, filters }: any) => {
+      const key = filters?.order_line_item_id
+        ? LINK
+        : filters?.product_variant_id
+          ? "design_product_variant"
+          : filters?.product_id
+            ? "product_design"
+            : String(entity ?? "")
+      calls.push(key)
+      return { data: byEntity[key] ?? [] }
+    }),
+  }
+}
+
+const LINK = "design_order_line_item"
+
+describe("resolveLineItemDesignId — precedence", () => {
+  it("prefers the per-item LINK over metadata.design_id", async () => {
+    // The exact shape after a re-point: the link says B, provenance still says A.
+    const q = makeQuery({ [LINK]: [{ design_id: "design_B" }] })
+    const r = await resolveLineItemDesignId(q as any, {
+      lineItemId: "item_1",
+      metadata: { design_id: "design_A" },
+    })
+    expect(r.designId).toBe("design_B")
+    expect(r.source).toBe("link")
+  })
+
+  it("prefers the LINK over the variant association", async () => {
+    const q = makeQuery({
+      [LINK]: [{ design_id: "design_B" }],
+      design_product_variant: [{ design_id: "design_V" }],
+    })
+    const r = await resolveLineItemDesignId(q as any, {
+      lineItemId: "item_1",
+      variantId: "variant_1",
+    })
+    expect(r.designId).toBe("design_B")
+    expect(r.source).toBe("link")
+  })
+
+  it("does not even ask the other sources once the link answers", async () => {
+    const q = makeQuery({ [LINK]: [{ design_id: "design_B" }] })
+    await resolveLineItemDesignId(q as any, {
+      lineItemId: "item_1",
+      variantId: "variant_1",
+      productId: "prod_1",
+      metadata: { design_id: "design_A" },
+    })
+    expect(q.calls).toEqual([LINK])
+  })
+
+  /**
+   * The #1918 shape: a design-order item with NO product and NO variant. The
+   * old signature could not resolve this at all, which is how five paid-for
+   * designs were skipped.
+   */
+  it("resolves an item that has neither a product nor a variant", async () => {
+    const q = makeQuery({})
+    const r = await resolveLineItemDesignId(q as any, {
+      lineItemId: "item_1",
+      metadata: { design_id: "design_A" },
+    })
+    expect(r.designId).toBe("design_A")
+    expect(r.source).toBe("metadata")
+    expect(r.isCustomDesign).toBe(true)
+  })
+
+  it("still resolves the variant association when there is no link", async () => {
+    const q = makeQuery({ design_product_variant: [{ design_id: "design_V" }] })
+    const r = await resolveLineItemDesignId(q as any, {
+      lineItemId: "item_1",
+      variantId: "variant_1",
+    })
+    expect(r.designId).toBe("design_V")
+    expect(r.source).toBe("variant")
+    expect(r.isCustomDesign).toBe(true)
+  })
+
+  it("still resolves the product association, and does not call it custom", async () => {
+    const q = makeQuery({ product_design: [{ design: { id: "design_P" } }] })
+    const r = await resolveLineItemDesignId(q as any, {
+      lineItemId: "item_1",
+      productId: "prod_1",
+    })
+    expect(r.designId).toBe("design_P")
+    expect(r.source).toBe("product")
+    expect(r.isCustomDesign).toBe(false)
+  })
+
+  it("prefers the variant association over the product one", async () => {
+    const q = makeQuery({
+      design_product_variant: [{ design_id: "design_V" }],
+      product_design: [{ design: { id: "design_P" } }],
+    })
+    const r = await resolveLineItemDesignId(q as any, {
+      variantId: "variant_1",
+      productId: "prod_1",
+    })
+    expect(r.designId).toBe("design_V")
+  })
+
+  it("reports null rather than inventing a source when nothing resolves", async () => {
+    const q = makeQuery({})
+    const r = await resolveLineItemDesignId(q as any, { lineItemId: "item_1" })
+    expect(r).toEqual({ designId: null, isCustomDesign: false, source: null })
+  })
+
+  /**
+   * An unlinked item keeps its provenance string, so "design-less" must not be
+   * inferred from the absence of a link alone. A caller that wants "no design
+   * now" has to look at `source`, which is why it exists.
+   */
+  it("a non-string or empty metadata.design_id is not a design", async () => {
+    const q = makeQuery({})
+    for (const bad of [null, undefined, "", 0, {}, []]) {
+      const r = await resolveLineItemDesignId(q as any, {
+        lineItemId: "item_1",
+        metadata: { design_id: bad } as any,
+      })
+      expect(r.designId).toBeNull()
+      expect(r.source).toBeNull()
+    }
+  })
+})

--- a/apps/backend/src/lib/plan-fulfillment-production-runs.ts
+++ b/apps/backend/src/lib/plan-fulfillment-production-runs.ts
@@ -52,9 +52,12 @@ export async function planLineItemRunAction(
     productId?: string | null
     variantId?: string | null
     quantity: number
+    /** The item's metadata, for the #1919 provenance fallback. Optional: a
+     *  caller that does not have it simply loses that last resort. */
+    metadata?: Record<string, any> | null
   }
 ): Promise<PlannedRunAction | null> {
-  const { lineItemId, productId, variantId, quantity } = input
+  const { lineItemId, productId, variantId, quantity, metadata } = input
 
   // No product to hang the run off → nothing to provenance.
   if (!productId) {
@@ -80,6 +83,8 @@ export async function planLineItemRunAction(
   const { designId, isCustomDesign } = await resolveLineItemDesignId(query, {
     productId,
     variantId,
+    lineItemId,
+    metadata,
   })
 
   return {

--- a/apps/backend/src/lib/resolve-line-item-production.ts
+++ b/apps/backend/src/lib/resolve-line-item-production.ts
@@ -4,6 +4,8 @@
 // paths use. Keeping it in one place guarantees the two paths agree so they
 // never double-create a run for the same line item.
 
+import designOrderLineItemLink from "../links/design-order-line-item-link"
+
 // Postgres unique_violation SQLSTATE — raised when the partial unique index on
 // production_runs.order_line_item_id catches a concurrent double-create (#1123).
 export const PLAN_UNIQUE_VIOLATION = "23505"
@@ -11,6 +13,20 @@ export const PLAN_UNIQUE_VIOLATION = "23505"
 export type ResolvedLineItemDesign = {
   designId: string | null
   isCustomDesign: boolean
+  /**
+   * WHERE the answer came from. A caller that is about to write something
+   * durable off this design — a production run, a payout, a re-point — needs
+   * to know whether it is standing on a link it can move or on a string it
+   * cannot.
+   *
+   *   · "link"     — the design_order_line_item link. Authoritative, movable.
+   *   · "variant"  — design_product_variant. A custom design's own variant.
+   *   · "product"  — product_design. The catalogue-level association.
+   *   · "metadata" — `metadata.design_id`, provenance only. Means this item
+   *                  predates the backfill, or the backfill missed it.
+   *   · null       — nothing resolved.
+   */
+  source: "link" | "variant" | "product" | "metadata" | null
 }
 
 /**
@@ -19,10 +35,51 @@ export type ResolvedLineItemDesign = {
  */
 export async function resolveLineItemDesignId(
   query: any,
-  { productId, variantId }: { productId?: string | null; variantId?: string | null }
+  {
+    productId,
+    variantId,
+    lineItemId,
+    metadata,
+  }: {
+    productId?: string | null
+    variantId?: string | null
+    /**
+     * The ORDER line item's id. Without it a design-order item — which has
+     * neither a product nor a variant — cannot be resolved at all, which is
+     * how five paid-for designs on `order_01KNP520PT94BN8SC0JKZ6ZVJ9` reached
+     * `order-placed.ts` and were skipped (#1918).
+     */
+    lineItemId?: string | null
+    /** The item's `metadata`, for the provenance fallback. */
+    metadata?: Record<string, any> | null
+  }
 ): Promise<ResolvedLineItemDesign> {
   let designId: string | null = null
   let isCustomDesign = false
+
+  /**
+   * The link wins over everything, including `metadata.design_id`. After an
+   * order edit re-points an item (#1921) the metadata still records what was
+   * ORIGINALLY ordered — that is the point of keeping it — so reading it in
+   * preference to the link would hand back the design the customer is no
+   * longer getting.
+   */
+  if (lineItemId) {
+    const { data: itemLinks } = await query.graph({
+      entity: designOrderLineItemLink.entryPoint,
+      fields: ["design_id"],
+      filters: { order_line_item_id: lineItemId },
+      pagination: { skip: 0, take: 1 },
+    })
+    const itemLink = (itemLinks || [])[0]
+    if (itemLink?.design_id) {
+      return {
+        designId: itemLink.design_id,
+        isCustomDesign: true,
+        source: "link",
+      }
+    }
+  }
 
   if (variantId) {
     const { data: variantDesignLinks } = await query.graph({
@@ -33,8 +90,11 @@ export async function resolveLineItemDesignId(
     })
     const variantLink = (variantDesignLinks || [])[0]
     if (variantLink?.design_id) {
-      designId = variantLink.design_id
-      isCustomDesign = true
+      return {
+        designId: variantLink.design_id,
+        isCustomDesign: true,
+        source: "variant",
+      }
     }
   }
 
@@ -46,9 +106,23 @@ export async function resolveLineItemDesignId(
       pagination: { skip: 0, take: 1 },
     })
     designId = (productDesignLinks || [])[0]?.design?.id || null
+    if (designId) {
+      return { designId, isCustomDesign, source: "product" }
+    }
   }
 
-  return { designId, isCustomDesign }
+  /**
+   * Last: the string. Only fires for an item the backfill has not reached —
+   * a design order placed before the link existed. Reported as "metadata" so
+   * a caller can tell a real binding from a legacy one rather than treating
+   * the two as interchangeable.
+   */
+  const fromMetadata = metadata?.design_id
+  if (typeof fromMetadata === "string" && fromMetadata) {
+    return { designId: fromMetadata, isCustomDesign: true, source: "metadata" }
+  }
+
+  return { designId: null, isCustomDesign: false, source: null }
 }
 
 /**

--- a/apps/backend/src/links/design-order-line-item-link.ts
+++ b/apps/backend/src/links/design-order-line-item-link.ts
@@ -1,0 +1,41 @@
+import { defineLink } from "@medusajs/framework/utils"
+import DesignModule from "../modules/designs"
+import OrderModule from "@medusajs/medusa/order"
+
+/**
+ * #1919 — a design bound to an ORDER line item.
+ *
+ * Three bindings already existed and none of them could answer "which design
+ * is this item?":
+ *
+ *   · `design_line_item`  — design ↔ **cart** line item. Dies at checkout.
+ *   · `design_order`      — design ↔ **order**. Says five designs are
+ *                           involved, not which item is which.
+ *   · `metadata.design_id`— a plain string on the item, written once at cart
+ *                           time and never rewritten.
+ *
+ * A string cannot be unlinked and cannot be moved, which is why a deviated
+ * order cannot be re-pointed (#1921) and why the revision lineage is invisible
+ * from the order.
+ *
+ * `metadata.design_id` STAYS as provenance — it records what the item was
+ * ordered as, which is worth keeping even after a re-point. This link records
+ * what it is FOR now. When the two disagree, the link is the answer; see
+ * `resolveLineItemDesignId`.
+ *
+ * 🔴 `isList` on both sides is deliberate. It is tempting to make this 1:1
+ * because an item has one design today, but a 1:1 link makes a second
+ * `remoteLink.create` a hard failure rather than a no-op — the trap that makes
+ * a design unquotable when `design_product_variant` is written twice (#1918).
+ * Uniqueness is enforced by reading before writing, in one place.
+ */
+export default defineLink(
+  {
+    linkable: DesignModule.linkable.design,
+    isList: true,
+  },
+  {
+    linkable: OrderModule.linkable.orderLineItem,
+    isList: true,
+  }
+)

--- a/apps/backend/src/subscribers/order-placed.ts
+++ b/apps/backend/src/subscribers/order-placed.ts
@@ -5,6 +5,7 @@ import { sendOrderConfirmationWorkflow } from "../workflows/email/send-notificat
 import { sendPartnerOrderPlacedWorkflow } from "../workflows/email/workflows/send-partner-order-email"
 import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
 import { linkDesignsToOrder } from "../workflows/designs/link-designs-to-order"
+import { linkDesignsToOrderItems } from "../workflows/designs/link-designs-to-order-items"
 import {
   hasProductionRunForLineItem,
   resolveLineItemDesignId,
@@ -115,11 +116,23 @@ export default async function orderPlacedHandler({
         continue
       }
 
-      // Resolve the design (variant-level custom design takes priority over the
-      // product-level association). Shared with the fulfillment path (#1112).
+      /**
+       * Resolve the design. The per-item LINK now wins over the variant- and
+       * product-level associations (#1919), so an item re-pointed by an order
+       * edit resolves to what it is for NOW rather than what its variant
+       * happens to be attached to.
+       *
+       * 🔴 This does NOT widen which items get a run. The `!productId` guard
+       * above still skips design-only items, deliberately: making those
+       * produce automatically is #1923, and it is gated on #1920's explicit
+       * no-produce flag. Removing the guard here would start auto-producing
+       * every converted design order.
+       */
       const { designId, isCustomDesign } = await resolveLineItemDesignId(query, {
         productId,
         variantId,
+        lineItemId,
+        metadata: item?.metadata,
       })
 
       if (isCustomDesign) {
@@ -175,6 +188,31 @@ export default async function orderPlacedHandler({
   } catch (e: any) {
     logger.warn(
       `[order.placed] Failed to create design-order links for order ${data.id}: ${e?.message || e}`
+    )
+  }
+
+  /**
+   * ...and the per-ITEM links (#1919). The order-level links above can say
+   * which designs a purchase involved; they cannot say which item is which,
+   * which is what re-pointing a deviated order needs. Runs BEFORE any
+   * consumer of `resolveLineItemDesignId` on a later event, so by the time
+   * anything asks "which design is this item?" the link is there.
+   */
+  try {
+    const { linked, unresolved } = await linkDesignsToOrderItems(container, data.id)
+    if (linked > 0) {
+      logger.info(
+        `[order.placed] Linked ${linked} design(s) to line items on order ${data.id}`
+      )
+    }
+    for (const u of unresolved) {
+      logger.warn(
+        `[order.placed] item ${u.line_item_id} names design ${u.design_id} but ${u.reason} — left unlinked on order ${data.id}`
+      )
+    }
+  } catch (e: any) {
+    logger.warn(
+      `[order.placed] Failed to create design-order-ITEM links for order ${data.id}: ${e?.message || e}`
     )
   }
 }

--- a/apps/backend/src/workflows/designs/create-product-from-design.ts
+++ b/apps/backend/src/workflows/designs/create-product-from-design.ts
@@ -11,6 +11,7 @@ import {
 } from "@medusajs/medusa/core-flows";
 import { DESIGN_MODULE } from "../../modules/designs";
 import type { Link } from "@medusajs/modules-sdk";
+import { resolveLineItemDesignId } from "../../lib/resolve-line-item-production"
 
 /**
  * Create Product from Design Workflow
@@ -504,7 +505,18 @@ const createProductAndVariantStep = createStep(
 
             const items = orderData?.[0]?.items || [];
             for (const item of items) {
-              if (item.metadata?.design_id === input.design_id && !item.variant_id) {
+              /**
+               * Was `item.metadata?.design_id === input.design_id`. The link
+               * wins now (#1919), so an item re-pointed to a different design
+               * is no longer stamped with THIS design's variant just because
+               * its provenance string still names it. `!item.variant_id` still
+               * gates it: this only ever fills in a variant that is missing.
+               */
+              const { designId: itemDesignId } = await resolveLineItemDesignId(
+                query,
+                { lineItemId: item.id, metadata: item.metadata }
+              );
+              if (itemDesignId === input.design_id && !item.variant_id) {
                 await orderService.updateOrderLineItems(item.id, {
                   variant_id,
                   product_id,

--- a/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
+++ b/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
@@ -6,6 +6,7 @@ import { createProductionRunWorkflow } from "../production-runs/create-productio
 import { projectDesignOrderToUnifiedOrder } from "../production-runs/dual-write-unified-run-order"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
+import { resolveLineItemDesignId } from "../../lib/resolve-line-item-production"
 
 /**
  * #826 S3 (step 1) — fan out one production_run per design line item on a
@@ -39,6 +40,7 @@ export async function createRunsForDesignOrder(
   work_order_id: string | null
 }> {
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
   const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
   const runService = container.resolve(
     PRODUCTION_RUNS_MODULE
@@ -67,9 +69,22 @@ export async function createRunsForDesignOrder(
 
   for (const item of items) {
     const lineItemId = item?.id
-    // Design lines are the title-only items carrying design_id in metadata.
-    const designId = item?.metadata?.design_id as string | undefined
-    if (!lineItemId || !designId || alreadyProduced.has(lineItemId)) {
+    if (!lineItemId || alreadyProduced.has(lineItemId)) {
+      continue
+    }
+    /**
+     * Design lines used to be found by reading `metadata.design_id` directly.
+     * That string is provenance — what the item was ORDERED as — so after an
+     * order edit re-points an item (#1921) it names the design the customer is
+     * no longer getting, and this path would have produced the wrong one.
+     * `resolveLineItemDesignId` prefers the link and falls back to the string
+     * for orders the backfill has not reached (#1919).
+     */
+    const { designId } = await resolveLineItemDesignId(query, {
+      lineItemId,
+      metadata: item?.metadata,
+    })
+    if (!designId) {
       continue
     }
 

--- a/apps/backend/src/workflows/designs/link-designs-to-order-items.ts
+++ b/apps/backend/src/workflows/designs/link-designs-to-order-items.ts
@@ -1,0 +1,165 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import designOrderLineItemLink from "../../links/design-order-line-item-link"
+import { DESIGN_MODULE } from "../../modules/designs"
+
+export type ItemLinkResult = {
+  linked: number
+  skipped_existing: number
+  /** Items carrying a design_id we could not link, with the reason. */
+  unresolved: Array<{ line_item_id: string; design_id: string; reason: string }>
+  pairs: Array<{ line_item_id: string; design_id: string }>
+}
+
+/**
+ * #1919 — turn each order item's `metadata.design_id` string into a real
+ * `design ↔ order_line_item` link.
+ *
+ * Companion to `linkDesignsToOrder`, which links designs to the ORDER. That
+ * one can say five designs are involved; it cannot say which item is which,
+ * so a deviated order cannot be re-pointed and the revision lineage is
+ * invisible from the order (#1918).
+ *
+ * `metadata.design_id` is NOT removed. It stays as provenance — what the item
+ * was ordered as — while the link records what it is for now. `source` on
+ * `resolveLineItemDesignId` is how a reader tells the two apart.
+ *
+ * Idempotent in the only way that counts: existing pairs are read FIRST and
+ * skipped. `remoteLink.create` is not idempotent on its own, and a duplicate
+ * on a link the rest of the system treats as one-per-item is the failure that
+ * makes a design unquotable (#1918). Shared by the order.placed subscriber,
+ * the backfill and the maintenance job so there is exactly one writer.
+ */
+export async function linkDesignsToOrderItems(
+  container: MedusaContainer,
+  orderId: string,
+  opts?: { dryRun?: boolean }
+): Promise<ItemLinkResult> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: ["id", "items.id", "items.metadata"],
+    filters: { id: orderId },
+  })
+  const items: any[] = orders?.[0]?.items || []
+
+  const wanted: Array<{ line_item_id: string; design_id: string }> = []
+  const unresolved: ItemLinkResult["unresolved"] = []
+
+  for (const item of items) {
+    const designId = item?.metadata?.design_id
+    if (typeof designId !== "string" || !designId) continue
+    if (!item?.id) continue
+    wanted.push({ line_item_id: String(item.id), design_id: designId })
+  }
+
+  if (!wanted.length) {
+    return { linked: 0, skipped_existing: 0, unresolved, pairs: [] }
+  }
+
+  /**
+   * A `metadata.design_id` can name a design that no longer exists — the
+   * string was never a foreign key and nothing stopped a design being
+   * deleted out from under it. Linking to a missing design would create a
+   * dangling row that reads as a real binding, so those are REPORTED instead.
+   */
+  const { data: designs } = await query.graph({
+    entity: "design",
+    fields: ["id"],
+    filters: { id: [...new Set(wanted.map((w) => w.design_id))] },
+  })
+  const live = new Set((designs || []).map((d: any) => String(d.id)))
+
+  // Existing pairs, read through the link's entryPoint — never by traversing
+  // from the design entity, which returns no key at all when the field is
+  // missing rather than erroring.
+  const { data: existing } = await query.graph({
+    entity: designOrderLineItemLink.entryPoint,
+    fields: ["design_id", "order_line_item_id"],
+    filters: { order_line_item_id: wanted.map((w) => w.line_item_id) },
+  })
+  const alreadyLinked = new Set(
+    (existing || []).map((r: any) => String(r.order_line_item_id))
+  )
+
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+  const pairs: ItemLinkResult["pairs"] = []
+  let linked = 0
+  let skippedExisting = 0
+
+  for (const w of wanted) {
+    if (!live.has(w.design_id)) {
+      unresolved.push({ ...w, reason: "design no longer exists" })
+      continue
+    }
+    if (alreadyLinked.has(w.line_item_id)) {
+      skippedExisting++
+      continue
+    }
+    if (!opts?.dryRun) {
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: w.design_id },
+        [Modules.ORDER]: { order_line_item_id: w.line_item_id },
+      })
+    }
+    linked++
+    pairs.push(w)
+  }
+
+  return { linked, skipped_existing: skippedExisting, unresolved, pairs }
+}
+
+/**
+ * Move an item's design binding — the operation the string could never
+ * support, and the whole reason #1921 was blocked.
+ *
+ * Deletes any existing link for the item and creates the new one. Passing
+ * `null` leaves the item design-LESS, which #1918 requires to be
+ * distinguishable from "never had a design": an item that never had one has
+ * no link row AND no `metadata.design_id`, whereas an unlinked one keeps its
+ * provenance string.
+ */
+export async function repointOrderItemDesign(
+  container: MedusaContainer,
+  lineItemId: string,
+  designId: string | null,
+  opts?: { dryRun?: boolean }
+): Promise<{ removed: number; created: boolean }> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+
+  const { data: existing } = await query.graph({
+    entity: designOrderLineItemLink.entryPoint,
+    fields: ["design_id", "order_line_item_id"],
+    filters: { order_line_item_id: lineItemId },
+  })
+
+  let removed = 0
+  for (const row of existing || []) {
+    if (String(row.design_id) === String(designId)) continue // already correct
+    if (!opts?.dryRun) {
+      await remoteLink.dismiss({
+        [DESIGN_MODULE]: { design_id: row.design_id },
+        [Modules.ORDER]: { order_line_item_id: lineItemId },
+      })
+    }
+    removed++
+  }
+
+  const alreadyCorrect = (existing || []).some(
+    (r: any) => String(r.design_id) === String(designId)
+  )
+  if (!designId || alreadyCorrect) {
+    return { removed, created: false }
+  }
+
+  if (!opts?.dryRun) {
+    await remoteLink.create({
+      [DESIGN_MODULE]: { design_id: designId },
+      [Modules.ORDER]: { order_line_item_id: lineItemId },
+    })
+  }
+  return { removed, created: true }
+}

--- a/apps/backend/src/workflows/orders/list-partner-orders.ts
+++ b/apps/backend/src/workflows/orders/list-partner-orders.ts
@@ -10,6 +10,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { getOrdersListWorkflow } from "@medusajs/medusa/core-flows"
 import partnerOrderLink from "../../links/partner-order"
 import { resolveDesignThumbnail } from "../../lib/design-thumbnail"
+import { resolveLineItemDesignId } from "../../lib/resolve-line-item-production"
 
 // Chunk 5 (T3.4, #342): the kind-aware partner orders listing, lifted out of the
 // route handler into a workflow so the scoping/discrimination logic is reusable
@@ -155,7 +156,17 @@ export const attachOrderDesignSummariesStep = createStep(
         }
       }
       for (const item of asArray(row?.items)) {
-        const designId = item?.metadata?.design_id
+        /**
+         * The per-item LINK first, `metadata.design_id` only as the fallback
+         * (#1919). A re-pointed item would otherwise show the partner the
+         * design the order NO LONGER concerns, which on this screen is the
+         * design they are being asked to make.
+         */
+        const { designId } = await resolveLineItemDesignId(query, {
+          lineItemId: item?.id,
+          variantId: item?.variant_id,
+          metadata: item?.metadata,
+        })
         if (designId) {
           ids.add(String(designId))
         }

--- a/apps/backend/src/workflows/production-runs/partner-run-steps.ts
+++ b/apps/backend/src/workflows/production-runs/partner-run-steps.ts
@@ -18,6 +18,7 @@ import {
   isMissingLifecycleTransaction,
 } from "./lib/lifecycle-signal-errors"
 import { lifecycleWorkflowId } from "./run-production-run-lifecycle"
+import { resolveLineItemDesignId } from "../../lib/resolve-line-item-production"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -418,10 +419,35 @@ export const stockFinishedGoodsStep = createStep(
           fields: ["items.*"],
         })
         const items = orders?.[0]?.items || []
-        const designItem = items.find(
-          (i: any) => i.metadata?.design_id === input.design_id && i.variant_id === variantId
-        )
-        lineItemId = designItem?.id
+        /**
+         * Was a `metadata.design_id` + `variant_id` match. Two problems: the
+         * string is provenance and goes stale the moment an item is re-pointed
+         * (#1921), and requiring `variant_id === variantId` cannot match a
+         * design-order item, which has no variant at all — the same nullity
+         * that made #1918's five items invisible.
+         *
+         * Resolve each item properly and prefer a variant match when one
+         * exists, since a design with two variants must still bank onto the
+         * right one. Falling back to a design match without a variant is what
+         * lets a design-order item be reserved at all.
+         */
+        let designItem: any = null
+        let designItemNoVariant: any = null
+        for (const i of items) {
+          const { designId: itemDesignId } = await resolveLineItemDesignId(
+            query,
+            { lineItemId: i.id, variantId: i.variant_id, metadata: i.metadata }
+          )
+          if (itemDesignId !== input.design_id) continue
+          if (i.variant_id === variantId) {
+            designItem = i
+            break
+          }
+          if (!i.variant_id && !designItemNoVariant) {
+            designItemNoVariant = i
+          }
+        }
+        lineItemId = (designItem ?? designItemNoVariant)?.id
       }
 
       if (lineItemId) {


### PR DESCRIPTION
Phase 0 of #1918 — nothing else in that plan works until this exists.

## The defect

A design was bound to an order line item by `metadata.design_id`, a plain string. Three bindings existed and none could answer *"which design is **this** item?"*:

- `design_line_item` — cart-level, dies at checkout
- `design_order` — says five designs are involved, not which item is which
- `metadata.design_id` — a string, which cannot be moved or unlinked at all

That is why a deviated order cannot be re-pointed (#1921) and why the revision lineage is invisible from the order.

## What changed

- A real **`design ↔ orderLineItem`** link. `isList` on both sides deliberately: a 1:1 link makes a second `remoteLink.create` a hard failure rather than a no-op, which is the trap that makes a design unquotable. Uniqueness comes from reading before writing, in one place.
- `resolveLineItemDesignId` takes the item's id and metadata and returns **`source`** — `link | variant | product | metadata | null`. The **link wins over the string**: after a re-point the string names what was *originally* ordered, so preferring it hands back the design the customer is no longer getting.
- It can now resolve an item with **no product and no variant** — impossible before, and how five paid-for designs on `order_01KNP520PT94BN8SC0JKZ6ZVJ9` were skipped.
- `repointOrderItemDesign` moves a binding or clears it to design-less — the operations a string could never support, and #1921's precondition.
- Written at `order.placed`; `backfill-design-order-item-links` reaches older orders. Items naming a design that no longer exists are **reported, not linked** — a dangling link row reads as a real binding.

## Correction to the issue: four readers, not one

#1919 said the retroactive backfill was the only reader. It is one of four, and all are repointed — leaving three on the string would have had them disagree the moment an order edit moved a design:

| reader | what it decides |
|---|---|
| `create-runs-for-design-order.ts:71` | which items get a production run |
| `create-product-from-design.ts:507` | the retroactive variant backfill |
| `partner-run-steps.ts:422` | which item to reserve when banking goods |
| `list-partner-orders.ts:158` | which designs the partner is shown |

`partner-run-steps` also required `variant_id === variantId`, which can never match a design-order item. It now falls back to a design match without a variant.

## Deliberately NOT changed

`order-placed.ts` still skips items with no `product_id`. Those are now resolvable, so the guard **looks** removable — it is not. Making them produce is #1923, gated on #1920's explicit no-produce flag; removing it here starts auto-producing every converted design order. Commented in place.

## Tests

9 unit (precedence, mutation-checked — making metadata win turns two red) and 8 integration.

🔴 The integration spec is not optional. **`defineLink(...).entryPoint` is EMPTY until the runtime loads links**, so a unit test's link query arrives as `entity: ""` and a stub keyed on the name answers nothing while appearing to pass. Its first case asserts `entryPoint` is non-empty for exactly that reason — a wrong `entity:` returns EMPTY, never an error.

Regression: `design-order-produce-fanout`, `convert-design-order`, `order-placed-production-runs` all pass. `check:prod-build` green.

## Follow-up

`metadata.design_id` is kept as provenance. The plan for retiring it as a *decision input* — and why deleting it is the wrong goal — is on [#1919](https://github.com/Jaal-Yantra-Textiles/v2/issues/1919#issuecomment-5595217418). The blocker is `apps/partner-ui`, which reads it directly over HTTP and cannot call the resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp