### PR TITLE
feat(production): commission the run as part of the design change (#1953)

### DIFF
--- a/apps/backend/integration-tests/http/design-order-changed-email.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-changed-email.spec.ts
@@ -350,6 +350,117 @@ setupSharedTestSuite(() => {
       expect(preview.data.notice.any_unknown).toBe(true)
     })
 
+    /**
+     * #1953 — bind the work to the line by COMMISSIONING it, not by claiming
+     * somebody else's run. `order_line_item_id` is written at creation and
+     * nowhere else, so a new run is the only binding that cannot mis-attribute
+     * a garment when a design is reused across customers.
+     */
+    it("commissions a run for each moved line, stamped with the line it is for", async () => {
+      const container = getContainer()
+      const stamp = Date.now()
+      const designA = await makeDesign(`Run Mint A ${stamp}`)
+      const designB = await makeDesign(`Run Mint B ${stamp}`)
+
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          is_draft_order: true,
+          status: "draft",
+          no_notification: true,
+          email: `run-mint-${stamp}@jyt.test`,
+          region_id: regionId,
+          currency_code: "inr",
+          items: [
+            {
+              title: "To be made",
+              quantity: 1,
+              unit_price: 100,
+              metadata: { design_id: designA },
+            },
+            {
+              title: "To be detached",
+              quantity: 1,
+              unit_price: 100,
+              metadata: { design_id: designA },
+            },
+          ] as any,
+        } as any,
+      })
+      await linkDesignsToOrderItems(container, order.id)
+      const [moved, detached] = order.items
+
+      // Preview writes nothing, and says so.
+      const preview = await api.post(
+        `/admin/orders/${order.id}/design-changes`,
+        {
+          changes: [{ line_item_id: moved.id, design_id: designB }],
+          production: { mode: "new", quantity: 3 },
+          dry_run: true,
+        },
+        adminHeaders
+      )
+      expect(preview.status).toBe(200)
+      expect(preview.data.items[0].production_run_id).toBeNull()
+      expect(preview.data.items[0].production_skipped_reason).toBe("dry run")
+
+      const res = await api.post(
+        `/admin/orders/${order.id}/design-changes`,
+        {
+          changes: [
+            { line_item_id: moved.id, design_id: designB },
+            { line_item_id: detached.id, design_id: null },
+          ],
+          production: { mode: "new", quantity: 3 },
+          notify: false,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      const movedResult = res.data.items.find(
+        (i: any) => i.line_item_id === moved.id
+      )
+      const detachedResult = res.data.items.find(
+        (i: any) => i.line_item_id === detached.id
+      )
+
+      // The moved line got a run...
+      expect(movedResult.production_run_id).toEqual(expect.any(String))
+      // ...and the DETACHED line did not. There is nothing to make.
+      expect(detachedResult.production_run_id).toBeNull()
+      expect(detachedResult.production_skipped_reason).toMatch(/detached/i)
+
+      // The run is stamped with the line it belongs to — the identity that
+      // makes it this customer's rather than merely this design's.
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: runs } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "design_id", "order_id", "order_line_item_id", "quantity"],
+        filters: { order_line_item_id: moved.id },
+      })
+      expect(runs).toHaveLength(1)
+      expect(runs[0].id).toBe(movedResult.production_run_id)
+      expect(runs[0].design_id).toBe(designB)
+      expect(runs[0].order_id).toBe(order.id)
+      expect(Number(runs[0].quantity)).toBe(3)
+
+      // Asking twice does not commission twice — the line already has its run.
+      const again = await api.post(
+        `/admin/orders/${order.id}/design-changes`,
+        {
+          changes: [{ line_item_id: moved.id, design_id: designA }],
+          production: { mode: "new" },
+          notify: false,
+        },
+        adminHeaders
+      )
+      expect(again.status).toBe(200)
+      expect(again.data.items[0].production_run_id).toBeNull()
+      expect(again.data.items[0].production_skipped_reason).toMatch(
+        /already has run/i
+      )
+    })
+
     it("refuses a change whose lines belong to another order — before writing", async () => {
       const container = getContainer()
       const stamp = Date.now()

--- a/apps/backend/src/api/admin/orders/[id]/design-changes/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design-changes/route.ts
@@ -46,6 +46,7 @@ export async function POST(
     const result = await changeOrderDesigns(req.scope, {
       changes: body.changes,
       order_id: orderId,
+      production: body.production,
       notify: body.notify,
       dry_run: body.dry_run,
     })

--- a/apps/backend/src/api/admin/orders/[id]/design-changes/validators.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design-changes/validators.ts
@@ -20,6 +20,18 @@ export const ChangeOrderDesignsSchema = z.object({
       })
     )
     .min(1, "Send at least one line to change."),
+  /**
+   * What production should do (#1953). `mode: "new"` commissions a run for
+   * every line this change actually moves — the only way to bind work to a
+   * line without guessing whose work it is.
+   */
+  production: z
+    .object({
+      mode: z.enum(["none", "new"]).optional(),
+      quantity: z.number().nullable().optional(),
+      partner_id: z.string().trim().min(1).nullable().optional(),
+    })
+    .optional(),
   /** Skip the customer email — for a correction they should not see. */
   notify: z.boolean().optional(),
   /** Preview the change and the email without performing either. */

--- a/apps/backend/src/workflows/designs/change-order-item-design.ts
+++ b/apps/backend/src/workflows/designs/change-order-item-design.ts
@@ -11,6 +11,7 @@ import {
   resolveLineItemDesignId,
 } from "../../lib/resolve-line-item-production"
 import { repointOrderItemDesign } from "./link-designs-to-order-items"
+import { createProductionRunWorkflow } from "../production-runs/create-production-run"
 import { sendDesignOrderChangedEmailWorkflow } from "../email/workflows/send-design-order-changed-email"
 import {
   buildDesignChangeNotice,
@@ -73,8 +74,28 @@ export type DesignChangeRequest = {
   design_id: string | null
 }
 
+/**
+ * What production should do about the change (#1953).
+ *
+ * 🔴 "new", never "adopt". A run's identity is its `order_line_item_id`, and
+ * that is written at CREATION and nowhere else — so the only way to bind work
+ * to a line without guessing is to commission work FOR that line. Claiming an
+ * existing unstamped run would be an attribution decision: an unattributed
+ * completed run may genuinely be another customer's, and designs are reused.
+ * Minting a run cannot take anybody's goods.
+ */
+export type ProductionDecision = {
+  /** "none" (default) leaves production untouched, exactly as before. */
+  mode?: "none" | "new"
+  /** Agreed quantity. Absent = 1; explicit null = open-ended (#1676). */
+  quantity?: number | null
+  partner_id?: string | null
+}
+
 export type ChangeOrderDesignsInput = {
   changes: DesignChangeRequest[]
+  /** Applied to every line this change actually moves. */
+  production?: ProductionDecision
   /**
    * The order these lines must belong to. Checked BEFORE anything is written,
    * so a caller addressing the wrong order is refused rather than half-applied.
@@ -89,7 +110,12 @@ export type ChangeOrderDesignsInput = {
 export type ChangedItemResult = Omit<
   ChangeOrderItemDesignResult,
   "notice" | "email" | "dry_run"
->
+> & {
+  /** The run commissioned for this line by this change, if any (#1953). */
+  production_run_id?: string | null
+  /** Why no run was created, when one was asked for. */
+  production_skipped_reason?: string | null
+}
 
 export type ChangeOrderDesignsResult = {
   order_id: string | null
@@ -426,6 +452,82 @@ export async function changeOrderDesigns(
       throw new Error(
         `Changed ${items.length} of ${reads.length} lines, then failed on ${reads[i].change.line_item_id}: ${e?.message ?? e}`
       )
+    }
+  }
+
+  /**
+   * ── Commission the work, when asked (#1953) ─────────────────────────────
+   *
+   * A run is minted per line that actually MOVED and now stands for a design.
+   * A detached line gets none — there is nothing to make.
+   *
+   * Per-line and non-fatal: the links are already committed, so a run that
+   * cannot be created is REPORTED against its line rather than thrown, which
+   * would leave the caller believing the whole change failed when the part it
+   * asked for first has already happened.
+   *
+   * The existing-run check is a courtesy, not the guarantee. The partial unique
+   * index on `order_line_item_id` is the guarantee, and it is the reason two
+   * concurrent callers cannot both commission the same line.
+   */
+  if (input.production?.mode === "new" && !dryRun) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      const designId = item.new_design_id
+      if (!designId) {
+        item.production_run_id = null
+        item.production_skipped_reason =
+          item.action === "detached"
+            ? "line was detached — nothing to make"
+            : "line has no design"
+        continue
+      }
+      if (item.action === "unchanged") {
+        item.production_run_id = null
+        item.production_skipped_reason = "line did not change"
+        continue
+      }
+
+      const existing = await getProductionRunForLineItem(
+        query,
+        item.line_item_id
+      ).catch(() => null)
+      if (existing) {
+        item.production_run_id = null
+        item.production_skipped_reason = `line already has run ${existing.id}`
+        continue
+      }
+
+      try {
+        const { result } = await createProductionRunWorkflow(container).run({
+          input: {
+            design_id: designId,
+            order_id: ctx?.order_id ?? undefined,
+            order_line_item_id: item.line_item_id,
+            quantity:
+              input.production.quantity === undefined
+                ? undefined
+                : input.production.quantity,
+            partner_id: input.production.partner_id ?? undefined,
+            metadata: {
+              source: "design-change",
+              previous_design_id: item.previous_design_id,
+            },
+          },
+        })
+        item.production_run_id = (result as any)?.id ?? null
+      } catch (e: any) {
+        item.production_run_id = null
+        item.production_skipped_reason = `run creation failed: ${e?.message ?? e}`
+        logger?.warn?.(
+          `[design-change] design moved on ${item.line_item_id} but the run could not be created: ${e?.message ?? e}`
+        )
+      }
+    }
+  } else if (input.production?.mode === "new" && dryRun) {
+    for (const item of items) {
+      item.production_run_id = null
+      item.production_skipped_reason = "dry run"
     }
   }
 


### PR DESCRIPTION
Founder's call: bind the work to the line by **making** a run for it, not by claiming an existing one. (Rebuild of #1954 on current main.)

## Why "new" and never "adopt"

A run's identity is `order_line_item_id` — written at **creation and nowhere else**; `approve` and `complete` only copy it forward. So a run minted before its line existed is permanently unattributable, which is why prod order #3 reads as `unknown`.

Adoption would fix the symptom by making an **attribution claim**: an unstamped completed run may genuinely be another customer's, and designs are reused across customers, so claiming one silently transfers their goods. Minting a run cannot take anybody's work.

## What it does

```
POST /admin/orders/:id/design-changes
{ "changes": [...], "production": { "mode": "new", "quantity": 3 } }
```

`none` is the default and today's behaviour exactly. `new` commissions one run per line the change actually **moved**, stamped with `order_id` and `order_line_item_id`. A **detached** line gets none — nothing to make — and says so.

Per-line and non-fatal: the links are committed by then, so a failed run is reported against its line rather than thrown. The existing-run check is a courtesy; the **partial unique index** is the guarantee.

## Evidence

One integration case: preview writes nothing; a moved line gets a run with the right design/order/line/quantity; a detached line gets none; asking twice reports `already has run`. Disabling the block turns it red (`Expected: Any<String>, Received: undefined`). 25 integration + 391 unit tests pass.

## Not in this PR

- The **UI step** in Edit Items that asks the question.
- **Design ↔ customer linking** on attach — deliberately left: the store checkout refuses a design the customer does not own, so auto-linking a house design to a buyer grants them access to it.
- The email still reports state as of BEFORE the change — correct, but it does not mention that work was just commissioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp