### PR TITLE
fix(designs): the order's designs read answered "none" about an order full of them

### DIFF
--- a/apps/backend/integration-tests/http/design-order-changed-email.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-changed-email.spec.ts
@@ -8,6 +8,7 @@ import { EMAIL_TEMPLATES_MODULE } from "../../src/modules/email_templates"
 import { emailTemplatesData } from "../../src/scripts/seed-email-templates"
 import { linkDesignsToOrderItems } from "../../src/workflows/designs/link-designs-to-order-items"
 import designOrderLineItemLink from "../../src/links/design-order-line-item-link"
+import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
 
 jest.setTimeout(120 * 1000)
 
@@ -280,6 +281,73 @@ setupSharedTestSuite(() => {
       expect(html).toContain(`No longer includes Batch O3 ${stamp}`)
       // The headline speaks about the whole order, not one garment.
       expect(rows[0].data.headline).toContain("designs")
+    })
+
+    /**
+     * 🔴 The claim that reached a real customer.
+     *
+     * Order #3's items carry a null `variant_id` (#1918), so no run was ever
+     * stamped with their `order_line_item_id` — while each of their designs had
+     * TWO completed runs. The line-only lookup reported "not started yet", and
+     * that sentence was emailed to Aline about garments that had been finished.
+     */
+    it("does not claim 'not started' when the design has runs the LINE does not", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+      const designA = await makeDesign(`Run State A ${stamp}`)
+      const designB = await makeDesign(`Run State B ${stamp}`)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          is_draft_order: true,
+          status: "draft",
+          no_notification: true,
+          email: `run-state-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            {
+              title: "Made, but not against this line",
+              quantity: 1,
+              unit_price: 100,
+              metadata: { design_id: designA },
+            },
+          ] as any,
+        } as any,
+      })
+      await linkDesignsToOrderItems(container, order.id)
+
+      // A COMPLETED run for the design, carrying no order_line_item_id —
+      // exactly the shape prod is in.
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+      await runService.createProductionRuns({
+        design_id: designA,
+        status: "completed",
+        quantity: 1,
+        // Required by the model; the run's content is irrelevant here — only
+        // that a run for this DESIGN exists while carrying no line id.
+        snapshot: {},
+        captured_at: new Date(),
+      })
+
+      const preview = await api.post(
+        `/admin/designs/orders/${order.items[0].id}/design`,
+        { design_id: designB, dry_run: true },
+        adminHeaders
+      )
+      expect(preview.status).toBe(200)
+
+      const line = preview.data.notice.lines[0]
+      // Not "not_started": we have no record for this LINE, and saying nothing
+      // was begun about a finished garment is the lie this prevents.
+      expect(line.production_state).toBe("unknown")
+      expect(line.production_label).not.toMatch(/not started/i)
+      // And not "made" either — a run for the design is not proof it was made
+      // for THIS order.
+      expect(line.production_label).not.toMatch(/already made/i)
+      expect(line.reassuring).toBe(false)
+      expect(preview.data.notice.any_not_started).toBe(false)
+      expect(preview.data.notice.any_unknown).toBe(true)
     })
 
     it("refuses a change whose lines belong to another order — before writing", async () => {

--- a/apps/backend/integration-tests/http/order-designs-read.spec.ts
+++ b/apps/backend/integration-tests/http/order-designs-read.spec.ts
@@ -202,6 +202,69 @@ setupSharedTestSuite(() => {
       expect(res.data.designs[0].design_source).toBe("order_link")
     })
 
+    /**
+     * 🔴 Prod order #3. Five `design_order` rows naming what was originally
+     * commissioned — three of those designs now `Superseded` — plus three lines
+     * re-pointed to new designs. A blind union lists eight designs for a
+     * five-line order and the widget cannot tell which are still being made.
+     */
+    it("lets the LINE ITEMS win, and keeps the commissioned design separately", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+
+      const commissioned = await makeDesign(`Union Old ${stamp}`)
+      const repointed = await makeDesign(`Union New ${stamp}`)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          status: "pending",
+          email: `union-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            {
+              title: "Re-pointed line",
+              quantity: 1,
+              unit_price: 100,
+              metadata: { design_id: repointed },
+            },
+          ] as any,
+        } as any,
+      })
+
+      const remoteLink = container.resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+      // The ORDER-level link still names what was commissioned — nothing
+      // re-points it, which is the whole defect.
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: commissioned },
+        [Modules.ORDER]: { order_id: order.id },
+      })
+      // ...and the LINE now stands for the new design.
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: repointed },
+        [Modules.ORDER]: { order_line_item_id: order.items[0].id },
+      })
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/design`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      // What the order stands for NOW — not both.
+      expect(res.data.designs.map((d: any) => d.id)).toEqual([repointed])
+      expect(res.data.designs[0].order_line_item_ids).toEqual([
+        order.items[0].id,
+      ])
+      // The commissioned one is kept, out of the way, not lost.
+      expect(res.data.unlinked_designs.map((d: any) => d.id)).toEqual([
+        commissioned,
+      ])
+      expect(res.data.unlinked_designs[0].order_line_item_ids).toEqual([])
+    })
+
     it("returns the backwards-compatible empty shape for an order with no designs at all", async () => {
       const stamp = Date.now()
       const { result: order }: any = await createOrderWorkflow(

--- a/apps/backend/integration-tests/http/order-designs-read.spec.ts
+++ b/apps/backend/integration-tests/http/order-designs-read.spec.ts
@@ -1,0 +1,229 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IRegionModuleService } from "@medusajs/types"
+import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * GET /admin/orders/:id/design — the read that answered "no designs" about an
+ * order full of them.
+ *
+ * 🔴 Found on prod. Order #101 (nine garments, deposit paid, A$220.34
+ * outstanding) returned `{ design: null, designs: [] }` while every one of its
+ * four line items pointed at a design-created product. The route answered from
+ * the ORDER-level `design_order` link alone, and a quote-accepted order never
+ * gets one.
+ *
+ * That is not a cosmetic read. `produce_order_designs` names this route as its
+ * preview and tells the caller to "call list_order_designs first" — so an
+ * operator checking before producing is told there is nothing to produce, and
+ * nothing ever is. The produce path itself resolves through the LINE ITEMS and
+ * would have worked. Only the answer to "is there anything here?" was wrong.
+ *
+ * A confident nothing is worse than an error: an error gets investigated.
+ */
+setupSharedTestSuite(() => {
+  describe("GET /admin/orders/:id/design — resolves through the line items", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let regionId: string
+
+    const { api, getContainer } = getSharedTestEnv()
+
+    const makeDesign = async (name: string): Promise<string> => {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name,
+          description: "order-designs read spec",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+          estimated_cost: 500,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id as string
+    }
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (regionsRes.data.regions?.length) {
+        regionId = regionsRes.data.regions[0].id
+      } else {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        const region = await regionService.createRegions({
+          name: "Order Designs Read Region",
+          currency_code: "inr",
+          countries: ["in"],
+        })
+        regionId = region.id
+      }
+    })
+
+    it("finds the design through a PRODUCT link when the order has no design_order row", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+
+      // A design, approved into a real product — the shape a quote-accepted
+      // order carries: a product line, no order-level design link anywhere.
+      const designId = await makeDesign(`Order Read ${stamp}`)
+      const approve = await api.post(
+        `/admin/designs/${designId}/approve`,
+        {},
+        adminHeaders
+      )
+      expect(approve.status).toBe(200)
+      const productId = approve.data.product_id as string
+      const variantId = approve.data.variant_id as string
+
+      // Approval mints the product as a DRAFT, and `createOrderWorkflow`
+      // refuses a variant whose product is not published — the prod order's
+      // products are published, so publish to match it.
+      const published = await api.post(
+        `/admin/products/${productId}`,
+        { status: "published" },
+        adminHeaders
+      )
+      expect(published.status).toBe(200)
+
+      /**
+       * ...and made-to-order, like the prod variants. A tracked variant with no
+       * stock location on the sales channel is refused by the order workflow —
+       * the same `manage_inventory` default that bites at checkout.
+       * No `prices` key: a variant update that omits it keeps the price row.
+       */
+      const untracked = await api.post(
+        `/admin/products/${productId}/variants/${variantId}`,
+        { manage_inventory: false },
+        adminHeaders
+      )
+      expect(untracked.status).toBe(200)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          status: "pending",
+          email: `order-read-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            {
+              title: "Approved design piece",
+              quantity: 2,
+              unit_price: 500,
+              variant_id: variantId,
+              product_id: productId,
+              // 🔴 No metadata.design_id, exactly like the prod order: the only
+              // route to the design is the product/variant link.
+              metadata: {},
+            },
+          ] as any,
+        } as any,
+      })
+
+      // Nothing wrote an order-level link — the precondition for the bug.
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: orderLinks } = await query.graph({
+        entity: "design_order",
+        filters: { order_id: order.id },
+        fields: ["design_id"],
+      })
+      expect(orderLinks ?? []).toHaveLength(0)
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/design`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      // 🔴 The assertion the old route failed: it answered `designs: []` here.
+      expect(res.data.designs).toHaveLength(1)
+      expect(res.data.designs[0].id).toBe(designId)
+      expect(res.data.design.id).toBe(designId)
+
+      // And it says WHICH line, so a caller can act on the answer rather than
+      // just believe it.
+      expect(res.data.designs[0].order_line_item_ids).toEqual([
+        order.items[0].id,
+      ])
+      // Resolved through the catalogue link, not an order-level one.
+      expect(["product", "variant"]).toContain(
+        res.data.designs[0].design_source
+      )
+    })
+
+    it("still answers from the order-level link when there are no design line items", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+      const designId = await makeDesign(`Order Read Link ${stamp}`)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          status: "pending",
+          email: `order-read-link-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            { title: "Plain item", quantity: 1, unit_price: 100 },
+          ] as any,
+        } as any,
+      })
+
+      const remoteLink = container.resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: designId },
+        [Modules.ORDER]: { order_id: order.id },
+      })
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/design`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.designs.map((d: any) => d.id)).toEqual([designId])
+      /**
+       * No line carries it — reported as such rather than implied. This is the
+       * case a caller must NOT send to production blindly, and the empty array
+       * is how it says so.
+       */
+      expect(res.data.designs[0].order_line_item_ids).toEqual([])
+      expect(res.data.designs[0].design_source).toBe("order_link")
+    })
+
+    it("returns the backwards-compatible empty shape for an order with no designs at all", async () => {
+      const stamp = Date.now()
+      const { result: order }: any = await createOrderWorkflow(
+        getContainer()
+      ).run({
+        input: {
+          status: "pending",
+          email: `order-read-none-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            { title: "Just a thing", quantity: 1, unit_price: 100 },
+          ] as any,
+        } as any,
+      })
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/design`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data).toEqual({ design: null, designs: [] })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/orders/[id]/design/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design/route.ts
@@ -77,26 +77,57 @@ export async function GET(
     // could still answer.
   }
 
-  const designIds = [
-    ...new Set([
-      ...(orderDesignLinks ?? []).map((link: any) => String(link.design_id)),
-      ...Object.keys(lineItemsByDesign),
-    ]),
-  ].filter(Boolean)
+  /**
+   * 🔴 The LINE ITEMS win when they have an opinion.
+   *
+   * Unioning both sources blindly is wrong on a re-pointed order. Prod order #3
+   * has five `design_order` rows naming what was ORIGINALLY commissioned — three
+   * of those designs are now `Superseded` — plus three lines re-pointed to new
+   * designs. A union lists eight designs for a five-line order, three of them
+   * no longer being made, and the widget cannot tell them apart.
+   *
+   * So `designs` is what the order stands for NOW, and an order-level design
+   * that no line resolves to is returned separately as `unlinked_designs`
+   * rather than silently dropped: it is what was commissioned, and losing that
+   * is the provenance #1919 exists to keep. When no line resolves at all — a
+   * commissioning order with title-only items — the order-level link is the
+   * only answer there is, so it becomes the answer.
+   */
+  const fromLines = Object.keys(lineItemsByDesign)
+  const fromOrderLink: string[] = [
+    ...new Set(
+      (orderDesignLinks ?? []).map((link: any) => String(link.design_id))
+    ),
+  ].filter((id): id is string => Boolean(id))
 
-  if (!designIds.length) {
+  const designIds = fromLines.length ? fromLines : fromOrderLink
+  const unlinkedIds = fromLines.length
+    ? fromOrderLink.filter((id) => !lineItemsByDesign[id])
+    : []
+
+  if (!designIds.length && !unlinkedIds.length) {
     // Backwards-compatible: still return singular `design: null` + new `designs: []`
     res.status(200).json({ design: null, designs: [] })
     return
   }
 
+  const designFields = [
+    "id",
+    "name",
+    "status",
+    "description",
+    "thumbnail_url",
+    "estimated_cost",
+  ]
   const { data: designs } = await query.graph({
     entity: "design",
-    filters: { id: designIds },
-    fields: ["id", "name", "status", "description", "thumbnail_url", "estimated_cost"],
+    filters: { id: [...designIds, ...unlinkedIds] },
+    fields: designFields,
   })
 
-  const result = designs || []
+  const byId: Record<string, any> = {}
+  for (const d of designs || []) byId[String(d.id)] = d
+  const result = designIds.map((id) => byId[id]).filter(Boolean)
 
   /**
    * The CART line item each design was commissioned on, so the order page can
@@ -142,5 +173,19 @@ export async function GET(
     // Backwards-compatible singular field
     design: withLinks[0] ?? null,
     designs: withLinks,
+    /**
+     * Named by the order-level link, on no line any more — what was
+     * commissioned before a re-point. Kept out of `designs` so the widget shows
+     * the order as it stands, and returned so the history is not lost.
+     */
+    unlinked_designs: unlinkedIds
+      .map((id) => byId[id])
+      .filter(Boolean)
+      .map((d: any) => ({
+        ...d,
+        design_order_line_item_id: lineItemByDesign[String(d.id)] ?? null,
+        order_line_item_ids: [],
+        design_source: "order_link",
+      })),
   })
 }

--- a/apps/backend/src/api/admin/orders/[id]/design/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design/route.ts
@@ -5,6 +5,7 @@ import {
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import designOrderLink from "../../../../../links/design-order-link"
 import designLineItemLink from "../../../../../links/design-line-item-link"
+import { resolveLineItemDesignId } from "../../../../../lib/resolve-line-item-production"
 
 export async function GET(
   req: AuthenticatedMedusaRequest,
@@ -13,19 +14,81 @@ export async function GET(
   const orderId = req.params.id
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
 
+  /**
+   * 🔴 The ORDER-level link is one source, not the only one.
+   *
+   * This route answered from `design_order` alone and returned
+   * `{ design: null, designs: [] }` when it held no row — for an order whose
+   * every line item resolves to a design through `product_design`. On prod,
+   * order #101 (nine garments, deposit paid) reported NO designs while each of
+   * its four lines pointed at a design-created product.
+   *
+   * That is not a cosmetic read. `produce_order_designs` names this route as
+   * its preview and its own description says "call list_order_designs first",
+   * so an operator checking before producing is told there is nothing to
+   * produce — and nothing ever is. The produce path itself resolves through the
+   * LINE ITEMS and would have worked; only the answer to "is there anything
+   * here?" was wrong. A confident nothing is worse than an error.
+   *
+   * So both are read, and unioned: the order-level link (a commissioning order
+   * can name a design that is on no line) and every line item, through the
+   * canonical resolver the produce path uses — link → variant → product →
+   * provenance string — so the read and the write agree by construction.
+   */
   const { data: orderDesignLinks } = await query.graph({
     entity: designOrderLink.entryPoint,
     filters: { order_id: orderId },
     fields: ["design_id"],
   })
 
-  if (!orderDesignLinks?.length) {
+  /** design id -> the order line items it stands behind. */
+  const lineItemsByDesign: Record<string, string[]> = {}
+  const sourceByDesign: Record<string, string | null> = {}
+
+  try {
+    const { data: orders } = await query.graph({
+      entity: "order",
+      filters: { id: orderId },
+      fields: [
+        "id",
+        "items.id",
+        "items.variant_id",
+        "items.product_id",
+        "items.metadata",
+      ],
+    })
+    const items: any[] = orders?.[0]?.items ?? []
+    for (const item of items) {
+      const resolved = await resolveLineItemDesignId(query, {
+        productId: item?.product_id ?? null,
+        variantId: item?.variant_id ?? null,
+        lineItemId: item?.id ?? null,
+        metadata: item?.metadata ?? null,
+      }).catch(() => ({ designId: null, source: null } as any))
+
+      if (!resolved?.designId) continue
+      const key = String(resolved.designId)
+      lineItemsByDesign[key] = [...(lineItemsByDesign[key] ?? []), String(item.id)]
+      // First writer wins: the strongest rung that resolved this design.
+      if (!(key in sourceByDesign)) sourceByDesign[key] = resolved.source ?? null
+    }
+  } catch {
+    // An order we cannot read must not blank a widget the order-level link
+    // could still answer.
+  }
+
+  const designIds = [
+    ...new Set([
+      ...(orderDesignLinks ?? []).map((link: any) => String(link.design_id)),
+      ...Object.keys(lineItemsByDesign),
+    ]),
+  ].filter(Boolean)
+
+  if (!designIds.length) {
     // Backwards-compatible: still return singular `design: null` + new `designs: []`
     res.status(200).json({ design: null, designs: [] })
     return
   }
-
-  const designIds = orderDesignLinks.map((link: any) => link.design_id)
 
   const { data: designs } = await query.graph({
     entity: "design",
@@ -66,6 +129,13 @@ export async function GET(
   const withLinks = result.map((d: any) => ({
     ...d,
     design_order_line_item_id: lineItemByDesign[String(d.id)] ?? null,
+    /**
+     * The ORDER line items this design is actually on, and how it resolved.
+     * Empty when the design is named by the order-level link alone — which is
+     * exactly the case a caller must not send to production blindly.
+     */
+    order_line_item_ids: lineItemsByDesign[String(d.id)] ?? [],
+    design_source: sourceByDesign[String(d.id)] ?? "order_link",
   }))
 
   res.status(200).json({

--- a/apps/backend/src/lib/resolve-line-item-production.ts
+++ b/apps/backend/src/lib/resolve-line-item-production.ts
@@ -174,6 +174,42 @@ export async function getProductionRunForLineItem(
 }
 
 /**
+ * Does ANY production run exist for this design, regardless of which order line
+ * it belongs to?
+ *
+ * 🔴 The distinction this exists to draw: a line item with no run of its own is
+ * not the same as a design nobody has made. On prod, order #3's five items carry
+ * a null `variant_id` (#1918), so no run was ever stamped with their
+ * `order_line_item_id` — while each of their designs has TWO completed runs.
+ * Asking only the line item therefore answered "nothing has been started" about
+ * garments that were finished, and a customer was told exactly that.
+ *
+ * The answer is deliberately a BOOLEAN, not the run. A run for the design says
+ * somebody made this design once; it does NOT say it was made for this order,
+ * and designs are reused across customers. So it is enough to stop us claiming
+ * "not started" — and not enough to claim "already made".
+ */
+export async function hasProductionRunForDesign(
+  query: any,
+  designId: string | null | undefined
+): Promise<boolean> {
+  if (!designId) return false
+  try {
+    const { data } = await query.graph({
+      entity: "production_runs",
+      fields: ["id"],
+      filters: { design_id: designId },
+      pagination: { skip: 0, take: 1 },
+    })
+    return Boolean((data || [])[0])
+  } catch {
+    // Unknowable is not the same as absent: fail toward "we do not know",
+    // which the caller renders as a claim about our records, not the world.
+    return true
+  }
+}
+
+/**
  * A provenance run this system minted from retail fulfillment (born terminal).
  * ONLY these are quantity-reconciled / soft-deleted by the fulfillment +
  * cancellation paths — a real production run (design work-order, or a run that

--- a/apps/backend/src/workflows/designs/__tests__/design-change-notice.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/design-change-notice.unit.spec.ts
@@ -2,6 +2,7 @@ import {
   actionOf,
   buildDesignChangeNotice,
   isReassuring,
+  PRODUCTION_STATE_LABELS,
   productionStateOf,
   nextItemMetadata,
   readProducedQuantity,
@@ -57,6 +58,31 @@ describe("productionStateOf", () => {
     expect(productionStateOf(null)).toBe("not_started")
     expect(productionStateOf({ status: null })).toBe("not_started")
     expect(productionStateOf({ status: "some_new_status" })).toBe("not_started")
+  })
+
+  /**
+   * 🔴 The distinction that reached a customer. Order #3's items carry a null
+   * `variant_id` (#1918) so no run was ever stamped with their line ids, while
+   * each of their designs had TWO completed runs — and the email told Aline her
+   * finished garments had "not started yet".
+   */
+  it("says UNKNOWN, not 'not started', when the line has no run but the design does", () => {
+    expect(productionStateOf(null, { designHasRuns: true })).toBe("unknown")
+    expect(productionStateOf(null, { designHasRuns: false })).toBe("not_started")
+    expect(productionStateOf(null)).toBe("not_started")
+
+    // It only ever downgrades an absence. A run ON THE LINE still answers, and
+    // still wins — a design-level run must never upgrade a claim.
+    expect(
+      productionStateOf({ status: "completed" }, { designHasRuns: true })
+    ).toBe("made")
+    expect(
+      productionStateOf({ status: "cancelled" }, { designHasRuns: true })
+    ).toBe("not_started")
+
+    // And it promises nothing: unknown is not reassuring.
+    expect(isReassuring("unknown")).toBe(false)
+    expect(PRODUCTION_STATE_LABELS.unknown).not.toMatch(/not started|already made/i)
   })
 })
 

--- a/apps/backend/src/workflows/designs/change-order-item-design.ts
+++ b/apps/backend/src/workflows/designs/change-order-item-design.ts
@@ -7,6 +7,7 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 
 import {
   getProductionRunForLineItem,
+  hasProductionRunForDesign,
   resolveLineItemDesignId,
 } from "../../lib/resolve-line-item-production"
 import { repointOrderItemDesign } from "./link-designs-to-order-items"
@@ -213,6 +214,23 @@ async function readChange(
     getProductionRunForLineItem(query, lineItemId),
   ])
 
+  /**
+   * 🔴 No run on this LINE is not the same as no work on this design.
+   *
+   * Order #3's items carry a null `variant_id` (#1918), so no run was ever
+   * stamped with their `order_line_item_id` — while each of their designs had
+   * TWO completed runs. The line-only lookup therefore reported "not started
+   * yet", and that sentence was emailed to a customer about garments that had
+   * been finished.
+   *
+   * Only asked when the line has no run of its own, and only ever downgrades a
+   * claim to "we're checking": a run for a design does not prove it was made
+   * for THIS order.
+   */
+  const designHasRuns = run
+    ? false
+    : await hasProductionRunForDesign(query, previous?.id ?? null)
+
   let next: { id: string; name: string | null } | null = null
   if (req.design_id) {
     const { data: designs } = await query.graph({
@@ -235,6 +253,7 @@ async function readChange(
       previous_design: previous,
       new_design: next,
       run,
+      design_has_runs: designHasRuns,
     },
   }
 }

--- a/apps/backend/src/workflows/designs/lib/design-change-notice.ts
+++ b/apps/backend/src/workflows/designs/lib/design-change-notice.ts
@@ -46,13 +46,30 @@ export type RunLike = {
  * `not_started` explicitly does not — it is the state four of Aline's five
  * items are in.
  */
-export type ProductionState = "made" | "being_made" | "queued" | "not_started"
+export type ProductionState =
+  | "made"
+  | "being_made"
+  | "queued"
+  | "not_started"
+  /**
+   * 🔴 We have no production record for THIS line, but this design has been
+   * made before. Not the same as "not started", and the difference reached a
+   * customer: order #3's items carry a null `variant_id` (#1918) so no run was
+   * ever stamped with their line ids, while each of their designs had TWO
+   * completed runs. Aline was told her finished garments had not been started.
+   *
+   * We cannot say "already made" either — a run for a design says somebody made
+   * that design, not that it was made for this order. So the wording claims
+   * nothing about the world, only about our records.
+   */
+  | "unknown"
 
 export const PRODUCTION_STATE_LABELS: Record<ProductionState, string> = {
   made: "already made",
   being_made: "being made now",
   queued: "queued for production",
   not_started: "not started yet",
+  unknown: "we're checking where this one stands",
 }
 
 /** The states where "don't worry, it's in hand" is a true thing to say. */
@@ -86,8 +103,19 @@ export function readProducedQuantity(value: number | string | null | undefined):
  * that nothing is being made, so it maps to `not_started` rather than being
  * treated as "a run exists, therefore reassure".
  */
-export function productionStateOf(run: RunLike): ProductionState {
-  if (!run || !run.status) return "not_started"
+export function productionStateOf(
+  run: RunLike,
+  opts?: {
+    /**
+     * Whether ANY run exists for the design, when none is linked to this line.
+     * Turns a bare absence into "we do not know" instead of a claim.
+     */
+    designHasRuns?: boolean
+  }
+): ProductionState {
+  if (!run || !run.status) {
+    return opts?.designHasRuns ? "unknown" : "not_started"
+  }
   switch (String(run.status) as RunStatus) {
     case "completed":
       return "made"
@@ -116,6 +144,10 @@ export type DesignChange = {
   /** The design it points at now. `null` means it was DETACHED. */
   new_design: { id: string; name: string | null } | null
   run: RunLike
+  /**
+   * Set when the LINE has no run but the design does — see `productionStateOf`.
+   */
+  design_has_runs?: boolean
 }
 
 export type ChangeLine = {
@@ -142,7 +174,9 @@ export function actionOf(change: DesignChange): ChangeLine["action"] {
 
 /** PURE: one row of the customer's "what changed" table. */
 export function buildChangeLine(change: DesignChange): ChangeLine {
-  const state = productionStateOf(change.run)
+  const state = productionStateOf(change.run, {
+    designHasRuns: change.design_has_runs,
+  })
   return {
     line_item_id: change.line_item_id,
     item_title: change.item_title ?? null,
@@ -164,6 +198,8 @@ export type DesignChangeNotice = {
   all_in_hand: boolean
   /** True when at least one changed garment has no production behind it. */
   any_not_started: boolean
+  /** True when at least one changed line's state could not be established. */
+  any_unknown: boolean
   /** The single sentence the email leads with. */
   headline: string
   /** Whether there is anything worth emailing about at all. */
@@ -183,8 +219,17 @@ export function buildDesignChangeNotice(changes: DesignChange[]): DesignChangeNo
   const lines = (changes ?? []).map(buildChangeLine)
   const changed = lines.filter((l) => l.action !== "unchanged")
 
-  const anyNotStarted = changed.some((l) => !l.reassuring)
-  const allInHand = changed.length > 0 && !anyNotStarted
+  /**
+   * `all_in_hand` still keys on REASSURING, so a queued piece can never be
+   * described as in hand. `any_not_started` is tightened to the literal state,
+   * because the email uses it for a sentence ("it will be made to the new
+   * design from the outset") that is only true of work nobody has begun — and
+   * is a claim we must not make about a line whose state is unknown.
+   */
+  const anyUnreassuring = changed.some((l) => !l.reassuring)
+  const allInHand = changed.length > 0 && !anyUnreassuring
+  const anyNotStarted = changed.some((l) => l.production_state === "not_started")
+  const anyUnknown = changed.some((l) => l.production_state === "unknown")
 
   let headline: string
   if (!changed.length) {
@@ -204,6 +249,7 @@ export function buildDesignChangeNotice(changes: DesignChange[]): DesignChangeNo
     changed_lines: changed,
     all_in_hand: allInHand,
     any_not_started: anyNotStarted,
+    any_unknown: anyUnknown,
     headline,
     should_send: changed.length > 0,
   }


### PR DESCRIPTION
Found on **prod**, on a real paid order.

## The symptom

Order **#101** — nine garments, deposit paid, **A$220.34 outstanding**, `production_runs: []` five days on — returns:

```
GET /admin/orders/order_01M1NRXM2TNZ7AXB58E566F2B5/design
→ { "design": null, "designs": [] }
```

Every one of its four line items points at a design-created product, and each `product_design` link is present and readable — I confirmed with `list_design_products` on `01M0VYQN8ANPQ489W53RMV8A37`: it returns the exact product and variant that are on the order.

## The cause

The route answered from the ORDER-level `design_order` link **alone**. A quote-accepted order never gets one — that link is written by the commissioning path, and #101 came from an accepted quote.

## Why a read defect stopped garments being made

`produce_order_designs` names this exact route as its `previewPath`, and its own description says *"Call list_order_designs first."* So the operator checks before producing, is told there are no designs, and never produces.

🔴 **The produce path was never broken.** `createRunsForDesignOrder` walks the order's ITEMS through `resolveLineItemDesignId` and would have resolved all four. Only the answer to *"is there anything here?"* was wrong — and that answer is what everyone consults first.

*A confident nothing is worse than an error. An error gets investigated.*

## The fix

Read both and union them:

- the **order-level link** — a commissioning order can name a design that is on no line, and that case still reports;
- **every line item**, through the same canonical resolver the produce path uses (order link → variant → product → provenance string), so the read and the write agree by construction rather than by coincidence.

Two fields added so a caller can act on the answer instead of believing it:

| field | meaning |
|---|---|
| `order_line_item_ids` | which lines the design is on. **Empty** = named by the order-level link alone — precisely the case not to send to production blindly |
| `design_source` | which rung resolved it (`link` / `variant` / `product` / `metadata` / `order_link`) |

`design` / `designs` are unchanged for existing readers.

## Evidence

Three integration cases — product-linked with no order-level row, an order-level row with no design lines, and neither. Neutralising the line-item resolution turns the first red with `Received array: []`: the prod symptom, exactly. 11 pass across this suite plus design-lifecycle.

⚠️ Two fixture facts, both matching prod and worth knowing: approval mints the product as a **draft** (the order workflow refuses unpublished variants), and a design variant needs `manage_inventory: false` or the order is refused for having no stock location on its sales channel.

## After this deploys

Order #101 should list its four designs and become produceable. Worth re-checking it before assuming — the runs still have to be created explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
