### PR TITLE
feat(tasks): the Photo Shoot category, its templates, and an MCP door to make more (#1920)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -3746,6 +3746,75 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     ],
   },
   {
+    name: "create_task_template",
+    description:
+      "Create a task template — a reusable process step that production-run dispatch can attach to a run. Use it when the work a run needs has no template yet (a photoshoot stage, a new finishing service), because dispatch resolves templates BY NAME and a name that does not exist fails the whole dispatch with 'Missing task templates'. 🔑 ALWAYS call list_task_templates first: 23+ already exist, names are not unique across categories, and creating a near-duplicate ('Stitching' when 'Stitching (Pre Production)' is what you meant) makes every later dispatch ambiguous. Give the template a `category_id` from that listing — CATEGORIES CANNOT BE CREATED through this API (the categories route is read-only), so a step in a category that does not exist yet needs the matching Data Plumbing seed job instead. Cost and duration are what make a step accountable rather than a checkbox: `estimated_cost` + `cost_currency` and `estimated_duration` (MINUTES) are copied onto every task dispatched from it. ⚠️ `required_fields` must be an OBJECT here — the route's validator declares `z.record`, so the ARRAY form used by the in-process seeds (ship-to-next-location, the photoshoot templates) is REJECTED with a 400. A template needing array-shaped field configs has to be seeded, not created here. [sensitive: requires confirm:true]",
+    method: "POST",
+    path: "/admin/task-templates",
+    bodyParams: [
+      "name",
+      "description",
+      "category_id",
+      "estimated_duration",
+      "estimated_cost",
+      "cost_currency",
+      "priority",
+      "required_fields",
+      "eventable",
+      "notifiable",
+      "message_template",
+      "metadata",
+    ],
+    write: true,
+    sensitive: true,
+    inputSchema: obj(
+      {
+        name: STR(
+          "The template's name. This is the DISPATCH KEY — runs are dispatched by name, so make it unambiguous across categories (prefer 'Stitching (Finishing)' over 'Stitching'). Required."
+        ),
+        description: STR(
+          "What the step actually involves, written for the partner who will do it. Required by the route — not optional."
+        ),
+        category_id: STR(
+          "The category this step belongs to, from list_task_templates' `category.id`. Omit only for a deliberately uncategorised step."
+        ),
+        estimated_duration: INT(
+          "Expected hands-on time in MINUTES — not hours, and not elapsed/transit time. Copied onto each dispatched task."
+        ),
+        estimated_cost: {
+          type: "number",
+          description:
+            "Default cost of this step, per task, in `cost_currency`. Omit for our own time rather than sending 0 — a 0 asserts the step is free, which is a different claim from 'not costed'.",
+        },
+        cost_currency: STR(
+          "Currency of estimated_cost, e.g. 'INR'. Send it whenever estimated_cost is set; a cost with no currency cannot be added up."
+        ),
+        priority: STR("'low' | 'medium' | 'high'. Defaults to 'medium'."),
+        required_fields: {
+          type: "object",
+          description:
+            "Field configuration the task collects, as an OBJECT keyed by field name. ⚠️ An ARRAY is rejected by the validator (see the tool description) even though the seeded templates carry one.",
+          additionalProperties: true,
+        },
+        eventable: BOOL("Whether completing this task emits an event."),
+        notifiable: BOOL("Whether this task notifies the assignee."),
+        message_template: STR(
+          "Notification body, with {{placeholders}} — e.g. 'Order {{order_id}} has been sent to partner.'"
+        ),
+        metadata: {
+          type: "object",
+          description:
+            "Free-form template metadata. Conventionally carries `entity` (what it attaches to, e.g. 'production_run') and, for a step the partner UI renders a real form for, `action` + `endpoint`.",
+          additionalProperties: true,
+        },
+      },
+      ["name", "description"]
+    ),
+    sideEffects:
+      "Creates a task template that becomes dispatchable by name immediately. It is not attached to any run until a dispatch names it.",
+    nextSteps: ["list_task_templates", "send_production_run_to_production"],
+  },
+  {
     name: "redispatch_parked_production_runs",
     description:
       "Re-send production runs parked in 'awaiting_reassignment' back to the PARTNER THEY CAME FROM, and dispatch them again — the batch answer to 'this partner says they'll take their lapsed runs now'. Each run goes to its own previous_partner_id; partner_id only FILTERS which parked runs are considered, so this can never hand one partner's work to another. THE DRY-RUN RECOVERS WHAT EACH RUN WAS DISPATCHED WITH LAST TIME (from its own tasks) and lists every available template, so you can show the user a real selection instead of asking them to remember: read `would_redispatch[].previous_template_names` and `available_template_names`. Then confirm with use_previous_templates:true to send each run back with ITS OWN set (parked runs usually do NOT share one), or template_names/template_ids to override them all. Recovered history dispatches by template ID where it identified one, so a run that used 'Stitching (Production)' cannot come back as 'Stitching (Pre Production)'; a run that would go out on an AMBIGUOUS name is reported as would_fail_on_ambiguous_name and must be given template_ids. Dry-run by default. Sensitive: requires confirm:true.",

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -6,6 +6,12 @@ import { DESIGN_MODULE } from "../../../../modules/designs"
 import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
 import { TASKS_MODULE } from "../../../../modules/tasks"
 import { TEMPLATE_DEF } from "../../../../scripts/seed-goods-transfer-task-template"
+import {
+  PHOTOSHOOT_CATEGORY_DEF,
+  PHOTOSHOOT_CATEGORY_NAME,
+  PHOTOSHOOT_TEMPLATE_DEFS,
+  photoshootBudget,
+} from "../../../../scripts/seed-photoshoot-task-templates"
 import { CONSUMPTION_LOG_MODULE } from "../../../../modules/consumption_log"
 import { RAW_MATERIAL_MODULE } from "../../../../modules/raw_material"
 import { buildGroupColorTitle } from "../../../../modules/raw_material/lib/group-order-helpers"
@@ -5816,6 +5822,124 @@ export const seedGoodsTransferTaskTemplateJob: MaintenanceJob = {
   },
 }
 
+// seed-photoshoot-task-templates (#1920) — install the "Photo Shoot" category
+// and its four templates. The shoot is the gate between "we made it" and "we
+// can sell it" (approval only reaches Commerce_Ready once the design's media
+// folder holds an image), and it was the one step in that chain with no task
+// behind it — 23 templates in prod and not one covering it.
+//
+// Idempotent in BOTH directions: an existing category is reused rather than
+// duplicated, and an existing template of the same name is left ALONE. Operators
+// edit durations, costs and wording, and a re-run must never undo that. Partial
+// installs re-run safely — only what is missing gets created.
+// ---------------------------------------------------------------------------
+
+export const seedPhotoshootTaskTemplatesJob: MaintenanceJob = {
+  id: "seed-photoshoot-task-templates",
+  label: "Install the 'Photo Shoot' task category and templates",
+  description:
+    "Create the Photo Shoot category and its four templates — styling, capture, retouch, upload (#1920). A produced garment is not sellable until it has been photographed, which is why run approval only reaches Commerce_Ready once the design's media folder holds an image; these make that work assignable, schedulable and COSTED, which it was not before. Each carries a starting estimated_cost and estimated_duration that operators are expected to tune. Dry-run reports exactly what is missing; apply creates only that. Never overwrites an existing category or template.",
+  params: [],
+  run: async (container, { dry_run }) => {
+    const taskService: any = container.resolve(TASKS_MODULE)
+
+    // 1. The category, found by name or created once.
+    const existingCategories = await taskService.listTaskCategories({
+      name: [PHOTOSHOOT_CATEGORY_NAME],
+    })
+    let categoryId: string | null = existingCategories?.[0]?.id ?? null
+    const categoryExisted = Boolean(categoryId)
+
+    if (!categoryId && !dry_run) {
+      const created = await taskService.createTaskCategories(
+        PHOTOSHOOT_CATEGORY_DEF as any
+      )
+      categoryId = (Array.isArray(created) ? created[0] : created)?.id ?? null
+    }
+
+    // 2. Which templates are already there. One read for all of them, so a
+    //    partial install is reported as a partial install rather than a clash.
+    const names = PHOTOSHOOT_TEMPLATE_DEFS.map((t) => t.name)
+    const existingTemplates = await taskService.listTaskTemplates({ name: names })
+    const present = new Set(
+      (existingTemplates ?? []).map((t: any) => t.name).filter(Boolean)
+    )
+    const missing = PHOTOSHOOT_TEMPLATE_DEFS.filter((t) => !present.has(t.name))
+
+    const changes: any[] = []
+
+    if (!categoryExisted) {
+      changes.push({
+        entity: "task_category",
+        id: categoryId ?? "(new)",
+        field: "created",
+        after: { name: PHOTOSHOOT_CATEGORY_NAME },
+      })
+    }
+
+    for (const def of missing) {
+      let createdId: string | null = null
+      if (!dry_run) {
+        const created = await taskService.createTaskTemplates({
+          ...def,
+          // `category_id` only when we have one — a template with no category
+          // is valid, and is better than one pointing at nothing.
+          ...(categoryId ? { category_id: categoryId } : {}),
+        } as any)
+        createdId = (Array.isArray(created) ? created[0] : created)?.id ?? null
+      }
+      changes.push({
+        entity: "task_template",
+        id: createdId ?? "(new)",
+        field: "created",
+        after: {
+          name: def.name,
+          stage: def.metadata.stage,
+          estimated_cost: def.estimated_cost,
+          cost_currency: def.cost_currency,
+          estimated_duration: def.estimated_duration,
+        },
+      })
+    }
+
+    const budget = photoshootBudget()
+    const budgetNote = `One full shoot budgets ${budget.cost} ${
+      budget.currency ?? ""
+    } and ${budget.minutes} minutes across the four steps.`.trim()
+
+    if (!changes.length) {
+      return {
+        job_id: seedPhotoshootTaskTemplatesJob.id,
+        dry_run,
+        applied: false,
+        summary: `Photo Shoot category and all ${names.length} templates already installed — nothing to do, and nothing overwritten. Edit them under Settings → Task Templates. ${budgetNote}`,
+        changes: [],
+      }
+    }
+
+    const what = [
+      categoryExisted ? null : `the "${PHOTOSHOOT_CATEGORY_NAME}" category`,
+      missing.length
+        ? `${missing.length} of ${names.length} template(s) (${missing
+            .map((m) => m.name)
+            .join(", ")})`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(" and ")
+
+    return {
+      job_id: seedPhotoshootTaskTemplatesJob.id,
+      dry_run,
+      applied: !dry_run,
+      summary: dry_run
+        ? `Would create ${what} — nothing written. ${budgetNote}`
+        : `Created ${what}. Attach them to a production run's dispatch step list to schedule the shoot. ${budgetNote}`,
+      changes,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   reconcileOrderBalancesJob,
   cancelInactiveProductionRunsJob,
@@ -5919,6 +6043,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   seedInvestorPanelsJob,
   seedPlatformStatsPanelJob,
   seedGoodsTransferTaskTemplateJob,
+  seedPhotoshootTaskTemplatesJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -203,6 +203,10 @@ const NO_ROUTE_VALIDATOR = new Set<string>([
  *     come back, not a claim that the omission is correct.
  */
 const DELIBERATELY_OMITTED: Record<string, Record<string, string>> = {
+  "admin:create_task_template": {
+    category:
+      "the validator accepts BOTH `category` (a bare string) and `category_id`, and only the id resolves to a real row — offering both would invite a model to name a category in prose and get a template attached to nothing",
+  },
   "admin:create_social_post": {
     post_url: "set by the publisher callback, not by the author",
     posted_at: "as post_url",

--- a/apps/backend/src/scripts/seed-photoshoot-task-templates.ts
+++ b/apps/backend/src/scripts/seed-photoshoot-task-templates.ts
@@ -1,0 +1,184 @@
+/**
+ * #1920 — the Photo Shoot task category and its templates.
+ *
+ * ## Why these exist
+ *
+ * A produced garment is not sellable until it has been PHOTOGRAPHED. That is
+ * why `applyRunApprovals` only moves a design to `Commerce_Ready` once its
+ * linked media folder holds an image — the shoot is the gate between "we made
+ * it" and "we can sell it".
+ *
+ * Until now the shoot was the one step in that chain nobody could see. There
+ * are 23 task templates in production and not one of them covers it, so the
+ * work that decides whether a design ever reaches the catalogue was happening
+ * off the system entirely — unassignable, unscheduled and uncosted.
+ *
+ * ## Why they carry a cost and a duration
+ *
+ * Production-run dispatch resolves templates BY NAME and copies
+ * `estimated_cost` / `estimated_duration` onto the task it creates. Costing the
+ * shoot is the point: a photoshoot is real money and real hours spent on a
+ * design AFTER production, and nothing in the design's cost estimate accounts
+ * for it today. `estimate-design-cost` totals
+ * `material_cost + production_cost + platform_fee` and stops there.
+ *
+ * 🔴 These figures are STARTING points, per shoot unless the name says
+ * otherwise, and deliberately conservative. They are what an operator edits in
+ * Settings → Task Templates once real shoots have been run — which is exactly
+ * why the installer never overwrites an existing template.
+ *
+ * ## What they are NOT
+ *
+ * Attaching these does not itself make anything `Commerce_Ready`. The status
+ * asks for the photographs, not for a ticked box: a task marked done with no
+ * images behind it is a claim, and the folder is the artefact. The tasks are
+ * how the work gets assigned, scheduled and paid for; the images are how it
+ * gets believed.
+ *
+ * Exported as plain definitions so the CLI seed and the Data Plumbing console
+ * job share one source of truth — the pattern
+ * `seed-goods-transfer-task-template` established.
+ */
+
+export const PHOTOSHOOT_CATEGORY_NAME = "Photo Shoot"
+
+export const PHOTOSHOOT_CATEGORY_DEF = {
+  name: PHOTOSHOOT_CATEGORY_NAME,
+  description:
+    "Everything between finished goods and a sellable listing: styling, the shoot itself, retouching, and getting the images onto the design.",
+}
+
+export type PhotoshootTemplateDef = {
+  name: string
+  description: string
+  priority: "low" | "medium" | "high"
+  estimated_duration: number
+  estimated_cost: number | null
+  cost_currency: string | null
+  eventable: boolean
+  notifiable: boolean
+  required_fields: Array<Record<string, any>>
+  metadata: Record<string, any>
+}
+
+/**
+ * Ordered as the work actually happens. Each is separately assignable because
+ * they are routinely done by different people — a stylist, a photographer and
+ * a retoucher are three bookings, not one.
+ */
+export const PHOTOSHOOT_TEMPLATE_DEFS: PhotoshootTemplateDef[] = [
+  {
+    name: "photoshoot-styling",
+    description:
+      "Prepare the produced garment for the camera: press and steam, style with props or a model, and set the look. Blocks the shoot itself.",
+    priority: "medium",
+    estimated_duration: 90,
+    estimated_cost: 1500,
+    cost_currency: "INR",
+    eventable: true,
+    notifiable: true,
+    required_fields: [
+      {
+        name: "styling_notes",
+        type: "text",
+        required: false,
+        label: "Styling notes",
+        help: "How the piece should be shown — on a model, flat lay, on a form.",
+      },
+    ],
+    metadata: { entity: "production_run", issue: "1920", stage: "styling" },
+  },
+  {
+    name: "photoshoot-capture",
+    description:
+      "Shoot the garment. Covers the photographer's time, studio or location, and lighting. The output is raw frames, not the final images.",
+    priority: "high",
+    estimated_duration: 180,
+    estimated_cost: 6000,
+    cost_currency: "INR",
+    eventable: true,
+    notifiable: true,
+    required_fields: [
+      {
+        name: "shoot_type",
+        type: "enum",
+        required: true,
+        label: "Shoot type",
+        options: ["studio", "location", "flat_lay", "on_model", "detail"],
+      },
+      {
+        name: "frames_captured",
+        type: "number",
+        required: false,
+        label: "Frames captured",
+      },
+    ],
+    metadata: { entity: "production_run", issue: "1920", stage: "capture" },
+  },
+  {
+    name: "photoshoot-retouch",
+    description:
+      "Select, colour-correct and retouch the frames worth keeping. Colour accuracy matters here — a customer returns a garment that arrives a different shade from the photograph.",
+    priority: "medium",
+    estimated_duration: 120,
+    estimated_cost: 2500,
+    cost_currency: "INR",
+    eventable: true,
+    notifiable: true,
+    required_fields: [
+      {
+        name: "images_delivered",
+        type: "number",
+        required: false,
+        label: "Images delivered",
+      },
+    ],
+    metadata: { entity: "production_run", issue: "1920", stage: "retouch" },
+  },
+  {
+    name: "photoshoot-upload",
+    description:
+      "Put the finished images in the design's linked media folder. 🔑 This is the step that actually makes the design Commerce_Ready — approval reads the FOLDER, not this task, so a design whose images never land here stays at Approved no matter how many tasks are ticked.",
+    priority: "high",
+    estimated_duration: 30,
+    // Our own time, not a billable outside cost.
+    estimated_cost: null,
+    cost_currency: null,
+    eventable: true,
+    notifiable: true,
+    required_fields: [
+      {
+        name: "media_folder_id",
+        type: "text",
+        required: true,
+        label: "Design media folder",
+        help: "The folder linked to the design. Images landing anywhere else do not count.",
+      },
+    ],
+    metadata: { entity: "production_run", issue: "1920", stage: "upload" },
+  },
+]
+
+/** Every template name this seed owns — the installer's idempotency key. */
+export const PHOTOSHOOT_TEMPLATE_NAMES = PHOTOSHOOT_TEMPLATE_DEFS.map(
+  (t) => t.name
+)
+
+/**
+ * What one full shoot is budgeted at, per design. Summed from the definitions
+ * rather than written down twice, so editing a template moves the number and
+ * nothing drifts. `null` costs (our own time) contribute nothing.
+ */
+export function photoshootBudget(
+  defs: PhotoshootTemplateDef[] = PHOTOSHOOT_TEMPLATE_DEFS
+): { cost: number; currency: string | null; minutes: number } {
+  const currency =
+    defs.find((d) => d.estimated_cost != null && d.cost_currency)
+      ?.cost_currency ?? null
+
+  return {
+    cost: defs.reduce((s, d) => s + (Number(d.estimated_cost) || 0), 0),
+    currency,
+    minutes: defs.reduce((s, d) => s + (Number(d.estimated_duration) || 0), 0),
+  }
+}

--- a/apps/backend/src/workflows/designs/list-designs.ts
+++ b/apps/backend/src/workflows/designs/list-designs.ts
@@ -21,7 +21,7 @@ export type ListDesignsStepInput = {
     q?: string;
     name?: string;
     design_type?: "Original" | "Derivative" | "Custom" | "Collaboration";
-    status?: "Conceptual" | "In_Development" | "Technical_Review" | "Sample_Production" | "Revision" | "Approved" | "Rejected" | "On_Hold";
+    status?: "Conceptual" | "In_Development" | "Technical_Review" | "Sample_Production" | "Revision" | "Approved" | "Rejected" | "On_Hold" | "Commerce_Ready" | "Superseded";
     priority?: "Low" | "Medium" | "High" | "Urgent";
     tags?: string[];
     partner_id?: string;

--- a/apps/backend/src/workflows/designs/update-design.ts
+++ b/apps/backend/src/workflows/designs/update-design.ts
@@ -13,7 +13,13 @@ import {
 import { normalizeProductType } from "../../modules/designs/lib/product-type";
 
 type DesignType = "Original" | "Derivative" | "Custom" | "Collaboration";
-type DesignStatus = "Conceptual" | "In_Development" | "Technical_Review" | "Sample_Production" | "Revision" | "Approved" | "Rejected" | "On_Hold";
+// The model's enum has ten values; this type had eight. `Commerce_Ready`
+// and `Superseded` were reachable through the HTTP validator and through
+// `create-design`, but NOT through the update workflow — so the one path
+// that transitions a design could not name the two statuses that matter
+// most at the end of its life. Kept in sync with
+// `src/modules/designs/models/design.ts`.
+type DesignStatus = "Conceptual" | "In_Development" | "Technical_Review" | "Sample_Production" | "Revision" | "Approved" | "Rejected" | "On_Hold" | "Commerce_Ready" | "Superseded";
 type PriorityLevel = "Low" | "Medium" | "High" | "Urgent";
 
 type UpdateDesignStepInput = {

--- a/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
@@ -6,6 +6,11 @@ const updateDesignRun = jest.fn().mockResolvedValue({ result: {} })
 jest.mock("../../designs/create-product-from-design", () => ({
   createProductFromDesignWorkflow: (...a: any[]) =>
     (createProductFromDesignWorkflow as any)(...a),
+  // The REAL helper — the photo gate must be exercised, not stubbed. Stubbing
+  // it would make every assertion below about the mock instead of the rule.
+  resolveDesignGallery: jest.requireActual(
+    "../../designs/create-product-from-design"
+  ).resolveDesignGallery,
 }))
 jest.mock("../../designs/update-design", () => ({
   __esModule: true,
@@ -45,6 +50,18 @@ const completedRun = (id: string, design_id: string | null, extra: any = {}) => 
   approval_decision: null,
   ...extra,
 })
+
+/** A folder of shoot images, the evidence Commerce_Ready is gated on. */
+const shot = (n = 2) => [
+  {
+    id: "fold_1",
+    media_files: Array.from({ length: n }, (_, i) => ({
+      id: `mf_${i}`,
+      file_path: `https://cdn/shoot-${i}.jpg`,
+      file_type: "image",
+    })),
+  },
+]
 
 /** A design the graph answers with. `products: []` = never approved. */
 const design = (id: string, extra: any = {}) => ({
@@ -110,6 +127,96 @@ describe("resolveApprovalCurrency", () => {
     expect(resolveApprovalCurrency({ storeCurrency: "AUD" })).toBe("aud")
     expect(resolveApprovalCurrency({})).toBe("inr")
     expect(resolveApprovalCurrency({})).not.toBe("usd")
+  })
+})
+
+describe("applyRunApprovals — the design's status after approval", () => {
+  /**
+   * #1920 — approving run output is the moment a design has been PRODUCED,
+   * reviewed, and minted into a product. That is what `Commerce_Ready` meant.
+   * Nothing ever set it: the only writer was a subscriber on `design.updated`,
+   * an event this codebase does not emit, so 0 of 123 prod designs had reached
+   * it. This transition is the one that fixes that, so it is asserted here —
+   * the suite passed either way before, which is how it went unnoticed.
+   */
+  it("moves a PHOTOGRAPHED design to Commerce_Ready, not Approved", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { folders: shot() }) })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(updateDesignRun).toHaveBeenCalledWith({
+      input: { id: "des_1", status: "Commerce_Ready" },
+    })
+  })
+
+  it("sets it once for two runs of the same design, not once per run", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1"),
+      completedRun("run_2", "des_1"),
+    ])
+    stubGraph({ des_1: design("des_1", { folders: shot() }) })
+
+    await applyRunApprovals(container, {
+      runIds: ["run_1", "run_2"],
+      decision: "approve",
+    })
+
+    const commerceReadyCalls = updateDesignRun.mock.calls.filter(
+      (c: any[]) => c[0]?.input?.status === "Commerce_Ready"
+    )
+    expect(commerceReadyCalls).toHaveLength(1)
+  })
+
+  /**
+   * 🔴 The gate. A produced garment with no photographs cannot be sold, so
+   * approval alone must NOT mark it sellable — it stays `Approved` and waits
+   * for the shoot. This is the case that keeps the transition honest.
+   */
+  it("leaves an UNPHOTOGRAPHED design at Approved", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1") })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(updateDesignRun).toHaveBeenCalledWith({
+      input: { id: "des_1", status: "Approved" },
+    })
+  })
+
+  it("does not count a folder of non-images as a shoot", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({
+      des_1: design("des_1", {
+        folders: [
+          {
+            id: "fold_1",
+            media_files: [
+              { id: "mf_0", file_path: "https://cdn/tech-pack.pdf", file_type: "document" },
+            ],
+          },
+        ],
+      }),
+    })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(updateDesignRun).toHaveBeenCalledWith({
+      input: { id: "des_1", status: "Approved" },
+    })
+  })
+
+  it("touches no status on a dry run", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1") })
+
+    await applyRunApprovals(container, {
+      runIds: ["run_1"],
+      decision: "approve",
+      dryRun: true,
+    })
+
+    expect(updateDesignRun).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/workflows/production-runs/approve-run-output.ts
+++ b/apps/backend/src/workflows/production-runs/approve-run-output.ts
@@ -8,7 +8,10 @@ import {
   resolveApprovalCurrency as resolveCurrency,
   resolveApprovalPrice,
 } from "./approval-pricing"
-import { createProductFromDesignWorkflow } from "../designs/create-product-from-design"
+import {
+  createProductFromDesignWorkflow,
+  resolveDesignGallery,
+} from "../designs/create-product-from-design"
 import updateDesignWorkflow from "../designs/update-design"
 
 /**
@@ -323,6 +326,13 @@ export async function applyRunApprovals(
           "cost_currency",
           "products.id",
           "products.variants.id",
+          // #1920 — the photoshoot evidence. Commerce_Ready means "we could
+          // SELL this", and a garment with no photographs cannot be sold.
+          "folders.id",
+          "folders.media_files.id",
+          "folders.media_files.file_path",
+          "folders.media_files.file_type",
+          "folders.media_files.mime_type",
         ],
       })
 
@@ -427,8 +437,48 @@ export async function applyRunApprovals(
       }
 
       if (!input.dryRun) {
+        /**
+         * `Commerce_Ready` only once the PHOTOS EXIST (#1920).
+         *
+         * Approving run output is the moment a design has been PRODUCED and
+         * a real product minted from it a few lines above. That is most of
+         * what `Commerce_Ready` means — but not all of it. In practice a
+         * produced garment is not sellable until it has been PHOTOGRAPHED,
+         * and the shoot happens after the goods exist. Approval alone would
+         * mark designs sellable that have no image to sell them with.
+         *
+         * So the shoot is the gate, and the evidence for it is the design's
+         * linked media folder holding at least one image — the same folder
+         * `resolveDesignGallery` draws the product's gallery from. Evidence,
+         * not a checkbox: a task ticked with no photographs behind it is a
+         * claim, and this asks the artefact instead.
+         *
+         * No photos yet → `Approved`, exactly as before, and the design waits
+         * for the shoot. Nothing regresses; the transition is only ADDED where
+         * it is earned.
+         *
+         * Nothing ever set `Commerce_Ready` at all — the only writer was a
+         * subscriber on `design.updated`, an event this codebase does not
+         * emit, which is why 0 of 123 prod designs had ever reached it.
+         *
+         * Safe against every gate that names `Approved`, all of which name
+         * `Commerce_Ready` too: `create-payment-submission`'s ELIGIBLE_STATUSES,
+         * the skip lists in `complete-production-run` / `finish-production-run`,
+         * and REVISABLE_STATUSES in both revise files. A design does not become
+         * unrevisable or unbillable by getting here.
+         *
+         * 🔑 It does NOT publish the product. The mint above is still `draft`,
+         * deliberately: producing a commission does not decide that we want to
+         * SELL it to other people. `Commerce_Ready` marks eligibility, and
+         * listing it stays a human choice.
+         */
+        const hasPhotos = resolveDesignGallery(design).images.length > 0
+
         await updateDesignWorkflow(container).run({
-          input: { id: designId, status: "Approved" },
+          input: {
+            id: designId,
+            status: hasPhotos ? "Commerce_Ready" : "Approved",
+          },
         })
 
         for (const run of designRuns) {


### PR DESCRIPTION
Stacks on #1936. Part of #1920.

## Why

The shoot is the gate between *"we made it"* and *"we can sell it"* — #1936 only moves a design to `Commerce_Ready` once its linked media folder holds an image. It was also the one step in that chain **nobody could see**: 23 task templates in production, not one covering it. The work that decides whether a design ever reaches the catalogue was happening off the system entirely — unassignable, unscheduled, uncosted.

## The templates

Four, in the order the work happens, separately assignable because a stylist, a photographer and a retoucher are three bookings and not one:

| template | duration | cost |
|---|---|---|
| `photoshoot-styling` | 90m | ₹1,500 |
| `photoshoot-capture` | 180m | ₹6,000 |
| `photoshoot-retouch` | 120m | ₹2,500 |
| `photoshoot-upload` | 30m | *null* — our own time, not 0 |

`null` rather than `0` deliberately: a `0` asserts the step is free, which is a different claim from "not costed".

`photoshootBudget()` sums the definitions rather than writing the total down twice, so editing a template moves the number and nothing drifts. **The figures are starting points** an operator is expected to tune — which is exactly why the installer never overwrites an existing template.

🔑 `photoshoot-upload` is the step that actually earns the status, and its description says so: **approval reads the folder, not the task.** A design whose images never land there stays at `Approved` however many boxes are ticked.

## The installer

Idempotent in both directions — an existing category is reused, existing templates are left alone, and a partial install re-runs creating only what is missing. Operators edit durations, costs and wording; a re-run must not undo that.

## `create_task_template` on the admin MCP

The route (`POST /admin/task-templates`) was **verified to exist before the tool was written down** — a tool wrapping a route that does not exist 404s on every call while its own tests stay green.

Two things the tool says out loud rather than letting a caller discover them:

- **Categories cannot be created over HTTP.** The categories route is GET-only, so a step in a new category needs the seed job, not this tool.
- **`required_fields` must be an OBJECT.** The route validator declares `z.record`, so the ARRAY form *every in-process seed uses* — including these templates and `ship-to-next-location` — is rejected with a 400. The API cannot reproduce what the seeds create.

`category` is declared a deliberate omission in the route-validator coverage test: the validator takes both it and `category_id`, only the id resolves to a real row, and offering both invites a model to name a category in prose and attach a template to nothing.

Classified by path prefix (`/admin/task-templates` → `production`), so the tool loads in a slice rather than in none.

## Verification

607 of 609 tests green across the MCP, task-template, designs and production-run suites. The 2 failures are in `route-validator-field-coverage` and are **pre-existing** — confirmed by stashing this change and watching the same two fail. `create_task_template` does not appear in either failure list. `tsc` clean.

## Not in this PR

Folding the shoot cost into a design's price. `estimate-design-cost` maintains `material_cost + production_cost + platform_fee === total_estimated`, and adding marketing/tech/shipping deltas on top of a costed shoot changes what customers are charged — that needs its own issue and its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp