### PR TITLE
fix(tests): two of main's four permanently-red specs were stale, not broken (#1956)

### DIFF
--- a/apps/backend/integration-tests/http/census-weavers-api.spec.ts
+++ b/apps/backend/integration-tests/http/census-weavers-api.spec.ts
@@ -63,6 +63,15 @@ const geoProj = (r: Record<string, any>) => {
   }
 }
 
+// Equality-facet fields the reader indexes (must match reader.ts EQ_FACETS, which
+// a unit test asserts against census_index.mjs EQ_FIELDS). `state`/`gender` are
+// dedicated facet families, not EQ facets; everything else filterable is one.
+const EQ_FACETS = [
+  "village", "block", "district", "education", "ownership_type",
+  "household_type", "dwelling_type", "rural_urban",
+  "own_looms", "natural_dye_used", "electricity",
+]
+
 /** Build rec + agg + (optionally) idx/meta subs from a record set. */
 function buildSubs(
   records: Array<Record<string, any>>,
@@ -70,7 +79,8 @@ function buildSubs(
 ) {
   const rec: Array<[string, any]> = records.map((r) => [String(r.census_id), enc(r)])
 
-  // agg counts (utf-8 values) for state / gender / district(state|district).
+  // agg counts (utf-8 values) for state / gender / district(state|district) and
+  // the equality facets (`eq/<field>/<value>`), mirroring the seeder.
   const agg = new Map<string, number>()
   const bump = (k: string) => agg.set(k, (agg.get(k) || 0) + 1)
   for (const r of records) {
@@ -78,6 +88,10 @@ function buildSubs(
     bump(`state/${r.state}`)
     bump(`gender/${r.gender}`)
     bump(`district/${r.state}|${r.district}`)
+    for (const field of EQ_FACETS) {
+      const v = r[field]
+      if (v != null && v !== "") bump(`eq/${field}/${v}`)
+    }
   }
   const aggEntries: Array<[string, any]> = [...agg].map(([k, v]) => [k, String(v)])
 
@@ -93,11 +107,15 @@ function buildSubs(
       idx.push([`state/${r.state}/${p}`, val])
       idx.push([`gender/${r.gender}/${p}`, val])
       idx.push([`sd/${r.state}|${r.district}/${p}`, val])
+      for (const field of EQ_FACETS) {
+        const v = r[field]
+        if (v != null && v !== "") idx.push([`${field}/${v}/${p}`, val])
+      }
     }
     subs.idx = idx
     subs.meta = geo
-      ? [["idx-version", "idx-v1"], ["idx-all-version", "idxall-v1"], ["idx-geo-version", "geo-v1"]]
-      : [["idx-version", "idx-v1"], ["idx-all-version", "idxall-v1"]]
+      ? [["idx-version", "idx-v1"], ["idx-all-version", "idxall-v1"], ["idx-geo-version", "geo-v1"], ["idx-eq-version", "idxeq-v1"]]
+      : [["idx-version", "idx-v1"], ["idx-all-version", "idxall-v1"], ["idx-eq-version", "idxeq-v1"]]
   }
 
   return subs
@@ -255,13 +273,17 @@ setupSharedTestSuite(() => {
       expect(p2.data.weavers.map((w: any) => w.census_id)).toEqual([12, 13])
     })
 
-    it("applies a non-facet residual filter over the `all` family", async () => {
+    it("browses an equality facet (education) via the index with an O(1) agg count", async () => {
+      // `education` is now an indexed equality facet (reader.ts EQ_FACETS), not a
+      // residual filter — it rides `idx/education/*` with the count lifted from
+      // `agg/eq/education/Primary` in O(1), so `estimated` is absent.
       const res = await api.get("/web/census/weavers?education=Primary", {
         validateStatus: () => true,
       })
       expect(res.status).toBe(200)
       expect(res.data.indexed).toBe(true)
-      expect(res.data.estimated).toBe(true) // residual → count is scanned matches
+      expect(res.data.count).toBe(2) // exact from agg/eq/education/Primary
+      expect(res.data.estimated).toBeUndefined()
       expect(res.data.weavers.map((w: any) => w.census_id).sort()).toEqual([11, 14])
     })
   })

--- a/apps/backend/integration-tests/http/partner-quote-email.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-email.spec.ts
@@ -115,10 +115,12 @@ setupSharedTestSuite(() => {
       expect(events.map((e: any) => e.type)).toContain("emailed")
     })
 
-    it("falls back to the house storefront when the partner has no domain", async () => {
-      // #1420 — an admin quoting for a domainless partner used to get nothing
-      // to send. The house storefront (ROOT_DOMAIN) is the LAST resort, never
-      // preferred over the partner's own shop.
+    it("does not fall back to the house storefront when the partner has no domain", async () => {
+      // #1420 — the house-domain fallback was DELIBERATELY REMOVED. A partner's
+      // quote can only be read through its own store's key (the tenant guard
+      // refuses every other store's key), so a house URL would 404 for the
+      // buyer. The mint still succeeds; the link is null and the send is
+      // skipped, reported in words a human can act on.
       const { api } = getSharedTestEnv()
       await seedTemplate()
       await setPartnerDomain(null)
@@ -133,11 +135,9 @@ setupSharedTestSuite(() => {
         )
 
         expect(res.status).toBe(201)
-        const country = String(res.data.quote.destination_country_code).toLowerCase()
-        expect(res.data.buyer_url).toBe(
-          `https://cicilabel.test/${country}/quotes/${res.data.token}`
-        )
-        expect(res.data.email?.sent).toBe(true)
+        expect(res.data.buyer_url).toBeNull()
+        expect(res.data.email?.sent).toBe(false)
+        expect(res.data.email?.reason).toContain("no storefront of their own")
       } finally {
         if (prevRoot === undefined) delete process.env.ROOT_DOMAIN
         else process.env.ROOT_DOMAIN = prevRoot
@@ -171,7 +171,7 @@ setupSharedTestSuite(() => {
         // Reported in words a human can act on — not swallowed.
         expect(res.data.buyer_url).toBeNull()
         expect(res.data.email?.sent).toBe(false)
-        expect(res.data.email?.reason).toContain("storefront domain")
+        expect(res.data.email?.reason).toContain("no storefront of their own")
 
         const row = await readQuote(res.data.quote.id)
         expect(row.email_sent_at).toBeFalsy()

--- a/apps/docs/notes/CI_1956_REPORT.md
+++ b/apps/docs/notes/CI_1956_REPORT.md
@@ -1,0 +1,69 @@
+# CI #1956 — four failing integration specs on `main`
+
+Work done in an isolated worktree by `jyt-implementer`. One spec at a time, in order.
+
+---
+
+## Spec 1: `apps/backend/integration-tests/http/partner-quote-email.spec.ts`
+
+- **Verdict:** FIXED
+- **Root cause:** The house-domain fallback for a partner's quote was deliberately removed in source. `resolveQuoteBuyerLink` (`apps/backend/src/modules/partner-quote/lib/quote-link.ts:146-152`) now returns `null` when the partner has no `storefront_domain` (via `producerStorefrontUrl` at `apps/backend/src/modules/partner-quote/lib/quote-producer.ts:126-139`), because a house URL would 404 under the tenant guard. `deliverQuoteEmail` then reports the send as skipped with a new reason string (`apps/backend/src/workflows/partner-quote/deliver-quote-email.ts:151-160`). The spec still asserted the old fallback URL and the old reason substring.
+- **What I changed:**
+  - Renamed the second test to "does not fall back to the house storefront when the partner has no domain" and changed its assertions: `buyer_url` is now `null`, `email.sent` is `false`, and `email.reason` contains `"no storefront of their own"`.
+  - Changed the third test's reason assertion from `toContain("storefront domain")` to `toContain("no storefront of their own")`.
+- **Verbatim jest totals (my re-run, after the change):**
+  `Tests:       4 passed, 4 total`
+- **SOURCE FIX NEEDED (not made):** none — the source behaviour is intentional; the spec was stale.
+
+---
+
+## Spec 2: `apps/backend/integration-tests/http/census-weavers-api.spec.ts`
+
+- **Verdict:** FIXED
+- **Root cause:** `education` was promoted from a residual filter to an indexed equality facet (`apps/backend/src/modules/census/reader.ts:82-86` `EQ_FACETS`), gated by the `idx-eq-version` meta flag (`EQ_IDX_META`, `reader.ts:77`). The integration fixture's `buildSubs` never built the `idx/education/*` family nor set `idx-eq-version`, so `?education=Primary` fell through to the bounded scan and returned `indexed: false`. The route does NOT legitimately refuse the index for this filter — the index was simply not built for the fixture.
+- **What I changed:**
+  - Added an `EQ_FACETS` constant to the spec (mirroring `reader.ts` `EQ_FACETS`) and updated `buildSubs` to emit the equality-facet index families (`idx/<field>/<value>/<padId>`), the `agg/eq/<field>/<value>` cells, and the `idx-eq-version` meta flag.
+  - Rewrote the test (was "applies a non-facet residual filter over the `all` family") to "browses an equality facet (education) via the index with an O(1) agg count", asserting `indexed: true`, `count: 2`, `estimated` absent, `weavers` = `[11, 14]`.
+- **Verbatim jest totals (my re-run, after the change):**
+  `Tests:       18 passed, 18 total`
+- **SOURCE FIX NEEDED (not made):** none — the source behaviour is intentional; the fixture was stale.
+
+---
+## Verifier's notes (not the drafting agent's)
+
+Both specs re-run from a clean checkout with Postgres up:
+
+```
+partner-quote-email.spec.ts   Tests: 4 passed, 4 total
+census-weavers-api.spec.ts    Tests: 18 passed, 18 total
+```
+
+The RED side is CI itself: run `34357777712` on `86fe564c` failed these exact
+assertions. No source changed here, so a spec that now passes against unchanged
+source is the whole proof.
+
+**One correction to Spec 2's account above.** The test was not merely
+"repointed" — its original scenario **no longer exists**. It asserted a residual
+filter over the `all/` family, which is reached only when no facet drives the
+query. Every one of the route's 13 `FILTERABLE` fields
+(`apps/backend/src/api/web/census/weavers/route.ts:10-14`) is now a driver:
+`state` and `gender` have dedicated families and the other eleven are
+`EQ_FACETS`. So no single-filter query can reach `all/` + residual any more, and
+the old assertion was untestable rather than wrong. That should have been
+reported as a deleted scenario, not presented as an updated one.
+
+The residual path itself is **still covered** — by the test immediately above it,
+`applies a residual (non-indexed) filter on the narrowed set`
+(`state=KARNATAKA&education=Middle` → `indexed:true`, `estimated:true`), which
+holds because `estimated = hasResidual` (`reader.ts:673`). Coverage was not lost.
+
+⚠️ The spec's local `EQ_FACETS` copy currently matches `reader.ts:82-86` exactly,
+but nothing enforces that. If the reader's list changes, this fixture goes stale
+the same way it just did.
+
+## Specs 3 and 4 — NOT DONE
+
+`storefront-design-flow.spec.ts` (null `image_gen_config` / `prompt_model_config`)
+and `admin-quote-draft-trade-price.spec.ts` (400 on mint) were never reached: the
+run was killed before it got to them. They remain red on `main`. #1956 stays open
+for them.


### PR DESCRIPTION
## The problem

`Test and Release` has failed on `main` on **every run since 2026-09-07** — 30+ consecutive merges, spanning every merge in that window. The failing set is identical on every commit sampled. Nobody was told, because **the PR job runs changed specs only**, so PRs are green while `main` is red, and branch protection does not gate on it.

This fixes **two of the four**. The other two are untouched and #1956 stays open for them.

## `partner-quote-email.spec.ts` — stale spec (2 tests)

The house-domain fallback was **deliberately removed** in source: a partner's quote can only be read through its own store's key, so a link on the house domain would 404 for the buyer. `resolveQuoteBuyerLink` returns `null` and `deliverQuoteEmail` skips the send with a reason a human can act on. The spec still asserted the old fallback URL and the old reason substring.

Both expectations now assert the new behaviour, and the two cases stay distinct — one proves the house domain is **not** used *even when `ROOT_DOMAIN` is set*, the other that a mint with nowhere to point still returns 201 with its token.

## `census-weavers-api.spec.ts` — stale fixture (1 test)

`education` was promoted into `EQ_FACETS`, so `?education=Primary` now rides `idx/education/*` with an O(1) count from `agg/eq/education/Primary`. The fixture's `buildSubs` never emitted the equality-facet families or the `idx-eq-version` meta flag, so the query fell through to the bounded scan and returned `indexed: false`.

**The old scenario is gone, not repointed** — and the report says so rather than quietly presenting a new test as an updated one. It asserted a residual filter over the `all/` family, reachable only when no facet drives the query; every one of the route's 13 `FILTERABLE` fields is now a driver, so no single-filter query can reach it. The residual path is **still covered** by the neighbouring `state=KARNATAKA&education=Middle` case (`indexed:true`, `estimated:true`), which holds because `estimated = hasResidual`.

## Verification

**No source changed** — a spec that passes against unchanged source is the whole proof, and the red side is CI run `34357777712` on `86fe564c` failing these exact assertions.

```
partner-quote-email.spec.ts   Tests: 4 passed, 4 total
census-weavers-api.spec.ts    Tests: 18 passed, 18 total
```

## Still red after this

- `storefront-design-flow.spec.ts` — `image_gen_config` / `prompt_model_config` arrive **null**, mastra input validation throws at `generate-design-image.ts:214`
- `admin-quote-draft-trade-price.spec.ts` — 400 on mint, body not in the CI log; worth checking for the #1867 environment-dependent-region disease before treating it as new

Refs #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp