### PR TITLE
fix(designs): "do not produce" is an explicit flag, not a missing variant_id (#1920)

### DIFF
--- a/apps/backend/src/lib/plan-fulfillment-production-runs.ts
+++ b/apps/backend/src/lib/plan-fulfillment-production-runs.ts
@@ -5,7 +5,9 @@
 //
 // Per fulfilled line item:
 //   - no run yet            → CREATE a completed provenance run (design-backed
-//                             or product-only), born terminal (goods shipped).
+//                             or product-only), born terminal (goods shipped),
+//                             UNLESS the item carries #1920's explicit
+//                             `no_auto_produce` veto.
 //   - run still pre-prod    → COMPLETE it (the order.placed run for a
 //     (draft/pending_review)  design-backed line never went through production;
 //                             the goods shipped from stock — #1126).
@@ -13,6 +15,7 @@
 
 import {
   getProductionRunForLineItem,
+  isAutoProduceSuppressed,
   resolveLineItemDesignId,
 } from "./resolve-line-item-production"
 
@@ -77,6 +80,16 @@ export async function planLineItemRunAction(
       }
     }
     // Already in production or completed — leave it untouched.
+    return null
+  }
+
+  /**
+   * #1920 — an explicit no-auto-produce veto blocks CREATION only, and only
+   * here at the automatic door. It is checked AFTER the existing-run branch on
+   * purpose: completing a run that an admin already created explicitly is not
+   * auto-production, and a shipped design order should still close its run.
+   */
+  if (isAutoProduceSuppressed(metadata)) {
     return null
   }
 

--- a/apps/backend/src/lib/resolve-line-item-production.ts
+++ b/apps/backend/src/lib/resolve-line-item-production.ts
@@ -198,3 +198,46 @@ export function isOwnedProvenanceRun(
   if (!run) return false
   return run.metadata?.source === "order.fulfillment_created"
 }
+
+/**
+ * #1920 (item 3) — "do not auto-produce this line item", as an EXPLICIT flag.
+ *
+ * Until now the suppression was an EMERGENT PROPERTY of a missing field:
+ * `convert-design-order.ts` builds TITLE-ONLY order items, so the automatic
+ * run-creation paths hit `if (!productId) continue` and skipped them. Nothing
+ * anywhere said "don't produce this" — the absence of a `product_id` said it,
+ * by accident.
+ *
+ * That coincidence is load-bearing in two directions and wrong in both:
+ *
+ *  · #1919 made design-order items RESOLVABLE, so the `!productId` guard now
+ *    looks like dead weight. Remove it without this flag and every converted
+ *    design order starts auto-producing customer orders.
+ *  · The same absent field ALSO suppressed five paid-for design items on
+ *    `order_01KNP520PT94BN8SC0JKZ6ZVJ9` that SHOULD have produced (#1918).
+ *    One condition was standing in for two opposite intentions.
+ *
+ * So: the intention is now written down. `no_auto_produce: true` on an order
+ * item's metadata means an AUTOMATIC door must not create a run for it. It says
+ * nothing about the EXPLICIT door — `createRunsForDesignOrder` is precisely the
+ * admin saying "produce this now", and deliberately ignores the flag.
+ *
+ * Absence of the flag is not permission on its own; it just means this
+ * particular veto was never cast.
+ */
+export const NO_AUTO_PRODUCE_METADATA_KEY = "no_auto_produce"
+
+/**
+ * True when the item carries an explicit no-auto-produce veto.
+ *
+ * Accepts the boolean `true` and the string `"true"`: metadata is JSONB and
+ * round-trips through the admin UI, MCP tools and CSV-ish imports, any of which
+ * can hand back a string. Everything else — `false`, `"false"`, `0`, `""`,
+ * `null`, absent — is NOT a veto.
+ */
+export function isAutoProduceSuppressed(
+  metadata?: Record<string, any> | null
+): boolean {
+  const raw = metadata?.[NO_AUTO_PRODUCE_METADATA_KEY]
+  return raw === true || raw === "true"
+}

--- a/apps/backend/src/subscribers/order-placed.ts
+++ b/apps/backend/src/subscribers/order-placed.ts
@@ -8,6 +8,7 @@ import { linkDesignsToOrder } from "../workflows/designs/link-designs-to-order"
 import { linkDesignsToOrderItems } from "../workflows/designs/link-designs-to-order-items"
 import {
   hasProductionRunForLineItem,
+  isAutoProduceSuppressed,
   resolveLineItemDesignId,
 } from "../lib/resolve-line-item-production"
 import { lineItemIdsNeedingShippingFlag } from "../lib/requires-shipping"
@@ -107,7 +108,28 @@ export default async function orderPlacedHandler({
       const variantId = item?.variant_id
       const quantity = item?.quantity
 
-      if (!lineItemId || !productId) {
+      if (!lineItemId) {
+        continue
+      }
+
+      /**
+       * #1920 — the EXPLICIT no-auto-produce veto, checked first and on its own
+       * terms. `convert-design-order` stamps it on every item of an admin-
+       * converted design order; producing one of those is an explicit admin
+       * step (`createRunsForDesignOrder`), never a side-effect of placement.
+       *
+       * This is deliberately independent of `productId`: when #1923 widens the
+       * guard below so design-only items DO produce, this flag is what still
+       * holds the converted orders back.
+       */
+      if (isAutoProduceSuppressed(item?.metadata)) {
+        logger.info(
+          `[order.placed] Line item ${lineItemId} carries no_auto_produce — skipping production run creation (#1920)`
+        )
+        continue
+      }
+
+      if (!productId) {
         continue
       }
 
@@ -123,10 +145,11 @@ export default async function orderPlacedHandler({
        * happens to be attached to.
        *
        * 🔴 This does NOT widen which items get a run. The `!productId` guard
-       * above still skips design-only items, deliberately: making those
-       * produce automatically is #1923, and it is gated on #1920's explicit
-       * no-produce flag. Removing the guard here would start auto-producing
-       * every converted design order.
+       * above still skips design-only items; making those produce
+       * automatically is #1923. The converted design orders that MUST stay
+       * unproduced now say so themselves, via the no_auto_produce check above
+       * (#1920), so #1923 can lift the productId guard without unleashing
+       * them.
        */
       const { designId, isCustomDesign } = await resolveLineItemDesignId(query, {
         productId,

--- a/apps/backend/src/workflows/designs/__tests__/no-auto-produce-flag.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/no-auto-produce-flag.unit.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * #1920 item 3 — "do not produce" is an EXPLICIT flag, not the accident of a
+ * missing `product_id`.
+ *
+ * Three halves have to agree, so all three are exercised here:
+ *   1. the WRITER  — convert-design-order stamps the veto on every order item;
+ *   2. the READERS — both automatic run-creation doors honour it;
+ *   3. the helper  — and it only reads as a veto when it really is one.
+ */
+
+jest.mock("@medusajs/medusa/core-flows", () => ({
+  convertDraftOrderWorkflow: jest.fn(() => ({ run: jest.fn(async () => ({ result: {} })) })),
+  createOrderPaymentCollectionWorkflow: jest.fn(() => ({
+    run: jest.fn(async () => ({ result: { id: "paycol_1" } })),
+  })),
+  createOrderWorkflow: jest.fn(),
+  markPaymentCollectionAsPaid: jest.fn(() => ({ run: jest.fn(async () => ({ result: {} })) })),
+}))
+
+import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
+import { convertDesignOrderToOrder } from "../convert-design-order"
+import {
+  NO_AUTO_PRODUCE_METADATA_KEY,
+  isAutoProduceSuppressed,
+} from "../../../lib/resolve-line-item-production"
+import { planLineItemRunAction } from "../../../lib/plan-fulfillment-production-runs"
+
+const CART = {
+  id: "cart_1",
+  region_id: "reg_1",
+  currency_code: "inr",
+  sales_channel_id: "sc_1",
+  customer_id: "cus_1",
+  email: "buyer@example.com",
+  completed_at: null,
+  metadata: {},
+  shipping_address: { first_name: "A", address_1: "1 St", city: "Bhuj", country_code: "in" },
+  billing_address: null,
+  items: [
+    {
+      id: "li_1",
+      title: "Ajrakh Jacket",
+      quantity: 2,
+      unit_price: 4500,
+      metadata: { design_id: "des_1", cost_confidence: "high" },
+    },
+  ],
+}
+
+const buildContainer = () => {
+  const cartService = {
+    listLineItems: jest.fn(async () => [{ id: "li_1", cart_id: "cart_1" }]),
+    updateCarts: jest.fn(async () => ({})),
+  }
+  const query = {
+    graph: jest.fn(async ({ entity }: any) =>
+      entity === "cart" ? { data: [CART] } : { data: [{ design_id: "des_1", line_item_id: "li_1" }] }
+    ),
+  }
+  const remoteLink = { create: jest.fn(async () => ({})) }
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  const registry: Record<string, any> = {
+    logger,
+    query,
+    link: remoteLink,
+    cart: cartService,
+    order: { updateOrders: jest.fn(async () => ({})) },
+  }
+  return {
+    resolve: jest.fn((key: string) => registry[key]),
+  } as any
+}
+
+describe("#1920 — the writer stamps an explicit no-auto-produce veto", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it("puts no_auto_produce on EVERY converted order item, alongside the design metadata", async () => {
+    ;(createOrderWorkflow as unknown as jest.Mock).mockReturnValue({
+      run: jest.fn(async () => ({
+        result: { id: "order_1", display_id: 42, status: "draft", payment_status: "captured" },
+      })),
+    })
+
+    await convertDesignOrderToOrder(buildContainer(), {
+      lineItemId: "li_1",
+      paymentMode: "cod",
+    })
+
+    // Assert AFTER the call, on what the real code handed to core.
+    const runMock = (createOrderWorkflow as unknown as jest.Mock).mock.results[0].value.run
+    const items = runMock.mock.calls[0][0].input.items
+
+    expect(items).toHaveLength(1)
+    expect(items[0].metadata[NO_AUTO_PRODUCE_METADATA_KEY]).toBe(true)
+    expect(items[0].metadata.no_auto_produce_reason).toBe("design-order-convert")
+    // and the veto did not cost us the design provenance it travels with
+    expect(items[0].metadata.design_id).toBe("des_1")
+    expect(isAutoProduceSuppressed(items[0].metadata)).toBe(true)
+  })
+})
+
+describe("#1920 — the automatic fulfillment door honours the veto", () => {
+  const query = { graph: jest.fn() }
+
+  it("does NOT create a provenance run for a vetoed item, even with a product_id", async () => {
+    // No existing run for this line item …
+    query.graph = jest.fn(async () => ({ data: [] }))
+
+    const action = await planLineItemRunAction(query, {
+      lineItemId: "li_1",
+      productId: "prod_1",
+      quantity: 1,
+      metadata: { [NO_AUTO_PRODUCE_METADATA_KEY]: true },
+    })
+
+    expect(action).toBeNull()
+  })
+
+  it("still COMPLETES an existing pre-production run on a vetoed item — the veto blocks creation only", async () => {
+    query.graph = jest.fn(async () => ({
+      data: [{ id: "prun_1", status: "draft", produced_quantity: null, design_id: "des_1", metadata: {} }],
+    }))
+
+    const action = await planLineItemRunAction(query, {
+      lineItemId: "li_1",
+      productId: "prod_1",
+      quantity: 1,
+      metadata: { [NO_AUTO_PRODUCE_METADATA_KEY]: true },
+    })
+
+    expect(action?.action).toBe("complete")
+    expect((action as any).production_run_id).toBe("prun_1")
+  })
+
+  it("still CREATES for the same item once the veto is absent (the veto is what stops it)", async () => {
+    query.graph = jest.fn(async () => ({ data: [] }))
+
+    const action = await planLineItemRunAction(query, {
+      lineItemId: "li_1",
+      productId: "prod_1",
+      quantity: 1,
+      metadata: { design_id: "des_1" },
+    })
+
+    expect(action?.action).toBe("create")
+  })
+})
+
+describe("#1920 — isAutoProduceSuppressed reads a veto only where one was cast", () => {
+  it.each([
+    [{ no_auto_produce: true }, true],
+    [{ no_auto_produce: "true" }, true],
+    [{ no_auto_produce: false }, false],
+    [{ no_auto_produce: "false" }, false],
+    [{ no_auto_produce: 0 }, false],
+    [{ no_auto_produce: "" }, false],
+    [{ no_auto_produce: null }, false],
+    [{ design_id: "des_1" }, false],
+    [{}, false],
+    [null, false],
+    [undefined, false],
+  ])("%j → %s", (metadata, expected) => {
+    expect(isAutoProduceSuppressed(metadata as any)).toBe(expected)
+  })
+})

--- a/apps/backend/src/workflows/designs/convert-design-order.ts
+++ b/apps/backend/src/workflows/designs/convert-design-order.ts
@@ -13,6 +13,7 @@ import {
 } from "@medusajs/medusa/core-flows"
 import { DESIGN_MODULE } from "../../modules/designs"
 import designLineItemLink from "../../links/design-line-item-link"
+import { NO_AUTO_PRODUCE_METADATA_KEY } from "../../lib/resolve-line-item-production"
 
 /**
  * #404 (#31) PR-A — admin "Convert to Order" for a design order.
@@ -36,9 +37,13 @@ import designLineItemLink from "../../links/design-line-item-link"
  * it composes core workflows the same way the partner routes do.
  *
  * PLACED side-effects (order-placed.ts) are deliberately safe here:
- *  - Line items are TITLE-ONLY (no product_id/variant_id), so the subscriber's
- *    production-run branch (`if (!productId) continue`) is skipped — converting
- *    a customer design order must NOT spawn a production work-order.
+ *  - Every order item is stamped `metadata.no_auto_produce: true` (#1920), so
+ *    the subscriber's production-run branch skips it BY DECISION rather than by
+ *    the accident of a missing product_id — converting a customer design order
+ *    must NOT spawn a production work-order. Producing one is an explicit admin
+ *    step (`createRunsForDesignOrder`), which ignores the flag on purpose.
+ *  - Line items remain TITLE-ONLY (no product_id/variant_id); that is now a
+ *    consequence of the cart's shape, not the thing suppressing production.
  *  - The cartless draft has no order↔cart link, so the subscriber's cart-based
  *    linkDesignsToOrder finds nothing; we link the design(s) EXPLICITLY below.
  *  - `no_notification: true` suppresses the customer order-confirmation email on
@@ -166,8 +171,9 @@ export async function convertDesignOrderToOrder(
     )
   }
 
-  // 3. Build TITLE-ONLY order items (see header: keeps the PLACED subscriber
-  // from spawning a production run for a customer design order).
+  // 3. Build TITLE-ONLY order items, each carrying the EXPLICIT no-auto-produce
+  // veto (#1920). The title-only shape is still what the cart gives us, but it
+  // is no longer what STOPS the production run: the flag is, and it says so.
   const orderItems = lineItems.map((li) => ({
     title: li.title,
     quantity: li.quantity,
@@ -175,6 +181,8 @@ export async function convertDesignOrderToOrder(
     metadata: {
       ...(li.metadata || {}),
       source_cart_line_item_id: li.id,
+      [NO_AUTO_PRODUCE_METADATA_KEY]: true,
+      no_auto_produce_reason: "design-order-convert",
     },
   }))
 

--- a/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
+++ b/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
@@ -14,10 +14,13 @@ import { resolveLineItemDesignId } from "../../lib/resolve-line-item-production"
  *
  * A design commissioning order (created by createDraftOrderFromDesignsWorkflow +
  * convert-design-order) carries one TITLE-ONLY line item per design, each with
- * `metadata.design_id`. Auto-run-creation is DELIBERATELY off for these (the
- * line items have no product_id precisely so order-placed skips them — see
- * convert-design-order header). Producing a design order is therefore an
- * explicit admin step: this function.
+ * `metadata.design_id`. Auto-run-creation is DELIBERATELY off for these: since
+ * #1920 every such item is stamped `metadata.no_auto_produce: true`, and both
+ * automatic doors (order.placed, order.fulfillment_created) honour it.
+ *
+ * 🔑 This function is the EXPLICIT door and ignores the flag by design — it IS
+ * the admin saying "produce this now". Do not add an `isAutoProduceSuppressed`
+ * check here; doing so would make design orders unproduceable altogether.
  *
  * Each run is stamped with `order_id` = the commissioning order and
  * `order_line_item_id` = its design line. `order_id` is the group key the


### PR DESCRIPTION
Part of #1920 (item 3), parent #1918.

## The problem

Converting a design order to a real order deliberately does **not** spawn a production run. Until now nothing said so. `convert-design-order` built TITLE-ONLY order items, and the automatic run-creation doors hit `if (!productId) continue`. **The absence of a field was carrying the decision.**

That coincidence is wrong in both directions:

- #1919 made design-order items *resolvable*, so the `!productId` guard now looks like dead weight. Removing it without a flag would start auto-producing every converted customer order.
- The same absent field **also** suppressed five paid-for design items on `order_01KNP520PT94BN8SC0JKZ6ZVJ9` that *should* have produced (#1918). One condition was standing in for two opposite intentions.

## The change

| file | what |
|---|---|
| `lib/resolve-line-item-production.ts` | `NO_AUTO_PRODUCE_METADATA_KEY` + `isAutoProduceSuppressed`, beside the resolver both run-creation paths already import — so they cannot drift |
| `workflows/designs/convert-design-order.ts` | stamps `no_auto_produce: true` + a reason on every order item it creates |
| `subscribers/order-placed.ts` | checks the veto **first**, independent of `productId`, so #1923 can lift that guard without unleashing converted orders |
| `lib/plan-fulfillment-production-runs.ts` | honours it for **creation only** — completing a run an admin already made explicitly is not auto-production, so a shipped design order still closes its run |
| `workflows/designs/create-runs-for-design-order.ts` | documented as the EXPLICIT door that ignores the flag by design; adding a check there would make design orders unproduceable altogether |

The reader accepts `true` and `"true"` only. Metadata is JSONB and round-trips through the admin UI and MCP tools, but `false`, `"false"`, `0`, `""` and `null` are **not** vetoes.

## Verification

- 15 unit tests in `workflows/designs/__tests__/no-auto-produce-flag.unit.spec.ts`, covering the writer (asserted on what the real code handed to `createOrderWorkflow`), both readers, and the truth table.
- **Reverted each half and watched the matching test go red** (2 failed, 13 passed) before restoring.
- `tsc --noEmit` clean on every touched file; `pnpm check:prod-build` exit 0.

## Not in this PR

The rest of #1920 — collapsing the three mint doors into `ensureDesignQuoteVariantWorkflow`, retiring `promote-design-to-product` and its dead subscriber, and passing `customer_id` through. This item was called out as "before anything else in this issue" and stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp