### PR TITLE
fix(mcp): the validator-coverage suite was red — six core-route tools undeclared, two dry_run twins unaccounted

### DIFF
--- a/apps/backend/src/lib/mcp-core/__tests__/inventory-tool-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/inventory-tool-field-coverage.unit.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * The inventory lifecycle tools (#1905) against core's own validators — the
+ * inventory sibling of product-tool-field-coverage.
+ *
+ * `route-validator-field-coverage` resolves each write tool's contract from
+ * THIS repo's `middlewares.ts`. These four wrap core routes
+ * (`/admin/inventory-items`, its `location-levels`, `/admin/reservations`),
+ * and core registers the validators in its own middleware config — so from
+ * that spec they can only ever be "unbound, declared as such". This file binds
+ * them to the imported validators directly, closing both directions the #1348
+ * family cares about: a param the tool never offers is silently stripped, and
+ * a param the route would reject is a 400.
+ *
+ * Every one of these tools today advertises EVERY field its validator accepts
+ * — zero deliberate omissions. That is the point of writing it down: the first
+ * field someone quietly drops will fail here with its name, not vanish the way
+ * `weight` did (#1393).
+ */
+
+// Imported, never transcribed — same rule as the product spec: a copy of
+// core's field list here would rot the moment core added a field.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const coreInventoryValidators = require("@medusajs/medusa/api/admin/inventory-items/validators")
+const {
+  AdminCreateInventoryItem,
+  AdminCreateInventoryLocationLevel,
+  AdminUpdateInventoryLocationLevel,
+} = coreInventoryValidators
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const coreReservationValidators = require("@medusajs/medusa/api/admin/reservations/validators")
+const { AdminCreateReservation } = coreReservationValidators
+
+import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
+import type { McpToolDef } from "../types"
+
+/** Keys a zod object validator accepts. */
+const acceptedKeys = (schema: any): string[] =>
+  Object.keys(schema?.shape ?? schema?._def?.shape?.() ?? {})
+
+const findTool = (tools: readonly McpToolDef[], name: string): McpToolDef => {
+  const tool = tools.find((t) => t.name === name)
+  if (!tool) throw new Error(`tool "${name}" not found — was it renamed?`)
+  return tool
+}
+
+/**
+ * Fields a tool knowingly does not expose, with the reason.
+ *
+ * Empty for all four today — kept (and asserted below) so the next omission
+ * is a written decision rather than a silent strip.
+ */
+const DELIBERATELY_OMITTED: Record<string, Record<string, string>> = {}
+
+const CASES: Array<{
+  key: string
+  tool: McpToolDef
+  validator: any
+  what: string
+}> = [
+  {
+    key: "admin:create_inventory_item",
+    tool: findTool(ADMIN_MCP_TOOLS, "create_inventory_item"),
+    validator: AdminCreateInventoryItem,
+    what: "core route, core validator",
+  },
+  {
+    key: "admin:set_inventory_level",
+    tool: findTool(ADMIN_MCP_TOOLS, "set_inventory_level"),
+    validator: AdminCreateInventoryLocationLevel,
+    what: "core route, core validator",
+  },
+  {
+    key: "admin:update_inventory_level",
+    tool: findTool(ADMIN_MCP_TOOLS, "update_inventory_level"),
+    validator: AdminUpdateInventoryLocationLevel,
+    what: "core route, core validator",
+  },
+  {
+    key: "admin:create_reservation",
+    tool: findTool(ADMIN_MCP_TOOLS, "create_reservation"),
+    validator: AdminCreateReservation,
+    what: "core route, core validator",
+  },
+]
+
+describe("inventory MCP tools cover the fields their routes accept", () => {
+  describe.each(CASES)("$key", ({ key, tool, validator, what }) => {
+    const accepted = acceptedKeys(validator)
+    const omitted = DELIBERATELY_OMITTED[key] ?? {}
+
+    it(`sanity: the validator was importable and non-empty (${what})`, () => {
+      // A bad import path would make every assertion below pass over an
+      // empty set — the test would go green by testing nothing. The level
+      // update validator is genuinely a TWO-key contract (stocked_quantity,
+      // incoming_quantity), so the floor is 1, not the product spec's 5.
+      expect(accepted.length).toBeGreaterThan(1)
+    })
+
+    it("advertises every accepted field, or names it as a deliberate omission", () => {
+      const advertised = new Set(tool.bodyParams ?? [])
+      const unaccounted = accepted.filter(
+        (field) => !advertised.has(field) && !(field in omitted)
+      )
+
+      expect(unaccounted).toEqual([])
+    })
+
+    it("advertises nothing the route would reject", () => {
+      // A body param the validator does not accept is a 400 waiting to
+      // happen on a .strict() core route.
+      const strays = (tool.bodyParams ?? []).filter(
+        (field) => !accepted.includes(field)
+      )
+
+      expect(strays).toEqual([])
+    })
+
+    it("declares every advertised body param in its input schema", () => {
+      const props = Object.keys((tool.inputSchema as any)?.properties ?? {})
+      const undeclared = (tool.bodyParams ?? []).filter((f) => !props.includes(f))
+
+      expect(undeclared).toEqual([])
+    })
+
+    it("has no stale entries in its deliberate-omission list", () => {
+      // An omission for a field the validator no longer accepts is a note
+      // about a world that stopped existing. Delete it rather than let it rot.
+      const stale = Object.keys(omitted).filter((f) => !accepted.includes(f))
+
+      expect(stale).toEqual([])
+    })
+  })
+})

--- a/apps/backend/src/lib/mcp-core/__tests__/product-tool-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/product-tool-field-coverage.unit.spec.ts
@@ -35,6 +35,13 @@
 const coreProductValidators = require("@medusajs/medusa/api/admin/products/validators")
 const { UpdateProduct, UpdateProductVariant, CreateProductVariant } =
   coreProductValidators
+/**
+ * The batch route's validator — the ONLY route core exposes for editing an
+ * option's values (#1907). Registered by core's own middleware config, so it
+ * never appears in this repo's and `route-validator-field-coverage` declares
+ * the tool unbound there. This spec binds it directly instead.
+ */
+const { AdminLinkProductOptions } = coreProductValidators
 
 import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
 import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
@@ -103,6 +110,23 @@ const DELIBERATELY_OMITTED: Record<string, Record<string, string>> = {
     external_id: "integration bookkeeping, never assistant-written",
     is_giftcard: "not a thing this catalogue sells",
   },
+  "admin:create_product_variant": {
+    ean: "retail barcode symbologies; no partner has asked, and a wrong one is worse than none",
+    upc: "as ean",
+    barcode: "as ean",
+    inventory_items: "stock is seeded by set_inventory_level, which this tool already points at",
+  },
+  "admin:update_product_option": {
+    /**
+     * Top-level `add`/`remove` on the batch route link or unlink WHOLE
+     * options to the product; the tool's `update[]` edits the VALUES an
+     * existing option offers — a different operation, advertised as the
+     * nested per-option add/remove instead.
+     */
+    add: "links whole options (an id, a new option, or an option-with-values) onto the product — a different operation from editing an option's values, and one the admin UI owns",
+    remove:
+      "unlinks whole options, stripping the option from every variant matched to it — a catalogue-wide change this tool deliberately does not offer",
+  },
 }
 
 const CASES: Array<{
@@ -110,6 +134,13 @@ const CASES: Array<{
   tool: McpToolDef
   validator: any
   what: string
+  /**
+   * Floor for the import sanity check below. Defaults to 5; the batch
+   * option-values editor is genuinely a THREE-key contract (add / remove /
+   * update), so it carries its own smaller floor rather than weakening the
+   * default for everyone else.
+   */
+  minFields?: number
 }> = [
   {
     key: "partner:update_product_variant",
@@ -135,17 +166,32 @@ const CASES: Array<{
     validator: UpdateProduct,
     what: "core route, core validator",
   },
+  {
+    key: "admin:create_product_variant",
+    tool: findTool(ADMIN_MCP_TOOLS, "create_product_variant"),
+    validator: CreateProductVariant,
+    what: "core route, core validator",
+  },
+  {
+    key: "admin:update_product_option",
+    tool: findTool(ADMIN_MCP_TOOLS, "update_product_option"),
+    validator: AdminLinkProductOptions,
+    what: "the batch route is the only one core exposes for editing an option's values (#1907)",
+    minFields: 3,
+  },
 ]
 
 describe("product/variant MCP tools cover the fields their routes accept", () => {
-  describe.each(CASES)("$key", ({ key, tool, validator, what }) => {
+  describe.each(CASES)("$key", ({ key, tool, validator, what, minFields }) => {
     const accepted = acceptedKeys(validator)
     const omitted = DELIBERATELY_OMITTED[key] ?? {}
 
     it(`sanity: the validator was importable and non-empty (${what})`, () => {
       // Without this, a bad import path would make every assertion below pass
-      // over an empty set — the test would go green by testing nothing.
-      expect(accepted.length).toBeGreaterThan(5)
+      // over an empty set — the test would go green by testing nothing. The
+      // default floor (>= 6) is the original > 5; a case with a genuinely
+      // smaller contract states its own floor via `minFields`.
+      expect(accepted.length).toBeGreaterThanOrEqual(minFields ?? 6)
     })
 
     it("advertises every accepted field, or names it as a deliberate omission", () => {
@@ -186,7 +232,11 @@ describe("product/variant MCP tools cover the fields their routes accept", () =>
   it("weight is advertised on every tool that can write one", () => {
     // The regression this whole file exists for, stated plainly so a future
     // reader sees the point without reconstructing it from the generic checks.
-    for (const { key, tool } of CASES) {
+    // A tool whose route has no `weight` field cannot write one — the batch
+    // option-values editor's contract is add/remove/update, nothing physical —
+    // so it is skipped rather than held to an assertion it cannot satisfy.
+    for (const { key, tool, validator } of CASES) {
+      if (!acceptedKeys(validator).includes("weight")) continue
       expect({ key, weight: (tool.bodyParams ?? []).includes("weight") }).toEqual({
         key,
         weight: true,

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -85,10 +85,33 @@ const NO_ROUTE_VALIDATOR = new Set<string>([
    */
   "partner:revoke_quote",
   // Core routes: core registers its own validator, so it never appears in this
-  // repo's middlewares config. The four product/variant ones are contract-
-  // checked against core's imported validators in the sibling spec.
+  // repo's middlewares config. The product/variant/option ones are contract-
+  // checked against core's imported validators in the sibling spec
+  // (product-tool-field-coverage); the inventory four in
+  // inventory-tool-field-coverage, its inventory sibling.
   "admin:create_product",
   "admin:update_product",
+  /**
+   * Variant and option writes, on core's own routes — same reason as the
+   * product rows above. `create_product_variant` posts to core's
+   * `/admin/products/:id/variants`; `update_product_option` posts to the
+   * batch route, the ONLY one core exposes for editing an option's values
+   * (#1907). Both are bound against core's imported validators in the
+   * sibling spec, so landing here is "not checked by THIS file" rather than
+   * "not checked".
+   */
+  "admin:create_product_variant",
+  "admin:update_product_option",
+  /**
+   * The inventory lifecycle (#1905), all four on core routes: core registers
+   * AdminCreateInventoryItem, the location-level validators and
+   * AdminCreateReservation in its own middleware config. Same deal as the
+   * rows above — the contract check lives in the inventory sibling spec.
+   */
+  "admin:create_inventory_item",
+  "admin:set_inventory_level",
+  "admin:update_inventory_level",
+  "admin:create_reservation",
   /**
    * Category and collection tools wrap core's own `/admin/product-categories`
    * and `/admin/collections` routes, so core registers the validators and they
@@ -226,6 +249,23 @@ const DELIBERATELY_OMITTED: Record<string, Record<string, string>> = {
     // OVERWRITE the path param in that spread. The tool takes the id as a
     // path param only, so the schema never offers a body id to clobber it.
     id: "the :id path param is the only id; a body id would overwrite it in the route's spread",
+  },
+  /**
+   * The dispatcher owns `dry_run` as a FRAMEWORK flag: it intercepts the arg
+   * and returns the planned request WITHOUT ever calling the route. Both
+   * routes accept `dry_run` for their HTTP callers, and BOTH offer `preview`
+   * as the passthrough twin for exactly this reason — see the note on
+   * `preview` in AdminRunApprovalsReq and OpsMaintenanceRunSchema. The tools
+   * advertise `preview`; advertising `dry_run` too would be a lie, since the
+   * dispatcher would eat it before the route ever saw it.
+   */
+  "admin:review_production_run_output": {
+    dry_run:
+      "the MCP dispatcher intercepts dry_run and never calls the route; the route's `preview` is the passthrough twin the tool advertises",
+  },
+  "admin:run_maintenance_job": {
+    dry_run:
+      "as review_production_run_output — the dispatcher's own flag never arrives; `preview` survives it and is what the tool advertises",
   },
   "admin:create_partner_task": {
     template_names: "see dispatch_template_names — approval INTENT, not a task field",


### PR DESCRIPTION
## What was red

`route-validator-field-coverage` had two failures on `main`, both predating the email-template PR (#1949) — confirmed there by stashing the change and diffing the pass/fail set, and both still failing on the merged `main`:

1. **"every write tool is either bound to a validator or written down as unbound"** — six tools that wrap CORE routes:
   - `create_inventory_item`, `set_inventory_level`, `update_inventory_level`, `create_reservation` (added in #1906)
   - `update_product_option` (repointed to the batch route in #1906), `create_product_variant`

   Core registers those routes' validators in its own middleware config, so they never appear in this repo's `middlewares.ts` — from this test they can only ever read as "unbound".

2. **"advertises every accepted field, or names it as a deliberate omission"** — `review_production_run_output` and `run_maintenance_job` accept `dry_run` on their routes, which the tools deliberately do not advertise.

## The fix

**The six, declared — and four of them actually checked.** The unbound entries land in `NO_ROUTE_VALIDATOR` with per-family reasons, per the file's own convention ("declared rather than deleted, because the tools work — what was missing was the note saying nobody had bound them"). But a declaration is a note, not a check, so where core's validators are importable the contracts are now bound directly:

- `product-tool-field-coverage` (the existing sibling) gains `admin:create_product_variant` (against `CreateProductVariant`, which it already imported) and `admin:update_product_option` (against `AdminLinkProductOptions` — the batch route's real validator). Omissions written down with reasons: `ean`/`upc`/`barcode`/`inventory_items` for the variant (same rationale as the partner twins), top-level `add`/`remove` for the option editor (link/unlink whole options ≠ editing an option's values).
- **New `inventory-tool-field-coverage`** — the inventory sibling — binds the four #1905 tools against core's imported `AdminCreateInventoryItem`, the location-level validators and `AdminCreateReservation`. All four advertise every field their validator accepts, with **zero** deliberate omissions; the spec exists so the first quietly-dropped field fails with its name instead of vanishing the way `weight` did (#1393).

**The two `dry_run` twins, written down.** The dispatcher owns `dry_run` as a framework flag: it intercepts the arg and returns the planned request without ever calling the route. Both routes offer `preview` as the passthrough twin for exactly this reason — the note lives in `AdminRunApprovalsReq` and `OpsMaintenanceRunSchema`, and in the tools' own descriptions. The `DELIBERATELY_OMITTED` entries now say so, so a future reader sees it's a designed alias, not an oversight.

**Guard strength preserved.** The product spec's import-sanity floor keeps its original `> 5` (as `>= 6`) for the existing cases; the three-key `AdminLinkProductOptions` contract carries its own `minFields: 3`. The "weight is advertised on every tool that can write one" regression check now skips tools whose route has no `weight` field at all — the option-values editor's contract is add/remove/update, nothing physical.

## Verified

- All three suites green: 59/59. Full MCP surface: **27 suites / 432 tests, 0 failures** (was 26/400 with 2 red).
- **Mutation-tested**: dropping `material` from `create_inventory_item`'s `bodyParams` fails exactly `advertises every accepted field` in the new inventory spec — a check that never ran reads as a pass, so this is the check.
- `tsc --noEmit`: zero errors in the touched files.