### PR TITLE
fix(ops): replay-fx-fanout could not reach house stores; make a red e2e visible

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -203,3 +203,101 @@ jobs:
             playwright-report/
           retention-days: 7
           if-no-files-found: ignore
+
+  # ===========================================================================
+  # Make a red e2e VISIBLE (#1963).
+  #
+  # This suite was red on every run on `main` from 2026-09-04 to 2026-09-10 —
+  # the same 9 failures, ~40 runs — and nobody was told. Three of those specs
+  # were marked 🔑 by their own authors and two turned out to be real production
+  # defects. Nothing gated on the check and nothing reported it, so the only way
+  # to learn it was red was to go and look.
+  #
+  # Deliberately a NOTIFIER, not a gate: `main` has no branch protection and
+  # adding a required check here would also block direct pushes. This opens or
+  # updates ONE sticky issue instead, so a week of redness cannot pass quietly.
+  #
+  # Sticky by design — it reuses the single open issue carrying the marker
+  # below rather than filing one per run, which is how this kind of job turns
+  # into noise that gets muted.
+  # ===========================================================================
+  notify-on-red:
+    needs: e2e
+    # Only `main`, and only a genuine failure. `cancelled()` is excluded on
+    # purpose: this workflow's own concurrency group cancels superseded runs,
+    # and reporting those as breakage is how a notifier loses its credibility.
+    if: ${{ failure() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the sticky "e2e is red" issue
+        uses: actions/github-script@v7
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        with:
+          script: |
+            const MARKER = '<!-- e2e-red-sticky -->'
+            const TITLE = '🔴 E2E (admin UI) is red on main'
+            const { owner, repo } = context.repo
+            const runUrl = process.env.RUN_URL
+            const sha = (process.env.SHA || '').slice(0, 9)
+
+            // Find the sticky by TITLE + marker, with no label filter.
+            // Deliberately label-free: this repo has no `ci` label, and
+            // `issues.create` 422s on a label that does not exist — which would
+            // leave the notifier silently unable to notify, the exact failure
+            // this job exists to prevent. Titles we control; labels we do not.
+            const existing = await github.paginate(
+              github.rest.issues.listForRepo,
+              { owner, repo, state: 'open', per_page: 100 }
+            )
+            const sticky = existing.find(
+              (i) => !i.pull_request && i.title === TITLE && (i.body || '').includes(MARKER)
+            )
+
+            const line = `- 🔴 \`${sha}\` failed — [run](${runUrl})`
+
+            if (sticky) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: sticky.number,
+                body: `${line}\n\nStill red. This is the same sticky issue, not a new one.`,
+              })
+              core.notice(`Updated sticky issue #${sticky.number}`)
+              return
+            }
+
+            const body = [
+              MARKER,
+              '## `E2E (admin UI)` is red on `main`',
+              '',
+              line,
+              '',
+              'This issue is **sticky**: while the suite stays red, each failing run on',
+              '`main` adds a comment here instead of filing a new issue. Close it once',
+              '`main` is green again — the next failure will open a fresh one.',
+              '',
+              '### Why this exists',
+              '',
+              'This suite was red on ~40 consecutive runs on `main` (2026-09-04 →',
+              '2026-09-10) with the same 9 failures and nobody was told. Two of those',
+              'turned out to be real production defects and one an operator dead-end',
+              '(#1963, fixed in #1964). Nothing gates on this check, so silence was',
+              'indistinguishable from success.',
+              '',
+              '### What to do',
+              '',
+              '1. Open the run above and read the **totals line**, not just the `●`',
+              '   assertion blocks — a spec\'s own diagnostic output (e.g. a printed',
+              '   response body) often sits thousands of lines earlier in the log.',
+              '2. A developer machine cannot reproduce CI by default: it may hold',
+              '   credentials CI lacks. Clear those and make a control fail first.',
+              '3. CI sets `PARTNER_UI=1` and boots :5173, so it runs a different spec',
+              '   population than a bare local run.',
+            ].join('\n')
+
+            const created = await github.rest.issues.create({
+              owner, repo, title: TITLE, body,
+            })
+            core.notice(`Opened sticky issue #${created.data.number}`)

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/replay-fx-fanout.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/replay-fx-fanout.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  collectHouseStoreTargets,
   MAX_FX_FANOUT_PARTNER_SCAN,
   planPriceSetFanout,
   previewFanoutCurrencies,
@@ -112,8 +113,157 @@ describe("replay-fx-fanout — registration", () => {
 
   it("exposes optional partner_id + limit params and a bounded scan cap", () => {
     const names = replayFxFanoutJob.params.map((p) => p.name)
-    expect(names).toEqual(["partner_id", "limit"])
+    // include_house_stores joined in when the job was extended past partner
+    // stores; the list is asserted exactly so a new param is a deliberate edit.
+    expect(names).toEqual(["partner_id", "limit", "include_house_stores"])
     expect(replayFxFanoutJob.params.every((p) => p.required === false)).toBe(true)
     expect(MAX_FX_FANOUT_PARTNER_SCAN).toBe(5000)
+  })
+})
+
+/**
+ * House stores — the ones no partner owns.
+ *
+ * This job used to walk `partners → stores` only, so a store with no partner
+ * was unreachable and every price on its channel was invisible to the replay.
+ * That is where admin-side custom-design products live, and the route that
+ * writes their prices (core's `/admin/products/:id/variants/batch`) does not
+ * fan out inline either — so those prices were stuck in one currency with no
+ * repair path. These cases pin the enumeration that closes it.
+ */
+describe("replay-fx-fanout — collectHouseStoreTargets", () => {
+  /** A `query.graph` stub that answers by entity. */
+  const fakeQuery = (stores: any[], partners: any[]) => ({
+    graph: async ({ entity }: { entity: string }) => {
+      if (entity === "stores") return { data: stores }
+      if (entity === "partners") return { data: partners }
+      throw new Error(`unexpected entity ${entity}`)
+    },
+  })
+
+  const currencies = (...codes: string[]) =>
+    codes.map((currency_code) => ({ currency_code }))
+
+  it("returns the store no partner owns, and excludes partner-owned ones", async () => {
+    const query = fakeQuery(
+      [
+        {
+          id: "store_house",
+          name: "JYT",
+          default_sales_channel_id: "sc_house",
+          supported_currencies: currencies("inr", "eur", "usd"),
+        },
+        {
+          id: "store_partner",
+          name: "Partner Shop",
+          default_sales_channel_id: "sc_partner",
+          supported_currencies: currencies("inr", "eur"),
+        },
+      ],
+      [{ id: "partner_1", stores: [{ id: "store_partner" }] }]
+    )
+
+    const { targets, skippedStores } = await collectHouseStoreTargets(query)
+
+    expect(targets.map((t) => t.storeId)).toEqual(["store_house"])
+    expect(skippedStores).toBe(0)
+    const [house] = targets
+    // partnerId null is what marks it as a house store in the result rows.
+    expect(house.partnerId).toBeNull()
+    expect(house.channelId).toBe("sc_house")
+    expect(house.supportedCurrencies).toEqual(["inr", "eur", "usd"])
+  })
+
+  it("skips a house store with no default sales channel — nothing is priced through it", async () => {
+    const query = fakeQuery(
+      [
+        {
+          id: "store_house",
+          name: "JYT",
+          default_sales_channel_id: null,
+          supported_currencies: currencies("inr", "eur"),
+        },
+      ],
+      []
+    )
+
+    const { targets, skippedStores } = await collectHouseStoreTargets(query)
+
+    expect(targets).toEqual([])
+    expect(skippedStores).toBe(1)
+  })
+
+  it("skips a house store with a single currency — there is nothing to convert to", async () => {
+    const query = fakeQuery(
+      [
+        {
+          id: "store_house",
+          name: "JYT",
+          default_sales_channel_id: "sc_house",
+          supported_currencies: currencies("inr"),
+        },
+      ],
+      []
+    )
+
+    const { targets, skippedStores } = await collectHouseStoreTargets(query)
+
+    expect(targets).toEqual([])
+    expect(skippedStores).toBe(1)
+  })
+
+  it("treats a store reachable from ANY partner as owned, not house", async () => {
+    const query = fakeQuery(
+      [
+        {
+          id: "store_shared",
+          name: "Shared",
+          default_sales_channel_id: "sc_shared",
+          supported_currencies: currencies("inr", "eur"),
+        },
+      ],
+      [
+        { id: "partner_1", stores: [] },
+        { id: "partner_2", stores: [{ id: "store_shared" }] },
+      ]
+    )
+
+    const { targets } = await collectHouseStoreTargets(query)
+
+    expect(targets).toEqual([])
+  })
+
+  it("tolerates partners with no stores array and stores with no currencies", async () => {
+    const query = fakeQuery(
+      [
+        { id: "store_a", default_sales_channel_id: "sc_a" },
+        {
+          id: "store_b",
+          default_sales_channel_id: "sc_b",
+          supported_currencies: currencies("inr", "usd"),
+        },
+      ],
+      [{ id: "partner_1" }]
+    )
+
+    const { targets, skippedStores } = await collectHouseStoreTargets(query)
+
+    expect(targets.map((t) => t.storeId)).toEqual(["store_b"])
+    expect(skippedStores).toBe(1)
+  })
+})
+
+describe("replay-fx-fanout — include_house_stores param", () => {
+  it("is declared, optional, and boolean so an operator can turn the expansion off", () => {
+    const param = (replayFxFanoutJob.params ?? []).find(
+      (p: any) => p.name === "include_house_stores"
+    )
+    expect(param).toBeDefined()
+    expect(param!.type).toBe("boolean")
+    expect(param!.required).toBe(false)
+  })
+
+  it("says in its description that house stores are covered", () => {
+    expect(replayFxFanoutJob.description.toLowerCase()).toContain("house")
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/fanout-fx-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/fanout-fx-job.ts
@@ -40,6 +40,13 @@ const fanoutFxParamsSchema = z.object({
     .max(MAX_FX_FANOUT_PARTNER_SCAN)
     .optional()
     .default(1000),
+  /**
+   * Also replay the HOUSE store(s) — the ones no partner owns. On by default:
+   * omitting them is what left admin-side products (custom-design products in
+   * particular) priced in a single currency with nothing to fix them. Ignored
+   * when `partner_id` is given, which is an explicit request for one partner.
+   */
+  include_house_stores: z.boolean().optional().default(true),
 })
 
 export type FanoutPriceRow = {
@@ -105,7 +112,8 @@ export function planPriceSetFanout(args: {
 }
 
 type StoreTarget = {
-  partnerId: string
+  /** null for a house store — one no partner owns. */
+  partnerId: string | null
   partnerName: string
   storeId: string
   storeName: string
@@ -165,6 +173,71 @@ async function collectStoreTargets(
   return { targets, skippedStores }
 }
 
+/**
+ * Stores NO partner owns — the house/admin store(s).
+ *
+ * Why this exists: `collectStoreTargets` walks `partners → stores`, so a store
+ * with no partner is unreachable by it, and every product on that store's
+ * channel is invisible to the replay. That is not a corner case — admin-side
+ * custom-design products live on the house channel, and the route that writes
+ * their prices (core's `/admin/products/:id/variants/batch`) does not fan out
+ * inline either. So those prices were written in one currency AND had no repair
+ * path. Four of them were found that way (#1900).
+ *
+ * Ownership rule is copied from `delete-orphan-store-job` — all stores minus
+ * the ones reachable through a partner — so "house" means the same thing in
+ * both jobs rather than two drifting definitions.
+ */
+export async function collectHouseStoreTargets(
+  query: any
+): Promise<{ targets: StoreTarget[]; skippedStores: number }> {
+  const { data: stores } = await query.graph({
+    entity: "stores",
+    fields: [
+      "id",
+      "name",
+      "default_sales_channel_id",
+      "supported_currencies.currency_code",
+    ],
+  })
+
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "stores.id"],
+  })
+  const partnerOwned = new Set<string>()
+  for (const p of (partners ?? []) as any[]) {
+    for (const st of (p?.stores ?? []) as any[]) {
+      if (st?.id) partnerOwned.add(String(st.id))
+    }
+  }
+
+  const targets: StoreTarget[] = []
+  let skippedStores = 0
+  for (const store of (stores ?? []) as any[]) {
+    if (!store?.id || partnerOwned.has(String(store.id))) continue
+    const channelId = store?.default_sales_channel_id
+    const supportedCurrencies = ((store?.supported_currencies ?? []) as any[])
+      .map((c) => c?.currency_code)
+      .filter(Boolean)
+    // Same two skips as the partner walk: no channel means nothing is priced
+    // through this store, <2 currencies means there is nothing to convert TO.
+    if (!channelId || supportedCurrencies.length < 2) {
+      skippedStores++
+      continue
+    }
+    targets.push({
+      partnerId: null,
+      partnerName: "House (no partner)",
+      storeId: String(store.id),
+      storeName: store.name ?? String(store.id),
+      supportedCurrencies,
+      channelId,
+    })
+  }
+  return { targets, skippedStores }
+}
+
 /** All variant price rows for a store's default sales channel, grouped by
  *  price_set. Uses the same sales_channel → products_link pivot the replay
  *  script documents (two-hop variant→sales_channel joins don't auto-resolve). */
@@ -213,7 +286,7 @@ export const replayFxFanoutJob: MaintenanceJob = {
   id: "replay-fx-fanout",
   label: "Replay FX price fanout",
   description:
-    `Materialise auto-converted variant prices in every currency of the owning store's supported_currencies, for products whose prices were created before FX fanout ran (or before the store gained the currency). Fixes products that read "not available" in non-native regions (e.g. an INR-priced product showing unavailable in the EUR region). Dry-run previews, per source price, exactly which currencies would be added — no writes, no FX calls. Apply runs the idempotent fanout workflow (skips currencies that already exist + auto-derived source rows). Optionally scope to one partner_id. Scans up to 'limit' partners per call (default 1000, max ${MAX_FX_FANOUT_PARTNER_SCAN}).`,
+    `Materialise auto-converted variant prices in every currency of the owning store's supported_currencies, for products whose prices were created before FX fanout ran (or before the store gained the currency). Fixes products that read "not available" in non-native regions (e.g. an INR-priced product showing unavailable in the EUR region). Dry-run previews, per source price, exactly which currencies would be added — no writes, no FX calls. Apply runs the idempotent fanout workflow (skips currencies that already exist + auto-derived source rows). Covers partner stores AND the house store(s) — the ones no partner owns, where admin-side custom-design products live; those were previously unreachable by this job, so prices written there had no repair path at all. Optionally scope to one partner_id (which excludes house stores). Scans up to 'limit' partners per call (default 1000, max ${MAX_FX_FANOUT_PARTNER_SCAN}).`,
   params: [
     {
       name: "partner_id",
@@ -227,6 +300,13 @@ export const replayFxFanoutJob: MaintenanceJob = {
       required: false,
       description: `Max partners to scan in one call (default 1000, max ${MAX_FX_FANOUT_PARTNER_SCAN})`,
     },
+    {
+      name: "include_house_stores",
+      type: "boolean",
+      required: false,
+      description:
+        "Also replay the house store(s) — the ones no partner owns, where admin-side custom-design products live. Default true. Ignored when partner_id is set.",
+    },
   ],
   run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
     const parsed = fanoutFxParamsSchema.safeParse(params)
@@ -236,16 +316,23 @@ export const replayFxFanoutJob: MaintenanceJob = {
         parsed.error.issues.map((i) => i.message).join("; ")
       )
     }
-    const { partner_id, limit } = parsed.data
+    const { partner_id, limit, include_house_stores } = parsed.data
 
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
 
-    const { targets, skippedStores } = await collectStoreTargets(
-      query,
-      partner_id,
-      limit
-    )
+    const partnerScan = await collectStoreTargets(query, partner_id, limit)
+
+    // `partner_id` is an explicit request for ONE partner, so house stores are
+    // not silently added to it. Otherwise they are part of "replay everything".
+    const houseScan =
+      !partner_id && include_house_stores
+        ? await collectHouseStoreTargets(query)
+        : { targets: [] as StoreTarget[], skippedStores: 0 }
+
+    const targets = [...partnerScan.targets, ...houseScan.targets]
+    const skippedStores = partnerScan.skippedStores + houseScan.skippedStores
+    const houseStoresScanned = houseScan.targets.length
 
     const changes: MaintenanceChange[] = []
     const errors: Array<{ id: string; message: string }> = []
@@ -322,12 +409,14 @@ export const replayFxFanoutJob: MaintenanceJob = {
     }
 
     const summary = dry_run
-      ? `Dry run — ${sourcesWithWork} source price(s) across ${storesScanned} store(s) would gain ${currenciesPlanned} auto-converted price(s)${
+      ? `Dry run — ${sourcesWithWork} source price(s) across ${storesScanned} store(s)${
+          houseStoresScanned ? ` (incl. ${houseStoresScanned} house)` : ""
+        } would gain ${currenciesPlanned} auto-converted price(s)${
           skippedStores ? ` (${skippedStores} store(s) skipped: no channel / <2 currencies)` : ""
         }.`
       : `Fanned out ${created} auto-converted price(s) from ${sourcesWithWork} source price(s) across ${storesScanned} store(s)${
-          errors.length ? `, ${errors.length} error(s)` : ""
-        }.`
+          houseStoresScanned ? ` (incl. ${houseStoresScanned} house)` : ""
+        }${errors.length ? `, ${errors.length} error(s)` : ""}.`
 
     return {
       job_id: replayFxFanoutJob.id,


### PR DESCRIPTION
Two pieces, both fallout from the #1900 tail. Separable if you'd rather split them.

## 1. `replay-fx-fanout` was partner-only — the repair job couldn't see the thing that needed repairing

`collectStoreTargets` walks `partners → stores → default sales channel`. A store **no partner owns** is unreachable by that walk, so every price on its channel is invisible to the replay. Not a corner case: admin-side custom-design products live on the house channel.

Two halves combined into a hole with no bottom:

1. Core's `POST /admin/products/:id/variants/batch` does **not** emit `fx.fanout_requested`. Medusa emits no `price.created`, so every price-writing route has to ask for the fanout itself — and this repo does not override that core route. A price written through it lands in **one currency, permanently**.
2. This job — the designated repair — could not reach it.

**Four production prices were written exactly that way and are INR-only** (#1900). They're unpublished drafts so nothing is customer-visible, but published they'd read "not available" in every non-INR region. Until this change they had *no* repair path.

### Approach

Adds `collectHouseStoreTargets`, reusing the ownership rule already in `delete-orphan-store-job` — all stores minus those reachable through a partner — so "house" means one thing across both jobs instead of two definitions that drift. Same two skips as the partner walk: no default channel means nothing is priced through the store; fewer than 2 currencies means nothing to convert to.

`include_house_stores` defaults to **true** — omitting them is the defect, not a feature. Passing `partner_id` still scopes to that partner alone, so an explicit single-partner request doesn't silently grow. `dry_run` previews the expansion and the summary reports how many house stores were in scope, so an operator sees the wider blast radius before applying.

### Tests

6 new cases over the enumeration plus the param contract. **Verified by mutation:** removing the ownership exclusion turns 2 of them red; restoring it returns 17/17. The pre-existing exact-param-list assertion failed on this change — which is what that assertion is for — and was updated deliberately.

## 2. A red e2e now tells someone (#1963)

`E2E (admin UI)` was red on ~40 consecutive runs on `main` (2026-09-04 → 2026-09-10), same 9 failures every time, and nobody was told. Two were real production defects and one an operator dead-end. Nothing gated on the check and nothing reported it, so silence and success were indistinguishable.

Adds a `notify-on-red` job that opens or updates **one sticky issue**.

Deliberately a notifier, **not a gate** — `main` has no branch protection, and a required check would also block direct pushes to `main` and the `--auto` squash pattern in use. That's a policy call and is left to you.

Details that matter:
- `main` pushes only, `failure()` only. `cancelled()` is excluded on purpose: this workflow's concurrency group cancels superseded runs, and reporting those as breakage is how a notifier gets muted.
- Sticky by **title + marker, with no label**. The repo has no `ci` label and `issues.create` 422s on a label that doesn't exist — which would leave the notifier silently unable to notify, the exact failure it exists to prevent. I checked; it doesn't exist.
- The issue body carries the three things that actually cost time on #1963: read the **totals line** rather than only the `●` blocks; clear credentials CI lacks and make a control fail before trusting a green; and CI runs a different spec population (`PARTNER_UI=1`, :5173).

## Verification

- `replay-fx-fanout` spec: **17/17**, mutation-checked as above.
- Workflow YAML parsed and asserted (job graph, `needs`, `if`, and that no API call passes a label).
- Typecheck: **84 errors with and without** this change — control run on untouched `main` returns the same 84. (`check:prod-build` bundles `src/admin` without type-checking it, so it wouldn't catch a regression here either way.)
- 🔴 **The notifier's trigger path is not exercised.** It only fires on a real red `main` push, which I can't produce on demand. The script logic is reviewable but unrun — worth a skeptical read of the `if:` condition in particular.

## Not done here

The four INR-only prices still need the replay actually run against prod once this lands (`dry_run` first — it previews per source price which currencies would be added, with no writes and no FX calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp