### PR TITLE
feat(designs): attach and detach the design behind an order item, and tell the customer honestly (#1918)

### DIFF
--- a/apps/backend/src/api/admin/designs/orders/[lineItemId]/design/route.ts
+++ b/apps/backend/src/api/admin/designs/orders/[lineItemId]/design/route.ts
@@ -1,0 +1,61 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { changeOrderItemDesign } from "../../../../../../workflows/designs/change-order-item-design"
+
+/**
+ * POST /admin/designs/orders/:lineItemId/design
+ *
+ * Attach, replace or detach the design behind an order line item (#1918).
+ *
+ * `{ "design_id": "01K..." }`  attaches or replaces
+ * `{ "design_id": null }`      DETACHES — the item keeps its
+ *                              `metadata.design_id` provenance, so "unlinked"
+ *                              stays distinguishable from "never had one"
+ *
+ * The customer is emailed what changed, with each garment's real production
+ * state. Pass `notify: false` for a correction they should not see, and
+ * `dry_run: true` to preview the change and the email without doing either.
+ *
+ * ⚠️ This is the ORDER line item link (#1919), not the cart one. The older
+ * `design_line_item` link dies at checkout and cannot be re-pointed afterwards,
+ * which is the whole reason this route exists.
+ */
+export async function POST(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  const { lineItemId } = req.params
+  const body = (req.validatedBody ?? {}) as {
+    design_id?: string | null
+    notify?: boolean
+    dry_run?: boolean
+  }
+
+  // `design_id` must be PRESENT — omitting it is ambiguous between "detach" and
+  // "I forgot the field", and one of those silently unlinks a paid-for garment.
+  if (!Object.prototype.hasOwnProperty.call(body, "design_id")) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "`design_id` is required. Send a design id to attach, or an explicit null to detach."
+    )
+  }
+
+  try {
+    const result = await changeOrderItemDesign(req.scope, {
+      line_item_id: lineItemId,
+      design_id: body.design_id ?? null,
+      notify: body.notify,
+      dry_run: body.dry_run,
+    })
+    res.json(result)
+  } catch (e: any) {
+    if (/does not exist/i.test(e?.message ?? "")) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, e.message)
+    }
+    throw e
+  }
+}

--- a/apps/backend/src/api/admin/designs/orders/[lineItemId]/design/validators.ts
+++ b/apps/backend/src/api/admin/designs/orders/[lineItemId]/design/validators.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+/**
+ * #1918 — re-point an order item's design.
+ *
+ * `design_id` is `.nullable()` but NOT `.optional()`: an explicit null is the
+ * detach instruction, and omitting the field entirely is rejected by the route.
+ * Those must stay distinguishable — treating a forgotten field as a detach
+ * would silently unlink a garment somebody paid for.
+ */
+export const ChangeOrderItemDesignSchema = z.object({
+  design_id: z.string().trim().min(1).nullable(),
+  /** Skip the customer email — for a correction they should not see. */
+  notify: z.boolean().optional(),
+  /** Preview the change and the email without performing either. */
+  dry_run: z.boolean().optional(),
+})
+
+export type ChangeOrderItemDesign = z.infer<typeof ChangeOrderItemDesignSchema>

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -3530,6 +3530,35 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       ["id", "taskId"]
     ),
   },
+  {
+    name: "change_order_item_design",
+    description:
+      "Attach, replace or DETACH the design behind an order line item, and email the customer what changed. Sensitive: requires confirm:true. 🔑 This is the ORDER line-item link (#1919) — the older cart-level link dies at checkout, which is why a paid order could never be re-pointed before. Send `design_id` to attach or replace; send an explicit **null** to detach. Omitting `design_id` is REJECTED, because a forgotten field and a deliberate detach must not look the same when the result is unlinking a garment somebody paid for. Detaching keeps the item's `metadata.design_id` provenance, so 'unlinked' stays distinguishable from 'never had a design'. 🔑 ALWAYS run with `dry_run: true` first: it returns the exact change AND the email the customer would receive, including each garment's real production state, without writing or sending. The email tells the customer the truth per garment — 'already made' only when a run actually completed; a cancelled run or no run at all is reported as not started, never as reassurance. Use `notify: false` for a correction the customer should not see.",
+    method: "POST",
+    path: "/admin/designs/orders/:lineItemId/design",
+    pathParams: ["lineItemId"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["design_id", "notify", "dry_run"],
+    inputSchema: obj(
+      {
+        lineItemId: STR(
+          "The ORDER line item id (starts `ordli_`), from get_order or list_order_designs. NOT a cart line item (`cali_`) and not the order id."
+        ),
+        design_id: STR(
+          "The design to point this item at. Send an explicit null to DETACH. Required — omitting it is an error, not a detach."
+        ),
+        notify: BOOL(
+          "Whether to email the customer what changed. Defaults to true. Set false only for a correction the customer should not see."
+        ),
+        dry_run: BOOL(
+          "Preview the change and the email WITHOUT writing the link or sending anything. Do this first."
+        ),
+      },
+      ["lineItemId"]
+    ),
+  },
+
   // ---- Platform cost config (#1939) --------------------------------------
   {
     name: "get_platform_cost_config",

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -214,6 +214,7 @@ import {
   UpdateExportLutSchema,
 } from "./admin/platform-tax-identities/validators";
 import { CreatePlatformCostConfigSchema } from "./admin/platform-cost-config/validators";
+import { ChangeOrderItemDesignSchema } from "./admin/designs/orders/[lineItemId]/design/validators";
 import { createPlanSchema, updatePlanSchema, createSubscriptionSchema } from "./admin/partner-plans/validators";
 import { subscribeSchema as partnerSubscribeSchema } from "./partners/subscription/validators";
 import { AdminPostInventoryOrderTasksReq } from "./admin/inventory-orders/[id]/tasks/validators";
@@ -2901,6 +2902,15 @@ export default defineMiddlewares({
       matcher: "/admin/platform-tax-identities",
       method: "GET",
       middlewares: [],
+    },
+    {
+      // #1918 — attach / replace / detach the design behind an ORDER line item.
+      // `design_id: null` detaches; omitting the field is rejected by the route.
+      matcher: "/admin/designs/orders/:lineItemId/design",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(ChangeOrderItemDesignSchema)),
+      ],
     },
     {
       matcher: "/admin/platform-cost-config",

--- a/apps/backend/src/workflows/designs/__tests__/design-change-notice.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/design-change-notice.unit.spec.ts
@@ -1,0 +1,203 @@
+import {
+  actionOf,
+  buildDesignChangeNotice,
+  isReassuring,
+  productionStateOf,
+  nextItemMetadata,
+  readProducedQuantity,
+  type DesignChange,
+} from "../lib/design-change-notice"
+
+/**
+ * #1918 — the honesty of the "your designs changed" email.
+ *
+ * The worked example throughout is Aline's real order
+ * (order_01KNP520PT94BN8SC0JKZ6ZVJ9): 5 design items, €335 captured, and
+ * exactly ONE production run — for the skirt that already shipped. Four
+ * garments are owed with no run at all.
+ */
+
+const change = (o: Partial<DesignChange>): DesignChange => ({
+  line_item_id: "ordli_x",
+  item_title: "Thing",
+  previous_design: { id: "d_old", name: "Old" },
+  new_design: { id: "d_new", name: "New" },
+  run: null,
+  ...o,
+})
+
+describe("productionStateOf", () => {
+  it("completed means MADE even when produced_quantity is null", () => {
+    // 12 parent runs in prod had a null produced_quantity while genuinely
+    // having produced goods. Requiring the quantity would tell a customer their
+    // finished garment was never started.
+    expect(productionStateOf({ status: "completed", produced_quantity: null })).toBe("made")
+    expect(productionStateOf({ status: "completed", produced_quantity: 1 })).toBe("made")
+  })
+
+  it("in-flight statuses mean BEING MADE", () => {
+    expect(productionStateOf({ status: "in_progress" })).toBe("being_made")
+    expect(productionStateOf({ status: "sent_to_partner" })).toBe("being_made")
+  })
+
+  it("pre-production statuses mean QUEUED, not made", () => {
+    for (const s of ["draft", "pending_review", "approved", "awaiting_reassignment"]) {
+      expect(productionStateOf({ status: s })).toBe("queued")
+    }
+  })
+
+  it("🔴 cancelled is NOT production — a run existing is not enough", () => {
+    // The naive rule "a run exists, therefore reassure" would tell a customer
+    // whose run was cancelled that their garment is in hand.
+    expect(productionStateOf({ status: "cancelled" })).toBe("not_started")
+    expect(isReassuring(productionStateOf({ status: "cancelled" }))).toBe(false)
+  })
+
+  it("no run, and an unrecognised status, promise the least", () => {
+    expect(productionStateOf(null)).toBe("not_started")
+    expect(productionStateOf({ status: null })).toBe("not_started")
+    expect(productionStateOf({ status: "some_new_status" })).toBe("not_started")
+  })
+})
+
+describe("readProducedQuantity", () => {
+  it("keeps a real 0 but returns null for absence", () => {
+    expect(readProducedQuantity(0)).toBe(0)
+    expect(readProducedQuantity(null)).toBeNull()
+    expect(readProducedQuantity(undefined)).toBeNull()
+    expect(readProducedQuantity("")).toBeNull()
+    expect(readProducedQuantity("1")).toBe(1)
+  })
+})
+
+describe("actionOf", () => {
+  it("names each change from the pair, not from a null", () => {
+    expect(actionOf(change({ previous_design: null }))).toBe("attached")
+    expect(actionOf(change({ new_design: null }))).toBe("detached")
+    expect(actionOf(change({}))).toBe("replaced")
+    expect(
+      actionOf(change({ previous_design: { id: "d", name: "D" }, new_design: { id: "d", name: "D" } }))
+    ).toBe("unchanged")
+  })
+
+  it("a detach from nothing is unchanged, not a detach", () => {
+    expect(actionOf(change({ previous_design: null, new_design: null }))).toBe("unchanged")
+  })
+})
+
+describe("buildDesignChangeNotice — Aline's order", () => {
+  /** The skirt: completed run, already delivered. */
+  const skirt = change({
+    line_item_id: "ordli_01KNP520PX9QTNFNKWPY3W0XFS",
+    item_title: "Flowy Skirt",
+    run: { id: "prod_run_01KY32DWYVDWC5NE9JTM533JV3", status: "completed", produced_quantity: 1 },
+  })
+  /** The jacket: no run at all. Three of her items look like this. */
+  const jacket = change({
+    line_item_id: "ordli_01KNP520PWJAES0MWCD6HCW4XC",
+    item_title: "Floral Prints Open Jacket",
+    run: null,
+  })
+
+  it("🔴 does NOT claim everything is in hand when one item has no run", () => {
+    const notice = buildDesignChangeNotice([skirt, jacket])
+    expect(notice.all_in_hand).toBe(false)
+    expect(notice.any_not_started).toBe(true)
+    // The headline must not carry the reassuring wording.
+    expect(notice.headline).not.toMatch(/already in hand|nothing is delayed/i)
+  })
+
+  it("reassures only when EVERY changed garment is in hand", () => {
+    const notice = buildDesignChangeNotice([skirt])
+    expect(notice.all_in_hand).toBe(true)
+    expect(notice.headline).toMatch(/already in hand/i)
+  })
+
+  it("reports each garment's state per line, not as a blanket", () => {
+    const notice = buildDesignChangeNotice([skirt, jacket])
+    const byItem = Object.fromEntries(notice.lines.map((l) => [l.item_title, l]))
+    expect(byItem["Flowy Skirt"].production_state).toBe("made")
+    expect(byItem["Flowy Skirt"].reassuring).toBe(true)
+    expect(byItem["Floral Prints Open Jacket"].production_state).toBe("not_started")
+    expect(byItem["Floral Prints Open Jacket"].reassuring).toBe(false)
+  })
+
+  it("all four of her unstarted items stay unreassured together", () => {
+    const four = ["Floral Prints Open Jacket", "Simple blue striped white dress", "Jolly jungle", "Dark Desires Dress"]
+      .map((t) => change({ item_title: t, run: null }))
+    const notice = buildDesignChangeNotice(four)
+    expect(notice.changed_lines).toHaveLength(4)
+    expect(notice.changed_lines.every((l) => !l.reassuring)).toBe(true)
+    expect(notice.all_in_hand).toBe(false)
+  })
+
+  it("does not send when nothing actually changed", () => {
+    const same = change({
+      previous_design: { id: "d", name: "D" },
+      new_design: { id: "d", name: "D" },
+    })
+    const notice = buildDesignChangeNotice([same])
+    expect(notice.should_send).toBe(false)
+    expect(notice.changed_lines).toHaveLength(0)
+    // An unchanged-only notice must not claim everything is in hand either.
+    expect(notice.all_in_hand).toBe(false)
+  })
+
+  it("does not send for an empty change set", () => {
+    expect(buildDesignChangeNotice([]).should_send).toBe(false)
+    expect(buildDesignChangeNotice([]).all_in_hand).toBe(false)
+  })
+
+  it("omits a produced quantity that was never recorded", () => {
+    const notice = buildDesignChangeNotice([
+      change({ run: { status: "completed", produced_quantity: null } }),
+    ])
+    expect(notice.changed_lines[0].production_state).toBe("made")
+    expect(notice.changed_lines[0].produced_quantity).toBeNull()
+  })
+})
+
+describe("nextItemMetadata", () => {
+  const original = { cost_type: "total", design_id: "d_first", other: 1 }
+
+  it("moves design_id to the new design", () => {
+    expect(nextItemMetadata(original, "d_second").design_id).toBe("d_second")
+  })
+
+  it("🔴 detach writes null — a key cannot be REMOVED through this API", () => {
+    const out = nextItemMetadata(original, null)
+    expect(out.design_id).toBeNull()
+    // The key stays present; both readers guard on typeof === "string", so a
+    // null correctly stops resolving.
+    expect(Object.prototype.hasOwnProperty.call(out, "design_id")).toBe(true)
+  })
+
+  it("🔴 preserves the FIRST design across repeated re-points", () => {
+    const once = nextItemMetadata(original, "d_second")
+    const twice = nextItemMetadata(once, "d_third")
+    const thrice = nextItemMetadata(twice, null)
+    // "What did the customer order?" has one answer however often it moves.
+    expect(once.original_design_id).toBe("d_first")
+    expect(twice.original_design_id).toBe("d_first")
+    expect(thrice.original_design_id).toBe("d_first")
+  })
+
+  it("does not invent provenance for an item that never had a design", () => {
+    const out = nextItemMetadata({ cost_type: "total" }, "d_new")
+    expect(out.original_design_id).toBeUndefined()
+    expect(out.design_id).toBe("d_new")
+  })
+
+  it("leaves every unrelated key untouched and does not mutate the input", () => {
+    const input = { ...original }
+    const out = nextItemMetadata(input, "d_second")
+    expect(out.cost_type).toBe("total")
+    expect(out.other).toBe(1)
+    expect(input.design_id).toBe("d_first")
+  })
+
+  it("tolerates a null/undefined metadata blob", () => {
+    expect(nextItemMetadata(null, "d").design_id).toBe("d")
+    expect(nextItemMetadata(undefined, null).design_id).toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/designs/change-order-item-design.ts
+++ b/apps/backend/src/workflows/designs/change-order-item-design.ts
@@ -1,0 +1,283 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import {
+  getProductionRunForLineItem,
+  resolveLineItemDesignId,
+} from "../../lib/resolve-line-item-production"
+import { repointOrderItemDesign } from "./link-designs-to-order-items"
+import {
+  buildDesignChangeNotice,
+  type DesignChange,
+  nextItemMetadata,
+  type DesignChangeNotice,
+} from "./lib/design-change-notice"
+
+/**
+ * #1918 — attach or detach the design behind an order line item, and tell the
+ * customer what changed.
+ *
+ * `repointOrderItemDesign` has existed since #1919 and had ZERO callers: the
+ * mechanism was built and no door was ever opened onto it. This is that door.
+ *
+ * ## Why the notice is computed BEFORE the write
+ *
+ * The previous design and the production run have to be read while the link
+ * still points at them. Reading afterwards would report the new state as though
+ * it were the old one, and the email would tell the customer nothing changed.
+ *
+ * ## Why the email is best-effort and the write is not
+ *
+ * The link write is the operation the admin asked for; the email is a courtesy
+ * about it. A notification provider being down must not leave the order
+ * pointing at the wrong design — so the write is committed first and a failed
+ * send is reported in the result rather than thrown. The reverse ordering would
+ * make the customer's inbox authoritative over the order.
+ */
+
+export type ChangeOrderItemDesignInput = {
+  line_item_id: string
+  /** The design to point the item at. `null` DETACHES it. */
+  design_id: string | null
+  /** Skip the customer email — for a correction the customer should not see. */
+  notify?: boolean
+  dry_run?: boolean
+}
+
+export type ChangeOrderItemDesignResult = {
+  line_item_id: string
+  action: "attached" | "detached" | "replaced" | "unchanged"
+  previous_design_id: string | null
+  /** Where the previous design came from: "link" (movable) or "metadata" (provenance only). */
+  previous_design_source: string | null
+  new_design_id: string | null
+  removed_links: number
+  created_link: boolean
+  /** Whether `metadata.design_id` was brought into step with the link. */
+  metadata_updated: boolean
+  notice: DesignChangeNotice
+  email: { sent: boolean; to: string | null; reason?: string }
+  dry_run: boolean
+}
+
+/**
+ * Read the design the item currently stands for, and WHERE that came from.
+ *
+ * Uses `resolveLineItemDesignId` rather than reading the link directly, because
+ * an item can carry a design without carrying a LINK: anything predating the
+ * #1919 backfill has only `metadata.design_id`. Reading the link alone reports
+ * such an item as design-less, and the email would then tell the customer a
+ * garment was "attached" when it was really re-pointed — losing the fact that
+ * something was there before.
+ *
+ * `source` is carried out to the caller because it changes what the write
+ * means: from `"link"` this is a move, from `"metadata"` it is the first link
+ * this item has ever had.
+ */
+async function readCurrentDesign(
+  query: any,
+  lineItemId: string,
+  item: { product_id?: string | null; variant_id?: string | null; metadata?: any }
+): Promise<{ id: string; name: string | null; source: string | null } | null> {
+  const resolved = await resolveLineItemDesignId(query, {
+    productId: item?.product_id ?? null,
+    variantId: item?.variant_id ?? null,
+    lineItemId,
+    metadata: item?.metadata ?? null,
+  })
+  if (!resolved.designId) return null
+
+  const { data: designs } = await query.graph({
+    entity: "design",
+    fields: ["id", "name"],
+    filters: { id: resolved.designId },
+  })
+  return {
+    id: resolved.designId,
+    name: designs?.[0]?.name ?? null,
+    source: resolved.source,
+  }
+}
+
+/** The order this item belongs to, with the customer's email and the title. */
+async function readItemContext(
+  query: any,
+  lineItemId: string
+): Promise<{
+  order_id: string | null
+  item: any | null
+  item_title: string | null
+  display_id: number | null
+  email: string | null
+  customer_first_name: string | null
+} | null> {
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "display_id",
+      "email",
+      "customer.first_name",
+      "items.id",
+      "items.title",
+      "items.product_id",
+      "items.variant_id",
+      "items.metadata",
+    ],
+    filters: { items: { id: lineItemId } },
+  })
+  const order = orders?.[0]
+  if (!order) return null
+  const item = (order.items || []).find((i: any) => String(i.id) === lineItemId)
+  return {
+    order_id: order.id ?? null,
+    item: item ?? null,
+    item_title: item?.title ?? null,
+    display_id: order.display_id ?? null,
+    email: order.email ?? null,
+    customer_first_name: order.customer?.first_name ?? null,
+  }
+}
+
+export async function changeOrderItemDesign(
+  container: MedusaContainer,
+  input: ChangeOrderItemDesignInput
+): Promise<ChangeOrderItemDesignResult> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const lineItemId = input.line_item_id
+  const dryRun = Boolean(input.dry_run)
+
+  // ── Read the world BEFORE touching it ────────────────────────────────────
+  // Context first: the design resolver needs the item's product/variant/metadata,
+  // so this one read cannot be parallelised with the other two.
+  const ctx = await readItemContext(query, lineItemId)
+  const [previous, run] = await Promise.all([
+    readCurrentDesign(query, lineItemId, ctx?.item ?? {}),
+    getProductionRunForLineItem(query, lineItemId),
+  ])
+
+  let next: { id: string; name: string | null } | null = null
+  if (input.design_id) {
+    const { data: designs } = await query.graph({
+      entity: "design",
+      fields: ["id", "name"],
+      filters: { id: input.design_id },
+    })
+    if (!designs?.length) {
+      throw new Error(`Design ${input.design_id} does not exist`)
+    }
+    next = { id: String(designs[0].id), name: designs[0].name ?? null }
+  }
+
+  const change: DesignChange = {
+    line_item_id: lineItemId,
+    item_title: ctx?.item_title ?? null,
+    previous_design: previous,
+    new_design: next,
+    run,
+  }
+  const notice = buildDesignChangeNotice([change])
+  const action = notice.lines[0].action
+
+  // ── Write ────────────────────────────────────────────────────────────────
+  const { removed, created } = await repointOrderItemDesign(
+    container,
+    lineItemId,
+    input.design_id,
+    { dryRun }
+  )
+
+  /**
+   * Keep `metadata.design_id` in step with the link (founder decision,
+   * 2026-09-09).
+   *
+   * #1919 froze this string as pure provenance and made the link the answer.
+   * That left the two disagreeing after a re-point — and `metadata.design_id`
+   * is still read over HTTP by partner-ui, which cannot be migrated yet. So a
+   * re-point that did not write it would move the design everywhere EXCEPT the
+   * surface a partner actually looks at.
+   *
+   * 🔴 The original is preserved once, under `original_design_id`, before the
+   * first overwrite. Losing what an item was ORDERED as is irreversible, and
+   * the whole reason #1918 could be diagnosed at all was that the string still
+   * said what the order originally meant. Written only when absent, so repeated
+   * re-points keep the FIRST value rather than the previous one.
+   */
+  let metadataUpdated = false
+  if (!dryRun && action !== "unchanged") {
+    try {
+      const orderService: any = container.resolve(Modules.ORDER)
+      const nextMeta = nextItemMetadata(
+        ctx?.item?.metadata as Record<string, any> | null,
+        input.design_id ?? null
+      )
+
+      await orderService.updateOrderLineItems(lineItemId, { metadata: nextMeta })
+      metadataUpdated = true
+    } catch (e: any) {
+      // Reported, not thrown: the LINK is authoritative and is already
+      // committed. A failed metadata sync leaves the two disagreeing, which is
+      // exactly the state #1919 built the link to survive.
+      logger?.warn?.(
+        `[design-change] link re-pointed on ${lineItemId} but metadata.design_id sync failed: ${e?.message ?? e}`
+      )
+    }
+  }
+
+  // ── Tell the customer (best-effort, never blocks the write) ──────────────
+  const wantsEmail = input.notify !== false && notice.should_send && !dryRun
+  let email: ChangeOrderItemDesignResult["email"] = {
+    sent: false,
+    to: ctx?.email ?? null,
+  }
+  if (!wantsEmail) {
+    email.reason = dryRun
+      ? "dry run"
+      : input.notify === false
+        ? "notify disabled"
+        : "nothing changed"
+  } else if (!ctx?.email) {
+    // Reported, not thrown: an order with no email is a data gap, not a reason
+    // to refuse the re-point the admin asked for.
+    email.reason = "order has no email address"
+  } else {
+    try {
+      const notificationService: any = container.resolve("notification")
+      await notificationService.createNotifications({
+        to: ctx.email,
+        channel: "email",
+        template: "design-order-changed",
+        data: {
+          order_id: ctx.order_id,
+          display_id: ctx.display_id,
+          customer_first_name: ctx.customer_first_name,
+          headline: notice.headline,
+          all_in_hand: notice.all_in_hand,
+          any_not_started: notice.any_not_started,
+          lines: notice.changed_lines,
+        },
+      })
+      email.sent = true
+    } catch (e: any) {
+      email.reason = `send failed: ${e?.message ?? String(e)}`
+      logger?.warn?.(
+        `[design-change] re-point of ${lineItemId} committed but email failed: ${email.reason}`
+      )
+    }
+  }
+
+  return {
+    line_item_id: lineItemId,
+    action,
+    previous_design_id: previous?.id ?? null,
+    previous_design_source: previous?.source ?? null,
+    new_design_id: next?.id ?? null,
+    removed_links: removed,
+    created_link: created,
+    metadata_updated: metadataUpdated,
+    notice,
+    email,
+    dry_run: dryRun,
+  }
+}

--- a/apps/backend/src/workflows/designs/lib/design-change-notice.ts
+++ b/apps/backend/src/workflows/designs/lib/design-change-notice.ts
@@ -1,0 +1,237 @@
+/**
+ * #1918 — what to tell a customer when the designs on their order change.
+ *
+ * PURE: no container, no I/O. Given a line item's production run (or its
+ * absence), it decides what is TRUE about that garment and what the customer
+ * should be told. Pure because the whole value here is the honesty of the
+ * mapping, and that deserves tests that cannot be faked by a stubbed container.
+ *
+ * ## Why the reassurance has to be earned
+ *
+ * The ask was: if runs are found, reassure the customer — "don't worry, the
+ * designs are produced, this is just our system letting you know." That is the
+ * right message for a garment already made. It is a FALSE message for a garment
+ * nobody has started, and the difference is invisible from the order.
+ *
+ * Aline's order is the worked example (#1918): 5 design items, €335 captured,
+ * and exactly ONE production run — for the skirt that already shipped. Four
+ * garments are owed with no run at all. A blanket "your designs are produced"
+ * would tell someone owed four garments that they are finished.
+ *
+ * So the reassurance keys on the run's ACTUAL state, and the no-run case gets
+ * its own wording rather than borrowing the comfortable one.
+ */
+
+/** Run statuses, as `production_runs.status` actually spells them. */
+export type RunStatus =
+  | "draft"
+  | "pending_review"
+  | "approved"
+  | "sent_to_partner"
+  | "in_progress"
+  | "completed"
+  | "cancelled"
+  | "awaiting_reassignment"
+
+export type RunLike = {
+  id?: string | null
+  status?: string | null
+  produced_quantity?: number | string | null
+} | null
+
+/**
+ * What is true about the garment behind a line item.
+ *
+ * `made` and `being_made` are the two states that earn the reassuring wording.
+ * `not_started` explicitly does not — it is the state four of Aline's five
+ * items are in.
+ */
+export type ProductionState = "made" | "being_made" | "queued" | "not_started"
+
+export const PRODUCTION_STATE_LABELS: Record<ProductionState, string> = {
+  made: "already made",
+  being_made: "being made now",
+  queued: "queued for production",
+  not_started: "not started yet",
+}
+
+/** The states where "don't worry, it's in hand" is a true thing to say. */
+export function isReassuring(state: ProductionState): boolean {
+  return state === "made" || state === "being_made"
+}
+
+/**
+ * PURE: read a produced quantity without letting absence become zero.
+ *
+ * `produced_quantity` is null on runs that genuinely produced goods — 12 parent
+ * runs in prod needed a backfill for exactly this. So a null here means "not
+ * recorded", NOT "produced nothing", and must never be rendered as a quantity.
+ */
+export function readProducedQuantity(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === "string" && value.trim() === "") return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * PURE: the garment's state, from its run.
+ *
+ * 🔴 `completed` alone means made. It deliberately does NOT also require
+ * `produced_quantity > 0`: that field is null on runs that really did produce
+ * goods, so requiring it would tell a customer their finished garment was never
+ * started. The quantity is reported only when it is actually recorded.
+ *
+ * 🔴 `cancelled` is NOT production. A cancelled run is the strongest evidence
+ * that nothing is being made, so it maps to `not_started` rather than being
+ * treated as "a run exists, therefore reassure".
+ */
+export function productionStateOf(run: RunLike): ProductionState {
+  if (!run || !run.status) return "not_started"
+  switch (String(run.status) as RunStatus) {
+    case "completed":
+      return "made"
+    case "in_progress":
+    case "sent_to_partner":
+      return "being_made"
+    case "approved":
+    case "pending_review":
+    case "draft":
+    case "awaiting_reassignment":
+      return "queued"
+    case "cancelled":
+      return "not_started"
+    default:
+      // An unrecognised status is not evidence of production. Fail toward the
+      // claim that promises the customer the least.
+      return "not_started"
+  }
+}
+
+export type DesignChange = {
+  line_item_id: string
+  item_title: string | null
+  /** The design the item pointed at before, if any. */
+  previous_design: { id: string; name: string | null } | null
+  /** The design it points at now. `null` means it was DETACHED. */
+  new_design: { id: string; name: string | null } | null
+  run: RunLike
+}
+
+export type ChangeLine = {
+  line_item_id: string
+  item_title: string | null
+  action: "attached" | "detached" | "replaced" | "unchanged"
+  previous_design_name: string | null
+  new_design_name: string | null
+  production_state: ProductionState
+  production_label: string
+  produced_quantity: number | null
+  reassuring: boolean
+}
+
+/** PURE: name the change so the email does not have to infer it from nulls. */
+export function actionOf(change: DesignChange): ChangeLine["action"] {
+  const prev = change.previous_design?.id ?? null
+  const next = change.new_design?.id ?? null
+  if (prev === next) return "unchanged"
+  if (!prev && next) return "attached"
+  if (prev && !next) return "detached"
+  return "replaced"
+}
+
+/** PURE: one row of the customer's "what changed" table. */
+export function buildChangeLine(change: DesignChange): ChangeLine {
+  const state = productionStateOf(change.run)
+  return {
+    line_item_id: change.line_item_id,
+    item_title: change.item_title ?? null,
+    action: actionOf(change),
+    previous_design_name: change.previous_design?.name ?? null,
+    new_design_name: change.new_design?.name ?? null,
+    production_state: state,
+    production_label: PRODUCTION_STATE_LABELS[state],
+    produced_quantity: readProducedQuantity(change.run?.produced_quantity),
+    reassuring: isReassuring(state),
+  }
+}
+
+export type DesignChangeNotice = {
+  lines: ChangeLine[]
+  /** Only the lines that actually changed — an unchanged row is not news. */
+  changed_lines: ChangeLine[]
+  /** True when EVERY changed garment is made or being made. */
+  all_in_hand: boolean
+  /** True when at least one changed garment has no production behind it. */
+  any_not_started: boolean
+  /** The single sentence the email leads with. */
+  headline: string
+  /** Whether there is anything worth emailing about at all. */
+  should_send: boolean
+}
+
+/**
+ * PURE: assemble the notice.
+ *
+ * The headline is chosen from the WEAKEST claim the evidence supports, not the
+ * strongest. If any changed garment has no run, the customer is not told that
+ * everything is in hand — even if three of four are — because the sentence they
+ * remember is the headline, and a reassurance that is 75% true reads as a
+ * promise about the item they are actually worried about.
+ */
+export function buildDesignChangeNotice(changes: DesignChange[]): DesignChangeNotice {
+  const lines = (changes ?? []).map(buildChangeLine)
+  const changed = lines.filter((l) => l.action !== "unchanged")
+
+  const anyNotStarted = changed.some((l) => !l.reassuring)
+  const allInHand = changed.length > 0 && !anyNotStarted
+
+  let headline: string
+  if (!changed.length) {
+    headline = "No designs changed on your order."
+  } else if (allInHand) {
+    headline =
+      changed.length === 1
+        ? "We've updated a design on your order — and it's already in hand, so nothing is delayed. This is just our system keeping you in the loop."
+        : "We've updated the designs on your order — they're all already in hand, so nothing is delayed. This is just our system keeping you in the loop."
+  } else {
+    headline =
+      "We've updated the designs on your order. Here's exactly what changed and where each piece stands."
+  }
+
+  return {
+    lines,
+    changed_lines: changed,
+    all_in_hand: allInHand,
+    any_not_started: anyNotStarted,
+    headline,
+    should_send: changed.length > 0,
+  }
+}
+
+/**
+ * PURE: the item's next `metadata`, keeping `design_id` in step with the link
+ * while preserving what the item was ORIGINALLY ordered as.
+ *
+ * 🔴 `updateOrderLineItems` MERGES metadata and offers no way to REMOVE a key
+ * (probed: `delete` on the copy is inert, and an explicit null stores a literal
+ * null with the key still present). So a detach writes `design_id: null`, which
+ * both in-repo readers decline to resolve — each guards on
+ * `typeof … === "string"`, not on key presence.
+ *
+ * 🔴 `original_design_id` is written ONCE, only when absent. Across repeated
+ * re-points it therefore keeps the FIRST design, not the previous one: the
+ * question it answers is "what did the customer order?", and that has exactly
+ * one answer no matter how many times the item is moved afterwards.
+ */
+export function nextItemMetadata(
+  existing: Record<string, any> | null | undefined,
+  newDesignId: string | null
+): Record<string, any> {
+  const meta: Record<string, any> = { ...(existing ?? {}) }
+  if (meta.design_id && !meta.original_design_id) {
+    meta.original_design_id = meta.design_id
+  }
+  meta.design_id = newDesignId ?? null
+  return meta
+}


### PR DESCRIPTION
First of four on #1918. The UI, the ordered-vs-delivered view and unfulfilled-line editing follow.

## The door that was never opened

`repointOrderItemDesign` has existed since #1919 with **zero callers**. The mechanism to move a design between order items was built and nothing was ever wired to it — which is why a paid order still could not be re-pointed. This is that door, plus the email that goes with it.

```
POST /admin/designs/orders/:lineItemId/design
  { "design_id": "01K..." }   attach or replace
  { "design_id": null }       detach
```

`design_id` must be **present**. Omitting it is rejected rather than treated as a detach — a forgotten field and a deliberate unlink must not look the same when the result is unlinking a garment somebody paid for.

## Why the reassurance has to be earned

The ask was: if runs are found, reassure the customer — *"don't worry, the designs are produced, this is just our system letting you know."* That's right for a garment already made and **false** for one nobody has started, and the difference is invisible from the order.

**Aline's order is the worked example.** `order_01KNP520PT94BN8SC0JKZ6ZVJ9`: 5 design items, €335 captured, and exactly **one** production run — for the skirt that already shipped, itself created by a backfill rather than the normal flow. Four garments are owed with no run at all. A blanket "your designs are produced" tells someone owed four garments that they're finished.

So the state comes from the run's actual status:

| run status | state | reassuring? |
|---|---|---|
| `completed` | made | ✅ |
| `in_progress`, `sent_to_partner` | being made | ✅ |
| `approved`, `pending_review`, `draft`, `awaiting_reassignment` | queued | ❌ |
| `cancelled`, no run, unknown | not started | ❌ |

Two rules a naive version gets wrong, both **mutation-tested**:

- **`completed` alone means made.** It deliberately does *not* also require `produced_quantity > 0` — that field is null on runs that really did produce goods (12 parent runs in prod needed a backfill for exactly this), so requiring it would tell a customer their finished garment was never started.
- **A cancelled run is not production.** "A run exists, therefore reassure" would tell a customer whose run was cancelled that their garment is in hand.

The headline is chosen from the **weakest** claim the evidence supports. If any changed garment has no run, the customer isn't told everything is in hand even if three of four are — the sentence they remember is the headline, and a reassurance that's 75% true reads as a promise about the item they're actually worried about.

## `metadata.design_id` now follows the link

Per your call today. #1919 froze the string as pure provenance and made the link the answer — which left the two disagreeing after a re-point, and `metadata.design_id` is still read over HTTP by partner-ui, which can't be migrated yet. A re-point that didn't write it would move the design everywhere **except** the surface a partner actually looks at.

`original_design_id` preserves what the item was *ordered* as, written **once** when absent, so repeated re-points keep the **first** design rather than the previous one. Losing that is irreversible, and it's the only reason #1918 was diagnosable at all.

🔴 **`updateOrderLineItems` merges metadata and cannot remove a key.** Probed directly: `delete` on the copy is inert — the stored value came back unchanged while the call reported success — and an explicit null stores a literal null with the key still present. So a detach writes `design_id: null`. Safe for both in-repo readers, which were **checked rather than assumed**: `resolveLineItemDesignId` guards on `typeof … === "string" && …`, `linkDesignsToOrderItems` on `typeof … !== "string"`. Both decline a null.

## Reading the previous design

Via `resolveLineItemDesignId`, not the link directly. An item can carry a design without carrying a **link** — anything predating the #1919 backfill has only the metadata string. Reading the link alone reported such an item as design-less, so a re-point looked like an *attach* and the email lost the fact that something was there before. **Caught by running it against real data.** `source` comes back to the caller because it changes what the write means: from `"link"` it's a move, from `"metadata"` it's the first link the item has ever had.

## Ordering, and what's best-effort

The notice is computed **before** the write — the previous design and the run must be read while the link still points at them. The link write commits first; both the metadata sync and the email are best-effort, because a notification provider being down must not leave the order pointing at the wrong design. The reverse would make the customer's inbox authoritative over the order.

## Verified

Route exercised over HTTP with a real token, against a 404 control:

```
control (no such route)        404
POST {}                        400   design_id required
POST {design_id:null,dry_run}  200
POST {design_id:"01NOPE"}      404   design does not exist
```

🔴 An **unauthenticated** probe could not tell these apart — auth answers before routing, so every `/admin` path returns 401 whether or not a handler exists. The 404 control is the only honest comparison.

- Live detach then re-attach against real data: `design_id` moved, `original_design_id` stayed at the first design across both.
- 21 unit tests; the two honesty guards mutation-tested (making `cancelled` read as produced, and reassuring on ANY rather than ALL — each fails exactly the test that claims to catch it).
- `tsc` byte-identical to baseline (431 pre-existing, none in new files).
- 841 passing across `designs|admin/mcp|mcp-core|tool-slice`. The 4 failures (`route-validator-field-coverage` ×2, `brief-shaper` ×2) are **pre-existing on main**, reproduced on a clean checkout, tracked in **#1943**.

## Next, and one blocker

PR 2 the attach/detach UI, PR 3 ordered-vs-delivered, PR 4 unfulfilled-line editing.

⚠️ **PR 4 is gated on #1937.** Three of Aline's four unfulfilled items still have `variant_id: null`, and the order-edit path needs a variant — the same null that blocked production *and* the repair in #1918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
