### PR TITLE
feat(inventory-orders): searchable To/From stock-location pickers

### DIFF
--- a/apps/backend/src/admin/components/creates/create-inventory-order.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order.tsx
@@ -1,18 +1,19 @@
 import { useForm, useFieldArray, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "@medusajs/framework/zod";
-import { Button, DatePicker, Heading, Text, ProgressTabs, ProgressStatus, Select, toast, Switch, Label, Input } from "@medusajs/ui";
+import { Button, DatePicker, Heading, Text, ProgressTabs, ProgressStatus, toast, Switch, Label, Input } from "@medusajs/ui";
 import { useRouteModal } from "../modal/use-route-modal";
 import { useCreateInventoryOrder } from "../../hooks/api/inventory-orders";
 import { RouteFocusModal } from "../modal/route-focus-modal";
 import { KeyboundForm } from "../utilitites/key-bound-form";
 import { Form } from "../common/form";
-import { useState, useEffect } from "react";
-import { useStockLocations } from "../../hooks/api/stock_location";
+import { useState, useEffect, useMemo } from "react";
+import { useAllStockLocations } from "../../hooks/api/stock_location";
 import { useInventoryCatalog } from "../../hooks/api/raw-materials";
 import { InventoryOrderLinesGrid } from "./inventory-order-lines-grid";
 import { AddMaterialGroupControl } from "../inventory-orders/add-material-group-control";
 import { toOrderLineRef } from "./order-line-ref";
+import { Combobox } from "../inputs/combobox/combobox";
 
 // The schema lives in its own module so it can be unit-tested: importing this
 // component pulls in `admin/lib/config`, which reads `import.meta.env` and
@@ -88,7 +89,17 @@ export const CreateInventoryOrderComponent = () => {
     setTabState(state);
   }, [tab]);
 
-  const { stock_locations = [] } = useStockLocations();
+  // Every location, not the default-limit first page: the pickers are
+  // searchable precisely so the LAST warehouse is as reachable as the first.
+  const { stock_locations = [] } = useAllStockLocations();
+  const locationOptions = useMemo(
+    () =>
+      stock_locations.map((loc) => ({
+        value: loc.id,
+        label: loc.name,
+      })),
+    [stock_locations]
+  );
   // Load the full catalog once (paginated to the true `count`) and filter the
   // item picker purely client-side (see inventory-order-lines-grid). A single
   // fixed-limit page used to silently truncate once the catalog grew past it
@@ -280,51 +291,54 @@ export const CreateInventoryOrderComponent = () => {
                       </Form.Item>
                     )}
                   />
-                  {/* To Stock Location */}
+                  {/* To Stock Location — searchable: the name is what the
+                      user knows, and a plain dropdown stops being usable
+                      once locations outgrow it. */}
                   <Form.Field
                     control={form.control}
                     name="stock_location_id"
-                    render={({ field }) => (
+                    render={({ field: { onChange, value, ref: _ref, ...field } }) => (
                       <Form.Item>
                         <Form.Label>To Stock Location</Form.Label>
                         <Form.Control>
-                          <Select value={field.value} onValueChange={field.onChange}>
-                            <Select.Trigger>
-                              <Select.Value placeholder="Select location" />
-                            </Select.Trigger>
-                            <Select.Content>
-                              {stock_locations.map((loc) => (
-                                <Select.Item key={loc.id} value={loc.id}>
-                                  {loc.name}
-                                </Select.Item>
-                              ))}
-                            </Select.Content>
-                          </Select>
+                          {/* The wrapper carries the test hook: when a value is
+                              selected the Combobox hides its input and renders
+                              the chosen label in a SIBLING element, so anchoring
+                              a test on the input alone cannot see what is
+                              selected. */}
+                          <div data-testid="inventory-order-to-location">
+                            <Combobox
+                              {...field}
+                              options={locationOptions}
+                              value={value}
+                              onChange={(next) => onChange((next as string) || "")}
+                              placeholder="Search locations"
+                            />
+                          </div>
                         </Form.Control>
                         <Form.ErrorMessage />
                       </Form.Item>
                     )}
                   />
-                  {/* From Stock Location (optional) */}
+                  {/* From Stock Location (optional) — searchable, and
+                      clearable because it is optional. */}
                   <Form.Field
                     control={form.control}
                     name="from_stock_location_id"
-                    render={({ field }) => (
+                    render={({ field: { onChange, value, ref: _ref, ...field } }) => (
                       <Form.Item>
-                        <Form.Label>From Stock Location</Form.Label>
+                        <Form.Label optional>From Stock Location</Form.Label>
                         <Form.Control>
-                          <Select value={field.value} onValueChange={field.onChange}>
-                            <Select.Trigger>
-                              <Select.Value placeholder="Select from location (optional)" />
-                            </Select.Trigger>
-                            <Select.Content>
-                              {stock_locations.map((loc) => (
-                                <Select.Item key={loc.id} value={loc.id}>
-                                  {loc.name}
-                                </Select.Item>
-                              ))}
-                            </Select.Content>
-                          </Select>
+                          <div data-testid="inventory-order-from-location">
+                            <Combobox
+                              {...field}
+                              options={locationOptions}
+                              value={value ?? ""}
+                              onChange={(next) => onChange(next as string | undefined)}
+                              allowClear
+                              placeholder="Search from location (optional)"
+                            />
+                          </div>
                         </Form.Control>
                         <Form.ErrorMessage />
                       </Form.Item>

--- a/apps/backend/src/admin/hooks/api/stock_location.ts
+++ b/apps/backend/src/admin/hooks/api/stock_location.ts
@@ -27,3 +27,51 @@ export const useStockLocations = (
   
     return { ...data, ...rest }
   }
+
+const STOCK_LOCATIONS_PAGE_SIZE = 100
+
+/**
+ * Every stock location, paged to the endpoint's true `count`. The plain list
+ * call defaults to `limit: 20`, so a picker fed by it silently loses every
+ * location past that row — the same truncation class as #947/#1552. Used by
+ * the searchable pickers, where "type the name and find it" has to hold for
+ * the LAST location as much as the first.
+ */
+export const useAllStockLocations = (
+  options?: Omit<
+    UseQueryOptions<
+      HttpTypes.AdminStockLocationListResponse,
+      FetchError,
+      HttpTypes.AdminStockLocationListResponse,
+      QueryKey
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: [...stockLocationsQueryKeys.lists(), "fetch-all"],
+    queryFn: async () => {
+      const stock_locations: HttpTypes.AdminStockLocation[] = []
+      let offset = 0
+      // Bound the round-trips, not the result — a page cap here would be the
+      // silent truncation this hook exists to prevent.
+      const maxPages = 50
+      for (let page = 0; page < maxPages; page++) {
+        const res = await sdk.admin.stockLocation.list({
+          limit: STOCK_LOCATIONS_PAGE_SIZE,
+          offset,
+        })
+        stock_locations.push(...(res.stock_locations ?? []))
+        const total = res.count ?? stock_locations.length
+        offset += res.stock_locations?.length ?? 0
+        if (!res.stock_locations?.length || offset >= total) {
+          break
+        }
+      }
+      return { stock_locations, count: stock_locations.length }
+    },
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}

--- a/e2e/specs/inventory-order-location-search.spec.ts
+++ b/e2e/specs/inventory-order-location-search.spec.ts
@@ -1,0 +1,248 @@
+import { test, expect, request as pwRequest } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+const BASE = "http://localhost:9000"
+
+/**
+ * The Create Inventory Order "To / From Stock Location" pickers are searchable
+ * comboboxes (the ariakit Combobox used by the data grid and the CRM forms),
+ * not plain `Select`s.
+ *
+ * What that has to mean in a browser, and what this spec holds it to:
+ *
+ *  1. EVERY location is offered — the list route defaults to `limit: 20`, so
+ *     a picker fed by the plain list call silently drops every location past
+ *     that row (the truncation class of #947/#1552). The fixtures push the
+ *     store past one page, so the count assertion is not vacuous.
+ *  2. Typing narrows: a warehouse found by name, a query that matches nothing
+ *     reads as no-results rather than as a full list.
+ *  3. The picked values live in the form, not just in the widget: the
+ *     schema's "from and to must differ" rule fires on a duplicate pair, and
+ *     stops firing once the optional From is cleared — the same code path a
+ *     buyer's Continue click takes.
+ */
+test.describe("Inventory order location pickers are searchable", () => {
+  let seed: { email: string; password: string }
+  let token: string
+  /** Locations this spec created — removed in afterAll so runs stay idempotent. */
+  const createdIds: string[] = []
+  const stamp = Date.now()
+  /**
+   * The trailing number+letter is load-bearing, not decoration: the picker
+   * filters with matchSorter, whose MATCHES ranking matches the query as a
+   * character SUBSEQUENCE — so "… Facility 11" fuzzy-matches "… Facility 1"
+   * + any later "1" (ten siblings!), and a "narrows to exactly one"
+   * assertion written against bare numbers cannot pass against the widget
+   * behaving exactly as designed (the CRM pickers are immune only because
+   * their fixture names are single tokens). Zero-padded two-digit numbers
+   * are not a subsequence of one another, and the unique last letter rules
+   * out skip-matching across number pairs ("7h" still matched "17r").
+   */
+  const locName = (i: number) =>
+    `E2E InvOrder ${stamp} Facility ${String(i).padStart(2, "0")}${String.fromCharCode(97 + i)}`
+  /** Enough to push the store past the list route's default 20-row page. */
+  const FILLER_COUNT = 24
+
+  test.beforeAll(async () => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+
+    const api = await pwRequest.newContext({ baseURL: BASE })
+    const auth = await api.post("/auth/user/emailpass", {
+      data: { email: seed.email, password: seed.password },
+    })
+    expect(auth.ok()).toBeTruthy()
+    token = (await auth.json()).token
+
+    for (let i = 0; i < FILLER_COUNT; i++) {
+      const res = await api.post("/admin/stock-locations", {
+        headers: { Authorization: `Bearer ${token}` },
+        data: { name: locName(i) },
+      })
+      expect([200, 201]).toContain(res.status())
+      createdIds.push((await res.json()).stock_location.id)
+    }
+    await api.dispose()
+  })
+
+  test.afterAll(async () => {
+    if (!createdIds.length) return
+    const api = await pwRequest.newContext({
+      baseURL: BASE,
+      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    })
+    for (const id of createdIds) {
+      await api.delete(`/admin/stock-locations/${id}`)
+    }
+    await api.dispose()
+  })
+
+  const login = async (page: import("@playwright/test").Page) => {
+    await page.goto("/app/login")
+    // `networkidle` never settles against `medusa develop` (the dev server holds
+    // long-lived connections open), so wait on the form itself.
+    await page.locator('input[name="email"]').waitFor({ timeout: 60000 })
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+  }
+
+  const openCreateForm = async (page: import("@playwright/test").Page) => {
+    await login(page)
+    await page.goto("/app/orders/inventory/create")
+    await expect(
+      page.getByRole("heading", { name: "Create Inventory Order" })
+    ).toBeVisible({ timeout: 20000 })
+  }
+
+  /**
+   * Pick `name` in the field under `testId`: open, narrow to the one match,
+   * select it. Returns nothing — the caller asserts what the field shows.
+   */
+  const pick = async (
+    page: import("@playwright/test").Page,
+    testId: string,
+    name: string
+  ) => {
+    const field = page.getByTestId(testId)
+    await field.getByRole("combobox").click()
+    await field.getByRole("combobox").fill(name)
+    await expect(page.getByRole("option")).toHaveCount(1)
+    await page.getByRole("option").first().click()
+    /**
+     * Blur and assert the popover is shut BEFORE reading the field: the
+     * Combobox renders its option list INSIDE the wrapper, so a wrapper that
+     * "contains the name" may just be showing an open dropdown with that
+     * option somewhere in it — a different claim from the field being
+     * selected. (The negative control for crm-open-a-deal showed exactly
+     * that: every option, concatenated.)
+     */
+    await page.getByRole("heading", { name: "Create Inventory Order" }).click()
+    await expect(page.getByRole("option")).toHaveCount(0)
+  }
+
+  test("offers every location, and narrows by what is typed", async ({
+    page,
+  }) => {
+    const api = await pwRequest.newContext({
+      baseURL: BASE,
+      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    })
+    const res = await api.get("/admin/stock-locations?limit=1")
+    const total = (await res.json()).count
+    await api.dispose()
+    // The beforeAll fixtures alone put us past the default page — if they
+    // somehow did not, the count assertion below is vacuous, so fail loudly
+    // instead of certifying a truncation bug it cannot see.
+    expect(total).toBeGreaterThan(20)
+
+    await openCreateForm(page)
+
+    const to = page.getByTestId("inventory-order-to-location")
+    await to.getByRole("combobox").click()
+
+    /**
+     * Every location, counted — not "the one I created is present". Presence
+     * alone passes on a truncated list whenever the fixture lands early; the
+     * count is what the default-limit truncation actually changes (20 vs
+     * total), which is exactly the bug the fetch-all hook exists to prevent.
+     */
+    await expect
+      .poll(async () => await page.getByRole("option").count(), {
+        timeout: 20000,
+      })
+      .toBe(total)
+
+    // A query that matches nothing reads as no-results, not as the full list.
+    await to.getByRole("combobox").fill(`no such facility ${stamp}`)
+    await expect(page.getByRole("option")).toHaveCount(0)
+
+    // The name is what the user knows — typing it must find THE warehouse.
+    await to.getByRole("combobox").fill(locName(23))
+    await expect(page.getByRole("option")).toHaveCount(1)
+    await page.getByRole("option").first().click()
+    await page.getByRole("heading", { name: "Create Inventory Order" }).click()
+    await expect(page.getByRole("option")).toHaveCount(0)
+    await expect(to).toContainText(locName(23))
+
+    // The From picker searches the same way — a transfer needs both ends.
+    const from = page.getByTestId("inventory-order-from-location")
+    await from.getByRole("combobox").click()
+    await from.getByRole("combobox").fill(locName(7))
+    await expect(page.getByRole("option")).toHaveCount(1)
+    await page.getByRole("option").first().click()
+    await page.getByRole("heading", { name: "Create Inventory Order" }).click()
+    await expect(page.getByRole("option")).toHaveCount(0)
+    await expect(from).toContainText(locName(7))
+  })
+
+  test("the picked pair goes through the form: duplicates refused, optional From clearable", async ({
+    page,
+  }) => {
+    await openCreateForm(page)
+
+    /**
+     * The from≠to rule lives in the schema's superRefine chain, and zod only
+     * runs refinements once the base object parses — so with the required
+     * delivery date still empty, Continue surfaces only THAT error and the
+     * duplicate pair sails past this screen's gate (verified against the real
+     * resolver: one issue, no refinement messages). The rule the buyer meets
+     * is the one with the dates valid, so that is the form this drives.
+     * (Order lines stay empty on purpose: with dates valid the refinements
+     * DO run, and Continue only re-validates the General-tab fields.)
+     */
+    const delivery = page.getByRole("group", { name: "Expected Delivery Date" })
+    await delivery.click()
+    // react-aria segments: month/day/year, auto-advancing per completed segment.
+    await page.keyboard.type("09152026")
+
+    // The SAME location at both ends is not a transfer.
+    const to = page.getByTestId("inventory-order-to-location")
+    const from = page.getByTestId("inventory-order-from-location")
+    await pick(page, "inventory-order-to-location", locName(11))
+    await expect(to).toContainText(locName(11))
+    await pick(page, "inventory-order-from-location", locName(11))
+    await expect(from).toContainText(locName(11))
+
+    await page.getByRole("button", { name: "Continue" }).click()
+    /**
+     * The schema's rule, not the widget's: this fires only because the
+     * combobox wrote real values into react-hook-form — a picker that kept
+     * the selection to itself leaves the rule silent and the pair ships.
+     */
+    const duplicateError = page.getByText(
+      "From and To stock locations must be different"
+    )
+    await expect(duplicateError).toBeVisible()
+
+    // From is optional — clearing it must clear it in the FORM too. (The
+    // clear button is the combobox's X, rendered when `allowClear` is on and
+    // a value is held; it is the only button in the widget offset from the
+    // disclosure chevron.)
+    await from.locator('button[class*="end-[28px]"]').click()
+    // The X unmounts mid-clear and focus hops to the input, which re-opens the
+    // popover — tab out so the next Continue click has no open list to fight.
+    await from.getByRole("combobox").press("Tab")
+
+    /**
+     * Cleared is not "": an empty From makes the pair valid, and Continue —
+     * which re-validates exactly the four General fields — must now advance
+     * to Order Lines. Staying put would mean the X left a stale string in
+     * the form state (or nothing changed at all).
+     */
+    await page.getByRole("button", { name: "Continue" }).click()
+    await expect(duplicateError).toHaveCount(0)
+    await expect(page.getByRole("tab", { name: "Order Lines" })).toHaveAttribute(
+      "data-state",
+      "active",
+      { timeout: 10000 }
+    )
+  })
+})


### PR DESCRIPTION
The Create Inventory Order "To / From Stock Location" fields were plain `Select`s. With more than a handful of warehouses a flat dropdown stops being usable, and — worse — the picker was fed by the stock-locations list route's default `limit: 20`, so every location past row 20 was silently unselectable (the #947/#1552 truncation class). The fields are now the same searchable ariakit `Combobox` the order-lines grid and the CRM forms already use, fed by a fetch-all that pages to the list's true count.

## What it does

- `useAllStockLocations` — pages `GET /admin/stock-locations` to the endpoint's real `count` instead of trusting the 20-row default. Used by the two pickers, where "type the name and find it" has to hold for the last warehouse as much as the first.
- To/From fields become `Combobox`es: fuzzy name search, and `allowClear` on the optional From so a transfer with no source can be expressed.
- A browser spec (`inventory-order-location-search.spec.ts`) drives both pickers: every location is offered (counted, not just "my fixture is present"), a nonsense query reads as no-results, typing a full name narrows to exactly one match, and the picked pair actually reaches the form — a duplicate To==From is refused by the schema, and clearing the optional From lets Continue advance.

## Evidence

- `create-inventory-order.tsx` + `stock_location.ts` typecheck clean; the spec typechecks clean against the Playwright types.
- The searchability case passed in a live browser run against this checkout's build (options render to the true count, narrowing works, both pickers select and display).
- ⚠️ A full green local `pnpm e2e` run wasn't possible from this machine: port 9000 is held by another checkout's `medusa start`, which is the exact "grading somebody else's build" situation `playwright.config.ts` warns about. CI owns a free :9000 and will exercise the real build.

## Not in this PR

- The shipment modal's "Ship from" picker (still a plain `Select` with `limit: 100`) — same disease, different screen, left alone to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
