### PR TITLE
feat(pricing): the platform's economic policy is a table you can read, not five constants in four files (#1939)

### DIFF
--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -250,6 +250,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/platform-tax-identity",
     },
     {
+      resolve: "./src/modules/platform-cost-config",
+    },
+    {
       resolve: "./src/modules/investor",
     },
 

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -3530,6 +3530,76 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       ["id", "taskId"]
     ),
   },
+  // ---- Platform cost config (#1939) --------------------------------------
+  {
+    name: "get_platform_cost_config",
+    description:
+      "Read the platform's ECONOMIC POLICY — the five numbers that decide what a design costs and what a buyer pays: the platform commission, the production overhead, the fallback material cost, the custom-design markup and the approval markup. Call this BEFORE quoting, explaining or changing any price, and before answering 'what do we charge': these numbers were previously compiled into the code and this is the only place they can be read. 🔑 A null field means NOT CONFIGURED, not zero — the code falls back to its own constant, so never report a null as 'we charge nothing'. ⚠️ There are TWO markups and they are different shapes: `custom_design_markup_percent` is a PERCENT (20 = +20%) on the quote/retail path, `approval_markup_multiplier` is a MULTIPLIER (1.4 = list at 140% of cost) on the run-approval path; at ×1.40 the MARGIN is 28.6%, not 40%. Pass `at` (an ISO date) to see the policy that was in force at a past moment — that is how a price quoted months ago is explained, since the table is effective-dated and old rows are kept.",
+    method: "GET",
+    path: "/admin/platform-cost-config",
+    queryParams: ["at"],
+    inputSchema: obj({
+      at: STR(
+        "ISO date/time to resolve the policy AT, e.g. '2026-03-01T00:00:00Z'. Omit for the policy in force now. Use it to explain a price that was quoted under an older policy."
+      ),
+    }),
+  },
+  {
+    name: "set_platform_cost_config",
+    description:
+      "Set the platform's next economic policy. ⚠️ THIS CHANGES WHAT CUSTOMERS PAY AND WHAT PARTNERS ARE PAID — it is not a settings tweak. Sensitive: requires confirm:true. 🔑 It INSERTS a new effective-dated policy rather than editing the current one, so every price already quoted stays explicable under the policy it was quoted under; there is deliberately no update tool. Fields you OMIT carry forward from the policy currently in force — so sending only `custom_design_markup_percent` changes the markup and leaves the other four alone. Sending a field as null UNSETS it, which makes the code fall back to its compiled-in constant; that is rarely what you want, so only send null when the intent is genuinely 'we have no policy on this'. ALWAYS call get_platform_cost_config first and tell the admin what is changing FROM and TO before you write. Pass a future `effective_from` to stage a change without applying it.",
+    method: "POST",
+    path: "/admin/platform-cost-config",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "effective_from",
+      "notes",
+      "platform_fee_percent",
+      "production_overhead_percent",
+      "default_material_cost",
+      "default_material_cost_currency",
+      "custom_design_markup_percent",
+      "approval_markup_multiplier",
+    ],
+    inputSchema: obj({
+      effective_from: STR(
+        "ISO date/time this policy takes effect. Defaults to now. A FUTURE date stages it without applying it; a PAST date back-dates a correction and inherits from whatever was in force at that moment, not from today's policy."
+      ),
+      notes: STR(
+        "Why the policy changed — write the DECISION and who made it, not the number (the number is its own field). This is what a person reads in six months asking why a price moved."
+      ),
+      platform_fee_percent: {
+        type: "number",
+        description:
+          "JYT's commission on partner production work, as a PERCENTAGE of material cost. 0 is meaningful and means 'we take no commission'; omit the field to leave it unchanged.",
+      },
+      production_overhead_percent: {
+        type: "number",
+        description:
+          "Production overhead as a PERCENTAGE of material cost.",
+      },
+      default_material_cost: {
+        type: "number",
+        description:
+          "Fallback per-unit material cost used ONLY when a BOM material has no resolved price (no order history, no unit cost, no consumption log). A guess standing in for a fact — raising it silently raises every design priced without real purchase data.",
+      },
+      default_material_cost_currency: STR(
+        "Currency of default_material_cost, e.g. 'INR'. Send it whenever you send the cost — an amount with no currency cannot be added up."
+      ),
+      custom_design_markup_percent: {
+        type: "number",
+        description:
+          "Markup on a custom/commissioned design, as a PERCENTAGE (20 = +20%). Applies to the quote path and, since the 2026-09-09 decision, to retail.",
+      },
+      approval_markup_multiplier: {
+        type: "number",
+        description:
+          "Markup applied when an approved run's output is listed, as a MULTIPLIER on cost (1.4 = list at 140% of cost). NOT a percentage — sending 40 here would list at 40x cost. At 1.4 the margin is 28.6%.",
+      },
+    }),
+  },
+
   {
     name: "get_production_run_policy",
     description:
@@ -3748,12 +3818,13 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "create_task_template",
     description:
-      "Create a task template — a reusable process step that production-run dispatch can attach to a run. Use it when the work a run needs has no template yet (a photoshoot stage, a new finishing service), because dispatch resolves templates BY NAME and a name that does not exist fails the whole dispatch with 'Missing task templates'. 🔑 ALWAYS call list_task_templates first: 23+ already exist, names are not unique across categories, and creating a near-duplicate ('Stitching' when 'Stitching (Pre Production)' is what you meant) makes every later dispatch ambiguous. Give the template a `category_id` from that listing — CATEGORIES CANNOT BE CREATED through this API (the categories route is read-only), so a step in a category that does not exist yet needs the matching Data Plumbing seed job instead. Cost and duration are what make a step accountable rather than a checkbox: `estimated_cost` + `cost_currency` and `estimated_duration` (MINUTES) are copied onto every task dispatched from it. ⚠️ `required_fields` must be an OBJECT here — the route's validator declares `z.record`, so the ARRAY form used by the in-process seeds (ship-to-next-location, the photoshoot templates) is REJECTED with a 400. A template needing array-shaped field configs has to be seeded, not created here. [sensitive: requires confirm:true]",
+      "Create a task template — a reusable process step that production-run dispatch can attach to a run. Use it when the work a run needs has no template yet (a photoshoot stage, a new finishing service), because dispatch resolves templates BY NAME and a name that does not exist fails the whole dispatch with 'Missing task templates'. 🔑 ALWAYS call list_task_templates first: 23+ already exist, names are not unique across categories, and creating a near-duplicate ('Stitching' when 'Stitching (Pre Production)' is what you meant) makes every later dispatch ambiguous. Give the template a `category_id` from that listing when the category already exists. ⚠️ If it does NOT exist, pass `category` (a NAME) instead and the route CREATES it — `checkCategory` looks the name up and creates a category when nothing matches. That is real power and a real hazard: a name that differs by so much as a space ('Photoshoot' when 'Photo Shoot' exists) silently creates a SECOND category and splits the taxonomy, and nothing over HTTP can merge or rename them afterwards (the categories route is read-only). So call list_task_templates first and reuse an EXACT existing name; pass `category` only when you have confirmed the category is genuinely absent. Cost and duration are what make a step accountable rather than a checkbox: `estimated_cost` + `cost_currency` and `estimated_duration` (MINUTES) are copied onto every task dispatched from it. ⚠️ `required_fields` must be an OBJECT here — the route's validator declares `z.record`, so the ARRAY form used by the in-process seeds (ship-to-next-location, the photoshoot templates) is REJECTED with a 400. A template needing array-shaped field configs has to be seeded, not created here. [sensitive: requires confirm:true]",
     method: "POST",
     path: "/admin/task-templates",
     bodyParams: [
       "name",
       "description",
+      "category",
       "category_id",
       "estimated_duration",
       "estimated_cost",
@@ -3775,8 +3846,11 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         description: STR(
           "What the step actually involves, written for the partner who will do it. Required by the route — not optional."
         ),
+        category: STR(
+          "The category this step belongs to, BY NAME — use this only when the category does not exist yet, because the route CREATES it when no category matches the name. Match an existing name EXACTLY or you create a duplicate that cannot be merged over HTTP. Ignored when category_id is given and resolves."
+        ),
         category_id: STR(
-          "The category this step belongs to, from list_task_templates' `category.id`. Omit only for a deliberately uncategorised step."
+          "The category this step belongs to, from list_task_templates' `category.id`. Prefer this whenever the category already exists — an id cannot typo into a new category the way a name can. Omit both only for a deliberately uncategorised step."
         ),
         estimated_duration: INT(
           "Expected hands-on time in MINUTES — not hours, and not elapsed/transit time. Copied onto each dispatched task."

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -113,6 +113,12 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   // Reading an attached image is domain-agnostic — it must be reachable from
   // any conversation, so it lives in the always-present core slice.
   ["/admin/assistant/vision", "core"],
+  // The platform's economic policy (#1939) — the markups, the commission and the
+  // fallback material cost. Rides `money` because every ask it answers ("what do
+  // we charge?", "why did this price move?", "raise the markup") is a money
+  // conversation. Without this entry both tools classify as undefined and load
+  // in NO slice, leaving the numbers unreadable from any ask.
+  ["/admin/platform-cost-config", "money"],
   ["/admin/payments", "money"],
   // The payout side of money. Without this entry every payable-runs /
   // payable-inventory-orders tool classifies as undefined and loads in NO

--- a/apps/backend/src/api/admin/platform-cost-config/__tests__/carry-forward.unit.spec.ts
+++ b/apps/backend/src/api/admin/platform-cost-config/__tests__/carry-forward.unit.spec.ts
@@ -1,0 +1,71 @@
+import { buildNextConfig, COST_CONFIG_FIELDS } from "../carry-forward"
+
+/**
+ * #1939 — the carry-forward rule.
+ *
+ * The failure this guards is quiet and expensive: a request that means "raise
+ * the markup to 25%" blanking the platform fee, the overhead and the approval
+ * markup because they were not mentioned.
+ */
+
+const current = {
+  id: "pcc_initial",
+  platform_fee_percent: 10,
+  production_overhead_percent: 30,
+  default_material_cost: 600,
+  default_material_cost_currency: "INR",
+  custom_design_markup_percent: 20,
+  approval_markup_multiplier: 1.4,
+}
+
+describe("buildNextConfig", () => {
+  it("🔴 a one-field change carries the other four forward", () => {
+    const next = buildNextConfig({ custom_design_markup_percent: 25 }, current)
+    expect(next.custom_design_markup_percent).toBe(25)
+    // The whole point: none of these became null.
+    expect(next.platform_fee_percent).toBe(10)
+    expect(next.production_overhead_percent).toBe(30)
+    expect(next.default_material_cost).toBe(600)
+    expect(next.default_material_cost_currency).toBe("INR")
+    expect(next.approval_markup_multiplier).toBe(1.4)
+  })
+
+  it("an EXPLICIT null unsets a field — distinct from omitting it", () => {
+    const unset = buildNextConfig({ platform_fee_percent: null }, current)
+    const omitted = buildNextConfig({}, current)
+    expect(unset.platform_fee_percent).toBeNull()
+    expect(omitted.platform_fee_percent).toBe(10)
+  })
+
+  it("carries a real 0 forward without mistaking it for absence", () => {
+    // A 0 fee is a policy ("we take no commission") and must survive a later
+    // unrelated edit. `?? null` on a 0 would be a bug; `??` only catches nullish.
+    const zeroed = { ...current, platform_fee_percent: 0 }
+    const next = buildNextConfig({ custom_design_markup_percent: 25 }, zeroed)
+    expect(next.platform_fee_percent).toBe(0)
+  })
+
+  it("treats an explicitly-undefined key as ABSENT, not as unset", () => {
+    // `{k: undefined}` and `{}` are indistinguishable after JSON round-trip, so
+    // they must behave identically — which `!== undefined` would get wrong.
+    const next = buildNextConfig({ platform_fee_percent: undefined }, current)
+    expect(next.platform_fee_percent).toBe(10)
+  })
+
+  it("yields all-null when there is no policy to inherit from", () => {
+    const next = buildNextConfig({}, null)
+    for (const f of COST_CONFIG_FIELDS) {
+      expect(next[f]).toBeNull()
+    }
+    // Never zeros — a zero would read as a decision nobody made.
+    expect(Object.values(next)).not.toContain(0)
+  })
+
+  it("returns exactly the config columns, never stray body keys", () => {
+    const next = buildNextConfig(
+      { custom_design_markup_percent: 25, notes: "x", is_active: false, id: "evil" },
+      current
+    )
+    expect(Object.keys(next).sort()).toEqual([...COST_CONFIG_FIELDS].sort())
+  })
+})

--- a/apps/backend/src/api/admin/platform-cost-config/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/admin/platform-cost-config/__tests__/validators.unit.spec.ts
@@ -1,0 +1,59 @@
+import { CreatePlatformCostConfigSchema as S } from "../validators"
+
+const ok = (b: unknown) => S.safeParse(b).success
+
+/**
+ * #1939 — the payload guards.
+ *
+ * The interesting case is the percent/multiplier confusion. `custom_design_
+ * markup_percent` takes 20 to mean +20%; `approval_markup_multiplier` takes 1.4
+ * to mean 140% of cost. Typing 40 into the multiplier means 4000%, and a live
+ * probe caught exactly that sailing through an earlier, looser ceiling.
+ */
+describe("CreatePlatformCostConfigSchema", () => {
+  it("accepts a single-field change — the carry-forward case", () => {
+    expect(ok({ custom_design_markup_percent: 25 })).toBe(true)
+    expect(ok({})).toBe(true)
+  })
+
+  it("accepts an explicit null (the deliberate 'unset')", () => {
+    expect(ok({ platform_fee_percent: null })).toBe(true)
+  })
+
+  it("accepts 0 — a zero commission is a real policy", () => {
+    expect(ok({ platform_fee_percent: 0 })).toBe(true)
+  })
+
+  it("rejects a negative percent", () => {
+    expect(ok({ platform_fee_percent: -5 })).toBe(false)
+  })
+
+  it("🔴 rejects a PERCENT typed into the MULTIPLIER field", () => {
+    // The live defect: 40 passed a max of 100 and would list at 4000% of cost.
+    expect(ok({ approval_markup_multiplier: 40 })).toBe(false)
+    expect(ok({ approval_markup_multiplier: 20 })).toBe(false)
+    expect(ok({ approval_markup_multiplier: 25 })).toBe(false)
+  })
+
+  it("still accepts real multipliers, including today's 1.4", () => {
+    expect(ok({ approval_markup_multiplier: 1.4 })).toBe(true)
+    expect(ok({ approval_markup_multiplier: 1 })).toBe(true)
+    expect(ok({ approval_markup_multiplier: 2.5 })).toBe(true)
+  })
+
+  it("rejects a multiplier below 1 — it would list BELOW cost", () => {
+    expect(ok({ approval_markup_multiplier: 0.9 })).toBe(false)
+  })
+
+  it("rejects a malformed currency and a malformed date", () => {
+    expect(ok({ default_material_cost_currency: "RUPEES" })).toBe(false)
+    expect(ok({ default_material_cost_currency: "INR" })).toBe(true)
+    expect(ok({ effective_from: "not a date" })).toBe(false)
+    expect(ok({ effective_from: "2026-10-01T00:00:00Z" })).toBe(true)
+  })
+
+  it("rejects a negative material cost", () => {
+    expect(ok({ default_material_cost: -1 })).toBe(false)
+    expect(ok({ default_material_cost: 600 })).toBe(true)
+  })
+})

--- a/apps/backend/src/api/admin/platform-cost-config/carry-forward.ts
+++ b/apps/backend/src/api/admin/platform-cost-config/carry-forward.ts
@@ -1,0 +1,59 @@
+import type { PlatformCostConfigRow } from "../../../modules/platform-cost-config/resolve-lib"
+
+/** The economic columns a new policy carries forward from the one in force. */
+export const COST_CONFIG_FIELDS = [
+  "platform_fee_percent",
+  "production_overhead_percent",
+  "default_material_cost",
+  "default_material_cost_currency",
+  "custom_design_markup_percent",
+  "approval_markup_multiplier",
+] as const
+
+export type CostConfigField = (typeof COST_CONFIG_FIELDS)[number]
+
+/**
+ * PURE: build the next policy's columns from a partial request and the policy
+ * currently in force (#1939).
+ *
+ * 🔴 The distinction this exists to protect:
+ *
+ *   field ABSENT from the body  -> carry the current value forward
+ *   field present as `null`     -> deliberately unset it
+ *   field present with a value  -> use it
+ *
+ * Without the first rule, `{ custom_design_markup_percent: 25 }` would insert a
+ * row with four nulls and silently switch off the platform fee, the production
+ * overhead and the approval markup. With the second collapsed into the first,
+ * there would be no way to ever unset a number once set.
+ *
+ * A key must be BOTH present and not `undefined` to count as given. Zod strips
+ * omitted optional keys, so the route sees `{}` for them (probed, not assumed) —
+ * but a JS caller spreading `{ ...patch, field: undefined }` produces a key that
+ * `hasOwnProperty` reports as present while carrying no value, and writing that
+ * `undefined` into the column would blank it. `undefined` therefore means absent
+ * and only an explicit `null` unsets.
+ *
+ * Pure so the rule can be tested without a database, which is the only way to be
+ * sure of it — the first version of this function got the `undefined` case wrong
+ * and its own unit test is what caught it.
+ */
+export function buildNextConfig(
+  body: Record<string, unknown>,
+  current: PlatformCostConfigRow | null | undefined
+): Record<CostConfigField, unknown> {
+  const out = {} as Record<CostConfigField, unknown>
+  for (const field of COST_CONFIG_FIELDS) {
+    if (
+      Object.prototype.hasOwnProperty.call(body, field) &&
+      body[field] !== undefined
+    ) {
+      // Given — including an explicit null, which means "unset".
+      out[field] = body[field]
+    } else {
+      // Absent — inherit, so a one-field change does not blank the rest.
+      out[field] = current?.[field] ?? null
+    }
+  }
+  return out
+}

--- a/apps/backend/src/api/admin/platform-cost-config/route.ts
+++ b/apps/backend/src/api/admin/platform-cost-config/route.ts
@@ -1,0 +1,104 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PLATFORM_COST_CONFIG_MODULE } from "../../../modules/platform-cost-config"
+import {
+  readCostConfig,
+  resolveCostConfig,
+} from "../../../modules/platform-cost-config/resolve-lib"
+import { buildNextConfig } from "./carry-forward"
+
+/**
+ * GET /admin/platform-cost-config
+ *
+ * The platform's economic policy (#1939): the five numbers that decide what a
+ * design costs and what a buyer pays.
+ *
+ * Returns BOTH the policy in force and the full history, because they answer
+ * different questions — "what are we charging?" and "what were we charging in
+ * March?" — and a surface that only answered the first would make the second
+ * require database access.
+ *
+ * `?at=<ISO date>` resolves the policy in force at that moment instead of now,
+ * which is how a past price is explained.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PLATFORM_COST_CONFIG_MODULE)
+
+  const atRaw = (req.query?.at as string) || null
+  const at = atRaw ? new Date(atRaw) : new Date()
+  if (Number.isNaN(at.getTime())) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `\`at\` is not a valid date: ${atRaw}`
+    )
+  }
+
+  const rows = await service.listPlatformCostConfigs({}, { take: null })
+  const inForce = resolveCostConfig(rows, at)
+
+  res.json({
+    /**
+     * The resolved numbers. Every one may be null — null means NOT CONFIGURED,
+     * never zero. A consumer must fall back to its own documented constant.
+     */
+    cost_config: readCostConfig(inForce),
+    /** Which row that came from, so a price can cite its policy. */
+    in_force_id: inForce?.id ?? null,
+    resolved_at: at.toISOString(),
+    /** Newest first — the audit trail, superseded rows included. */
+    history: [...(rows ?? [])].sort(
+      (a: any, b: any) =>
+        new Date(b.effective_from).getTime() -
+        new Date(a.effective_from).getTime()
+    ),
+  })
+}
+
+/**
+ * POST /admin/platform-cost-config
+ *
+ * Set the next economic policy. This is an INSERT, never an update: the table is
+ * effective-dated so a price already quoted stays explicable under the policy it
+ * was quoted under.
+ *
+ * 🔴 OMITTED fields carry forward from the policy currently in force; an
+ * explicit `null` unsets one. See `buildNextConfig` — without that rule, sending
+ * a single field would blank the other four and silently switch off the
+ * platform's economics.
+ *
+ * ⚠️ This changes what customers pay. It is marked sensitive on the MCP surface.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PLATFORM_COST_CONFIG_MODULE)
+  const body = (req.validatedBody ?? {}) as Record<string, unknown>
+
+  const effectiveFrom = body.effective_from
+    ? new Date(String(body.effective_from))
+    : new Date()
+  if (Number.isNaN(effectiveFrom.getTime())) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `\`effective_from\` is not a valid date: ${body.effective_from}`
+    )
+  }
+
+  const rows = await service.listPlatformCostConfigs({}, { take: null })
+  // Carry forward from the policy in force AT THE NEW ROW'S OWN DATE — not
+  // simply the latest row. Back-dating a correction must inherit from what was
+  // actually in force then, otherwise it would import a later policy's numbers
+  // into an earlier period.
+  const current = resolveCostConfig(rows, effectiveFrom)
+
+  const created = await service.createPlatformCostConfigs({
+    effective_from: effectiveFrom,
+    notes: Object.prototype.hasOwnProperty.call(body, "notes")
+      ? body.notes
+      : null,
+    is_active: true,
+    ...buildNextConfig(body, current),
+  })
+
+  const row = Array.isArray(created) ? created[0] : created
+  res.status(201).json({ cost_config: row })
+}

--- a/apps/backend/src/api/admin/platform-cost-config/validators.ts
+++ b/apps/backend/src/api/admin/platform-cost-config/validators.ts
@@ -1,0 +1,91 @@
+import { z } from "zod"
+
+/**
+ * Platform cost-config payloads (#1939).
+ *
+ * ## Why there is no PATCH
+ *
+ * The table is EFFECTIVE-DATED: a policy change is a new row, never an edit to
+ * an old one, because a price already quoted must stay explicable under the
+ * policy it was quoted under. So the only write is a POST that inserts the next
+ * policy. Editing in place would silently rewrite the past.
+ *
+ * ## The carry-forward rule — the load-bearing part
+ *
+ * A caller who wants to move the markup to 25% sends ONLY
+ * `custom_design_markup_percent`. If the other four columns then landed as null,
+ * that request would silently switch OFF the platform fee, the overhead and the
+ * approval markup — a one-field edit quietly unsetting the platform's economics.
+ *
+ * So an OMITTED field carries forward from the policy currently in force, and an
+ * EXPLICIT `null` unsets it. Those are different requests and zod can tell them
+ * apart: absent parses to `undefined`, `null` parses to `null`. Every field is
+ * therefore `.nullable().optional()` — the two markers are not interchangeable
+ * here, and collapsing them would destroy the distinction.
+ */
+
+/** A percentage: 0 is a real policy ("no commission"), so the floor is 0 not 1. */
+const percent = z
+  .number()
+  .min(0, "a percentage cannot be negative")
+  .max(1000, "a percentage above 1000 is almost certainly a typo")
+
+export const CreatePlatformCostConfigSchema = z.object({
+  /**
+   * When this policy takes effect. Defaults to now. A FUTURE date stages the
+   * policy without applying it — the resolver skips rows dated ahead of the
+   * moment it is asked about.
+   */
+  effective_from: z
+    .string()
+    .min(1)
+    .refine((v) => !Number.isNaN(new Date(v).getTime()), {
+      message: "must be a valid date",
+    })
+    .optional(),
+
+  /** Why the policy changed. Write the decision; the number is a column. */
+  notes: z.string().trim().max(2000).nullable().optional(),
+
+  platform_fee_percent: percent.nullable().optional(),
+  production_overhead_percent: percent.nullable().optional(),
+
+  /** Fallback per-unit material cost. Not a percentage — an amount. */
+  default_material_cost: z
+    .number()
+    .min(0, "a cost cannot be negative")
+    .nullable()
+    .optional(),
+  default_material_cost_currency: z
+    .string()
+    .trim()
+    .length(3, "a currency code is 3 letters, e.g. INR")
+    .nullable()
+    .optional(),
+
+  custom_design_markup_percent: percent.nullable().optional(),
+
+  /**
+   * A MULTIPLIER, not a percentage: 1.4 lists at 140% of cost. Floored at 1
+   * because a multiplier below 1 lists BELOW cost, which is a loss on every
+   * unit and is far more likely a percentage typed into the wrong field.
+   */
+  approval_markup_multiplier: z
+    .number()
+    .min(1, "a multiplier below 1 would list below cost — did you mean a percent?")
+    // 🔴 Ceiling of 10, not 100. The realistic range is 1.0–2.0 (1.4 today), and
+    // 10x cost is already a 90% margin. A loose ceiling here does not catch the
+    // one mistake this field actually invites: typing the PERCENT (20, 25, 40)
+    // into the MULTIPLIER. A probe caught `40` sailing through a max of 100 and
+    // listing at 4000% of cost.
+    .max(
+      10,
+      "a multiplier above 10 is almost certainly a percentage — 1.4 means 140% of cost, 40 would mean 4000%"
+    )
+    .nullable()
+    .optional(),
+})
+
+export type CreatePlatformCostConfig = z.infer<
+  typeof CreatePlatformCostConfigSchema
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -213,6 +213,7 @@ import {
   CreateExportLutSchema,
   UpdateExportLutSchema,
 } from "./admin/platform-tax-identities/validators";
+import { CreatePlatformCostConfigSchema } from "./admin/platform-cost-config/validators";
 import { createPlanSchema, updatePlanSchema, createSubscriptionSchema } from "./admin/partner-plans/validators";
 import { subscribeSchema as partnerSubscribeSchema } from "./partners/subscription/validators";
 import { AdminPostInventoryOrderTasksReq } from "./admin/inventory-orders/[id]/tasks/validators";
@@ -2900,6 +2901,21 @@ export default defineMiddlewares({
       matcher: "/admin/platform-tax-identities",
       method: "GET",
       middlewares: [],
+    },
+    {
+      matcher: "/admin/platform-cost-config",
+      method: "GET",
+      middlewares: [],
+    },
+    {
+      // #1939 — an INSERT, not an update: the table is effective-dated so a
+      // price already quoted stays explicable under the policy it was quoted
+      // under. There is deliberately no PATCH.
+      matcher: "/admin/platform-cost-config",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(CreatePlatformCostConfigSchema)),
+      ],
     },
     {
       matcher: "/admin/platform-tax-identities/:id/export-luts",

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -203,10 +203,6 @@ const NO_ROUTE_VALIDATOR = new Set<string>([
  *     come back, not a claim that the omission is correct.
  */
 const DELIBERATELY_OMITTED: Record<string, Record<string, string>> = {
-  "admin:create_task_template": {
-    category:
-      "the validator accepts BOTH `category` (a bare string) and `category_id`, and only the id resolves to a real row — offering both would invite a model to name a category in prose and get a template attached to nothing",
-  },
   "admin:create_social_post": {
     post_url: "set by the publisher callback, not by the author",
     posted_at: "as post_url",

--- a/apps/backend/src/modules/platform-cost-config/__tests__/read-config.unit.spec.ts
+++ b/apps/backend/src/modules/platform-cost-config/__tests__/read-config.unit.spec.ts
@@ -1,0 +1,105 @@
+import { EMPTY_COST_CONFIG, loadCostConfig } from "../read-config"
+import { PLATFORM_COST_CONFIG_MODULE } from "../index"
+
+/**
+ * #1939 — the I/O wrapper's failure modes.
+ *
+ * Every one of these is a path where a naive implementation returns zeros and
+ * prices a garment at nothing. The contract is: never throw, never zero, always
+ * an all-null policy the caller can recognise as "no policy".
+ */
+
+const rows = [
+  {
+    id: "pcc_initial",
+    effective_from: "2025-01-01T00:00:00Z",
+    is_active: true,
+    platform_fee_percent: 10,
+    custom_design_markup_percent: 20,
+    approval_markup_multiplier: 1.4,
+  },
+]
+
+const containerWith = (service: any) => ({
+  resolve: (key: string) => {
+    if (key === PLATFORM_COST_CONFIG_MODULE) return service
+    throw new Error(`unknown module ${key}`)
+  },
+})
+
+describe("loadCostConfig", () => {
+  it("reads the policy in force through the module", async () => {
+    const out = await loadCostConfig(
+      containerWith({ listPlatformCostConfigs: async () => rows })
+    )
+    expect(out.platform_fee_percent).toBe(10)
+    expect(out.custom_design_markup_percent).toBe(20)
+    expect(out.approval_markup_multiplier).toBe(1.4)
+    expect(out.source_config_id).toBe("pcc_initial")
+  })
+
+  it("returns an all-null policy when the module is not registered", async () => {
+    const container = {
+      resolve: () => {
+        throw new Error("module not found")
+      },
+    }
+    await expect(loadCostConfig(container)).resolves.toEqual(EMPTY_COST_CONFIG)
+  })
+
+  it("returns an all-null policy when the query throws", async () => {
+    const out = await loadCostConfig(
+      containerWith({
+        listPlatformCostConfigs: async () => {
+          throw new Error("connection reset")
+        },
+      })
+    )
+    expect(out).toEqual(EMPTY_COST_CONFIG)
+  })
+
+  it("returns an all-null policy when the table is empty", async () => {
+    const out = await loadCostConfig(
+      containerWith({ listPlatformCostConfigs: async () => [] })
+    )
+    expect(out).toEqual(EMPTY_COST_CONFIG)
+  })
+
+  it("returns an all-null policy when the service lacks the list method", async () => {
+    const out = await loadCostConfig(containerWith({}))
+    expect(out).toEqual(EMPTY_COST_CONFIG)
+  })
+
+  it("🔴 no failure path ever yields a zero — a zero would price at nothing", async () => {
+    const failures = [
+      containerWith({}),
+      containerWith({ listPlatformCostConfigs: async () => [] }),
+      containerWith({
+        listPlatformCostConfigs: async () => {
+          throw new Error("boom")
+        },
+      }),
+    ]
+    for (const c of failures) {
+      const out = await loadCostConfig(c)
+      // Asserted on values, not with toBeFalsy — `toBeFalsy` passes on 0, which
+      // is precisely the value this test exists to forbid.
+      expect(Object.values(out)).not.toContain(0)
+      expect(out.platform_fee_percent).toBeNull()
+      expect(out.approval_markup_multiplier).toBeNull()
+    }
+  })
+
+  it("honours the `at` moment, not just the latest row", async () => {
+    const twoPolicies = [
+      { id: "old", effective_from: "2025-01-01T00:00:00Z", is_active: true, custom_design_markup_percent: 20 },
+      { id: "new", effective_from: "2026-06-01T00:00:00Z", is_active: true, custom_design_markup_percent: 25 },
+    ]
+    const service = { listPlatformCostConfigs: async () => twoPolicies }
+    const before = await loadCostConfig(containerWith(service), new Date("2026-03-01T00:00:00Z"))
+    const after = await loadCostConfig(containerWith(service), new Date("2026-09-01T00:00:00Z"))
+    // A design quoted in March stays explicable after the policy moves in June.
+    expect(before.custom_design_markup_percent).toBe(20)
+    expect(after.custom_design_markup_percent).toBe(25)
+  })
+})

--- a/apps/backend/src/modules/platform-cost-config/__tests__/resolve-lib.unit.spec.ts
+++ b/apps/backend/src/modules/platform-cost-config/__tests__/resolve-lib.unit.spec.ts
@@ -1,0 +1,174 @@
+import {
+  effectiveAtMs,
+  readCostConfig,
+  readNumber,
+  resolveCostConfig,
+  type PlatformCostConfigRow,
+} from "../resolve-lib"
+
+/**
+ * #1939 — the cost-config resolver.
+ *
+ * These tests are almost entirely about ABSENCE, because absence is what has
+ * gone wrong here before: a `0` that meant "I found nothing" reached storefront
+ * checkout. So the assertions that matter most are the ones distinguishing
+ * `null` (nobody decided) from `0` (we decided it is free).
+ */
+
+const row = (o: Partial<PlatformCostConfigRow>): PlatformCostConfigRow => ({
+  id: "pcc_x",
+  effective_from: "2025-01-01T00:00:00Z",
+  is_active: true,
+  ...o,
+})
+
+describe("readNumber", () => {
+  it("preserves a real zero — a zero fee is a policy, not an absence", () => {
+    expect(readNumber(0)).toBe(0)
+    expect(readNumber("0")).toBe(0)
+  })
+
+  it("returns null (never 0) for every flavour of unset", () => {
+    // Number(null) === 0 and Number("") === 0; both must NOT survive as 0.
+    expect(readNumber(null)).toBeNull()
+    expect(readNumber(undefined)).toBeNull()
+    expect(readNumber("")).toBeNull()
+    expect(readNumber("   ")).toBeNull()
+  })
+
+  it("returns null for a corrupt value rather than NaN/Infinity", () => {
+    expect(readNumber("abc")).toBeNull()
+    expect(readNumber(NaN)).toBeNull()
+    expect(readNumber(Infinity)).toBeNull()
+  })
+
+  it("reads a numeric string, as a DECIMAL column comes back", () => {
+    expect(readNumber("1.4")).toBe(1.4)
+    expect(readNumber("600")).toBe(600)
+  })
+})
+
+describe("effectiveAtMs", () => {
+  it("accepts a Date and an ISO string alike", () => {
+    const iso = "2026-03-01T00:00:00Z"
+    expect(effectiveAtMs(new Date(iso))).toBe(Date.parse(iso))
+    expect(effectiveAtMs(iso)).toBe(Date.parse(iso))
+  })
+
+  it("returns null for a missing or unparseable date", () => {
+    expect(effectiveAtMs(null)).toBeNull()
+    expect(effectiveAtMs(undefined)).toBeNull()
+    expect(effectiveAtMs("not a date")).toBeNull()
+  })
+})
+
+describe("resolveCostConfig", () => {
+  const at = new Date("2026-06-01T00:00:00Z")
+
+  it("picks the LATEST policy effective at or before the moment", () => {
+    const old = row({ id: "old", effective_from: "2025-01-01T00:00:00Z" })
+    const current = row({ id: "current", effective_from: "2026-01-01T00:00:00Z" })
+    expect(resolveCostConfig([old, current], at)?.id).toBe("current")
+    // order of the input must not decide the answer
+    expect(resolveCostConfig([current, old], at)?.id).toBe("current")
+  })
+
+  it("does NOT apply a future-dated row — staging is not taking effect", () => {
+    const current = row({ id: "current", effective_from: "2026-01-01T00:00:00Z" })
+    const staged = row({ id: "staged", effective_from: "2026-12-01T00:00:00Z" })
+    expect(resolveCostConfig([current, staged], at)?.id).toBe("current")
+  })
+
+  it("skips an inactive row and falls back to the one it superseded", () => {
+    const old = row({ id: "old", effective_from: "2025-01-01T00:00:00Z" })
+    const revoked = row({
+      id: "revoked",
+      effective_from: "2026-01-01T00:00:00Z",
+      is_active: false,
+    })
+    expect(resolveCostConfig([old, revoked], at)?.id).toBe("old")
+  })
+
+  it("skips a row with a broken or missing date instead of guessing one", () => {
+    const broken = row({ id: "broken", effective_from: "nonsense" })
+    const undated = row({ id: "undated", effective_from: null })
+    expect(resolveCostConfig([broken, undated], at)).toBeNull()
+  })
+
+  it("returns null for no rows, empty rows, or nullish input", () => {
+    expect(resolveCostConfig([], at)).toBeNull()
+    expect(resolveCostConfig(null, at)).toBeNull()
+    expect(resolveCostConfig(undefined, at)).toBeNull()
+  })
+
+  it("treats a row effective at exactly the moment as in force", () => {
+    const exact = row({ id: "exact", effective_from: at.toISOString() })
+    expect(resolveCostConfig([exact], at)?.id).toBe("exact")
+  })
+})
+
+describe("readCostConfig", () => {
+  it("🔴 returns NULLS, not zeros, when there is no policy at all", () => {
+    const out = readCostConfig(null)
+    // The bug this guards: a caller doing arithmetic on these would price at 0.
+    expect(out.platform_fee_percent).toBeNull()
+    expect(out.production_overhead_percent).toBeNull()
+    expect(out.default_material_cost).toBeNull()
+    expect(out.custom_design_markup_percent).toBeNull()
+    expect(out.approval_markup_multiplier).toBeNull()
+    expect(out.default_material_cost_currency).toBeNull()
+    expect(out.source_config_id).toBeNull()
+    expect(out.effective_from).toBeNull()
+    // Stated explicitly, because `toBeFalsy` would pass on 0 and hide this.
+    expect(Object.values(out)).not.toContain(0)
+  })
+
+  it("preserves a deliberate zero fee distinctly from an unset one", () => {
+    const zeroed = readCostConfig(row({ platform_fee_percent: 0 }))
+    const unset = readCostConfig(row({ platform_fee_percent: null }))
+    expect(zeroed.platform_fee_percent).toBe(0)
+    expect(unset.platform_fee_percent).toBeNull()
+    // The two must not be conflated — this is the whole distinction.
+    expect(zeroed.platform_fee_percent).not.toBe(unset.platform_fee_percent)
+  })
+
+  it("reads the seeded policy — today's compiled constants", () => {
+    const out = readCostConfig(
+      row({
+        id: "pcc_initial",
+        platform_fee_percent: 10,
+        production_overhead_percent: 30,
+        default_material_cost: "600",
+        default_material_cost_currency: "INR",
+        custom_design_markup_percent: 20,
+        approval_markup_multiplier: 1.4,
+      })
+    )
+    expect(out.platform_fee_percent).toBe(10)
+    expect(out.production_overhead_percent).toBe(30)
+    expect(out.default_material_cost).toBe(600)
+    expect(out.default_material_cost_currency).toBe("INR")
+    expect(out.custom_design_markup_percent).toBe(20)
+    expect(out.approval_markup_multiplier).toBe(1.4)
+  })
+
+  it("returns the source id and date so a price can record what it used", () => {
+    const out = readCostConfig(
+      row({ id: "pcc_initial", effective_from: "2025-01-01T00:00:00Z" })
+    )
+    expect(out.source_config_id).toBe("pcc_initial")
+    expect(out.effective_from?.toISOString()).toBe("2025-01-01T00:00:00.000Z")
+  })
+
+  it("keeps the two markups separate — they differ in shape AND value", () => {
+    const out = readCostConfig(
+      row({ custom_design_markup_percent: 20, approval_markup_multiplier: 1.4 })
+    )
+    // 20 is a PERCENT, 1.4 is a MULTIPLIER. Conflating them misprices by ~17%.
+    expect(out.custom_design_markup_percent).toBe(20)
+    expect(out.approval_markup_multiplier).toBe(1.4)
+    expect(out.custom_design_markup_percent).not.toBe(
+      out.approval_markup_multiplier
+    )
+  })
+})

--- a/apps/backend/src/modules/platform-cost-config/index.ts
+++ b/apps/backend/src/modules/platform-cost-config/index.ts
@@ -1,0 +1,12 @@
+import { Module } from "@medusajs/framework/utils"
+import PlatformCostConfigService from "./service"
+
+export const PLATFORM_COST_CONFIG_MODULE = "platform_cost_config"
+
+const PlatformCostConfigModule = Module(PLATFORM_COST_CONFIG_MODULE, {
+  service: PlatformCostConfigService,
+})
+
+export { PlatformCostConfigModule }
+
+export default PlatformCostConfigModule

--- a/apps/backend/src/modules/platform-cost-config/migrations/Migration20260909120000.ts
+++ b/apps/backend/src/modules/platform-cost-config/migrations/Migration20260909120000.ts
@@ -1,0 +1,74 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1939 — create `platform_cost_config` and seed the policy currently compiled
+ * into the code, so the table's first row states today's behaviour exactly.
+ *
+ * Hand-written `create table if not exists` rather than a generated migration,
+ * so it lands cleanly on databases that already exist. The seed is idempotent
+ * (`on conflict (id) do nothing`) with a deterministic id, so re-runs are no-ops.
+ *
+ * 🔴 The seeded numbers are the ones in the code TODAY, not the ones we think
+ * are right. Seeding an improved number here would make the config disagree with
+ * every compiled fallback on day one and change prices as a side effect of a
+ * migration. Policy changes are a later INSERT with a new `effective_from`,
+ * which is the whole point of the table being effective-dated.
+ *
+ *   platform_fee_percent          10    <- estimate-design-cost.ts DEFAULT_PLATFORM_FEE_PERCENT
+ *   production_overhead_percent   30    <- estimate-design-cost.ts DEFAULT_PRODUCTION_PERCENT
+ *   default_material_cost         600   <- estimate-design-cost.ts DEFAULT_MATERIAL_COST (INR)
+ *   custom_design_markup_percent  20    <- partner-quote/lib/design-quote-price.ts
+ *   approval_markup_multiplier    1.4   <- production-runs/approval-pricing.ts APPROVAL_MARKUP
+ *
+ * `effective_from` is backdated to 2025-01-01 so the first row covers every
+ * price already computed under these constants — a row effective from today
+ * would leave all prior history resolving to "no policy".
+ */
+export class Migration20260909120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "platform_cost_config" (
+      "id" text not null,
+      "effective_from" timestamptz not null,
+      "notes" text null,
+      "is_active" boolean not null default true,
+      "platform_fee_percent" real null,
+      "production_overhead_percent" real null,
+      "default_material_cost" real null,
+      "default_material_cost_currency" text null,
+      "custom_design_markup_percent" real null,
+      "approval_markup_multiplier" real null,
+      "created_at" timestamptz not null default now(),
+      "updated_at" timestamptz not null default now(),
+      "deleted_at" timestamptz null,
+      constraint "platform_cost_config_pkey" primary key ("id")
+    );`);
+
+    this.addSql(`create index if not exists "IDX_platform_cost_config_deleted_at" on "platform_cost_config" ("deleted_at") where "deleted_at" is null;`);
+
+    this.addSql(`create index if not exists "IDX_platform_cost_config_effective_from" on "platform_cost_config" ("effective_from") where "deleted_at" is null;`);
+
+    this.addSql(`insert into "platform_cost_config"
+      ("id", "effective_from", "notes", "is_active",
+       "platform_fee_percent", "production_overhead_percent",
+       "default_material_cost", "default_material_cost_currency",
+       "custom_design_markup_percent", "approval_markup_multiplier")
+      values (
+        'pcc_initial',
+        '2025-01-01T00:00:00Z',
+        'Initial row: the constants compiled into the code as of #1939. Not a policy change — a statement of what was already true.',
+        true,
+        10,
+        30,
+        600,
+        'INR',
+        20,
+        1.4
+      )
+      on conflict ("id") do nothing;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "platform_cost_config";`);
+  }
+}

--- a/apps/backend/src/modules/platform-cost-config/models/platform-cost-config.ts
+++ b/apps/backend/src/modules/platform-cost-config/models/platform-cost-config.ts
@@ -1,0 +1,125 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Platform cost config (#1939) — the economic constants that decide what a
+ * design costs and what a buyer pays, in one readable place.
+ *
+ * ## Why this exists
+ *
+ * These numbers were scattered across four files as `export const`s, so the
+ * only way to see the platform's pricing policy was to grep for it — and the
+ * only way to change it was a deploy. Worse, nobody could see them TOGETHER:
+ * there are two different markups in this codebase (20% on the quote path,
+ * ×1.40 on the approval path) and that is invisible until they sit in one row.
+ *
+ * ## Why typed columns and not key/value
+ *
+ * A `key`/`value` table would be more flexible and would be a mistake. These
+ * numbers decide payouts and retail prices, and this codebase has already paid
+ * for untyped contracts twice — a `metadata` blob that decided partner payouts,
+ * and typed fields at the door with an untyped contract behind them. A column
+ * per number means a migration to add one, a type error when a reader guesses,
+ * and a grep that actually finds the readers.
+ *
+ * ## Why effective-dated and not a mutable singleton
+ *
+ * ONE ROW PER POLICY PERIOD, not a row someone edits in place — the same shape
+ * `platform_export_lut` uses for LUTs. A design quoted in March at 20% markup
+ * must still be explicable in June after the markup moves to 25%. Changing a
+ * price is an INSERT with a new `effective_from`; the old row stays readable,
+ * which is the only way to answer "what did we charge under, and why?" later.
+ *
+ * 🔴 Every economic column is NULLABLE and null means NOT CONFIGURED — it does
+ * NOT mean zero. A 0 platform fee is a real, deliberate policy ("we take no
+ * commission"); a null is the absence of a decision. Readers must ask
+ * `!= null`, never truthiness, because `0` is falsy and `Number(null)` is `0`.
+ * This codebase has shipped that exact bug: an estimator reported "I found
+ * nothing" as `total_estimated: 0` and it reached storefront checkout.
+ *
+ * ## What deliberately is NOT here
+ *
+ * The photoshoot budget. It lives in the Photo Shoot task templates and is
+ * summed by `photoshootBudget()` — operator-editable in Settings → Task
+ * Templates, which is the right home for a number the ops team tunes per shoot.
+ * Duplicating it here would create two sources of truth for the same money.
+ * Marketing, tech and shipping overheads are also absent: #1939 has not settled
+ * their UNIT yet, and a column nobody writes is a field readers will guess at.
+ */
+const PlatformCostConfig = model.define("platform_cost_config", {
+  id: model.id().primaryKey(),
+
+  /**
+   * The instant this policy takes effect. The row in force at a given moment is
+   * the active one with the LATEST `effective_from` at or before it — so a
+   * future-dated row can be staged without taking effect.
+   */
+  effective_from: model.dateTime(),
+
+  /**
+   * Why this policy changed, for the person reading it back in six months.
+   * Free text, but write the decision, not the number — the number is a column.
+   */
+  notes: model.text().nullable(),
+
+  /**
+   * Superseded rows are deactivated rather than deleted: a policy a past quote
+   * was priced under must stay readable. Inactive rows are skipped entirely.
+   */
+  is_active: model.boolean().default(true),
+
+  /**
+   * JYT's commission on partner production work, as a percentage of material
+   * cost. Was `DEFAULT_PLATFORM_FEE_PERCENT = 10`.
+   * 0 is meaningful here: "we take no commission". null is "undecided".
+   */
+  platform_fee_percent: model.float().nullable(),
+
+  /**
+   * Production overhead as a percentage of material cost. Was the un-exported
+   * `DEFAULT_PRODUCTION_PERCENT = 30` — un-exported meant no test could reach it.
+   */
+  production_overhead_percent: model.float().nullable(),
+
+  /**
+   * Fallback per-unit material cost when a BOM material has NO resolved price
+   * (no order history, no unit_cost, no consumption log). Was
+   * `DEFAULT_MATERIAL_COST = 600`.
+   *
+   * 🔴 A fallback, applied only when a caller opts in. It is a guess standing in
+   * for a fact, and a design priced on it is less certain than one priced on
+   * real purchases — which is why the estimator reports `confidence` alongside.
+   *
+   * `float`, not `bigNumber`, deliberately: this replaces a plain
+   * `const DEFAULT_MATERIAL_COST = 600` and feeds an estimator that does
+   * ordinary JS arithmetic with a `round2` helper throughout. `bigNumber` would
+   * add a companion `raw_default_material_cost` jsonb column and MikroORM
+   * hydration machinery to a configuration default that never participates in a
+   * transaction — precision this number does not have to begin with, since it
+   * is a stand-in for a price nobody looked up.
+   */
+  default_material_cost: model.float().nullable(),
+
+  /** Currency of `default_material_cost` (e.g. "INR"). A cost with no currency cannot be added up. */
+  default_material_cost_currency: model.text().nullable(),
+
+  /**
+   * Markup on a custom/commissioned design's quoted price, as a PERCENTAGE.
+   * Was `DEFAULT_CUSTOM_DESIGN_MARKUP_PERCENT = 20`. The founder's 2026-09-09
+   * decision extends this from quotes to the retail path too.
+   */
+  custom_design_markup_percent: model.float().nullable(),
+
+  /**
+   * Markup applied when a production run's approved output is listed, as a
+   * MULTIPLIER on cost. Was `APPROVAL_MARKUP = 1.4`.
+   *
+   * ⚠️ A multiplier, not a percentage, and deliberately a different column from
+   * `custom_design_markup_percent` — they are different shapes AND different
+   * numbers (×1.40 vs 20%). Storing both as "markup" would invite a reader to
+   * use one where the other belongs. Note ×1.40 is a markup ON COST: the margin
+   * is 28.6% (0.4/1.4), not 40%.
+   */
+  approval_markup_multiplier: model.float().nullable(),
+})
+
+export default PlatformCostConfig

--- a/apps/backend/src/modules/platform-cost-config/read-config.ts
+++ b/apps/backend/src/modules/platform-cost-config/read-config.ts
@@ -1,0 +1,60 @@
+import { PLATFORM_COST_CONFIG_MODULE } from "./index"
+import {
+  readCostConfig,
+  resolveCostConfig,
+  type ResolvedCostConfig,
+} from "./resolve-lib"
+
+/**
+ * The I/O half of cost-config reading (#1939): load the rows, hand them to the
+ * pure resolver. Kept separate so the resolution rules stay unit-testable
+ * without a container — the split `platform-tax-identity` uses.
+ */
+
+/** An all-null policy: what a caller gets when nothing is configured. */
+export const EMPTY_COST_CONFIG: ResolvedCostConfig = {
+  platform_fee_percent: null,
+  production_overhead_percent: null,
+  default_material_cost: null,
+  default_material_cost_currency: null,
+  custom_design_markup_percent: null,
+  approval_markup_multiplier: null,
+  source_config_id: null,
+  effective_from: null,
+}
+
+/**
+ * Read the cost policy in force at `at` (default now).
+ *
+ * 🔴 Never throws and never returns zeros. A container without the module
+ * registered, a table that is empty, or a query that fails all resolve to
+ * `EMPTY_COST_CONFIG` — every field null — so a caller falls through to its own
+ * documented default instead of silently pricing at zero. That failure mode is
+ * not hypothetical here: an estimator that reported "found nothing" as `0`
+ * reached storefront checkout once already.
+ *
+ * The cost of that safety is that a genuine outage is indistinguishable from an
+ * unconfigured platform. Both mean "I have no policy", both make the caller use
+ * its compiled-in constant, and neither invents a number — which is the right
+ * trade when the alternative is billing someone on a guess.
+ */
+export async function loadCostConfig(
+  container: { resolve: (key: string) => any },
+  at: Date = new Date()
+): Promise<ResolvedCostConfig> {
+  let service: any
+  try {
+    service = container.resolve(PLATFORM_COST_CONFIG_MODULE)
+  } catch {
+    return EMPTY_COST_CONFIG
+  }
+  if (!service?.listPlatformCostConfigs) {
+    return EMPTY_COST_CONFIG
+  }
+  try {
+    const rows = await service.listPlatformCostConfigs({}, { take: null })
+    return readCostConfig(resolveCostConfig(rows, at))
+  } catch {
+    return EMPTY_COST_CONFIG
+  }
+}

--- a/apps/backend/src/modules/platform-cost-config/resolve-lib.ts
+++ b/apps/backend/src/modules/platform-cost-config/resolve-lib.ts
@@ -1,0 +1,135 @@
+/**
+ * Platform cost-config resolution (#1939).
+ *
+ * A PURE library — no container, no I/O. Given the rows and a moment, it picks
+ * the policy in force and reads numbers out of it safely. The I/O wrapper that
+ * loads rows from the module lives in `read-config.ts`.
+ *
+ * Pure because the interesting logic is entirely in the edge cases — a null that
+ * must not become 0, a future-dated row that must not take effect early — and
+ * those deserve unit tests that cannot be faked by a stubbed container.
+ */
+
+/** A row of `platform_cost_config` (only the fields resolution reads). */
+export interface PlatformCostConfigRow {
+  id?: string | null
+  effective_from?: Date | string | null
+  is_active?: boolean | null
+  notes?: string | null
+  platform_fee_percent?: number | string | null
+  production_overhead_percent?: number | string | null
+  default_material_cost?: number | string | null
+  default_material_cost_currency?: string | null
+  custom_design_markup_percent?: number | string | null
+  approval_markup_multiplier?: number | string | null
+}
+
+/**
+ * PURE: coerce a stored numeric to a usable number, preserving ABSENCE.
+ *
+ * 🔴 The whole point is that this returns `null` — not `0` — for an unset value.
+ * `Number(null)` is `0`, `Number("")` is `0` and `Number(undefined)` is `NaN`,
+ * so a naive `Number(row.field)` turns "nobody decided" into "the fee is zero"
+ * and bills a partner accordingly. `0` itself is preserved, because a zero fee
+ * is a real policy and must survive.
+ *
+ * Also rejects NaN and Infinity: a corrupt row must read as absent, not as a
+ * number that poisons every arithmetic downstream of it.
+ */
+export function readNumber(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+  if (typeof value === "string" && value.trim() === "") {
+    return null
+  }
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+/** PURE: parse `effective_from` to epoch ms, or null when unusable. */
+export function effectiveAtMs(value: Date | string | null | undefined): number | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+  const ms = value instanceof Date ? value.getTime() : Date.parse(String(value))
+  return Number.isFinite(ms) ? ms : null
+}
+
+/**
+ * Resolve the policy in force at `at` (default: now).
+ *
+ * The active row with the LATEST `effective_from` at or before `at`. Rows that
+ * are inactive, undated, or dated in the future are skipped — so a policy can be
+ * staged ahead of time without silently taking effect, and a row with a broken
+ * date is ignored rather than being treated as the epoch (which would make it
+ * win nothing) or as now (which would make it win everything).
+ *
+ * Returns null when nothing is in force. A caller MUST treat that as "no
+ * configured policy" and fall back explicitly — never as zeros.
+ */
+export function resolveCostConfig(
+  rows: PlatformCostConfigRow[] | null | undefined,
+  at: Date = new Date()
+): PlatformCostConfigRow | null {
+  const atMs = at.getTime()
+  let best: PlatformCostConfigRow | null = null
+  let bestMs = -Infinity
+
+  for (const row of rows ?? []) {
+    if (!row || row.is_active === false) {
+      continue
+    }
+    const ms = effectiveAtMs(row.effective_from)
+    if (ms === null || ms > atMs) {
+      continue
+    }
+    if (ms > bestMs) {
+      best = row
+      bestMs = ms
+    }
+  }
+  return best
+}
+
+/** The numbers a caller actually wants, with absence preserved throughout. */
+export interface ResolvedCostConfig {
+  platform_fee_percent: number | null
+  production_overhead_percent: number | null
+  default_material_cost: number | null
+  default_material_cost_currency: string | null
+  custom_design_markup_percent: number | null
+  approval_markup_multiplier: number | null
+  /** The row these came from, for recording WHAT WAS USED alongside a price. */
+  source_config_id: string | null
+  /** When that policy took effect — the other half of an auditable price. */
+  effective_from: Date | null
+}
+
+/**
+ * PURE: flatten a row into typed numbers, every one of which may be null.
+ *
+ * Returns an all-null shape when there is no row, rather than throwing: a caller
+ * that has no policy configured is in a normal state (a fresh install), and the
+ * nulls make it apply its own documented fallbacks. What it must never get is
+ * zeros, which would look like a decision.
+ *
+ * `source_config_id` and `effective_from` come back so a caller can record which
+ * policy a price was computed under — #1939 asks for "what it used at the time,
+ * rather than recomputing history", and that is impossible without the id.
+ */
+export function readCostConfig(
+  row: PlatformCostConfigRow | null | undefined
+): ResolvedCostConfig {
+  const effMs = effectiveAtMs(row?.effective_from)
+  return {
+    platform_fee_percent: readNumber(row?.platform_fee_percent),
+    production_overhead_percent: readNumber(row?.production_overhead_percent),
+    default_material_cost: readNumber(row?.default_material_cost),
+    default_material_cost_currency: row?.default_material_cost_currency ?? null,
+    custom_design_markup_percent: readNumber(row?.custom_design_markup_percent),
+    approval_markup_multiplier: readNumber(row?.approval_markup_multiplier),
+    source_config_id: row?.id ?? null,
+    effective_from: effMs === null ? null : new Date(effMs),
+  }
+}

--- a/apps/backend/src/modules/platform-cost-config/service.ts
+++ b/apps/backend/src/modules/platform-cost-config/service.ts
@@ -1,0 +1,12 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import PlatformCostConfig from "./models/platform-cost-config"
+
+class PlatformCostConfigService extends MedusaService({
+  PlatformCostConfig,
+}) {
+  constructor() {
+    super(...arguments)
+  }
+}
+
+export default PlatformCostConfigService

--- a/apps/backend/src/scripts/seed-photoshoot-task-templates.ts
+++ b/apps/backend/src/scripts/seed-photoshoot-task-templates.ts
@@ -22,10 +22,22 @@
  * for it today. `estimate-design-cost` totals
  * `material_cost + production_cost + platform_fee` and stops there.
  *
- * 🔴 These figures are STARTING points, per shoot unless the name says
- * otherwise, and deliberately conservative. They are what an operator edits in
- * Settings → Task Templates once real shoots have been run — which is exactly
- * why the installer never overwrites an existing template.
+ * 🔴 These figures are STARTING points and are PER SHOOT — not per design.
+ * A shoot costs around ₹5,000 whether it covers one design or several, so the
+ * cost a single design carries is `photoshootBudget() / (designs in that
+ * shoot)`. The divisor is the number of designs actually shot together, which
+ * is KNOWN once the shoot has happened — it is not a forecast of future sales
+ * volume, and must never be treated as one.
+ *
+ * The consequence for #1939: a design that has NOT been shot yet carries
+ * `null`, not a guess and emphatically not `0`. There is no honest per-design
+ * shoot cost before the shoot exists, because the divisor does not exist yet.
+ * The number is attributed afterwards, from the actual grouping, and recorded
+ * as what was used at the time.
+ *
+ * They are what an operator edits in Settings → Task Templates once real
+ * shoots have been run — which is exactly why the installer never overwrites
+ * an existing template.
  *
  * ## What they are NOT
  *
@@ -73,7 +85,7 @@ export const PHOTOSHOOT_TEMPLATE_DEFS: PhotoshootTemplateDef[] = [
       "Prepare the produced garment for the camera: press and steam, style with props or a model, and set the look. Blocks the shoot itself.",
     priority: "medium",
     estimated_duration: 90,
-    estimated_cost: 1500,
+    estimated_cost: 750,
     cost_currency: "INR",
     eventable: true,
     notifiable: true,
@@ -94,7 +106,7 @@ export const PHOTOSHOOT_TEMPLATE_DEFS: PhotoshootTemplateDef[] = [
       "Shoot the garment. Covers the photographer's time, studio or location, and lighting. The output is raw frames, not the final images.",
     priority: "high",
     estimated_duration: 180,
-    estimated_cost: 6000,
+    estimated_cost: 3000,
     cost_currency: "INR",
     eventable: true,
     notifiable: true,
@@ -121,7 +133,7 @@ export const PHOTOSHOOT_TEMPLATE_DEFS: PhotoshootTemplateDef[] = [
       "Select, colour-correct and retouch the frames worth keeping. Colour accuracy matters here — a customer returns a garment that arrives a different shade from the photograph.",
     priority: "medium",
     estimated_duration: 120,
-    estimated_cost: 2500,
+    estimated_cost: 1250,
     cost_currency: "INR",
     eventable: true,
     notifiable: true,


### PR DESCRIPTION
Closes part of #1939. Builds on the founder decisions recorded on #1939 and #1920.

## The problem

The five numbers that decide what a design costs and what a buyer pays lived as `export const`s across four files. The only way to see the policy was to grep; the only way to change it was a deploy. And nobody could see them **together** — which matters:

| | value | shape | path |
|---|---:|---|---|
| `custom_design_markup_percent` | 20 | **percent** | quote / retail |
| `approval_markup_multiplier` | 1.4 | **multiplier** | run approval |

🔴 **There are two markups and they are not the same shape.** At ×1.40 the margin is 28.6%, not 40%. The 2026-09-09 decision ("retail carries the 20% markup") did not mention the approval path at all — a gap only visible once both sit in one row. **Worth a decision before #1939's build.**

## What this adds

`src/modules/platform-cost-config` — model, service, pure `resolve-lib`, hand-written migration, unit tests — following the `platform-tax-identity` shape. Plus `GET`/`POST /admin/platform-cost-config` and two MCP tools.

Today's values are seeded exactly:

```
platform_fee_percent          10    <- estimate-design-cost.ts:164
production_overhead_percent   30    <- estimate-design-cost.ts (un-exported!)
default_material_cost         600   <- estimate-design-cost.ts:169 (INR)
custom_design_markup_percent  20    <- partner-quote/lib/design-quote-price.ts
approval_markup_multiplier    1.4   <- production-runs/approval-pricing.ts
```

## Three design decisions

**Typed columns, not key/value.** More flexible would be a mistake — these numbers decide payouts and retail prices, and this repo has paid twice for untyped contracts deciding money. A column per number means a migration to add one and a grep that finds the readers.

**Effective-dated, not mutable.** One row per policy period, the shape `platform_export_lut` already uses. A design quoted in March at 20% stays explicable in June at 25%. A change is an INSERT; **there is deliberately no PATCH**, because editing in place rewrites the past. `readCostConfig` returns `source_config_id` and `effective_from` so a price can cite the policy it was computed under — #1939's own "record what it used at the time" requirement.

**`null` is not `0`.** null means *not configured*; `0` means *we decided it is free*. `readNumber` preserves a real `0` and returns null for null/undefined/`""`/NaN — `Number(null) === 0` would turn "nobody decided" into "the fee is zero". `loadCostConfig` never throws and never returns zeros: unregistered module, empty table and failed query all resolve to an all-null policy, so callers fall back to their documented constant instead of pricing at nothing.

*Accepted cost:* an outage is indistinguishable from an unconfigured platform. Both mean "no policy", neither invents a number — the right trade when the alternative is billing on a guess.

## The carry-forward rule

A request meaning "raise the markup to 25%" sends one field. If the other four landed as null it would silently switch off the platform fee, the overhead and the approval markup.

```
field ABSENT     -> carry forward from the policy in force AT THE NEW ROW'S DATE
field = null     -> deliberately unset
field = value    -> use it
```

Carry-forward reads the policy in force at the **new row's own date**, not merely the latest row — back-dating a correction must not import a later policy's numbers. `undefined` counts as absent, because a caller spreading `{...patch, f: undefined}` would otherwise blank a column. **The first version got that wrong and its own unit test caught it.**

## On the MCP

- `get_platform_cost_config` — reads the policy, `at` for a past moment
- `set_platform_cost_config` — inserts the next one (sensitive, `confirm:true`)

Classified under `money` in `tool-slice`. Without that line both classify as undefined and load in **no** slice: registered, callable in principle, reachable from no ask.

## Two corrections carried in

**The shoot is priced per SHOOT, ~₹5,000 not ₹10,000.** A shoot covers one design or several, so the divisor is the number of designs shot *together* — known once the shoot happens, not the forecast of future volume #1939 assumed. Templates scaled proportionally (750 / 3,000 / 1,250). Safe: prod has never been seeded (23 templates, no Photo Shoot category). `photoshootBudget()` stays the single source of truth.

**`create_task_template` CAN create a category.** #1938 recorded otherwise, conflating two routes: `/admin/task-templates/categories` is GET-only, but `POST /admin/task-templates` takes `category` as a NAME and `checkCategory` creates it when nothing matches. The tool had omitted that field, leaving it demanding a `category_id` nothing could produce. Restored, with the real hazard stated instead — a name differing by a space creates a second category nothing over HTTP can merge. (`required_fields` must still be an OBJECT, so the photoshoot templates still need the seed job; the category was never the blocker.)

## Verified

- **Migration run against a real database** — table created, seed row correct, re-run gives `INSERT 0 0`. Backdated to 2025-01-01 so it covers prices already computed under these constants.
- **Routes exercised over HTTP with a real token.** A nonexistent control route returns 404 while these return 200/201 — an *unauthenticated* probe could not tell them apart, since auth answers before routing.
- **Carry-forward confirmed live:** posting only the markup left the other four intact. **Effective-dating confirmed:** `?at=` before the new row returns the old policy.
- 🔴 **A live probe caught a real defect:** `approval_markup_multiplier: 40` was **accepted** under a max of 100 — listing at 4000% of cost, the exact percent/multiplier confusion the field warns about. Ceiling tightened to 10; now rejected, with 1.4 still accepted.
- **39 unit tests**, and the null-preservation guard is **mutation-tested** — replacing `readNumber` with the naive `Number(value)` fails exactly the two tests that claim to catch it.
- `model.float()`, not `bigNumber()` — caught in review that `bigNumber` needs a companion `raw_<field>` jsonb column the hand-written migration lacked, which would have failed at runtime.
- **547 passing** across `platform-cost-config|admin/mcp|mcp-core|task-template|tool-slice`. The 2 failures in `route-validator-field-coverage` are **pre-existing** (confirmed by stashing and diffing the pass/fail set — identical).
- `tsc` byte-identical to baseline (431 pre-existing errors before and after, none in the new files).

## ⚠️ Nothing reads the table yet, on purpose

The constants are unchanged and still authoritative. Rewiring `estimate-design-cost`, `design-quote-price` and `approval-pricing` changes live pricing and belongs in #1939's build with integration tests behind it. The seeded row states today's behaviour exactly, so that rewiring is a no-op on day one.

## Deploy note

`create_task_template` (from #1938) is still **absent from the prod MCP surface** — prod is running a pre-#1938 build. These two new tools land with the same deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
