### PR TITLE
feat(mcp): an MCP door to the email templates — list, read, create, edit, retire

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/email-template-tools.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/email-template-tools.unit.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * The email-template tools — the outbound email surface.
+ *
+ * These assert the two things that actually break in production: a tool that
+ * exists but can never be reached (wrong domain, no keyword), and a write tool
+ * that isn't gated. Both fail silently — the model just says it can't do it.
+ *
+ * Plus the two traps specific to this family:
+ *  - the route handler DESTRUCTURES `order` and `fields` and then drops them,
+ *    so the list tool must not advertise a sort it will silently ignore; and
+ *  - the create route's required fields are the route's zod contract, so the
+ *    tool's `required` must carry every one of them or a model following the
+ *    schema gets a 400 (#1348/#1371).
+ */
+import { ADMIN_MCP_TOOLS } from "../registry"
+import {
+  selectAdminToolSlice,
+  toolDomain,
+  matchDomains,
+} from "../tool-slice"
+
+const byName = (name: string) => {
+  const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+  if (!def) {
+    throw new Error(`tool ${name} is not registered`)
+  }
+  return def
+}
+
+const NEW_TOOLS = [
+  "list_email_templates",
+  "get_email_template",
+  "create_email_template",
+  "update_email_template",
+  "delete_email_template",
+]
+
+describe("registry — email template tools", () => {
+  it("registers every new tool exactly once", () => {
+    for (const name of NEW_TOOLS) {
+      const matches = ADMIN_MCP_TOOLS.filter((t) => t.name === name)
+      expect([name, matches.length]).toEqual([name, 1])
+    }
+  })
+
+  it("gates every mutation behind write + confirm", () => {
+    for (const name of [
+      "create_email_template",
+      "update_email_template",
+      "delete_email_template",
+    ]) {
+      const def = byName(name)
+      expect([name, def.write === true, def.sensitive === true]).toEqual([
+        name,
+        true,
+        true,
+      ])
+    }
+  })
+
+  it("does NOT gate reads", () => {
+    for (const name of ["list_email_templates", "get_email_template"]) {
+      expect([name, !!byName(name).write]).toEqual([name, false])
+    }
+  })
+
+  it("declares every :param in the path as a pathParam", () => {
+    for (const name of NEW_TOOLS) {
+      const def = byName(name)
+      const placeholders = (def.path?.match(/:(\w+)/g) ?? []).map((p) => p.slice(1))
+      expect([name, def.pathParams ?? []]).toEqual([name, placeholders])
+    }
+  })
+
+  it("only forwards body params the tool's own schema declares", () => {
+    for (const name of NEW_TOOLS) {
+      const def = byName(name)
+      const props = Object.keys(def.inputSchema?.properties ?? {})
+      for (const key of def.bodyParams ?? []) {
+        expect([name, key, props.includes(key)]).toEqual([name, key, true])
+      }
+    }
+  })
+
+  it("requires exactly what the create route's validator requires", () => {
+    // EmailTemplateSchema (the route's body validator) makes name, from,
+    // template_key, subject, html_content and template_type required. A
+    // model following the tool's own `required` list must never be able to
+    // build a call the route rejects (#1348).
+    const def = byName("create_email_template")
+    expect([...(def.inputSchema?.required ?? [])].sort()).toEqual(
+      [
+        "name",
+        "from",
+        "template_key",
+        "subject",
+        "html_content",
+        "template_type",
+      ].sort()
+    )
+  })
+
+  it("never advertises a sort the route silently drops", () => {
+    // The GET handler destructures `order` and `fields` and then never
+    // forwards them — declaring them would silently ignore the model's
+    // request while reporting ok, the same defect class as #1172.
+    const def = byName("list_email_templates")
+    expect(def.queryParams).not.toContain("order")
+    expect(def.queryParams).not.toContain("fields")
+    for (const key of def.queryParams ?? []) {
+      expect(key in (def.inputSchema?.properties ?? {})).toBe(true)
+    }
+  })
+
+  it("gives the update and delete tools a dry-run preview of the template", () => {
+    // Both write the row a sender will render — the dry-run must show the
+    // current template so the confirmation card is a review, not a blank.
+    for (const name of ["update_email_template", "delete_email_template"]) {
+      const def = byName(name)
+      expect([name, def.previewPath]).toEqual([name, def.path])
+    }
+  })
+})
+
+describe("tool-slice — reachability", () => {
+  it("classifies every email-template tool as marketing", () => {
+    for (const name of NEW_TOOLS) {
+      expect([name, toolDomain(byName(name))]).toEqual([name, "marketing"])
+    }
+  })
+
+  it("lights up for how an operator asks about outbound email", () => {
+    for (const ask of [
+      "what does the partner task email say?",
+      "edit the order confirmation email",
+      "add a newsletter template",
+      "retire the old welcome email",
+    ]) {
+      expect([ask, matchDomains(ask)]).toEqual([ask, expect.arrayContaining(["marketing"])])
+    }
+  })
+
+  it("loads the whole family for one email ask", () => {
+    const slice = selectAdminToolSlice(
+      "update the footer on the order confirmation email and deactivate the old one",
+      ADMIN_MCP_TOOLS as any
+    )
+    for (const name of [
+      "list_email_templates",
+      "get_email_template",
+      "update_email_template",
+    ]) {
+      expect([name, slice.names.includes(name)]).toEqual([name, true])
+    }
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1349,6 +1349,160 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     inputSchema: obj({ ...PAGINATION }),
   },
 
+  // ===== Email templates ===================================================
+  // The outbound email surface: the DB-stored templates the senders render
+  // and dispatch (jobs/process-email-queue, agreement/blog/digest workflows,
+  // task-assigned notifications). Senders resolve a template by template_key
+  // + is_active — see EmailTemplatesService.getTemplateByKey — so a template
+  // that is not ACTIVE is invisible to every sender, and a key no row holds
+  // makes the send fail outright. These tools let the assistant do exactly
+  // what the admin UI's email-templates pages do.
+  {
+    name: "list_email_templates",
+    description:
+      "List email templates (paginated) — the stored subjects/bodies the platform emails from: order updates, partner task notifications, blog broadcasts. Filter by template_key (the exact key senders resolve), template_type, is_active, or free-text search on name. Use it to find a template id, or to check which template a key will actually hit — a key with more than one active row makes which one sends depend on list order.",
+    method: "GET",
+    path: "/admin/email-templates",
+    // ONLY the filters the handler actually forwards. `order` and `fields`
+    // are accepted by the route and then DROPPED — the handler destructures
+    // them but never passes them on — so declaring them would silently
+    // ignore the model's sort, the same defect as #1172.
+    queryParams: ["limit", "offset", "q", "is_active", "template_type", "template_key"],
+    inputSchema: obj({
+      ...PAGINATION,
+      is_active: BOOL("Filter by active state. Only is_active:true rows are ever sent — false rows exist but no sender resolves them."),
+      template_type: STR("Filter by template type, e.g. 'general' | 'transactional' | 'marketing'."),
+      template_key: STR("Filter by the exact lookup key senders use, e.g. 'partner-task-assigned'."),
+    }),
+  },
+  {
+    name: "get_email_template",
+    description:
+      "Get a single email template by id — subject, html_content, from/to/cc/bcc, its documented variables and its active state. Use to review a template's body before editing or deactivating it.",
+    method: "GET",
+    path: "/admin/email-templates/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Email template id.") }, ["id"]),
+  },
+  {
+    name: "create_email_template",
+    description:
+      "Create a new email template. 🔑 Call list_email_templates FIRST: senders resolve the FIRST active row for a template_key, so creating a second active row for a key that already has one makes which one sends depend on list order — create a key variant only deliberately. `variables` is the documentation of what the body substitutes: list the {{placeholders}} the subject and html_content actually use, e.g. {'order_id': 'The order number'}. is_active defaults to TRUE — the template becomes sendable the moment it exists. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/email-templates",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "description",
+      "to",
+      "cc",
+      "bcc",
+      "from",
+      "template_key",
+      "subject",
+      "html_content",
+      "variables",
+      "is_active",
+      "template_type",
+    ],
+    inputSchema: obj(
+      {
+        name: STR("Human-readable template name, e.g. 'Partner task assigned'. Required."),
+        template_key: STR(
+          "The lookup key senders resolve, snake_case, e.g. 'partner-task-assigned'. Must be unique among ACTIVE rows to be predictable. Required."
+        ),
+        subject: STR("Email subject line. May carry {{placeholders}}. Required."),
+        html_content: STR(
+          "Email body as HTML. May carry {{placeholders}} the sender substitutes at send time. Required."
+        ),
+        from: STR("From address, a valid email, e.g. 'no-reply@jyt.com'. Required."),
+        to: STR("Fixed recipient address for single-recipient templates; senders usually override this. Pass null to clear."),
+        cc: STR("Fixed CC address. Pass null to clear."),
+        bcc: STR("Fixed BCC address. Pass null to clear."),
+        description: STR("What this template is for and when it fires."),
+        variables: {
+          type: "object",
+          description:
+            "The {{placeholders}} the subject/body use, as documentation for whoever edits the template next: {'order_id': 'The order number'}. Not enforced at send time.",
+          additionalProperties: true,
+        },
+        is_active: BOOL("Whether senders can resolve this template. Defaults to true."),
+        template_type: STR("Template type, e.g. 'general' | 'transactional' | 'marketing'. Required by the route."),
+      },
+      ["name", "template_key", "subject", "html_content", "from", "template_type"]
+    ),
+    sideEffects:
+      "Creates a template row. Nothing sends at creation — a send only happens when a sender (a job, workflow or notification) resolves the key later.",
+    nextSteps: ["get_email_template", "update_email_template"],
+  },
+  {
+    name: "update_email_template",
+    description:
+      "Update an email template by id — partial: only the fields you pass change. Use to edit subject/html_content, fix a from address, document the variables, or retire a template with is_active:false (deactivation is reversible and leaves the content auditable). ⚠️ Changing template_key orphans every sender still referencing the old one — they stop finding the template and the send fails. There is no draft/publish step: the next email sent with the key picks the change up immediately. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/email-templates/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/email-templates/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "description",
+      "to",
+      "cc",
+      "bcc",
+      "from",
+      "template_key",
+      "subject",
+      "html_content",
+      "variables",
+      "is_active",
+      "template_type",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Email template id to update."),
+        name: STR("New template name."),
+        template_key: STR(
+          "New lookup key. ⚠️ Renaming the key orphans every sender still referencing the old one — they stop finding the template."
+        ),
+        subject: STR("New subject line."),
+        html_content: STR("New HTML body."),
+        from: STR("New from address (must be a valid email)."),
+        to: STR("New fixed recipient, or null to clear."),
+        cc: STR("New fixed CC, or null to clear."),
+        bcc: STR("New fixed BCC, or null to clear."),
+        description: STR("New description."),
+        variables: {
+          type: "object",
+          description: "New {{placeholder}} documentation object.",
+          additionalProperties: true,
+        },
+        is_active: BOOL(
+          "Activate or deactivate the template. false retires it for every sender WITHOUT deleting it — the preferred way to stop a template being used."
+        ),
+        template_type: STR("New template type."),
+      },
+      ["id"]
+    ),
+    sideEffects:
+      "Rewrites the template row in place, effective on the very next send that resolves its key. Compensation restores the prior row if the workflow fails.",
+    nextSteps: ["get_email_template"],
+  },
+  {
+    name: "delete_email_template",
+    description:
+      "Delete an email template by id. 🔑 Prefer update_email_template with is_active:false — deactivation is reversible and leaves the row auditable; deletion is neither, and every sender still holding the key fails with 'Email template with key ... not found'. Dry-run first to see the template you are about to remove. Sensitive: requires confirm:true.",
+    method: "DELETE",
+    path: "/admin/email-templates/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/email-templates/:id",
+    write: true,
+    sensitive: true,
+    inputSchema: obj({ id: STR("Email template id to delete.") }, ["id"]),
+  },
+
   // ===== Social posts & platforms =========================================
   // Social-platform integrations (Facebook, Instagram, Twitter/X, LinkedIn)
   // are stored as SocialPlatform rows with category "social". These tools let

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -132,6 +132,12 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   ["/admin/partners/:id/credits", "money"],
   ["/admin/publishing-campaigns", "marketing"],
   ["/admin/notifications", "marketing"],
+  // The stored email bodies every sender renders from. Rides `marketing`
+  // because the asks that reach it ("edit the order-confirmation email",
+  // "what does the partner task email say?") are email/marketing vocabulary —
+  // the domain keywords already carry "email", so without this entry the ask
+  // lights the slice but the template tools load in NO slice.
+  ["/admin/email-templates", "marketing"],
   // Social posts and platform integrations belong to marketing — they are the
   // organic publishing surface alongside the automated campaigns.
   ["/admin/social-posts", "marketing"],

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -213,6 +213,20 @@ const DELIBERATELY_OMITTED: Record<string, Record<string, string>> = {
     related_item_type: "GAP (#1394): linking is done by a separate tool",
     related_item_id: "GAP (#1394): as related_item_type",
   },
+  "admin:create_email_template": {
+    // The create route validates with the BASE EmailTemplateSchema, which
+    // leaves `id` optional-but-accepted. A create must let the module assign
+    // the id — an assistant-supplied one would either collide or, worse,
+    // shadow an existing row's identity — so it is not advertised.
+    id: "assigned by the module on create, never assistant-supplied",
+  },
+  "admin:update_email_template": {
+    // The update route builds its workflow input as
+    // `{ id: req.params.id, ...req.validatedBody }` — a body `id` would
+    // OVERWRITE the path param in that spread. The tool takes the id as a
+    // path param only, so the schema never offers a body id to clobber it.
+    id: "the :id path param is the only id; a body id would overwrite it in the route's spread",
+  },
   "admin:create_partner_task": {
     template_names: "see dispatch_template_names — approval INTENT, not a task field",
     eventable: "notification plumbing, not an assistant concern",


### PR DESCRIPTION
## What

The email templates had every layer except an MCP door: a module (`email_templates`), four workflows, admin routes with zod validators — and zero tools. The assistant could see `bypass_partner_email_verification` but not the templates that decide what the platform actually emails. This adds the five registry rows that wrap the existing routes 1:1:

| Tool | Route | Rail |
| --- | --- | --- |
| `list_email_templates` | GET /admin/email-templates | read |
| `get_email_template` | GET /admin/email-templates/:id | read |
| `create_email_template` | POST /admin/email-templates | write + confirm |
| `update_email_template` | POST /admin/email-templates/:id | write + confirm, dry-run preview |
| `delete_email_template` | DELETE /admin/email-templates/:id | write + confirm, dry-run preview |

Because the dispatcher is a loopback proxy, the tools inherit the routes' admin auth and `validateAndTransformBody` contracts for free.

## Decisions worth reviewing

- **Slice classification:** `/admin/email-templates` → `marketing` (the domain keywords already carry "email"). Without the prefix entry the tools load in NO slice and are unreachable from any ask — the exact trap the tool-slice invariant test exists to prevent.
- **`order`/`fields` are NOT advertised on the list tool:** the GET handler destructures them and then drops them. Declaring them would silently ignore the model's sort while reporting `ok: true` — the same defect class as #1172.
- **`id` is deliberately omitted from both write bodies**, written down in `DELIBERATELY_OMITTED` with reasons: on create the module assigns it; on update a body `id` would overwrite the `:id` path param in the route's spread (`{ id: req.params.id, ...req.validatedBody }`).
- **`create`'s `required` mirrors the route's zod contract** (`name`, `from`, `template_key`, `subject`, `html_content`, `template_type`) — verified against the real validator, so a model following the schema can never build a call the route 400s.
- **No tier override:** the tools stay confirm-gated `sensitive`, so a `write`-scoped third-party credential cannot rewrite outbound email content.
- **Deactivation is the recommended retirement path** — encoded in the `delete` description — because senders resolve `template_key` + `is_active` and a missing key fails the send outright.

## Tests

- New `email-template-tools.unit.spec.ts` (11 tests): registration, gating, pathParams, body-params-vs-schema, create's required-vs-route contract, the silent-sort guard, dry-run previews, marketing classification, and slice reachability for how operators actually ask about outbound email.
- Full MCP suites: 26 suites / 400 tests pass. The 2 failures in `route-validator-field-coverage` are pre-existing on `main` (verified by stashing this change: the same six unbound inventory/variant tools and the two `dry_run` omissions fail identically) and are unrelated to this PR.
- `tsc --noEmit`: no errors in the touched files (83 pre-existing errors elsewhere, all in admin UI components / integration tests).