### PR TITLE
feat(designs): approving run output sets Commerce_Ready, once the design has been PHOTOGRAPHED (#1920)

### DIFF
--- a/apps/backend/src/workflows/designs/list-designs.ts
+++ b/apps/backend/src/workflows/designs/list-designs.ts
@@ -21,7 +21,7 @@ export type ListDesignsStepInput = {
     q?: string;
     name?: string;
     design_type?: "Original" | "Derivative" | "Custom" | "Collaboration";
-    status?: "Conceptual" | "In_Development" | "Technical_Review" | "Sample_Production" | "Revision" | "Approved" | "Rejected" | "On_Hold";
+    status?: "Conceptual" | "In_Development" | "Technical_Review" | "Sample_Production" | "Revision" | "Approved" | "Rejected" | "On_Hold" | "Commerce_Ready" | "Superseded";
     priority?: "Low" | "Medium" | "High" | "Urgent";
     tags?: string[];
     partner_id?: string;

--- a/apps/backend/src/workflows/designs/update-design.ts
+++ b/apps/backend/src/workflows/designs/update-design.ts
@@ -13,7 +13,13 @@ import {
 import { normalizeProductType } from "../../modules/designs/lib/product-type";
 
 type DesignType = "Original" | "Derivative" | "Custom" | "Collaboration";
-type DesignStatus = "Conceptual" | "In_Development" | "Technical_Review" | "Sample_Production" | "Revision" | "Approved" | "Rejected" | "On_Hold";
+// The model's enum has ten values; this type had eight. `Commerce_Ready`
+// and `Superseded` were reachable through the HTTP validator and through
+// `create-design`, but NOT through the update workflow — so the one path
+// that transitions a design could not name the two statuses that matter
+// most at the end of its life. Kept in sync with
+// `src/modules/designs/models/design.ts`.
+type DesignStatus = "Conceptual" | "In_Development" | "Technical_Review" | "Sample_Production" | "Revision" | "Approved" | "Rejected" | "On_Hold" | "Commerce_Ready" | "Superseded";
 type PriorityLevel = "Low" | "Medium" | "High" | "Urgent";
 
 type UpdateDesignStepInput = {

--- a/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
@@ -6,6 +6,11 @@ const updateDesignRun = jest.fn().mockResolvedValue({ result: {} })
 jest.mock("../../designs/create-product-from-design", () => ({
   createProductFromDesignWorkflow: (...a: any[]) =>
     (createProductFromDesignWorkflow as any)(...a),
+  // The REAL helper — the photo gate must be exercised, not stubbed. Stubbing
+  // it would make every assertion below about the mock instead of the rule.
+  resolveDesignGallery: jest.requireActual(
+    "../../designs/create-product-from-design"
+  ).resolveDesignGallery,
 }))
 jest.mock("../../designs/update-design", () => ({
   __esModule: true,
@@ -45,6 +50,18 @@ const completedRun = (id: string, design_id: string | null, extra: any = {}) => 
   approval_decision: null,
   ...extra,
 })
+
+/** A folder of shoot images, the evidence Commerce_Ready is gated on. */
+const shot = (n = 2) => [
+  {
+    id: "fold_1",
+    media_files: Array.from({ length: n }, (_, i) => ({
+      id: `mf_${i}`,
+      file_path: `https://cdn/shoot-${i}.jpg`,
+      file_type: "image",
+    })),
+  },
+]
 
 /** A design the graph answers with. `products: []` = never approved. */
 const design = (id: string, extra: any = {}) => ({
@@ -110,6 +127,96 @@ describe("resolveApprovalCurrency", () => {
     expect(resolveApprovalCurrency({ storeCurrency: "AUD" })).toBe("aud")
     expect(resolveApprovalCurrency({})).toBe("inr")
     expect(resolveApprovalCurrency({})).not.toBe("usd")
+  })
+})
+
+describe("applyRunApprovals — the design's status after approval", () => {
+  /**
+   * #1920 — approving run output is the moment a design has been PRODUCED,
+   * reviewed, and minted into a product. That is what `Commerce_Ready` meant.
+   * Nothing ever set it: the only writer was a subscriber on `design.updated`,
+   * an event this codebase does not emit, so 0 of 123 prod designs had reached
+   * it. This transition is the one that fixes that, so it is asserted here —
+   * the suite passed either way before, which is how it went unnoticed.
+   */
+  it("moves a PHOTOGRAPHED design to Commerce_Ready, not Approved", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { folders: shot() }) })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(updateDesignRun).toHaveBeenCalledWith({
+      input: { id: "des_1", status: "Commerce_Ready" },
+    })
+  })
+
+  it("sets it once for two runs of the same design, not once per run", async () => {
+    listProductionRuns.mockResolvedValue([
+      completedRun("run_1", "des_1"),
+      completedRun("run_2", "des_1"),
+    ])
+    stubGraph({ des_1: design("des_1", { folders: shot() }) })
+
+    await applyRunApprovals(container, {
+      runIds: ["run_1", "run_2"],
+      decision: "approve",
+    })
+
+    const commerceReadyCalls = updateDesignRun.mock.calls.filter(
+      (c: any[]) => c[0]?.input?.status === "Commerce_Ready"
+    )
+    expect(commerceReadyCalls).toHaveLength(1)
+  })
+
+  /**
+   * 🔴 The gate. A produced garment with no photographs cannot be sold, so
+   * approval alone must NOT mark it sellable — it stays `Approved` and waits
+   * for the shoot. This is the case that keeps the transition honest.
+   */
+  it("leaves an UNPHOTOGRAPHED design at Approved", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1") })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(updateDesignRun).toHaveBeenCalledWith({
+      input: { id: "des_1", status: "Approved" },
+    })
+  })
+
+  it("does not count a folder of non-images as a shoot", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({
+      des_1: design("des_1", {
+        folders: [
+          {
+            id: "fold_1",
+            media_files: [
+              { id: "mf_0", file_path: "https://cdn/tech-pack.pdf", file_type: "document" },
+            ],
+          },
+        ],
+      }),
+    })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(updateDesignRun).toHaveBeenCalledWith({
+      input: { id: "des_1", status: "Approved" },
+    })
+  })
+
+  it("touches no status on a dry run", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1") })
+
+    await applyRunApprovals(container, {
+      runIds: ["run_1"],
+      decision: "approve",
+      dryRun: true,
+    })
+
+    expect(updateDesignRun).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/workflows/production-runs/approve-run-output.ts
+++ b/apps/backend/src/workflows/production-runs/approve-run-output.ts
@@ -8,7 +8,10 @@ import {
   resolveApprovalCurrency as resolveCurrency,
   resolveApprovalPrice,
 } from "./approval-pricing"
-import { createProductFromDesignWorkflow } from "../designs/create-product-from-design"
+import {
+  createProductFromDesignWorkflow,
+  resolveDesignGallery,
+} from "../designs/create-product-from-design"
 import updateDesignWorkflow from "../designs/update-design"
 
 /**
@@ -323,6 +326,13 @@ export async function applyRunApprovals(
           "cost_currency",
           "products.id",
           "products.variants.id",
+          // #1920 — the photoshoot evidence. Commerce_Ready means "we could
+          // SELL this", and a garment with no photographs cannot be sold.
+          "folders.id",
+          "folders.media_files.id",
+          "folders.media_files.file_path",
+          "folders.media_files.file_type",
+          "folders.media_files.mime_type",
         ],
       })
 
@@ -427,8 +437,48 @@ export async function applyRunApprovals(
       }
 
       if (!input.dryRun) {
+        /**
+         * `Commerce_Ready` only once the PHOTOS EXIST (#1920).
+         *
+         * Approving run output is the moment a design has been PRODUCED and
+         * a real product minted from it a few lines above. That is most of
+         * what `Commerce_Ready` means — but not all of it. In practice a
+         * produced garment is not sellable until it has been PHOTOGRAPHED,
+         * and the shoot happens after the goods exist. Approval alone would
+         * mark designs sellable that have no image to sell them with.
+         *
+         * So the shoot is the gate, and the evidence for it is the design's
+         * linked media folder holding at least one image — the same folder
+         * `resolveDesignGallery` draws the product's gallery from. Evidence,
+         * not a checkbox: a task ticked with no photographs behind it is a
+         * claim, and this asks the artefact instead.
+         *
+         * No photos yet → `Approved`, exactly as before, and the design waits
+         * for the shoot. Nothing regresses; the transition is only ADDED where
+         * it is earned.
+         *
+         * Nothing ever set `Commerce_Ready` at all — the only writer was a
+         * subscriber on `design.updated`, an event this codebase does not
+         * emit, which is why 0 of 123 prod designs had ever reached it.
+         *
+         * Safe against every gate that names `Approved`, all of which name
+         * `Commerce_Ready` too: `create-payment-submission`'s ELIGIBLE_STATUSES,
+         * the skip lists in `complete-production-run` / `finish-production-run`,
+         * and REVISABLE_STATUSES in both revise files. A design does not become
+         * unrevisable or unbillable by getting here.
+         *
+         * 🔑 It does NOT publish the product. The mint above is still `draft`,
+         * deliberately: producing a commission does not decide that we want to
+         * SELL it to other people. `Commerce_Ready` marks eligibility, and
+         * listing it stays a human choice.
+         */
+        const hasPhotos = resolveDesignGallery(design).images.length > 0
+
         await updateDesignWorkflow(container).run({
-          input: { id: designId, status: "Approved" },
+          input: {
+            id: designId,
+            status: hasPhotos ? "Commerce_Ready" : "Approved",
+          },
         })
 
         for (const run of designRuns) {


### PR DESCRIPTION
Replaces #1936, which GitHub **closed** — not retargeted — when its base branch (#1935) was merged and deleted. Same commit, rebased onto `main`.

## The gap

Reviewing a production run's output **already mints the product**: `applyRunApprovals` prices the design, creates the product when none exists, and fans out its currencies. What it did not do is say what that *means* about the design. It set `Approved` — the status a design reaches when someone approves the **drawing**, long before anything has been made.

`Commerce_Ready` is the status for *"we have produced this and could sell it"*, and **nothing in the codebase ever set it**. Its only writer was `design-commerce-ready.ts`, a subscriber on `design.updated` — an event this codebase does not emit — which is why **0 of 123** prod designs had ever reached it.

## But production is not the whole of it

A produced garment is not sellable until it has been **photographed**, and the shoot happens after the goods exist. So the shoot is the gate, and the evidence asked for is the design's linked media folder holding at least one image — the same folder the product's gallery is drawn from.

**Evidence, not a checkbox:** a task ticked with no photographs behind it is a claim; the folder is the artefact.

```
photographed  → Commerce_Ready
not yet       → Approved, exactly as before
```

Nothing regresses. The transition is only *added* where it is earned.

## Checked, not assumed

- **Every backend gate that names `Approved` also names `Commerce_Ready`**: `ELIGIBLE_STATUSES` in `create-payment-submission`, the skip lists in `complete-production-run` and `finish-production-run`, and `REVISABLE_STATUSES` in both revise files. A design becomes neither unbillable nor unrevisable.
- **`updateDesignWorkflow`'s `DesignStatus` type listed eight of the model's ten values.** `Commerce_Ready` and `Superseded` were reachable through the HTTP validator and through `create-design`, but **not through the one workflow that transitions a design** — so this was a type error before it was a behaviour change. Widened to match the model, as was `list-designs`.

## What it does not do

🔑 **It publishes nothing.** The minted product is still `draft`: producing a commission does not decide that we want to sell it to other people. `Commerce_Ready` marks eligibility; listing stays a human choice.

## Verification

The **19 pre-existing tests passed both before and after** the original change — nothing asserted this transition, which is how it went unnoticed. Five now do, including the unphotographed case and a folder holding only a tech-pack PDF. Removing the gate turns two red (verified). 507 tests green across the designs, production-run, MCP and task-template suites after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp