### PR TITLE
fix(pricing): the approve door's 0-price and single currency (#1900), and the pricers read the policy table (#1939)

### DIFF
--- a/apps/backend/integration-tests/http/design-lifecycle.spec.ts
+++ b/apps/backend/integration-tests/http/design-lifecycle.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../helpers/create-customer";
 import { setupCheckoutInfrastructure } from "../helpers/setup-checkout-infrastructure";
 import { DESIGN_MODULE } from "../../src/modules/designs";
+import { FX_FANOUT_REQUESTED } from "../../src/workflows/fx/fanout-variant-prices";
 
 jest.setTimeout(60 * 1000);
 
@@ -227,6 +228,94 @@ setupSharedTestSuite(() => {
         expect(response.status).toBe(200);
         expect(typeof response.data.product_id).toBe("string");
         expect(typeof response.data.variant_id).toBe("string");
+      });
+
+      /**
+       * 🔴 #1900 — a design with no cost must not become a product listed at 0.
+       *
+       * `estimated_cost || 0` reached `resolveListedPrice`, which passed the
+       * zero straight through to the price row. Two such products are on prod.
+       * A 0 is worse than the ×100 it replaced: a hundred-fold price is absurd
+       * on sight, a free product looks plausible.
+       */
+      it("refuses to approve a design with no cost, and creates nothing", async () => {
+        const { api } = getSharedTestEnv();
+        const unique = Date.now() + Math.random().toString(36).slice(2, 8);
+
+        const created = await api.post(
+          "/admin/designs",
+          {
+            name: `Costless Design ${unique}`,
+            description: "no estimated_cost — must not be listable",
+            design_type: "Original",
+            status: "Commerce_Ready",
+            priority: "Medium",
+          },
+          adminHeaders
+        );
+        expect(created.status).toBe(201);
+        const costlessId = created.data.design.id as string;
+        expect(created.data.design.estimated_cost ?? null).toBeNull();
+
+        const res = await api
+          .post(`/admin/designs/${costlessId}/approve`, {}, adminHeaders)
+          .catch((e: any) => e.response);
+
+        expect(res.status).toBe(400);
+        expect(res.data.message).toMatch(/no estimated cost/i);
+
+        // Nothing was created, and — because the guard runs BEFORE the status
+        // write — the design is not left Approved with no product behind it.
+        const after = await api.get(`/admin/designs/${costlessId}`, adminHeaders);
+        expect(after.data.design.status).not.toBe("Approved");
+      });
+
+      /**
+       * 🔴 #1900 — every design approved here was listed in ONE currency.
+       *
+       * Medusa's pricing module emits no `price.created`, so a path that
+       * writes a variant price must ASK for the FX fanout. This door never
+       * did; the five 2026-08-28 Oshen products carry an AUD price only.
+       */
+      it("asks for the FX fanout so the other currencies get prices", async () => {
+        const { api, getContainer } = getSharedTestEnv();
+        const eventBus: any = getContainer().resolve(Modules.EVENT_BUS);
+
+        const seen: any[] = [];
+        const handler = async (payload: any) => {
+          seen.push(payload?.data ?? payload);
+        };
+        eventBus.subscribe(FX_FANOUT_REQUESTED, handler);
+
+        try {
+          const res = await api.post(
+            `/admin/designs/${designId}/approve`,
+            {},
+            adminHeaders
+          );
+          expect(res.status).toBe(200);
+
+          // The variant is priced, and priced above zero.
+          const variantRes = await api.get(
+            `/admin/products/${res.data.product_id}?fields=*variants.prices`,
+            adminHeaders
+          );
+          const prices =
+            variantRes.data.product.variants?.[0]?.prices ?? [];
+          expect(prices.length).toBeGreaterThan(0);
+          expect(Number(prices[0].amount)).toBeGreaterThan(0);
+
+          // And the fanout was requested for THIS variant.
+          for (let i = 0; i < 25 && !seen.length; i++) {
+            await new Promise((r) => setTimeout(r, 200));
+          }
+          const forVariant = seen.filter((d: any) =>
+            (d?.variant_ids ?? []).includes(res.data.variant_id)
+          );
+          expect(forVariant.length).toBeGreaterThan(0);
+        } finally {
+          eventBus.unsubscribe?.(FX_FANOUT_REQUESTED, handler);
+        }
       });
 
       it("returns 401 without admin auth", async () => {

--- a/apps/backend/integration-tests/http/platform-cost-config-wiring.spec.ts
+++ b/apps/backend/integration-tests/http/platform-cost-config-wiring.spec.ts
@@ -1,0 +1,142 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { estimateDesignCostWorkflow } from "../../src/workflows/designs/estimate-design-cost"
+import { PLATFORM_COST_CONFIG_MODULE } from "../../src/modules/platform-cost-config/module-key"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * #1939 slice 1 — the pricers READ the policy table.
+ *
+ * #1942 put the platform's economic policy in an effective-dated table and
+ * deliberately left the compiled constants authoritative: nothing read it. So
+ * inserting the founder's 30% row would have changed no price, silently.
+ *
+ * 🔴 This spec exists because "wired" and "working" are different claims and a
+ * no-op proof cannot tell them apart. Against the seeded row the wiring
+ * changes nothing — which is the point, and also means every existing test
+ * passing proves only that nothing broke. The only way to show the config is
+ * actually read is to make it DIFFER and watch the number move.
+ */
+setupSharedTestSuite(() => {
+  describe("#1939 — the estimator prices from the config table", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    const { api, getContainer } = getSharedTestEnv()
+
+    const makeDesign = async (name: string): Promise<string> => {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name,
+          description: "cost-config wiring spec",
+          design_type: "Original",
+          status: "Conceptual",
+          priority: "Medium",
+          estimated_cost: 1000,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id as string
+    }
+
+    const estimate = async (designId: string) => {
+      const { result }: any = await estimateDesignCostWorkflow(
+        getContainer()
+      ).run({ input: { design_id: designId } })
+      return result
+    }
+
+    /** Wipe the policy table so each case starts from a known world. */
+    const clearConfig = async () => {
+      const svc: any = getContainer().resolve(PLATFORM_COST_CONFIG_MODULE)
+      const rows = await svc.listPlatformCostConfigs({}, { take: null })
+      for (const row of rows ?? []) {
+        await svc.deletePlatformCostConfigs(row.id)
+      }
+    }
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("falls back to the compiled constant when NOTHING is configured, then follows the table", async () => {
+      const stamp = Date.now()
+      await clearConfig()
+
+      // ── No policy at all: the compiled 30% overhead answers ──────────────
+      const designId = await makeDesign(`Cost Config A ${stamp}`)
+      const unconfigured = await estimate(designId)
+      expect(unconfigured.breakdown.production_percent).toBe(30)
+
+      /**
+       * 🔴 The failure mode this guards. `loadCostConfig` must never turn an
+       * empty table into zeros — an estimator that reported "found nothing" as
+       * 0 reached storefront checkout once already.
+       */
+      expect(unconfigured.total_estimated).toBeGreaterThan(0)
+
+      // ── A policy row with a DIFFERENT overhead: the number moves ─────────
+      const inserted = await api.post(
+        "/admin/platform-cost-config",
+        {
+          production_overhead_percent: 60,
+          notes: `wiring spec ${stamp}`,
+        },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(inserted.status)
+
+      const configured = await estimate(await makeDesign(`Cost Config B ${stamp}`))
+      expect(configured.breakdown.production_percent).toBe(60)
+
+      /**
+       * And the invariant #1554 exists to protect still holds under config:
+       * material + production + platform fee === total. A design costed from
+       * an admin estimate splits that estimate by the overhead, so the SPLIT
+       * moves with the policy even though the total does not — which is the
+       * behaviour to check, not the total.
+       */
+      const sum = (r: any) =>
+        Math.round(
+          (Number(r.material_cost) +
+            Number(r.production_cost) +
+            Number(r.platform_fee ?? 0)) *
+            100
+        ) / 100
+      expect(sum(configured)).toBeCloseTo(Number(configured.total_estimated), 2)
+      expect(sum(unconfigured)).toBeCloseTo(Number(unconfigured.total_estimated), 2)
+
+      // A higher overhead claims MORE of the same total as production.
+      expect(Number(configured.production_cost)).toBeGreaterThan(
+        Number(unconfigured.production_cost)
+      )
+      expect(Number(configured.material_cost)).toBeLessThan(
+        Number(unconfigured.material_cost)
+      )
+
+      await clearConfig()
+    })
+
+    it("survives a container with no policy module at all", async () => {
+      // The reader must answer EMPTY rather than throw — a platform that has
+      // never been configured still has to be able to price.
+      const { loadCostConfig, EMPTY_COST_CONFIG } = await import(
+        "../../src/modules/platform-cost-config/read-config"
+      )
+      const resolved = await loadCostConfig({
+        resolve: () => {
+          throw new Error("not registered")
+        },
+      } as any)
+      expect(resolved).toEqual(EMPTY_COST_CONFIG)
+      expect(resolved.production_overhead_percent).toBeNull()
+      // Null, not 0. A zero here would price every design at material cost.
+      expect(resolved.approval_markup_multiplier).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/api/admin/designs/[id]/approve/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/approve/route.ts
@@ -6,9 +6,11 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils";
 import type { IEventBusModuleService } from "@medusajs/types";
 import updateDesignWorkflow from "../../../../../workflows/designs/update-design";
 import { createProductFromDesignWorkflow } from "../../../../../workflows/designs/create-product-from-design";
+import { requestVariantPriceFanout } from "../../../../../workflows/fx/fanout-variant-prices";
 import designCustomerLink from "../../../../../links/design-customer-link";
 import {
   readStoreCurrency,
+  readStoreId,
   resolveApprovalCurrency,
 } from "../../../../../workflows/production-runs/approve-run-output";
 
@@ -48,6 +50,35 @@ export async function POST(
 
     const design = designs[0];
 
+    /**
+     * 🔴 #1900 — a design with no cost must not become a product listed at 0.
+     *
+     * `estimated_cost || 0` handed `createProductFromDesignWorkflow` a zero,
+     * `resolveListedPrice` passed it straight through, and the catalogue got a
+     * FREE product with nothing anywhere saying the design had no cost. Two
+     * such rows are on prod today. This is worse than the ×100 it replaced: a
+     * hundred-fold price is absurd on sight, a 0 looks plausible — the same
+     * shape as the estimator's "found nothing = 0" that reached checkout.
+     *
+     * Refused, not defaulted, and refused BEFORE the status write so a design
+     * cannot end up Approved with no product. `> 0` rather than `!= null`,
+     * because `Number(null)` is 0 and a real zero is just as unlistable.
+     *
+     * The sibling door (`approve-run-output`, #1914) already refuses this;
+     * they now agree.
+     */
+    const estimatedCost = Number(design.estimated_cost)
+    if (!(Number.isFinite(estimatedCost) && estimatedCost > 0)) {
+      res.status(400).json({
+        message:
+          `Design "${design.name ?? designId}" has no estimated cost, so it cannot be priced. ` +
+          `Cost the design first — approving it would list the product at 0.`,
+        design_id: designId,
+        estimated_cost: design.estimated_cost ?? null,
+      });
+      return;
+    }
+
     // Look up the customer linked to this design
     const { data: customerLinks } = await query.graph({
       entity: designCustomerLink.entryPoint,
@@ -83,7 +114,7 @@ export async function POST(
       await createProductFromDesignWorkflow(req.scope).run({
         input: {
           design_id: designId,
-          estimated_cost: design.estimated_cost || 0,
+          estimated_cost: estimatedCost,
           customer_id: customerId,
           /**
            * 🔴 Was hardcoded `"usd"` on a platform that trades in AUD and INR,
@@ -106,6 +137,39 @@ export async function POST(
         errors: productErrors,
       });
       return;
+    }
+
+    /**
+     * 🔴 #1900 — materialise the OTHER currencies.
+     *
+     * Medusa's pricing module emits no `price.created` event, so every path
+     * that writes a variant price has to ASK for the fanout. This door never
+     * did: `create-product-from-design` writes a ONE-element price array, so
+     * every design approved here has been listed in a single currency and
+     * reads as unavailable in every other region. The five 2026-08-28 Oshen
+     * products carry an AUD price only.
+     *
+     * The sibling door (`approve-run-output`, #1914) already asks; this is the
+     * same call, deliberately identical. Requested rather than run inline: the
+     * handler is a subscriber, so the work lands on the WORKER — running this
+     * fanout on the request path OOM-killed prod twice on 2026-08-19 (exit
+     * 137). It never throws, and currencies the price set already carries are
+     * skipped, so a re-approval is a no-op.
+     */
+    try {
+      const storeId = await readStoreId(req.scope)
+      if (storeId && productResult?.variant_id) {
+        await requestVariantPriceFanout(req.scope, {
+          storeId,
+          variantIds: [productResult.variant_id],
+        })
+      }
+    } catch (e: any) {
+      // The product exists and is priced in its own currency; a missing fanout
+      // is a narrower catalogue, not a failed approval.
+      logger.warn(
+        `[Admin] design ${designId} approved but FX fanout could not be requested: ${e?.message ?? e}`
+      )
     }
 
     // Emit design.approved so partners can be notified

--- a/apps/backend/src/api/partners/designs/[designId]/recalculate-cost/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/recalculate-cost/route.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_PLATFORM_FEE_PERCENT,
   DEFAULT_MATERIAL_COST,
 } from "../../../../../workflows/designs/estimate-design-cost"
+import { loadCostConfig } from "../../../../../modules/platform-cost-config/read-config"
 import { DESIGN_MODULE } from "../../../../../modules/designs"
 import { assertPartnerOwnsDesign } from "../../helpers"
 
@@ -45,12 +46,24 @@ export async function POST(
     productionCostOverride = parsed
   }
 
+  const costConfig = await loadCostConfig(req.scope)
+
   const { result, errors } = await estimateDesignCostWorkflow(req.scope).run({
     input: {
       design_id: designId,
       production_cost_override: productionCostOverride ?? null,
-      platform_fee_percent: DEFAULT_PLATFORM_FEE_PERCENT,
-      default_material_cost: DEFAULT_MATERIAL_COST,
+      /**
+       * #1939 — the platform's economic policy, read rather than compiled.
+       * This is the ONE caller that opts into these two, so config is read
+       * here rather than inside the estimator: reading it there would switch
+       * them on for every caller that deliberately passes nothing.
+       * The compiled constants remain the fallback for an unconfigured
+       * platform, so this is a no-op against the seeded row.
+       */
+      platform_fee_percent:
+        costConfig.platform_fee_percent ?? DEFAULT_PLATFORM_FEE_PERCENT,
+      default_material_cost:
+        costConfig.default_material_cost ?? DEFAULT_MATERIAL_COST,
     },
   })
   if (errors && errors.length > 0) {

--- a/apps/backend/src/modules/platform-cost-config/index.ts
+++ b/apps/backend/src/modules/platform-cost-config/index.ts
@@ -1,7 +1,10 @@
 import { Module } from "@medusajs/framework/utils"
 import PlatformCostConfigService from "./service"
 
-export const PLATFORM_COST_CONFIG_MODULE = "platform_cost_config"
+// Re-exported so existing importers are unchanged; the constant itself lives
+// in a leaf file that pulls no model. See module-key.ts.
+export { PLATFORM_COST_CONFIG_MODULE } from "./module-key"
+import { PLATFORM_COST_CONFIG_MODULE } from "./module-key"
 
 const PlatformCostConfigModule = Module(PLATFORM_COST_CONFIG_MODULE, {
   service: PlatformCostConfigService,

--- a/apps/backend/src/modules/platform-cost-config/module-key.ts
+++ b/apps/backend/src/modules/platform-cost-config/module-key.ts
@@ -1,0 +1,10 @@
+/**
+ * The module's registration key, on its own.
+ *
+ * 🔴 Split out of `index.ts` because importing that file pulls in the service
+ * and its `model.define(...)`, which is undefined outside a booted runtime. A
+ * pricer that reads config would therefore drag the whole module into every
+ * unit test importing it — and the failure mode is a suite that fails to RUN,
+ * which reads in the totals as neither pass nor fail.
+ */
+export const PLATFORM_COST_CONFIG_MODULE = "platform_cost_config"

--- a/apps/backend/src/modules/platform-cost-config/read-config.ts
+++ b/apps/backend/src/modules/platform-cost-config/read-config.ts
@@ -1,4 +1,4 @@
-import { PLATFORM_COST_CONFIG_MODULE } from "./index"
+import { PLATFORM_COST_CONFIG_MODULE } from "./module-key"
 import {
   readCostConfig,
   resolveCostConfig,

--- a/apps/backend/src/workflows/designs/estimate-design-cost.ts
+++ b/apps/backend/src/workflows/designs/estimate-design-cost.ts
@@ -5,6 +5,7 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import { loadCostConfig } from "../../modules/platform-cost-config/read-config";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -256,6 +257,16 @@ export function computeCostBreakdown(input: {
   /** Fallback per-unit cost for a material with no resolved cost. Default 0 (off). */
   defaultMaterialCost?: number;
   /**
+   * Production overhead as a percentage of material cost, used by the rungs of
+   * the waterfall that have no better figure.
+   *
+   * #1939 — was the compiled `DEFAULT_PRODUCTION_PERCENT` in four places.
+   * Passed in so the platform's economic policy can come from the
+   * effective-dated config table; the constant remains the fallback, so a
+   * platform with no policy row prices exactly as before.
+   */
+  productionOverheadPercent?: number;
+  /**
    * What comparable work has actually cost — settled costs of designs of this
    * type, and prices of products previously created from designs. Gathered
    * regardless; it only PRICES anything under `allowHistoricalBasis`.
@@ -282,6 +293,12 @@ export function computeCostBreakdown(input: {
     return { ...m, cost, cost_source, commission };
   });
   const materialCost = materials.reduce((sum, m) => sum + m.cost * m.quantity, 0);
+
+  const overheadPercent =
+    Number.isFinite(Number(input.productionOverheadPercent)) &&
+    Number(input.productionOverheadPercent) >= 0
+      ? Number(input.productionOverheadPercent)
+      : DEFAULT_PRODUCTION_PERCENT;
 
   let productionCost: number;
   let productionPercent: number;
@@ -333,10 +350,10 @@ export function computeCostBreakdown(input: {
     productionSource = "admin_estimate";
     productionIsEstimated = false; // admin set a concrete estimate
   } else if (adminEstimate != null && adminEstimate > 0 && materialCost === 0) {
-    const materialShare = adminEstimate / (1 + DEFAULT_PRODUCTION_PERCENT / 100);
+    const materialShare = adminEstimate / (1 + overheadPercent / 100);
     impliedMaterialCost = materialShare;
     productionCost = adminEstimate - materialShare;
-    productionPercent = DEFAULT_PRODUCTION_PERCENT;
+    productionPercent = overheadPercent;
     productionSource = "admin_estimate";
   } else if (similarDesigns.length > 0 && materialCost > 0) {
     const avgSimilarCost =
@@ -364,15 +381,15 @@ export function computeCostBreakdown(input: {
       productionCost = Math.max(basis - materialCost, materialCost * 0.1);
       productionPercent = (productionCost / materialCost) * 100;
     } else {
-      const materialShare = basis / (1 + DEFAULT_PRODUCTION_PERCENT / 100);
+      const materialShare = basis / (1 + overheadPercent / 100);
       impliedMaterialCost = materialShare;
       productionCost = basis - materialShare;
-      productionPercent = DEFAULT_PRODUCTION_PERCENT;
+      productionPercent = overheadPercent;
     }
     productionSource = "historical_comparables";
   } else {
-    productionCost = materialCost * (DEFAULT_PRODUCTION_PERCENT / 100);
-    productionPercent = DEFAULT_PRODUCTION_PERCENT;
+    productionCost = materialCost * (overheadPercent / 100);
+    productionPercent = overheadPercent;
   }
 
   // JYT platform commission — the sum of the per-material commissions (each is
@@ -1025,8 +1042,23 @@ const calculateTotalCostStep = createStep(
     defaultMaterialCost?: number;
     historical?: HistoricalComparable[];
     allowHistoricalBasis?: boolean;
-  }) => {
+  }, { container }) => {
     const design = input.design;
+
+    /**
+     * #1939 — the platform's economic policy, read rather than compiled.
+     *
+     * ONLY the production overhead is taken from config here. `platformFeePercent`
+     * and `defaultMaterialCost` are deliberately OPT-IN per caller (they default
+     * to 0/off so store, admin and draft-order flows are unaffected), and
+     * reading them from config here would switch them on for every caller —
+     * a price change wearing a refactor's clothes. The one caller that opts in
+     * reads config itself.
+     *
+     * `loadCostConfig` never throws and never returns zeros: an unconfigured
+     * platform yields nulls, and the compiled constant answers.
+     */
+    const costConfig = await loadCostConfig(container as any);
     const platformFeePercent = input.platformFeePercent ?? 0;
     const hasOverride =
       input.productionCostOverride != null && input.productionCostOverride >= 0;
@@ -1083,6 +1115,8 @@ const calculateTotalCostStep = createStep(
       productionCostOverride: input.productionCostOverride ?? null,
       platformFeePercent,
       defaultMaterialCost: input.defaultMaterialCost ?? 0,
+      productionOverheadPercent:
+        costConfig.production_overhead_percent ?? undefined,
       historical: input.historical ?? [],
       allowHistoricalBasis: !!input.allowHistoricalBasis,
     });

--- a/apps/backend/src/workflows/partner-quote/ensure-design-quote-variant.ts
+++ b/apps/backend/src/workflows/partner-quote/ensure-design-quote-variant.ts
@@ -15,6 +15,7 @@ import {
 } from "../../modules/partner-quote/lib/design-lines"
 import { estimateDesignCostWorkflow } from "../designs/estimate-design-cost"
 import { createProductFromDesignWorkflow } from "../designs/create-product-from-design"
+import { loadCostConfig } from "../../modules/platform-cost-config/read-config"
 
 /**
  * Make a CUSTOM design quotable, without inventing a second pricing path.
@@ -200,11 +201,23 @@ const ensureVariantStep = createStep(
       if (!Number.isFinite(Number(fxRate)) || Number(fxRate) <= 0) fxRate = null
     }
 
+    /**
+     * #1939 — the retail markup, read rather than compiled.
+     *
+     * Precedence: an explicit caller value, then the effective-dated config
+     * row, then the compiled `DEFAULT_CUSTOM_DESIGN_MARKUP_PERCENT` inside the
+     * pure pricer. Against the seeded row (20) this is a no-op — which is the
+     * point of wiring before changing the number.
+     */
+    const costConfig = await loadCostConfig(container as any)
     const priced = designQuoteUnitPrice({
       total_estimated: estimate?.total_estimated,
       confidence: estimate?.confidence,
       fx_rate: fxRate,
-      markup_percent: input.markup_percent,
+      markup_percent:
+        input.markup_percent ??
+        costConfig.custom_design_markup_percent ??
+        undefined,
     })
 
     if (priced.unit_price === null) {

--- a/apps/backend/src/workflows/production-runs/approve-run-output.ts
+++ b/apps/backend/src/workflows/production-runs/approve-run-output.ts
@@ -111,6 +111,7 @@ export {
   resolveApprovalCurrency,
   resolveApprovalPrice,
 } from "./approval-pricing"
+import { loadCostConfig } from "../../modules/platform-cost-config/read-config"
 
 /** The store the FX fanout is scoped to. Null is survivable; see the call site. */
 export async function readStoreId(container: any): Promise<string | null> {
@@ -295,6 +296,7 @@ export async function applyRunApprovals(
    * `replay-fx-fanout` can materialise the rest later.
    */
   const storeId = await readStoreId(container)
+  const costConfig = await loadCostConfig(container)
 
   /** design_id → the runs of that design in this batch, in the order given. */
   const byDesign = new Map<string, any[]>()
@@ -373,9 +375,15 @@ export async function applyRunApprovals(
         }
       }
 
+      /**
+       * #1939 — the approval markup, read rather than compiled. Against the
+       * seeded row (1.4) this is a no-op; the compiled `APPROVAL_MARKUP`
+       * answers for an unconfigured platform.
+       */
       const priced = resolveApprovalPrice({
         runCostPerUnit,
         designEstimatedCost: Number(design.estimated_cost ?? 0),
+        markup: costConfig.approval_markup_multiplier ?? undefined,
       })
       if (!priced) {
         throw new Error(


### PR DESCRIPTION
Two pricing fixes, both with a red-without-the-fix test.

## #1900 — the DESIGN-approve door still listed at 0, in one currency

#1914 fixed these on the **run-approval** door. The **design-approve** door — `POST /admin/designs/:id/approve`, the button on the design-order page — still had both, so the issue's handoff ("both live defects are fixed") was true of one caller and not the other.

- **Listed at 0.** `estimated_cost || 0` reached `resolveListedPrice`, which passed the zero through to the price row. Two such rows are on prod. A 0 is worse than the ×100 it replaced: a hundred-fold price is absurd on sight, a free product looks plausible. Now refused, naming the design, and refused **before** the status write so a design cannot end up Approved with no product behind it. Asked as `> 0`, not `!= null`.
- **One currency.** Medusa's pricing module emits no `price.created`, so every path writing a variant price must ASK for the FX fanout. This door never did; the five 2026-08-28 Oshen products carry an AUD price only. It now emits `fx.fanout_requested` — on the worker, because running that fanout inline OOM-killed prod twice on 2026-08-19.

The 7 residue rows are **not** touched: they need the #1939 markup decision first, or they get repriced twice.

## #1939 slice 1 — the pricers read the policy table

#1942 built the effective-dated table and deliberately left the compiled constants authoritative. **Nothing read it**, so inserting the founder's 30% row would have changed no price, silently.

Five policy values now resolve config → compiled constant. 🔴 `platform_fee_percent` and `default_material_cost` are read at the **route**, not inside the estimator: they are opt-in per caller, and reading them centrally would switch them on for every caller — a price change wearing a refactor's clothes.

**The 30 / 1.30 INSERT is deliberately NOT here.** Inserting before this deploys re-couples the rewiring and the price change, which is what the issue's application order exists to prevent.

## Evidence

- **No-op:** 17 integration tests across the cost suites, 95 unit tests, unchanged against the seeded row.
- **Actually read:** a new spec clears the table (compiled 30% answers), inserts 60%, and watches the split move — #1554's invariant still holding and `total_estimated > 0` so an empty table can never read as free. Reverting the wiring turns it red (expected 60, received 30).
- **#1900:** costless approve returns 400 and leaves the design un-Approved; the fanout is asserted by subscribing to `fx.fanout_requested` and matching the created variant id. Both red when neutralised.

🔴 Also fixed along the way: importing the config reader pulled `model.define` into the unit environment and `estimate-design-cost.unit.spec.ts` **failed to run** — which contributes neither a pass nor a fail, so a green "281 passed" was hiding it. The module key now lives in a leaf file.

⚠️ Pre-existing red, not from this branch: `route-validator-field-coverage` fails with exactly the six tools listed in #1943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
