### PR TITLE
fix(e2e): the 9 permanently-red admin specs were three real defects (#1963)

### DIFF
--- a/apps/backend/src/admin/components/partners/partner-credits-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-credits-section.tsx
@@ -270,8 +270,17 @@ export const PartnerCreditsSection = ({ partnerId }: { partnerId: string }) => {
         }
       })
 
+  /**
+   * #1963 — `data-partner-section` disambiguates this panel from the Payments
+   * (ledger) panel, which stamps the same `data-partner-id`. The e2e spec
+   * selects on both attributes so its locator resolves to exactly one element.
+   */
   return (
-    <Container className="divide-y p-0" data-partner-id={partnerId}>
+    <Container
+      className="divide-y p-0"
+      data-partner-id={partnerId}
+      data-partner-section="credits"
+    >
       <div className="flex items-center justify-between px-6 py-4">
         <div className="flex items-center gap-x-2">
           <Heading level="h2">Credits</Heading>

--- a/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-ledger-section.tsx
@@ -339,8 +339,17 @@ export const PartnerLedgerSection = ({ partnerId }: { partnerId: string }) => {
    */
   const showTotals = !!totals?.currency && rows.length > 0
 
+  /**
+   * #1963 — `data-partner-section` disambiguates this panel from the Credits
+   * panel, which stamps the same `data-partner-id`. The e2e spec selects on
+   * both attributes so its locator resolves to exactly one element.
+   */
   return (
-    <Container className="divide-y p-0" data-partner-id={partnerId}>
+    <Container
+      className="divide-y p-0"
+      data-partner-id={partnerId}
+      data-partner-section="ledger"
+    >
       <div className="flex items-center justify-between px-6 py-4">
         <div className="flex items-center gap-x-2">
           <Heading level="h2">Payments</Heading>

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -324,6 +324,47 @@ async function seedProvenanceProductRun(container: any): Promise<string> {
 }
 
 /**
+ * #1867 / #1963 — a region that DECLARES countries, seeded on OUR side rather
+ * than assumed to exist.
+ *
+ * The quote-draft spec selects a region by name and then asserts the country
+ * Select fills from it. `Singapore` existed only on one developer's laptop, so
+ * every CI run timed out waiting for an option that was never rendered. A
+ * region with an EMPTY countries list would fill the currency but leave the
+ * country Select empty — the exact regression the spec guards — so this one
+ * declares ["in"] on purpose.
+ *
+ * Find-or-create by name, never blind-create: the seed re-runs, and a duplicate
+ * region would make the option ambiguous and break the spec a different way.
+ */
+async function seedQuoteRegion(container: any): Promise<{
+  id: string
+  name: string
+}> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const regionService: any = container.resolve(Modules.REGION)
+
+  const { data: existing } = await query.graph({
+    entity: "region",
+    fields: ["id", "name"],
+  })
+  const found = (existing ?? []).find(
+    (r: any) => r.name === "E2E Quote Region"
+  )
+  if (found) {
+    return { id: found.id, name: found.name }
+  }
+
+  const created = await regionService.createRegions({
+    name: "E2E Quote Region",
+    currency_code: "inr",
+    countries: ["in"],
+  })
+  const row = Array.isArray(created) ? created[0] : created
+  return { id: row.id, name: row.name }
+}
+
+/**
  * #1439 S3/S4 — two quotes on one partner, so the admin quote surface can be
  * driven in a browser (#1463 shipped without ever having been).
  *
@@ -355,6 +396,8 @@ async function seedAdminQuotes(container: any): Promise<{
   zeroDepositQuoteCompany: string
 }> {
   const partnerModule: any = container.resolve("partner")
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const link: any = container.resolve(ContainerRegistrationKeys.LINK)
   // 🔴 `partnerQuote`, camelCase — NOT `partner_quote`.
   //
   // The module registers itself as `PARTNER_QUOTE_MODULE = "partnerQuote"`
@@ -376,6 +419,49 @@ async function seedAdminQuotes(container: any): Promise<{
     is_verified: true,
   })
   const partner = Array.isArray(createdPartner) ? createdPartner[0] : createdPartner
+
+  /**
+   * #1963 — the quote partner needs a DEDICATED store, or the draft route
+   * refuses to price for it ("Partner ... has no store, so a quote cannot be
+   * priced for them") and every Save 400s. Mirrors the gate-partner store block
+   * below: the partner↔store link is one store per partner, so reusing an
+   * already-linked store throws "Cannot create multiple links between 'partner'
+   * and 'store'" the second time the seed runs.
+   */
+  const { data: quoteRegions } = await query.graph({
+    entity: "region",
+    fields: ["id"],
+  })
+  const { data: quoteChannels } = await query.graph({
+    entity: "sales_channel",
+    fields: ["id"],
+  })
+  const { data: quoteLocations } = await query.graph({
+    entity: "stock_location",
+    fields: ["id"],
+  })
+  const quoteRegionId = quoteRegions?.[0]?.id
+  const quoteChannelId = quoteChannels?.[0]?.id
+  const quoteLocationId = quoteLocations?.[0]?.id
+  if (!quoteRegionId || !quoteChannelId || !quoteLocationId) {
+    throw new Error(
+      `E2E seed: the quote partner's store needs a region (${quoteRegionId}), a sales channel (${quoteChannelId}) and a stock location (${quoteLocationId}). Without all three the draft route cannot price a quote for this partner. Run the demo seed first: \`medusa exec ./src/scripts/seed.ts\`.`
+    )
+  }
+
+  const storeModule: any = container.resolve(Modules.STORE)
+  const createdStore: any = await storeModule.createStores({
+    name: `E2E Quote Store ${stamp}`,
+    default_sales_channel_id: quoteChannelId,
+    default_location_id: quoteLocationId,
+    default_region_id: quoteRegionId,
+  })
+  const storeId = Array.isArray(createdStore) ? createdStore[0].id : createdStore.id
+
+  await link.create({
+    partner: { partner_id: partner.id },
+    store: { store_id: storeId },
+  })
 
   // Stamped company names: the spec SEARCHES for these, and the search reaches
   // the server (#1461), so a duplicate from a previous seed would make a
@@ -2418,6 +2504,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: partner ledger fixture (#1612)...")
   const partnerLedger = await seedPartnerLedgerFixture(container)
 
+  logger.info("E2E seed: creating the #1867 quote region (declares countries)...")
+  const quoteRegion = await seedQuoteRegion(container)
+
   logger.info("E2E seed: creating the #1439 admin quote fixtures (active + superseded)...")
   const adminQuotes = await seedAdminQuotes(container)
 
@@ -2563,6 +2652,10 @@ export default async function e2eSeed({ container }: ExecArgs) {
     // rather than confirming it, so a re-run finds the same active quote.
     quotePartnerId: adminQuotes.partnerId,
     quotePartnerName: adminQuotes.partnerName,
+    // #1867 — the region the quote-draft spec selects by name; it must declare
+    // countries or the country Select stays empty.
+    quoteRegionId: quoteRegion.id,
+    quoteRegionName: quoteRegion.name,
     activeQuoteId: adminQuotes.activeQuoteId,
     activeQuoteCompany: adminQuotes.activeQuoteCompany,
     supersededQuoteId: adminQuotes.supersededQuoteId,

--- a/e2e/specs/admin-quote-drafts.spec.ts
+++ b/e2e/specs/admin-quote-drafts.spec.ts
@@ -104,7 +104,7 @@ test.describe("Admin quote drafts (#1446)", () => {
 
     await page.getByText("Select a region").click()
     // A region that declares countries — at least one of ours declares none.
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: /E2E Quote Region/ }).click()
 
     // The region wrote the currency; nobody typed it.
     await expect(currency).not.toHaveValue("")
@@ -122,7 +122,7 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
     await page.getByText("Select a region").click()
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: /E2E Quote Region/ }).click()
 
     await page.getByRole("button", { name: "Save" }).click()
 
@@ -167,7 +167,7 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
     await page.getByText("Select a region").click()
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: /E2E Quote Region/ }).click()
     await page.getByRole("button", { name: "Save" }).click()
     await page.waitForURL(/\/app\/quotes\/drafts\//, { timeout: 30000 })
 
@@ -231,7 +231,7 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
     await page.getByText("Select a region").click()
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: /E2E Quote Region/ }).click()
     await page.getByRole("button", { name: "Save" }).click()
     await page.waitForURL(/\/app\/quotes\/drafts\//, { timeout: 30000 })
 
@@ -246,7 +246,12 @@ test.describe("Admin quote drafts (#1446)", () => {
 
     // Back on the draft, and the units are on the record — not zero.
     await page.waitForURL(/\/app\/quotes\/drafts\/[^/]+$/, { timeout: 30000 })
-    await expect(page.getByText("500")).toBeVisible({ timeout: 15000 })
+    // #1963 — the basket now persists, so "500" renders twice: the quantity
+    // ("500×") and the line amount ("500"). Assert the exact amount, not a
+    // substring that matches both.
+    await expect(page.getByText("500", { exact: true })).toBeVisible({
+      timeout: 15000,
+    })
   })
 
   test("the buyer drawer saves without emptying the basket", async ({ page }) => {
@@ -256,7 +261,7 @@ test.describe("Admin quote drafts (#1446)", () => {
     await page.getByText("Select a partner").click()
     await page.getByRole("option", { name: /E2E Content Partner/ }).first().click()
     await page.getByText("Select a region").click()
-    await page.getByRole("option", { name: /Singapore/ }).click()
+    await page.getByRole("option", { name: /E2E Quote Region/ }).click()
     await page.getByRole("button", { name: "Save" }).click()
     await page.waitForURL(/\/app\/quotes\/drafts\//, { timeout: 30000 })
 

--- a/e2e/specs/partner-ledger-panel.spec.ts
+++ b/e2e/specs/partner-ledger-panel.spec.ts
@@ -61,8 +61,12 @@ test.describe("Partner ledger panel (#1612)", () => {
    * several `Container`s, and the heading sits beside a count badge that an
    * accessible-name match would swallow.
    */
+  // #1963 — scoped by BOTH attributes: the Credits panel stamps the same
+  // `data-partner-id`, so the id alone resolves to two elements.
   const ledgerPanel = (page: any) =>
-    page.locator(`[data-partner-id="${seed.ledgerPartnerId}"]`)
+    page.locator(
+      `[data-partner-section="ledger"][data-partner-id="${seed.ledgerPartnerId}"]`
+    )
 
   const openPartner = async (page: any) => {
     await login(page)


### PR DESCRIPTION
Closes the diagnosis half of #1963. `E2E (admin UI)` has failed on **every run on `main` since 2026-09-04** with the same 9 failures. They were neither flake nor one bug — **three unrelated causes**, one of them a defect in shipped admin code.

## The three

**1. Two panels stamped the same identifier** (`partner-ledger-panel`, 3 failures)

`partner-ledger-section.tsx:343` and `partner-credits-section.tsx:274` rendered the *identical* `<Container className="divide-y p-0" data-partner-id={partnerId}>`. The spec's `ledgerPanel()` matched both and Playwright's strict mode refused.

All three failures died in the shared `openPartner` helper at line 70 — **before any assertion of their own ran**. So 🔑 *"separates what is owed from what has moved"* had never once exercised what it guards. Both panels now carry `data-partner-section`; the spec selects on both attributes.

**2. The seeded quote partner had no store** (`admin-quote-deposit-terms`, 1 failure)

`POST /admin/quotes/drafts` correctly refuses a storeless partner — Save 400d and `waitForURL` timed out. **The route was right; the fixture was wrong.** `seedAdminQuotes` now creates and links a dedicated store, mirroring the gate-partner block (one store per partner, so an already-linked one cannot be reused).

**3. A region that exists on nobody's CI** (`admin-quote-drafts`, 5 failures) — #1867

Five specs selected `/Singapore/`, created **nowhere**. A previous attempt renamed it to `Europe` and made things *worse* (6 pass → 5 fail), because the spec's own docblock requires a region that **declares countries**. `seedQuoteRegion` find-or-creates `E2E Quote Region` (inr, `countries: ["in"]`). Safe to claim `"in"`: the demo seed's only region declares `gb/de/dk/se/fr/es/it`.

## One assertion tightened — because a working fix exposed it

`getByText("500")` began matching **two** elements (`500×` and `500`) once the basket actually persisted; before, the spec never got far enough for either to exist. Now `{ exact: true }`.

**Tightened, not relaxed.** Nothing in this PR is skipped, `.fixme`'d, quarantined, or given a longer timeout.

## Verification — the suite was run, twice

```
before the assertion fix:  36 failed / 62 passed (3.7m)
after:                     35 failed / 62 passed (3.3m)
```

| spec | before | after |
|---|---|---|
| `admin-quote-drafts` | 5 failed | **6/6 pass** |
| `partner-ledger-panel` | 3 failed | **3/3 pass** |
| `admin-quote-deposit-terms` | 1 failed | **4/4 pass** |

Checked against the raw log, not a summary: **0** of the 35 remaining failures are in the target specs, and **35/35** are tag-gated (`@partnerui`/`@storefront`/`@localstack`/`@llm`) hitting `ERR_CONNECTION_REFUSED` on :5173/:8000. CI excludes every one via `grepInvert`. Per-file counts sum to exactly 35.

## The risk this branch carried, and why it is clear

It **adds a second region**, and five other blocks in `e2e-seed.ts` do `const region = regions?.[0]` and take its currency. The demo seed creates exactly one (`Europe|eur`, confirmed in the database), so `[0]` could have flipped and switched those fixtures eur → inr.

**No untagged spec fails**, so it did not. Still worth knowing it is load-bearing: `regions?.[0]` is unordered.

## ⚠️ What this does not prove

CI sets `PARTNER_UI=1` and boots :5173, so it runs a **different population**. Those 35 could not pass locally and are evidence either way. **`E2E (admin UI)` on CI is the final word** — #1963 stays open until it goes green on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp