### PR TITLE
fix(ci): the last two permanently-red specs were three real defects (#1956)

### DIFF
--- a/apps/backend/integration-tests/http/admin-quote-draft-trade-price.spec.ts
+++ b/apps/backend/integration-tests/http/admin-quote-draft-trade-price.spec.ts
@@ -162,8 +162,27 @@ setupSharedTestSuite(() => {
         )
       )
 
+      /**
+       * 🔴 The freight override is not decoration — without it this test is a
+       * carrier-availability test wearing a pricing test's clothes.
+       *
+       * `quote-readiness` refuses the mint with `freight_needs_manual_rate`
+       * whenever the carrier returns no rates and only a flat fallback exists.
+       * A developer machine has carrier credentials, gets real rates, and never
+       * reaches that guard; CI has none, so this 400d on every run for a month
+       * (#1956) while passing for everyone locally. Typing the rate in is what
+       * the guard's own message tells an operator to do, and it makes the
+       * outcome the same on both.
+       *
+       * The subject here is the NEGOTIATED UNIT PRICE. Freight is incidental to
+       * it, and must not be allowed to decide whether the assertion runs.
+       */
       const res = await loud("mint", () =>
-        api.post(`/admin/quotes/drafts/${draftId}/mint`, {}, adminHeaders)
+        api.post(
+          `/admin/quotes/drafts/${draftId}/mint`,
+          { freight_override_amount: 1200 },
+          adminHeaders
+        )
       )
 
       const quoteId = res.data.quote.id

--- a/apps/backend/src/api/admin/quotes/drafts/[id]/mint/route.ts
+++ b/apps/backend/src/api/admin/quotes/drafts/[id]/mint/route.ts
@@ -55,7 +55,35 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     )
   }
 
+  /**
+   * The hand-typed freight rate, forwarded from the request (#1956).
+   *
+   * 🔴 Without this an unrateable lane cannot be minted through the draft door
+   * AT ALL. `quote-readiness` refuses with `freight_needs_manual_rate` whenever
+   * the carrier returns no rates and only a flat fallback exists, and the
+   * message it prints names the remedy outright: "Look up the real rate (DHL and
+   * the like) and type it in." `POST /admin/quotes` accepts exactly that field —
+   * but this route builds its body purely from the stored draft, and the draft
+   * has nowhere to keep a freight override (there is no freight field on the
+   * draft PATCH validator). So the operator was told to type in a number that
+   * this door had no way to receive.
+   *
+   * That is the same shape as #1806: a body assembled from a fixed list of
+   * fields, where the missing name is invisible at every layer that "passes".
+   * It is also why `admin-quote-draft-trade-price` has been red in CI for a
+   * month while passing on every developer machine — a laptop with carrier
+   * credentials gets real rates and never reaches the guard.
+   *
+   * Forwarded, not persisted: the ordinary mint validates and records it
+   * (`quoted_freight_source` / `_basis`), so this adds no second contract. A
+   * draft that should REMEMBER a typed rate is a separate slice.
+   */
+  const freightOverride = (req.body as any)?.freight_override_amount
+
   const body = {
+    ...(freightOverride != null
+      ? { freight_override_amount: Number(freightOverride) }
+      : {}),
     partner_id: draft.partner_id,
     buyer_email: draft.email_sent_to,
     recipient_name: draft.recipient_name,

--- a/apps/backend/src/mastra/workflows/imagegen/index.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/index.ts
@@ -68,6 +68,34 @@ const promptEnhancerAgent = new Agent({
     "Create detailed, professional prompts suitable for text-to-image generation.",
 });
 
+/**
+ * A platform's credentials, handed down from the Medusa container because the
+ * Mastra runtime has no container of its own.
+ *
+ * 🔴 `.nullish()`, not `.optional()`. `generate-design-image.ts` initialises
+ * both configs to `null` and leaves them null when no AI platform is configured
+ * and no Cloudflare env fallback is set — which is every fresh database,
+ * including CI's. `.optional()` accepts `undefined` and REJECTS `null`, so the
+ * workflow died at input validation ("expected object, received null") before
+ * reaching the env provider chain it documents as the fallback, and before the
+ * `isTestEnvironment()` stub that exists precisely so this runs without
+ * credentials. That was two of the four specs red on `main` for a month (#1956).
+ *
+ * Every consumer already reads these through `?.`, so a null is safe once it is
+ * allowed through. Declared once rather than inlined three times — the three
+ * copies were identical, and a fix applied to two of them would have been worse
+ * than no fix at all.
+ */
+const platformConfigSchema = z
+  .object({
+    provider_type: z.string().optional(),
+    api_key: z.string().optional(),
+    account_id: z.string().optional(),
+    base_url: z.string().optional(),
+    model: z.string().nullable().optional(),
+  })
+  .nullish();
+
 // Trigger schema (workflow input)
 export const triggerSchema = z.object({
   mode: z.enum(["preview", "commit"]).default("preview"),
@@ -143,15 +171,7 @@ export const triggerSchema = z.object({
   // `resolveImageProvider` decides whether it is usable here — Cloudflare and
   // FAL both are; anything else falls through to the env provider chain and
   // SAYS SO rather than pretending the admin's choice was honoured.
-  image_gen_config: z
-    .object({
-      provider_type: z.string().optional(),
-      api_key: z.string().optional(),
-      account_id: z.string().optional(),
-      base_url: z.string().optional(),
-      model: z.string().nullable().optional(),
-    })
-    .optional(),
+  image_gen_config: platformConfigSchema,
   /**
    * The TEXT model that rewrites the brief into an image prompt.
    *
@@ -165,15 +185,7 @@ export const triggerSchema = z.object({
    * "use the image platform for text" cannot work there at all. The caller
    * resolves a text-capable platform from the container and hands it down.
    */
-  prompt_model_config: z
-    .object({
-      provider_type: z.string().optional(),
-      api_key: z.string().optional(),
-      account_id: z.string().optional(),
-      base_url: z.string().optional(),
-      model: z.string().nullable().optional(),
-    })
-    .optional(),
+  prompt_model_config: platformConfigSchema,
 });
 
 // Final output schema (workflow output)
@@ -252,15 +264,7 @@ const step1OutputSchema = z.object({
   // Passthrough fields needed by subsequent steps
   mode: z.enum(["preview", "commit"]),
   customer_id: z.string(),
-  image_gen_config: z
-    .object({
-      provider_type: z.string().optional(),
-      api_key: z.string().optional(),
-      account_id: z.string().optional(),
-      base_url: z.string().optional(),
-      model: z.string().nullable().optional(),
-    })
-    .optional(),
+  image_gen_config: platformConfigSchema,
 });
 
 /** Cloudflare text model for prompt enhancement (same account/token as image gen). */

--- a/apps/backend/src/workflows/media/upload-and-organize-media.ts
+++ b/apps/backend/src/workflows/media/upload-and-organize-media.ts
@@ -57,7 +57,38 @@ export const createFolderStep = createStep(
       folderData.level = 0;
     }
     
-    const folder = await service.createFolders(folderData);
+    /**
+     * Find-or-create, because `slug` is unique and two callers can arrive at
+     * once (#1956).
+     *
+     * `generate-design-image` uploads its two A/B takes CONCURRENTLY. Each one
+     * looks for the `ai-designs` folder, both find nothing, and both then
+     * insert — so the second died on the unique constraint with "Folder with
+     * slug: ai-designs, already exists" and took the whole generation down. A
+     * caller-side lookup cannot close that window; only the step that does the
+     * insert can.
+     *
+     * 🔴 The compensation id is returned ONLY for a folder this step actually
+     * created. Reusing someone else's folder and then soft-deleting it on
+     * rollback would destroy a folder — and every file filed under it — that
+     * this workflow did not own.
+     */
+    const existing = await service.listFolders({ slug });
+    if (existing?.length) {
+      return new StepResponse(existing[0], undefined);
+    }
+
+    let folder: any;
+    try {
+      folder = await service.createFolders(folderData);
+    } catch (e: any) {
+      // Lost the race between the lookup above and this insert. Re-read rather
+      // than fail: the folder now exists and is exactly what we wanted. Any
+      // other error is not ours to swallow.
+      const raced = await service.listFolders({ slug });
+      if (!raced?.length) throw e;
+      return new StepResponse(raced[0], undefined);
+    }
     return new StepResponse(folder, folder.id);
   },
   async (folderId: string | undefined, { container }) => {


### PR DESCRIPTION
Completes #1956 — `main`'s Test and Release should be green after this.

**Neither spec was flaky, and neither was merely stale.** Each hid a defect reachable only on an environment *without* credentials — which is precisely why they failed on every CI run and passed on every developer machine.

## `storefront-design-flow` — two faults, stacked

**1. A null config rejected before the fallback could run.** `generate-design-image` initialises `image_gen_config` and `prompt_model_config` to `null` and leaves them null when no AI platform row exists and no `CLOUDFLARE_AI_*` env fallback is set — every fresh database, CI's included. The trigger schema was `.optional()`, which accepts `undefined` and **rejects `null`**. So the workflow died at input validation before reaching the env provider chain it documents as its fallback, and before the `isTestEnvironment()` stub that exists so this runs without credentials.

Now `.nullish()`, with the three byte-identical copies of that schema declared once — a fix applied to two of three would have been worse than no fix.

**2. Behind it, a race.** The two A/B takes upload **concurrently**: both look up the `ai-designs` folder, both find nothing, both insert, and the second dies on the unique slug. A caller-side lookup cannot close that window — only the step doing the insert can — so `createFolderStep` is now find-or-create.

🔴 It returns a compensation id **only** for a folder it actually created. Reusing someone else's folder and then soft-deleting it on rollback would destroy a folder, and every file filed under it, that this workflow does not own.

## `admin-quote-draft-trade-price` — an operator remedy with no door

`quote-readiness` refuses a mint with `freight_needs_manual_rate` when the carrier returns no rates and only a flat fallback exists, and its message names the remedy: *"Look up the real rate (DHL and the like) and type it in."*

`POST /admin/quotes` accepts `freight_override_amount`. But the drafts-mint route builds its body **purely from the stored draft**, and a draft has nowhere to keep a freight override — there is no freight field on its PATCH validator. So an unrateable lane could not be minted through the draft door **at all**, and the operator was told to type in a number this door had no way to receive.

Same shape as #1806: a body assembled from a fixed list of fields, where the missing name is invisible at every layer that "passes". The route now forwards it; the ordinary mint still validates and records it (`quoted_freight_source` / `_basis`), so there is no second contract. Forwarded, not persisted — a draft that should *remember* a typed rate is a separate slice.

The spec now types the rate rather than depending on a reachable carrier: its subject is the negotiated unit price, and freight must not decide whether that assertion runs.

## Verification — by reproducing CI's environment, not by hoping

```
storefront-design-flow, CLOUDFLARE_AI_* cleared
  before: 2 failed, 8 passed — "expected object, received null"
  after:  10 passed, 10 total     (and 10/10 with the env set, unchanged)

admin-quote-draft-trade-price, carrier credentials cleared
  before: 1 failed, 3 passed — CI's 400 reproduced byte for byte
  after:  4 passed, 4 total
```

🔴 **Both specs pass on an unmodified developer machine, so the first green run proved nothing.** Neutralising the imagegen fix left the suite green until the env vars were cleared. Every claim above comes from a run where the control went red first.

Regression on the shared folder step: `media-upload-api` 7/7, `media-upload-binary-integrity` 3/3, `production-run-attach-media` 6/6.

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp