### PR TITLE
feat(orders): ask whether to commission production when re-pointing a design (#1953)

### DIFF
--- a/apps/backend/src/admin/components/forms/design-order-items/edit-design-items-form.tsx
+++ b/apps/backend/src/admin/components/forms/design-order-items/edit-design-items-form.tsx
@@ -8,6 +8,7 @@ import {
   DataTableFilteringState,
   DataTablePaginationState,
   Heading,
+  Label,
   StatusBadge,
   Text,
   createDataTableColumnHelper,
@@ -293,6 +294,19 @@ export const EditDesignItemsForm = ({
    * the order yet so no server row carries its name.
    */
   const [stagedNames, setStagedNames] = useState<Record<string, string>>({})
+  /**
+   * #1953 — commission production for the lines this change moves.
+   *
+   * The API has accepted `production: { mode: "new" }` since #1955; nothing in
+   * the admin asked the question, so the only way to answer it was to call the
+   * route by hand. Off by default, matching the route's own default: making
+   * work is not a side effect of re-pointing a design.
+   *
+   * Request-level rather than per-line because that is the API's shape — "new"
+   * commissions one run per line the change actually MOVED. A detached line or
+   * a line that did not move gets none, and says why.
+   */
+  const [commissionRuns, setCommissionRuns] = useState(false)
 
   const orderId: string | null = designOrder?.order?.id ?? null
   const rows: OrderItemRow[] = designOrder?.order_items?.items ?? []
@@ -366,6 +380,7 @@ export const EditDesignItemsForm = ({
       const preview: any = await mutateAsync({
         order_id: orderId,
         changes: stagedEntries,
+        production: { mode: commissionRuns ? "new" : "none" },
         dry_run: true,
       })
       headline = preview?.notice?.headline ?? ""
@@ -390,6 +405,17 @@ export const EditDesignItemsForm = ({
           ? `⚠️ ${deliveredCount} of these ${deliveredCount === 1 ? "lines has" : "lines have"} already been DELIVERED — changing the design does not change what the customer received.`
           : "",
         "The order itself is not changed: price, quantity and totals stay as they are.",
+        /**
+         * Commissioning work is the one part of this dialog that is not
+         * reversible by re-pointing the line again, so it is stated plainly
+         * rather than left to the checkbox the operator ticked a moment ago.
+         * The preview cannot enumerate which lines get a run — a dry run
+         * returns `production_skipped_reason: "dry run"` for every line — so
+         * this says what WILL happen, not what did.
+         */
+        commissionRuns
+          ? `🏭 A production run will be commissioned for each line this change actually moves${deliveredCount ? ", which does not include lines that did not move" : ""}. Lines that already have an active run are skipped. Cancelling a run afterwards is a separate step.`
+          : "",
         headline ? `The customer will be told: “${headline}”` : "",
       ]
         .filter(Boolean)
@@ -405,14 +431,49 @@ export const EditDesignItemsForm = ({
       const res: any = await mutateAsync({
         order_id: orderId,
         changes: stagedEntries,
+        production: { mode: commissionRuns ? "new" : "none" },
       })
       setStaged({})
       setSelectedItem(null)
-      toast.success(
-        res?.email?.sent
-          ? `${stagedEntries.length === 1 ? "1 line" : `${stagedEntries.length} lines`} re-pointed. The customer has been told, once.`
-          : `${stagedEntries.length === 1 ? "1 line" : `${stagedEntries.length} lines`} re-pointed. No email was sent: ${res?.email?.reason ?? "unknown reason"}.`
+      setCommissionRuns(false)
+
+      const lines =
+        stagedEntries.length === 1 ? "1 line" : `${stagedEntries.length} lines`
+      const emailPart = res?.email?.sent
+        ? "The customer has been told, once."
+        : `No email was sent: ${res?.email?.reason ?? "unknown reason"}.`
+
+      /**
+       * Report what production actually did, per line, from the response —
+       * never from the fact that we asked. A run can be skipped for reasons
+       * only the server knows (the line did not move, it already has a run,
+       * creation failed), and each arrives as `production_skipped_reason`.
+       * Claiming "runs commissioned" because the box was ticked would be a
+       * confident nothing.
+       */
+      const items: any[] = Array.isArray(res?.items) ? res.items : []
+      const made = items.filter((i) => i?.production_run_id).length
+      const skipped = items.filter(
+        (i) => !i?.production_run_id && i?.production_skipped_reason
       )
+      let runPart = ""
+      if (commissionRuns) {
+        runPart =
+          made > 0
+            ? ` ${made === 1 ? "1 run" : `${made} runs`} commissioned.`
+            : " No run was commissioned."
+        if (skipped.length) {
+          // The first reason verbatim: with a handful of lines it is the whole
+          // story, and a count alone sends the operator to the network tab.
+          runPart += ` ${skipped.length} skipped (${skipped[0].production_skipped_reason}).`
+        }
+      }
+
+      if (commissionRuns && made === 0) {
+        toast.warning(`${lines} re-pointed.${runPart} ${emailPart}`)
+      } else {
+        toast.success(`${lines} re-pointed.${runPart} ${emailPart}`)
+      }
     } catch (e: any) {
       toast.error(e?.message ?? "Could not apply the design changes")
     }
@@ -575,6 +636,30 @@ export const EditDesignItemsForm = ({
                 : `${stagedEntries.length} changes staged — the customer will get one email.`}
             </Text>
           ) : null}
+          {/**
+            * #1953 — the question the API has been able to answer since #1955
+            * and nothing in the admin asked. Only shown once something is
+            * staged: with nothing to move there are no lines to commission work
+            * for, and an always-visible toggle would imply otherwise.
+            */}
+          {stagedEntries.length > 0 ? (
+            <div className="flex items-center gap-x-2">
+              <Checkbox
+                id="commission-runs"
+                checked={commissionRuns}
+                onCheckedChange={(value) => setCommissionRuns(Boolean(value))}
+                disabled={isPending}
+              />
+              <Label
+                htmlFor="commission-runs"
+                size="small"
+                weight="plus"
+                className="cursor-pointer"
+              >
+                Commission production
+              </Label>
+            </div>
+          ) : null}
           <Button
             size="small"
             variant="secondary"
@@ -582,6 +667,8 @@ export const EditDesignItemsForm = ({
             onClick={() => {
               setStaged({})
               setSelectedItem(null)
+              // The toggle belongs to the staged batch, not to the modal.
+              setCommissionRuns(false)
             }}
           >
             Discard

--- a/apps/backend/src/admin/hooks/api/__tests__/design-changes-body-forwards-vars.unit.spec.ts
+++ b/apps/backend/src/admin/hooks/api/__tests__/design-changes-body-forwards-vars.unit.spec.ts
@@ -1,0 +1,151 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * #1953 — a key named in a mutation's `vars` type but absent from its `body`
+ * literal is accepted by TypeScript and then silently dropped on the wire.
+ *
+ * `useChangeOrderDesigns` builds its request body as an explicit object
+ * literal, not a spread:
+ *
+ *     body: { changes: vars.changes, notify: vars.notify, dry_run: vars.dry_run }
+ *
+ * So adding `production` to the `vars` type alone compiles, type-checks, and
+ * sends nothing. The mutation resolves, the route applies its default
+ * (`mode: "none"`), and production is simply never asked for — a success
+ * response for work that was never requested. That is the same shape as the
+ * `weight` field that made freight unquotable for a third of the catalogue,
+ * and as `bulk_update_products` accepting a `prices` array and dropping it.
+ *
+ * This test reads the source and asserts every `vars` key is actually
+ * forwarded, so the next field added to the type cannot go missing quietly.
+ * It is deliberately source-analysis rather than a runtime mock: the defect is
+ * a field that is never referenced, and a mock can only observe calls that
+ * happen.
+ */
+
+const HOOK_FILE = path.join(__dirname, "..", "design-orders.ts");
+
+/** Index of the `}` matching the `{` at `open`, skipping string contents. */
+const matchBrace = (src: string, open: number): number => {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (quote) {
+      if (c === "\\") i++;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") quote = c;
+    else if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return i;
+  }
+  return -1;
+};
+
+/**
+ * Comments removed BEFORE any scanning.
+ *
+ * Learned the hard way writing this: an apostrophe in prose ("the route's
+ * default") opens a quote state the brace/segment scanner never closes, and
+ * every offset after it is wrong. A docblock is not code and must not be
+ * parsed as if it were.
+ */
+const stripComments = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+
+/**
+ * The source of one exported hook — from its declaration to the next
+ * `export const`, so sibling hooks in the same file cannot satisfy an
+ * assertion about this one.
+ */
+const hookSource = (src: string, name: string): string => {
+  const start = src.indexOf(`export const ${name} =`);
+  if (start === -1) {
+    throw new Error(`hook "${name}" not found — was it renamed?`);
+  }
+  const next = src.indexOf("\nexport const ", start + 1);
+  return src.slice(start, next === -1 ? src.length : next);
+};
+
+/** Top-level property names of the `vars: { ... }` parameter type. */
+const varsKeys = (hookSrc: string): string[] => {
+  const marker = "(vars: {";
+  const at = hookSrc.indexOf(marker);
+  if (at === -1) {
+    throw new Error("no `(vars: {` parameter found in hook source");
+  }
+  const open = at + marker.length - 1;
+  const close = matchBrace(hookSrc, open);
+  const body = hookSrc.slice(open + 1, close);
+
+  const keys: string[] = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let lineStart = 0;
+  const lines: string[] = [];
+  // Split on top-level `;` / newline boundaries, ignoring nested objects so
+  // that `production: { mode?: ... }` contributes `production`, not `mode`.
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (quote) {
+      if (c === "\\") i++;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") quote = c;
+    else if (c === "{" || c === "(" || c === "[") depth++;
+    else if (c === "}" || c === ")" || c === "]") depth--;
+    else if ((c === ";" || c === "\n") && depth === 0) {
+      lines.push(body.slice(lineStart, i));
+      lineStart = i + 1;
+    }
+  }
+  lines.push(body.slice(lineStart));
+
+  for (const raw of lines) {
+    // Input is already comment-free (see stripComments).
+    const line = raw.trim();
+    if (!line) continue;
+    const m = /^([A-Za-z_$][\w$]*)\s*\??\s*:/.exec(line);
+    if (m) keys.push(m[1]);
+  }
+  return keys;
+};
+
+describe("useChangeOrderDesigns — every vars key reaches the request", () => {
+  const src = fs.readFileSync(HOOK_FILE, "utf8");
+  const hook = stripComments(hookSource(src, "useChangeOrderDesigns"));
+
+  /**
+   * `order_id` is interpolated into the URL, not sent in the body, so it is
+   * forwarded by `vars.order_id` appearing in the path template — which the
+   * reference check below covers without needing an exception for where.
+   */
+  it("references every declared vars key as `vars.<key>`", () => {
+    const keys = varsKeys(hook);
+
+    // Guard the parser itself: if it silently returned [] this suite would
+    // pass while asserting nothing.
+    expect(keys).toContain("changes");
+    expect(keys).toContain("order_id");
+    expect(keys.length).toBeGreaterThanOrEqual(4);
+
+    const missing = keys.filter((k) => !hook.includes(`vars.${k}`));
+    expect(missing).toEqual([]);
+  });
+
+  it("forwards `production` in the body literal, not just in the type", () => {
+    // The specific key #1953 needs. Named explicitly so a rename of the
+    // generic check above cannot quietly stop covering it.
+    expect(varsKeys(hook)).toContain("production");
+    expect(hook).toMatch(/production:\s*vars\.production/);
+  });
+
+  it("still forwards the keys that were already working", () => {
+    expect(hook).toMatch(/changes:\s*vars\.changes/);
+    expect(hook).toMatch(/notify:\s*vars\.notify/);
+    expect(hook).toMatch(/dry_run:\s*vars\.dry_run/);
+  });
+});

--- a/apps/backend/src/admin/hooks/api/design-orders.ts
+++ b/apps/backend/src/admin/hooks/api/design-orders.ts
@@ -636,6 +636,21 @@ export const useChangeOrderDesigns = (
     mutationFn: async (vars: {
       order_id: string;
       changes: Array<{ line_item_id: string; design_id: string | null }>;
+      /**
+       * #1953 — what production should do about the change. `mode: "new"`
+       * commissions one run per line the change actually MOVES; "none" (the
+       * route's default) leaves production untouched.
+       *
+       * 🔴 This key has to be listed BOTH here and in the body below. The body
+       * is an explicit literal, not a spread, so a field named only in the
+       * type is accepted by TypeScript and then silently dropped on the way
+       * out — the request succeeds and production is simply never asked for.
+       */
+      production?: {
+        mode?: "none" | "new";
+        quantity?: number | null;
+        partner_id?: string | null;
+      };
       notify?: boolean;
       dry_run?: boolean;
     }) =>
@@ -643,6 +658,7 @@ export const useChangeOrderDesigns = (
         method: "POST",
         body: {
           changes: vars.changes,
+          production: vars.production,
           notify: vars.notify,
           dry_run: vars.dry_run,
         },


### PR DESCRIPTION
Closes the open UI step on #1953.

The API has accepted `production: { mode: "new" }` since #1955 — it commissions one run per line the change actually **moves**, stamped with `order_id` and `order_line_item_id`, which is the whole point of binding work at the moment of the edit rather than inferring it later. **Nothing in the admin asked the question**, so the only way to answer it was to call the route by hand. No operator could.

Your decision from #1953 is the one implemented: always **mint a new run**, never adopt an existing one.

## What changed

A **"Commission production"** checkbox in the Edit Items footer, shown only once something is staged — with nothing to move there are no lines to commission work for, and an always-visible toggle would imply otherwise. **Off by default**, matching the route's own default: making work is not a side effect of re-pointing a design. It resets on Discard and after a successful apply, because it belongs to the staged batch rather than to the modal.

Request-level rather than per-line, because that's the API's shape. A detached line, or one that didn't move, gets no run and says why.

## The hook was silently dropping the field

`useChangeOrderDesigns` builds its request body as an explicit object literal, not a spread. So naming `production` in the `vars` type alone **compiles, type-checks, and sends nothing** — the mutation resolves, the route applies `mode: "none"`, and production is never asked for. A success response for work that was never requested.

That's the same shape as `weight` missing from the variant tools (freight unquotable across a third of the catalogue) and `bulk_update_products` accepting a `prices` array and discarding it (#1966). So rather than just adding the key, this adds a **source-analysis spec** asserting every `vars` key is actually referenced as `vars.<key>` — which catches the *next* field too.

Worth noting how that spec went: it failed first on **its own parser**. An apostrophe in a docblock ("the route's default") opened a quote state the scanner never closed, so every offset after it was wrong. Comments are now stripped before any scanning, and the parser asserts it found the keys it expects so a silent `[]` can't read as a pass.

## Reporting what happened, not what was asked

The success toast reads results from the **response** — counts `production_run_id` per item, surfaces the first `production_skipped_reason` verbatim — and **warns** rather than succeeds when runs were requested and none were made. Claiming "runs commissioned" because the box was ticked would be a confident nothing.

The confirm dialog states plainly that work will be commissioned, since that's the one part of this flow not undone by re-pointing the line again.

## A server-side gap this exposes

The dialog says what *will* happen, not what *would*, because **a dry run can't tell us**: with `mode: "new"` and `dry_run: true`, every item comes back `production_skipped_reason: "dry run"`. So the preview cannot enumerate which lines would get a run, which is exactly what an operator would want to see before committing. Worth a follow-up on the workflow — it already knows which lines moved and which have an active run.

## Verification

- New spec **3/3**, **mutation-checked**: removing `production: vars.production` from the body turns 2 of 3 red; restored, green. The existing `mutation-option-order` spec (#1800) still passes.
- Typecheck: **84 errors with and without**, matching a control run on untouched `main`. I confirmed this tsconfig really does cover `src/admin` by injecting a deliberate type error and watching it get caught — `check:prod-build` bundles admin *without* type-checking it, so that assurance had to be earned rather than assumed.
- 🔴 **Not rendered in a browser.** No screenshot, no e2e spec. The checkbox, its disabled states, and the toast wording are unverified against a real modal. Given that every recent admin-UI defect here was invisible to reading and tests and visible on render, **this wants a render before merge.**

## Still open on #1953

- The design ↔ customer link on attach, deliberately not done silently — `/store/custom/designs/:id/checkout` refuses a design the customer doesn't own, so auto-linking a house design grants storefront access. That's a permission change and wants a decision.
- The change email still reports state as of before the change, and now omits that work has just been commissioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp