### PR TITLE
feat(production): commission the run as part of the design change (#1953)

### DIFF
--- a/apps/backend/integration-tests/http/design-order-changed-email.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-changed-email.spec.ts
@@ -8,6 +8,7 @@ import { EMAIL_TEMPLATES_MODULE } from "../../src/modules/email_templates"
 import { emailTemplatesData } from "../../src/scripts/seed-email-templates"
 import { linkDesignsToOrderItems } from "../../src/workflows/designs/link-designs-to-order-items"
 import designOrderLineItemLink from "../../src/links/design-order-line-item-link"
+import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
 
 jest.setTimeout(120 * 1000)
 
@@ -280,6 +281,73 @@ setupSharedTestSuite(() => {
       expect(html).toContain(`No longer includes Batch O3 ${stamp}`)
       // The headline speaks about the whole order, not one garment.
       expect(rows[0].data.headline).toContain("designs")
+    })
+
+    /**
+     * 🔴 The claim that reached a real customer.
+     *
+     * Order #3's items carry a null `variant_id` (#1918), so no run was ever
+     * stamped with their `order_line_item_id` — while each of their designs had
+     * TWO completed runs. The line-only lookup reported "not started yet", and
+     * that sentence was emailed to Aline about garments that had been finished.
+     */
+    it("does not claim 'not started' when the design has runs the LINE does not", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+      const designA = await makeDesign(`Run State A ${stamp}`)
+      const designB = await makeDesign(`Run State B ${stamp}`)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          is_draft_order: true,
+          status: "draft",
+          no_notification: true,
+          email: `run-state-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            {
+              title: "Made, but not against this line",
+              quantity: 1,
+              unit_price: 100,
+              metadata: { design_id: designA },
+            },
+          ] as any,
+        } as any,
+      })
+      await linkDesignsToOrderItems(container, order.id)
+
+      // A COMPLETED run for the design, carrying no order_line_item_id —
+      // exactly the shape prod is in.
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+      await runService.createProductionRuns({
+        design_id: designA,
+        status: "completed",
+        quantity: 1,
+        // Required by the model; the run's content is irrelevant here — only
+        // that a run for this DESIGN exists while carrying no line id.
+        snapshot: {},
+        captured_at: new Date(),
+      })
+
+      const preview = await api.post(
+        `/admin/designs/orders/${order.items[0].id}/design`,
+        { design_id: designB, dry_run: true },
+        adminHeaders
+      )
+      expect(preview.status).toBe(200)
+
+      const line = preview.data.notice.lines[0]
+      // Not "not_started": we have no record for this LINE, and saying nothing
+      // was begun about a finished garment is the lie this prevents.
+      expect(line.production_state).toBe("unknown")
+      expect(line.production_label).not.toMatch(/not started/i)
+      // And not "made" either — a run for the design is not proof it was made
+      // for THIS order.
+      expect(line.production_label).not.toMatch(/already made/i)
+      expect(line.reassuring).toBe(false)
+      expect(preview.data.notice.any_not_started).toBe(false)
+      expect(preview.data.notice.any_unknown).toBe(true)
     })
 
     it("refuses a change whose lines belong to another order — before writing", async () => {

--- a/apps/backend/integration-tests/http/design-order-changed-email.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-changed-email.spec.ts
@@ -350,6 +350,117 @@ setupSharedTestSuite(() => {
       expect(preview.data.notice.any_unknown).toBe(true)
     })
 
+    /**
+     * #1953 — bind the work to the line by COMMISSIONING it, not by claiming
+     * somebody else's run. `order_line_item_id` is written at creation and
+     * nowhere else, so a new run is the only binding that cannot mis-attribute
+     * a garment when a design is reused across customers.
+     */
+    it("commissions a run for each moved line, stamped with the line it is for", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+      const designA = await makeDesign(`Run Mint A ${stamp}`)
+      const designB = await makeDesign(`Run Mint B ${stamp}`)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          is_draft_order: true,
+          status: "draft",
+          no_notification: true,
+          email: `run-mint-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            {
+              title: "To be made",
+              quantity: 1,
+              unit_price: 100,
+              metadata: { design_id: designA },
+            },
+            {
+              title: "To be detached",
+              quantity: 1,
+              unit_price: 100,
+              metadata: { design_id: designA },
+            },
+          ] as any,
+        } as any,
+      })
+      await linkDesignsToOrderItems(container, order.id)
+      const [moved, detached] = order.items
+
+      // Preview writes nothing, and says so.
+      const preview = await api.post(
+        `/admin/orders/${order.id}/design-changes`,
+        {
+          changes: [{ line_item_id: moved.id, design_id: designB }],
+          production: { mode: "new", quantity: 3 },
+          dry_run: true,
+        },
+        adminHeaders
+      )
+      expect(preview.status).toBe(200)
+      expect(preview.data.items[0].production_run_id).toBeNull()
+      expect(preview.data.items[0].production_skipped_reason).toBe("dry run")
+
+      const res = await api.post(
+        `/admin/orders/${order.id}/design-changes`,
+        {
+          changes: [
+            { line_item_id: moved.id, design_id: designB },
+            { line_item_id: detached.id, design_id: null },
+          ],
+          production: { mode: "new", quantity: 3 },
+          notify: false,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      const movedResult = res.data.items.find(
+        (i: any) => i.line_item_id === moved.id
+      )
+      const detachedResult = res.data.items.find(
+        (i: any) => i.line_item_id === detached.id
+      )
+
+      // The moved line got a run...
+      expect(movedResult.production_run_id).toEqual(expect.any(String))
+      // ...and the DETACHED line did not. There is nothing to make.
+      expect(detachedResult.production_run_id).toBeNull()
+      expect(detachedResult.production_skipped_reason).toMatch(/detached/i)
+
+      // The run is stamped with the line it belongs to — the identity that
+      // makes it this customer's rather than merely this design's.
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: runs } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "design_id", "order_id", "order_line_item_id", "quantity"],
+        filters: { order_line_item_id: moved.id },
+      })
+      expect(runs).toHaveLength(1)
+      expect(runs[0].id).toBe(movedResult.production_run_id)
+      expect(runs[0].design_id).toBe(designB)
+      expect(runs[0].order_id).toBe(order.id)
+      expect(Number(runs[0].quantity)).toBe(3)
+
+      // Asking twice does not commission twice — the line already has its run.
+      const again = await api.post(
+        `/admin/orders/${order.id}/design-changes`,
+        {
+          changes: [{ line_item_id: moved.id, design_id: designA }],
+          production: { mode: "new" },
+          notify: false,
+        },
+        adminHeaders
+      )
+      expect(again.status).toBe(200)
+      expect(again.data.items[0].production_run_id).toBeNull()
+      expect(again.data.items[0].production_skipped_reason).toMatch(
+        /already has run/i
+      )
+    })
+
     it("refuses a change whose lines belong to another order — before writing", async () => {
       const container = getContainer()
       const stamp = Date.now()

--- a/apps/backend/integration-tests/http/order-designs-read.spec.ts
+++ b/apps/backend/integration-tests/http/order-designs-read.spec.ts
@@ -202,6 +202,69 @@ setupSharedTestSuite(() => {
       expect(res.data.designs[0].design_source).toBe("order_link")
     })
 
+    /**
+     * 🔴 Prod order #3. Five `design_order` rows naming what was originally
+     * commissioned — three of those designs now `Superseded` — plus three lines
+     * re-pointed to new designs. A blind union lists eight designs for a
+     * five-line order and the widget cannot tell which are still being made.
+     */
+    it("lets the LINE ITEMS win, and keeps the commissioned design separately", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+
+      const commissioned = await makeDesign(`Union Old ${stamp}`)
+      const repointed = await makeDesign(`Union New ${stamp}`)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          status: "pending",
+          email: `union-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            {
+              title: "Re-pointed line",
+              quantity: 1,
+              unit_price: 100,
+              metadata: { design_id: repointed },
+            },
+          ] as any,
+        } as any,
+      })
+
+      const remoteLink = container.resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+      // The ORDER-level link still names what was commissioned — nothing
+      // re-points it, which is the whole defect.
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: commissioned },
+        [Modules.ORDER]: { order_id: order.id },
+      })
+      // ...and the LINE now stands for the new design.
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: repointed },
+        [Modules.ORDER]: { order_line_item_id: order.items[0].id },
+      })
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/design`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      // What the order stands for NOW — not both.
+      expect(res.data.designs.map((d: any) => d.id)).toEqual([repointed])
+      expect(res.data.designs[0].order_line_item_ids).toEqual([
+        order.items[0].id,
+      ])
+      // The commissioned one is kept, out of the way, not lost.
+      expect(res.data.unlinked_designs.map((d: any) => d.id)).toEqual([
+        commissioned,
+      ])
+      expect(res.data.unlinked_designs[0].order_line_item_ids).toEqual([])
+    })
+
     it("returns the backwards-compatible empty shape for an order with no designs at all", async () => {
       const stamp = Date.now()
       const { result: order }: any = await createOrderWorkflow(

--- a/apps/backend/integration-tests/http/order-designs-read.spec.ts
+++ b/apps/backend/integration-tests/http/order-designs-read.spec.ts
@@ -1,0 +1,229 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IRegionModuleService } from "@medusajs/types"
+import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * GET /admin/orders/:id/design — the read that answered "no designs" about an
+ * order full of them.
+ *
+ * 🔴 Found on prod. Order #101 (nine garments, deposit paid, A$220.34
+ * outstanding) returned `{ design: null, designs: [] }` while every one of its
+ * four line items pointed at a design-created product. The route answered from
+ * the ORDER-level `design_order` link alone, and a quote-accepted order never
+ * gets one.
+ *
+ * That is not a cosmetic read. `produce_order_designs` names this route as its
+ * preview and tells the caller to "call list_order_designs first" — so an
+ * operator checking before producing is told there is nothing to produce, and
+ * nothing ever is. The produce path itself resolves through the LINE ITEMS and
+ * would have worked. Only the answer to "is there anything here?" was wrong.
+ *
+ * A confident nothing is worse than an error: an error gets investigated.
+ */
+setupSharedTestSuite(() => {
+  describe("GET /admin/orders/:id/design — resolves through the line items", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let regionId: string
+
+    const { api, getContainer } = getSharedTestEnv()
+
+    const makeDesign = async (name: string): Promise<string> => {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name,
+          description: "order-designs read spec",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+          estimated_cost: 500,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id as string
+    }
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (regionsRes.data.regions?.length) {
+        regionId = regionsRes.data.regions[0].id
+      } else {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        const region = await regionService.createRegions({
+          name: "Order Designs Read Region",
+          currency_code: "inr",
+          countries: ["in"],
+        })
+        regionId = region.id
+      }
+    })
+
+    it("finds the design through a PRODUCT link when the order has no design_order row", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+
+      // A design, approved into a real product — the shape a quote-accepted
+      // order carries: a product line, no order-level design link anywhere.
+      const designId = await makeDesign(`Order Read ${stamp}`)
+      const approve = await api.post(
+        `/admin/designs/${designId}/approve`,
+        {},
+        adminHeaders
+      )
+      expect(approve.status).toBe(200)
+      const productId = approve.data.product_id as string
+      const variantId = approve.data.variant_id as string
+
+      // Approval mints the product as a DRAFT, and `createOrderWorkflow`
+      // refuses a variant whose product is not published — the prod order's
+      // products are published, so publish to match it.
+      const published = await api.post(
+        `/admin/products/${productId}`,
+        { status: "published" },
+        adminHeaders
+      )
+      expect(published.status).toBe(200)
+
+      /**
+       * ...and made-to-order, like the prod variants. A tracked variant with no
+       * stock location on the sales channel is refused by the order workflow —
+       * the same `manage_inventory` default that bites at checkout.
+       * No `prices` key: a variant update that omits it keeps the price row.
+       */
+      const untracked = await api.post(
+        `/admin/products/${productId}/variants/${variantId}`,
+        { manage_inventory: false },
+        adminHeaders
+      )
+      expect(untracked.status).toBe(200)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          status: "pending",
+          email: `order-read-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            {
+              title: "Approved design piece",
+              quantity: 2,
+              unit_price: 500,
+              variant_id: variantId,
+              product_id: productId,
+              // 🔴 No metadata.design_id, exactly like the prod order: the only
+              // route to the design is the product/variant link.
+              metadata: {},
+            },
+          ] as any,
+        } as any,
+      })
+
+      // Nothing wrote an order-level link — the precondition for the bug.
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: orderLinks } = await query.graph({
+        entity: "design_order",
+        filters: { order_id: order.id },
+        fields: ["design_id"],
+      })
+      expect(orderLinks ?? []).toHaveLength(0)
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/design`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      // 🔴 The assertion the old route failed: it answered `designs: []` here.
+      expect(res.data.designs).toHaveLength(1)
+      expect(res.data.designs[0].id).toBe(designId)
+      expect(res.data.design.id).toBe(designId)
+
+      // And it says WHICH line, so a caller can act on the answer rather than
+      // just believe it.
+      expect(res.data.designs[0].order_line_item_ids).toEqual([
+        order.items[0].id,
+      ])
+      // Resolved through the catalogue link, not an order-level one.
+      expect(["product", "variant"]).toContain(
+        res.data.designs[0].design_source
+      )
+    })
+
+    it("still answers from the order-level link when there are no design line items", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+      const designId = await makeDesign(`Order Read Link ${stamp}`)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          status: "pending",
+          email: `order-read-link-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            { title: "Plain item", quantity: 1, unit_price: 100 },
+          ] as any,
+        } as any,
+      })
+
+      const remoteLink = container.resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: designId },
+        [Modules.ORDER]: { order_id: order.id },
+      })
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/design`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.designs.map((d: any) => d.id)).toEqual([designId])
+      /**
+       * No line carries it — reported as such rather than implied. This is the
+       * case a caller must NOT send to production blindly, and the empty array
+       * is how it says so.
+       */
+      expect(res.data.designs[0].order_line_item_ids).toEqual([])
+      expect(res.data.designs[0].design_source).toBe("order_link")
+    })
+
+    it("returns the backwards-compatible empty shape for an order with no designs at all", async () => {
+      const stamp = Date.now()
+      const { result: order }: any = await createOrderWorkflow(
+        getContainer()
+      ).run({
+        input: {
+          status: "pending",
+          email: `order-read-none-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            { title: "Just a thing", quantity: 1, unit_price: 100 },
+          ] as any,
+        } as any,
+      })
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/design`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data).toEqual({ design: null, designs: [] })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/orders/[id]/design-changes/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design-changes/route.ts
@@ -46,6 +46,7 @@ export async function POST(
     const result = await changeOrderDesigns(req.scope, {
       changes: body.changes,
       order_id: orderId,
+      production: body.production,
       notify: body.notify,
       dry_run: body.dry_run,
     })

--- a/apps/backend/src/api/admin/orders/[id]/design-changes/validators.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design-changes/validators.ts
@@ -20,6 +20,18 @@ export const ChangeOrderDesignsSchema = z.object({
       })
     )
     .min(1, "Send at least one line to change."),
+  /**
+   * What production should do (#1953). `mode: "new"` commissions a run for
+   * every line this change actually moves — the only way to bind work to a
+   * line without guessing whose work it is.
+   */
+  production: z
+    .object({
+      mode: z.enum(["none", "new"]).optional(),
+      quantity: z.number().nullable().optional(),
+      partner_id: z.string().trim().min(1).nullable().optional(),
+    })
+    .optional(),
   /** Skip the customer email — for a correction they should not see. */
   notify: z.boolean().optional(),
   /** Preview the change and the email without performing either. */

--- a/apps/backend/src/api/admin/orders/[id]/design/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design/route.ts
@@ -77,26 +77,57 @@ export async function GET(
     // could still answer.
   }
 
-  const designIds = [
-    ...new Set([
-      ...(orderDesignLinks ?? []).map((link: any) => String(link.design_id)),
-      ...Object.keys(lineItemsByDesign),
-    ]),
-  ].filter(Boolean)
+  /**
+   * 🔴 The LINE ITEMS win when they have an opinion.
+   *
+   * Unioning both sources blindly is wrong on a re-pointed order. Prod order #3
+   * has five `design_order` rows naming what was ORIGINALLY commissioned — three
+   * of those designs are now `Superseded` — plus three lines re-pointed to new
+   * designs. A union lists eight designs for a five-line order, three of them
+   * no longer being made, and the widget cannot tell them apart.
+   *
+   * So `designs` is what the order stands for NOW, and an order-level design
+   * that no line resolves to is returned separately as `unlinked_designs`
+   * rather than silently dropped: it is what was commissioned, and losing that
+   * is the provenance #1919 exists to keep. When no line resolves at all — a
+   * commissioning order with title-only items — the order-level link is the
+   * only answer there is, so it becomes the answer.
+   */
+  const fromLines = Object.keys(lineItemsByDesign)
+  const fromOrderLink: string[] = [
+    ...new Set(
+      (orderDesignLinks ?? []).map((link: any) => String(link.design_id))
+    ),
+  ].filter((id): id is string => Boolean(id))
 
-  if (!designIds.length) {
+  const designIds = fromLines.length ? fromLines : fromOrderLink
+  const unlinkedIds = fromLines.length
+    ? fromOrderLink.filter((id) => !lineItemsByDesign[id])
+    : []
+
+  if (!designIds.length && !unlinkedIds.length) {
     // Backwards-compatible: still return singular `design: null` + new `designs: []`
     res.status(200).json({ design: null, designs: [] })
     return
   }
 
+  const designFields = [
+    "id",
+    "name",
+    "status",
+    "description",
+    "thumbnail_url",
+    "estimated_cost",
+  ]
   const { data: designs } = await query.graph({
     entity: "design",
-    filters: { id: designIds },
-    fields: ["id", "name", "status", "description", "thumbnail_url", "estimated_cost"],
+    filters: { id: [...designIds, ...unlinkedIds] },
+    fields: designFields,
   })
 
-  const result = designs || []
+  const byId: Record<string, any> = {}
+  for (const d of designs || []) byId[String(d.id)] = d
+  const result = designIds.map((id) => byId[id]).filter(Boolean)
 
   /**
    * The CART line item each design was commissioned on, so the order page can
@@ -142,5 +173,19 @@ export async function GET(
     // Backwards-compatible singular field
     design: withLinks[0] ?? null,
     designs: withLinks,
+    /**
+     * Named by the order-level link, on no line any more — what was
+     * commissioned before a re-point. Kept out of `designs` so the widget shows
+     * the order as it stands, and returned so the history is not lost.
+     */
+    unlinked_designs: unlinkedIds
+      .map((id) => byId[id])
+      .filter(Boolean)
+      .map((d: any) => ({
+        ...d,
+        design_order_line_item_id: lineItemByDesign[String(d.id)] ?? null,
+        order_line_item_ids: [],
+        design_source: "order_link",
+      })),
   })
 }

--- a/apps/backend/src/api/admin/orders/[id]/design/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design/route.ts
@@ -5,6 +5,7 @@ import {
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import designOrderLink from "../../../../../links/design-order-link"
 import designLineItemLink from "../../../../../links/design-line-item-link"
+import { resolveLineItemDesignId } from "../../../../../lib/resolve-line-item-production"
 
 export async function GET(
   req: AuthenticatedMedusaRequest,
@@ -13,19 +14,81 @@ export async function GET(
   const orderId = req.params.id
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
 
+  /**
+   * 🔴 The ORDER-level link is one source, not the only one.
+   *
+   * This route answered from `design_order` alone and returned
+   * `{ design: null, designs: [] }` when it held no row — for an order whose
+   * every line item resolves to a design through `product_design`. On prod,
+   * order #101 (nine garments, deposit paid) reported NO designs while each of
+   * its four lines pointed at a design-created product.
+   *
+   * That is not a cosmetic read. `produce_order_designs` names this route as
+   * its preview and its own description says "call list_order_designs first",
+   * so an operator checking before producing is told there is nothing to
+   * produce — and nothing ever is. The produce path itself resolves through the
+   * LINE ITEMS and would have worked; only the answer to "is there anything
+   * here?" was wrong. A confident nothing is worse than an error.
+   *
+   * So both are read, and unioned: the order-level link (a commissioning order
+   * can name a design that is on no line) and every line item, through the
+   * canonical resolver the produce path uses — link → variant → product →
+   * provenance string — so the read and the write agree by construction.
+   */
   const { data: orderDesignLinks } = await query.graph({
     entity: designOrderLink.entryPoint,
     filters: { order_id: orderId },
     fields: ["design_id"],
   })
 
-  if (!orderDesignLinks?.length) {
+  /** design id -> the order line items it stands behind. */
+  const lineItemsByDesign: Record<string, string[]> = {}
+  const sourceByDesign: Record<string, string | null> = {}
+
+  try {
+    const { data: orders } = await query.graph({
+      entity: "order",
+      filters: { id: orderId },
+      fields: [
+        "id",
+        "items.id",
+        "items.variant_id",
+        "items.product_id",
+        "items.metadata",
+      ],
+    })
+    const items: any[] = orders?.[0]?.items ?? []
+    for (const item of items) {
+      const resolved = await resolveLineItemDesignId(query, {
+        productId: item?.product_id ?? null,
+        variantId: item?.variant_id ?? null,
+        lineItemId: item?.id ?? null,
+        metadata: item?.metadata ?? null,
+      }).catch(() => ({ designId: null, source: null } as any))
+
+      if (!resolved?.designId) continue
+      const key = String(resolved.designId)
+      lineItemsByDesign[key] = [...(lineItemsByDesign[key] ?? []), String(item.id)]
+      // First writer wins: the strongest rung that resolved this design.
+      if (!(key in sourceByDesign)) sourceByDesign[key] = resolved.source ?? null
+    }
+  } catch {
+    // An order we cannot read must not blank a widget the order-level link
+    // could still answer.
+  }
+
+  const designIds = [
+    ...new Set([
+      ...(orderDesignLinks ?? []).map((link: any) => String(link.design_id)),
+      ...Object.keys(lineItemsByDesign),
+    ]),
+  ].filter(Boolean)
+
+  if (!designIds.length) {
     // Backwards-compatible: still return singular `design: null` + new `designs: []`
     res.status(200).json({ design: null, designs: [] })
     return
   }
-
-  const designIds = orderDesignLinks.map((link: any) => link.design_id)
 
   const { data: designs } = await query.graph({
     entity: "design",
@@ -66,6 +129,13 @@ export async function GET(
   const withLinks = result.map((d: any) => ({
     ...d,
     design_order_line_item_id: lineItemByDesign[String(d.id)] ?? null,
+    /**
+     * The ORDER line items this design is actually on, and how it resolved.
+     * Empty when the design is named by the order-level link alone — which is
+     * exactly the case a caller must not send to production blindly.
+     */
+    order_line_item_ids: lineItemsByDesign[String(d.id)] ?? [],
+    design_source: sourceByDesign[String(d.id)] ?? "order_link",
   }))
 
   res.status(200).json({

--- a/apps/backend/src/lib/resolve-line-item-production.ts
+++ b/apps/backend/src/lib/resolve-line-item-production.ts
@@ -174,6 +174,42 @@ export async function getProductionRunForLineItem(
 }
 
 /**
+ * Does ANY production run exist for this design, regardless of which order line
+ * it belongs to?
+ *
+ * 🔴 The distinction this exists to draw: a line item with no run of its own is
+ * not the same as a design nobody has made. On prod, order #3's five items carry
+ * a null `variant_id` (#1918), so no run was ever stamped with their
+ * `order_line_item_id` — while each of their designs has TWO completed runs.
+ * Asking only the line item therefore answered "nothing has been started" about
+ * garments that were finished, and a customer was told exactly that.
+ *
+ * The answer is deliberately a BOOLEAN, not the run. A run for the design says
+ * somebody made this design once; it does NOT say it was made for this order,
+ * and designs are reused across customers. So it is enough to stop us claiming
+ * "not started" — and not enough to claim "already made".
+ */
+export async function hasProductionRunForDesign(
+  query: any,
+  designId: string | null | undefined
+): Promise<boolean> {
+  if (!designId) return false
+  try {
+    const { data } = await query.graph({
+      entity: "production_runs",
+      fields: ["id"],
+      filters: { design_id: designId },
+      pagination: { skip: 0, take: 1 },
+    })
+    return Boolean((data || [])[0])
+  } catch {
+    // Unknowable is not the same as absent: fail toward "we do not know",
+    // which the caller renders as a claim about our records, not the world.
+    return true
+  }
+}
+
+/**
  * A provenance run this system minted from retail fulfillment (born terminal).
  * ONLY these are quantity-reconciled / soft-deleted by the fulfillment +
  * cancellation paths — a real production run (design work-order, or a run that

--- a/apps/backend/src/workflows/designs/__tests__/design-change-notice.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/design-change-notice.unit.spec.ts
@@ -2,6 +2,7 @@ import {
   actionOf,
   buildDesignChangeNotice,
   isReassuring,
+  PRODUCTION_STATE_LABELS,
   productionStateOf,
   nextItemMetadata,
   readProducedQuantity,
@@ -57,6 +58,31 @@ describe("productionStateOf", () => {
     expect(productionStateOf(null)).toBe("not_started")
     expect(productionStateOf({ status: null })).toBe("not_started")
     expect(productionStateOf({ status: "some_new_status" })).toBe("not_started")
+  })
+
+  /**
+   * 🔴 The distinction that reached a customer. Order #3's items carry a null
+   * `variant_id` (#1918) so no run was ever stamped with their line ids, while
+   * each of their designs had TWO completed runs — and the email told Aline her
+   * finished garments had "not started yet".
+   */
+  it("says UNKNOWN, not 'not started', when the line has no run but the design does", () => {
+    expect(productionStateOf(null, { designHasRuns: true })).toBe("unknown")
+    expect(productionStateOf(null, { designHasRuns: false })).toBe("not_started")
+    expect(productionStateOf(null)).toBe("not_started")
+
+    // It only ever downgrades an absence. A run ON THE LINE still answers, and
+    // still wins — a design-level run must never upgrade a claim.
+    expect(
+      productionStateOf({ status: "completed" }, { designHasRuns: true })
+    ).toBe("made")
+    expect(
+      productionStateOf({ status: "cancelled" }, { designHasRuns: true })
+    ).toBe("not_started")
+
+    // And it promises nothing: unknown is not reassuring.
+    expect(isReassuring("unknown")).toBe(false)
+    expect(PRODUCTION_STATE_LABELS.unknown).not.toMatch(/not started|already made/i)
   })
 })
 

--- a/apps/backend/src/workflows/designs/change-order-item-design.ts
+++ b/apps/backend/src/workflows/designs/change-order-item-design.ts
@@ -11,6 +11,7 @@ import {
   resolveLineItemDesignId,
 } from "../../lib/resolve-line-item-production"
 import { repointOrderItemDesign } from "./link-designs-to-order-items"
+import { createProductionRunWorkflow } from "../production-runs/create-production-run"
 import { sendDesignOrderChangedEmailWorkflow } from "../email/workflows/send-design-order-changed-email"
 import {
   buildDesignChangeNotice,
@@ -73,8 +74,28 @@ export type DesignChangeRequest = {
   design_id: string | null
 }
 
+/**
+ * What production should do about the change (#1953).
+ *
+ * 🔴 "new", never "adopt". A run's identity is its `order_line_item_id`, and
+ * that is written at CREATION and nowhere else — so the only way to bind work
+ * to a line without guessing is to commission work FOR that line. Claiming an
+ * existing unstamped run would be an attribution decision: an unattributed
+ * completed run may genuinely be another customer's, and designs are reused.
+ * Minting a run cannot take anybody's goods.
+ */
+export type ProductionDecision = {
+  /** "none" (default) leaves production untouched, exactly as before. */
+  mode?: "none" | "new"
+  /** Agreed quantity. Absent = 1; explicit null = open-ended (#1676). */
+  quantity?: number | null
+  partner_id?: string | null
+}
+
 export type ChangeOrderDesignsInput = {
   changes: DesignChangeRequest[]
+  /** Applied to every line this change actually moves. */
+  production?: ProductionDecision
   /**
    * The order these lines must belong to. Checked BEFORE anything is written,
    * so a caller addressing the wrong order is refused rather than half-applied.
@@ -89,7 +110,12 @@ export type ChangeOrderDesignsInput = {
 export type ChangedItemResult = Omit<
   ChangeOrderItemDesignResult,
   "notice" | "email" | "dry_run"
->
+> & {
+  /** The run commissioned for this line by this change, if any (#1953). */
+  production_run_id?: string | null
+  /** Why no run was created, when one was asked for. */
+  production_skipped_reason?: string | null
+}
 
 export type ChangeOrderDesignsResult = {
   order_id: string | null
@@ -426,6 +452,82 @@ export async function changeOrderDesigns(
       throw new Error(
         `Changed ${items.length} of ${reads.length} lines, then failed on ${reads[i].change.line_item_id}: ${e?.message ?? e}`
       )
+    }
+  }
+
+  /**
+   * ── Commission the work, when asked (#1953) ─────────────────────────────
+   *
+   * A run is minted per line that actually MOVED and now stands for a design.
+   * A detached line gets none — there is nothing to make.
+   *
+   * Per-line and non-fatal: the links are already committed, so a run that
+   * cannot be created is REPORTED against its line rather than thrown, which
+   * would leave the caller believing the whole change failed when the part it
+   * asked for first has already happened.
+   *
+   * The existing-run check is a courtesy, not the guarantee. The partial unique
+   * index on `order_line_item_id` is the guarantee, and it is the reason two
+   * concurrent callers cannot both commission the same line.
+   */
+  if (input.production?.mode === "new" && !dryRun) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      const designId = item.new_design_id
+      if (!designId) {
+        item.production_run_id = null
+        item.production_skipped_reason =
+          item.action === "detached"
+            ? "line was detached — nothing to make"
+            : "line has no design"
+        continue
+      }
+      if (item.action === "unchanged") {
+        item.production_run_id = null
+        item.production_skipped_reason = "line did not change"
+        continue
+      }
+
+      const existing = await getProductionRunForLineItem(
+        query,
+        item.line_item_id
+      ).catch(() => null)
+      if (existing) {
+        item.production_run_id = null
+        item.production_skipped_reason = `line already has run ${existing.id}`
+        continue
+      }
+
+      try {
+        const { result } = await createProductionRunWorkflow(container).run({
+          input: {
+            design_id: designId,
+            order_id: ctx?.order_id ?? undefined,
+            order_line_item_id: item.line_item_id,
+            quantity:
+              input.production.quantity === undefined
+                ? undefined
+                : input.production.quantity,
+            partner_id: input.production.partner_id ?? undefined,
+            metadata: {
+              source: "design-change",
+              previous_design_id: item.previous_design_id,
+            },
+          },
+        })
+        item.production_run_id = (result as any)?.id ?? null
+      } catch (e: any) {
+        item.production_run_id = null
+        item.production_skipped_reason = `run creation failed: ${e?.message ?? e}`
+        logger?.warn?.(
+          `[design-change] design moved on ${item.line_item_id} but the run could not be created: ${e?.message ?? e}`
+        )
+      }
+    }
+  } else if (input.production?.mode === "new" && dryRun) {
+    for (const item of items) {
+      item.production_run_id = null
+      item.production_skipped_reason = "dry run"
     }
   }
 

--- a/apps/backend/src/workflows/designs/change-order-item-design.ts
+++ b/apps/backend/src/workflows/designs/change-order-item-design.ts
@@ -7,6 +7,7 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 
 import {
   getProductionRunForLineItem,
+  hasProductionRunForDesign,
   resolveLineItemDesignId,
 } from "../../lib/resolve-line-item-production"
 import { repointOrderItemDesign } from "./link-designs-to-order-items"
@@ -213,6 +214,23 @@ async function readChange(
     getProductionRunForLineItem(query, lineItemId),
   ])
 
+  /**
+   * 🔴 No run on this LINE is not the same as no work on this design.
+   *
+   * Order #3's items carry a null `variant_id` (#1918), so no run was ever
+   * stamped with their `order_line_item_id` — while each of their designs had
+   * TWO completed runs. The line-only lookup therefore reported "not started
+   * yet", and that sentence was emailed to a customer about garments that had
+   * been finished.
+   *
+   * Only asked when the line has no run of its own, and only ever downgrades a
+   * claim to "we're checking": a run for a design does not prove it was made
+   * for THIS order.
+   */
+  const designHasRuns = run
+    ? false
+    : await hasProductionRunForDesign(query, previous?.id ?? null)
+
   let next: { id: string; name: string | null } | null = null
   if (req.design_id) {
     const { data: designs } = await query.graph({
@@ -235,6 +253,7 @@ async function readChange(
       previous_design: previous,
       new_design: next,
       run,
+      design_has_runs: designHasRuns,
     },
   }
 }

--- a/apps/backend/src/workflows/designs/lib/design-change-notice.ts
+++ b/apps/backend/src/workflows/designs/lib/design-change-notice.ts
@@ -46,13 +46,30 @@ export type RunLike = {
  * `not_started` explicitly does not — it is the state four of Aline's five
  * items are in.
  */
-export type ProductionState = "made" | "being_made" | "queued" | "not_started"
+export type ProductionState =
+  | "made"
+  | "being_made"
+  | "queued"
+  | "not_started"
+  /**
+   * 🔴 We have no production record for THIS line, but this design has been
+   * made before. Not the same as "not started", and the difference reached a
+   * customer: order #3's items carry a null `variant_id` (#1918) so no run was
+   * ever stamped with their line ids, while each of their designs had TWO
+   * completed runs. Aline was told her finished garments had not been started.
+   *
+   * We cannot say "already made" either — a run for a design says somebody made
+   * that design, not that it was made for this order. So the wording claims
+   * nothing about the world, only about our records.
+   */
+  | "unknown"
 
 export const PRODUCTION_STATE_LABELS: Record<ProductionState, string> = {
   made: "already made",
   being_made: "being made now",
   queued: "queued for production",
   not_started: "not started yet",
+  unknown: "we're checking where this one stands",
 }
 
 /** The states where "don't worry, it's in hand" is a true thing to say. */
@@ -86,8 +103,19 @@ export function readProducedQuantity(value: number | string | null | undefined):
  * that nothing is being made, so it maps to `not_started` rather than being
  * treated as "a run exists, therefore reassure".
  */
-export function productionStateOf(run: RunLike): ProductionState {
-  if (!run || !run.status) return "not_started"
+export function productionStateOf(
+  run: RunLike,
+  opts?: {
+    /**
+     * Whether ANY run exists for the design, when none is linked to this line.
+     * Turns a bare absence into "we do not know" instead of a claim.
+     */
+    designHasRuns?: boolean
+  }
+): ProductionState {
+  if (!run || !run.status) {
+    return opts?.designHasRuns ? "unknown" : "not_started"
+  }
   switch (String(run.status) as RunStatus) {
     case "completed":
       return "made"
@@ -116,6 +144,10 @@ export type DesignChange = {
   /** The design it points at now. `null` means it was DETACHED. */
   new_design: { id: string; name: string | null } | null
   run: RunLike
+  /**
+   * Set when the LINE has no run but the design does — see `productionStateOf`.
+   */
+  design_has_runs?: boolean
 }
 
 export type ChangeLine = {
@@ -142,7 +174,9 @@ export function actionOf(change: DesignChange): ChangeLine["action"] {
 
 /** PURE: one row of the customer's "what changed" table. */
 export function buildChangeLine(change: DesignChange): ChangeLine {
-  const state = productionStateOf(change.run)
+  const state = productionStateOf(change.run, {
+    designHasRuns: change.design_has_runs,
+  })
   return {
     line_item_id: change.line_item_id,
     item_title: change.item_title ?? null,
@@ -164,6 +198,8 @@ export type DesignChangeNotice = {
   all_in_hand: boolean
   /** True when at least one changed garment has no production behind it. */
   any_not_started: boolean
+  /** True when at least one changed line's state could not be established. */
+  any_unknown: boolean
   /** The single sentence the email leads with. */
   headline: string
   /** Whether there is anything worth emailing about at all. */
@@ -183,8 +219,17 @@ export function buildDesignChangeNotice(changes: DesignChange[]): DesignChangeNo
   const lines = (changes ?? []).map(buildChangeLine)
   const changed = lines.filter((l) => l.action !== "unchanged")
 
-  const anyNotStarted = changed.some((l) => !l.reassuring)
-  const allInHand = changed.length > 0 && !anyNotStarted
+  /**
+   * `all_in_hand` still keys on REASSURING, so a queued piece can never be
+   * described as in hand. `any_not_started` is tightened to the literal state,
+   * because the email uses it for a sentence ("it will be made to the new
+   * design from the outset") that is only true of work nobody has begun — and
+   * is a claim we must not make about a line whose state is unknown.
+   */
+  const anyUnreassuring = changed.some((l) => !l.reassuring)
+  const allInHand = changed.length > 0 && !anyUnreassuring
+  const anyNotStarted = changed.some((l) => l.production_state === "not_started")
+  const anyUnknown = changed.some((l) => l.production_state === "unknown")
 
   let headline: string
   if (!changed.length) {
@@ -204,6 +249,7 @@ export function buildDesignChangeNotice(changes: DesignChange[]): DesignChangeNo
     changed_lines: changed,
     all_in_hand: allInHand,
     any_not_started: anyNotStarted,
+    any_unknown: anyUnknown,
     headline,
     should_send: changed.length > 0,
   }


### PR DESCRIPTION
Founder's call: bind the work to the line by **making** a run for it, not by claiming an existing one.

## Why "new" and never "adopt"

A run's identity is `order_line_item_id` — and that column is written at **creation and nowhere else**. `approve` and `complete` only copy it forward. So a run minted before its line existed (a sample, a work-order made ahead of demand, any #1918 order whose title-only items had no variant) is permanently unattributable. That is why prod order #3 reads as `unknown`.

Adoption would have fixed the symptom by making an **attribution claim**: an unstamped completed run may genuinely be another customer's, and a design is reused across customers, so claiming one silently transfers their goods. Minting a run cannot take anybody's work. The only thing it costs is a run.

## What it does

```
POST /admin/orders/:id/design-changes
{ "changes": [...], "production": { "mode": "new", "quantity": 3 } }
```

`none` is the default and today's behaviour exactly. `new` commissions one run per line the change actually **moved**, stamped with `order_id` and `order_line_item_id` — the identity that makes it this customer's rather than merely this design's.

A **detached** line gets no run: there is nothing to make, and it says so via `production_skipped_reason`.

Per-line and non-fatal. The links are committed by the time this runs, so a run that cannot be created is reported against its line rather than thrown — throwing would tell the caller the whole change failed when the part they asked for first had already happened.

🔑 The existing-run check is a courtesy. The **partial unique index** on `order_line_item_id` is the guarantee, and it is why two concurrent callers cannot both commission the same line.

## Evidence

One integration case covering the whole shape:

- a preview that writes nothing and says `dry run`;
- a moved line that gets a run stamped with the right design, order, line and quantity;
- a detached line that correctly gets none;
- asking twice, which reports `already has run` instead of commissioning a second.

Disabling the block turns it red on `Expected: Any<String>, Received: undefined`. 25 integration and 391 unit tests pass.

## Not in this PR

- The **UI step** in Edit Items that asks the question. The API answers it; the modal still needs to offer it.
- **Design ↔ customer linking** on attach. Worth doing deliberately, not silently: the store checkout refuses a design the customer does not own, so auto-linking a house design to a buyer grants them access to it.
- The change email still reports the state as it was BEFORE the change, which is correct but now slightly incomplete — it does not mention that work has just been commissioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
