### PR TITLE
feat(inventory-orders): searchable "Ship from" picker in the shipment modal

### DIFF
--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Drawer, Button, DatePicker, Input, Label, Select, Text, toast } from "@medusajs/ui";
 
 import {
@@ -7,7 +7,8 @@ import {
   useCreateInventoryOrderShipment,
   useInventoryOrderShiprocketRates,
 } from "../../hooks/api/inventory-orders";
-import { useStockLocations } from "../../hooks/api/stock_location";
+import { useAllStockLocations } from "../../hooks/api/stock_location";
+import { Combobox } from "../inputs/combobox/combobox";
 
 /** DatePicker works in Date objects; the API wants "YYYY-MM-DD" (local). */
 const toYMD = (d: Date) =>
@@ -46,7 +47,17 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
   const { mutateAsync, isPending } = useCreateInventoryOrderShipment(inventoryOrder.id);
   const { mutateAsync: fetchRates, isPending: isFetchingRates } =
     useInventoryOrderShiprocketRates(inventoryOrder.id);
-  const { stock_locations = [] } = useStockLocations({ limit: 100 });
+  // Every location, not the default-limit first page: the picker is searchable
+  // precisely so the LAST warehouse is as reachable as the first (#947/#1552).
+  const { stock_locations = [] } = useAllStockLocations();
+  const locationOptions = useMemo(
+    () =>
+      stock_locations.map((loc) => ({
+        value: loc.id,
+        label: loc.name,
+      })),
+    [stock_locations]
+  );
 
   const handleGetRates = async () => {
     try {
@@ -111,18 +122,20 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
           </Text>
           <div className="flex flex-col gap-1">
             <Label size="small" htmlFor="pickup">Ship from (pickup location)</Label>
-            <Select value={pickup} onValueChange={setPickup}>
-              <Select.Trigger id="pickup">
-                <Select.Value placeholder="Use registered carrier pickup (optional)" />
-              </Select.Trigger>
-              <Select.Content>
-                {stock_locations.map((loc) => (
-                  <Select.Item key={loc.id} value={loc.id}>
-                    {loc.name}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select>
+            {/* The wrapper carries the test hook: when a value is selected the
+                Combobox hides its input and renders the chosen label in a
+                SIBLING element, so anchoring a test on the input alone cannot
+                see what is selected. */}
+            <div data-testid="shipment-ship-from-location">
+              <Combobox
+                id="pickup"
+                options={locationOptions}
+                value={pickup}
+                onChange={(next) => setPickup((next as string) || "")}
+                allowClear
+                placeholder="Use registered carrier pickup (optional)"
+              />
+            </div>
           </div>
           <div className="flex flex-col gap-1">
             <Label size="small" htmlFor="carrier">Carrier</Label>


### PR DESCRIPTION
Finishes what #1961 started. That PR made the create-inventory-order modal's **To**/**From** stock-location pickers searchable; the **shipment** modal's "Ship from" picker was the one it missed, still a Radix `Select` fed by `useStockLocations({ limit: 100 })`.

This swaps it for `useAllStockLocations()` + the searchable `Combobox`, matching #1961's approach so the two modals behave identically.

### Honest scope — this is not a truncation fix

Prod has **23 stock locations**. `limit: 100` is not hiding anything today. The previous session's handoff called this a live truncation; it is not. The value here is searchability and consistency with #1961, and removing a cap that would bite silently if the count ever grew.

A side benefit: a Radix `Select` whose value is set before its items exist shows its placeholder forever. The `Combobox` has no such failure mode.

### Verification — and what is NOT verified

- ✅ **Typecheck, with a control.** Scoped `tsc --noEmit -p tsconfig.json` → **84 errors with the change, 84 without** (control run on untouched `main`). This adds none. Note `check:prod-build` bundles `src/admin` but does not type-check it, so it could not have caught a regression here.
- 🔴 **Not rendered in a browser.** No screenshot, no e2e spec. #1961 shipped with `e2e/specs/inventory-order-location-search.spec.ts`; this has no equivalent. Every admin-UI defect I have shipped recently was invisible to reading and tests and visible on render, so **this should get a render before merge** rather than be taken on the typecheck.
- The wrapper carries `data-testid="shipment-ship-from-location"` because the `Combobox` hides its input once a value is chosen and renders the label in a sibling element — anchoring a future spec on the input alone would not see the selection.

### Left deliberately untouched

Two sibling sites still read `limit: 100`:
- `apps/backend/src/admin/components/inbound-emails/execute-action-dialog.tsx:35`
- `apps/backend/src/admin/routes/designs/[id]/@inventory/[inventoryId]/page.tsx:47`

And `useAllStockLocations` caps at `maxPages = 50` while its comment claims to bound round-trips rather than results — worth tightening separately.

### Provenance note

The draft for this came off `agent/ship-from`. That branch's *commit* turned out to be a stale duplicate of #1961 (all three of its files are byte-identical to `main`); the real work was an **uncommitted** change in its worktree. This PR is that change, replayed onto current `main`. `agent/ship-from` and its worktree can be removed once this lands, but they hold the only other copy until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp