### PR TITLE
fix(payments): "Copy payment link" pointed at no host and no page (#1985)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -46,6 +46,28 @@ module.exports = defineConfig({
     }),
     disable: process.env.DISABLE_MEDUSA_ADMIN === "true",
     backendUrl: process.env.MEDUSA_BACKEND_URL,
+    /**
+     * Where the admin's "Copy payment link" button points (#1985).
+     *
+     * ⚠️ This is baked into the admin bundle at BUILD time and has exactly ONE
+     * consumer in the dashboard — `copy-payment-link.tsx`, which builds
+     * `${storefrontUrl}/payment-collection/:id?order_id=:order`.
+     *
+     * It is deliberately the BACKEND, not a storefront. Our storefront is
+     * multi-tenant (the house shop and partner shops are different apps on
+     * different domains) and a single build-time constant could only ever name
+     * one of them. `/payment-collection/:id` on this backend forwards to the
+     * hosted Stripe page, which resolves each collection's own partner routing.
+     *
+     * 🔴 Left unset, `@medusajs/admin-bundler` defines it as `""` — and the
+     * dashboard's `__STOREFRONT_URL__ ?? "http://localhost:8000"` does NOT
+     * catch an empty string, so the button copied a link with no host at all.
+     * `||` rather than `??` here for the same reason.
+     */
+    storefrontUrl:
+      process.env.MEDUSA_STOREFRONT_URL ||
+      process.env.MEDUSA_BACKEND_URL ||
+      "https://v3.jaalyantra.com",
     
   },
   featureFlags: {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -48,6 +48,28 @@ module.exports = defineConfig({
   },
 
   admin: {
+    /**
+     * Where the admin's "Copy payment link" button points (#1985).
+     *
+     * ⚠️ This is baked into the admin bundle at BUILD time and has exactly ONE
+     * consumer in the dashboard — `copy-payment-link.tsx`, which builds
+     * `${storefrontUrl}/payment-collection/:id?order_id=:order`.
+     *
+     * It is deliberately the BACKEND, not a storefront. Our storefront is
+     * multi-tenant (the house shop and partner shops are different apps on
+     * different domains) and a single build-time constant could only ever name
+     * one of them. `/payment-collection/:id` on this backend forwards to the
+     * hosted Stripe page, which resolves each collection's own partner routing.
+     *
+     * 🔴 Left unset, `@medusajs/admin-bundler` defines it as `""` — and the
+     * dashboard's `__STOREFRONT_URL__ ?? "http://localhost:8000"` does NOT
+     * catch an empty string, so the button copied a link with no host at all.
+     * `||` rather than `??` here for the same reason.
+     */
+    storefrontUrl:
+      process.env.MEDUSA_STOREFRONT_URL ||
+      process.env.MEDUSA_BACKEND_URL ||
+      "https://v3.jaalyantra.com",
     vite: () => ({
       resolve: {
         alias: {

--- a/apps/backend/src/api/payment-collection/[id]/route.ts
+++ b/apps/backend/src/api/payment-collection/[id]/route.ts
@@ -1,0 +1,55 @@
+/**
+ * GET /payment-collection/:id — the URL the admin's "Copy payment link" button
+ * builds (#1985).
+ *
+ * The button is core dashboard code we do not own:
+ *
+ *   `${MEDUSA_STOREFRONT_URL}/payment-collection/${collection.id}?order_id=${order.id}`
+ *
+ * We cannot change the shape of that string, only where it points. Setting
+ * `admin.storefrontUrl` to this backend makes the copied link land here, and
+ * this route forwards to the hosted Stripe page that actually collects the
+ * money. That keeps the fix to one config value plus one redirect, with no
+ * patched dashboard component and no page duplicated across two storefront
+ * apps.
+ *
+ * `order_id` rides along in the query string and is deliberately ignored: the
+ * collection id alone identifies what is owed, and trusting an order id from a
+ * URL would let one link ask about another order's money.
+ *
+ * A 302 rather than rendering here, so there is exactly ONE payment page to
+ * maintain and the buyer's address bar shows the page they are actually on.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+/**
+ * PURE: the hosted page a collection link forwards to.
+ *
+ * Rejects anything that is not a plain id — the value arrives from a URL, and a
+ * path segment is being built from it. Returns null when it is unusable so the
+ * caller 404s instead of emitting a `Location` header an attacker chose.
+ * Exported for unit testing.
+ */
+export function collectionPayPath(id: unknown): string | null {
+  const raw = typeof id === "string" ? id.trim() : ""
+  if (!raw || !/^[A-Za-z0-9_-]{1,128}$/.test(raw)) {
+    return null
+  }
+  return `/stripe/pay/collection/${raw}`
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const path = collectionPayPath(req.params.id)
+
+  if (!path) {
+    res.status(404)
+    res.setHeader("Content-Type", "text/html; charset=utf-8")
+    res.send(
+      "<!doctype html><meta charset=utf-8><title>Payment link</title>" +
+        "<p>This payment link is not valid.</p>"
+    )
+    return
+  }
+
+  res.redirect(302, path)
+}

--- a/apps/backend/src/api/stripe/pay/collection/[id]/route.ts
+++ b/apps/backend/src/api/stripe/pay/collection/[id]/route.ts
@@ -1,0 +1,153 @@
+/**
+ * GET /stripe/pay/collection/:id — the buyer's page for an OUTSTANDING payment
+ * collection (#1985).
+ *
+ * `:id` is the PAYMENT COLLECTION id. This is the rail for money raised by an
+ * order EDIT: adding or re-pointing items leaves the order owing a difference,
+ * and core records that as a second, non-completed payment collection.
+ *
+ * ## Why this route exists
+ *
+ * The admin's "Copy payment link" button builds
+ * `${storefrontUrl}/payment-collection/:id?order_id=:order` and hands it to the
+ * operator. Two things were wrong with that: `storefrontUrl` was never
+ * configured (so the copied string had no host at all), and no storefront
+ * implements that page — in EITHER of our two storefront apps. Pointing the
+ * button at the backend instead means ONE implementation rather than two, on
+ * the same hosted-Stripe rail the deposit and the balance already use and that
+ * is already proven in production.
+ *
+ * It also stays correct for every tenant. The storefront is multi-tenant — the
+ * house shop and partner shops are different apps on different domains — but
+ * `storefrontUrl` is a single value baked into the admin bundle at BUILD time,
+ * so it could only ever have named one of them. The backend is single, and this
+ * page resolves the partner's Stripe Connect routing per collection.
+ *
+ * ## Unlike `stripe/pay/balance/:id`
+ *
+ * The balance page's session is minted by `request-order-balance` before the
+ * link is sent. Nothing mints one for an order edit, so this page creates it on
+ * demand — see `ensureStripeSessionForCollection`.
+ *
+ * Public, like the deposit's page, the balance page and a PayU link: the buyer
+ * opens it directly and the unguessable ULID is the credential.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  buildStripePaymentPageHtml,
+  clientSecretOf,
+  formatAmount,
+} from "../../../lib/payment-page"
+import {
+  ensureStripeSessionForCollection,
+  isCollectionSettled,
+} from "../../../../../lib/payments/ensure-stripe-session"
+
+// Allow Stripe.js + our inline bootstrap; keep everything else self-only.
+// Identical to the cart and balance pages — the three must not drift, or one
+// of them silently stops loading Stripe.
+const STRIPE_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://js.stripe.com",
+  "style-src 'self' 'unsafe-inline'",
+  "frame-src https://js.stripe.com https://hooks.stripe.com",
+  "connect-src 'self' https://api.stripe.com",
+  "img-src 'self' data:",
+].join("; ")
+
+const sendHtml = (res: MedusaResponse, status: number, html: string) => {
+  res.status(status)
+  res.setHeader("Content-Type", "text/html; charset=utf-8")
+  res.setHeader("Content-Security-Policy", STRIPE_CSP)
+  res.send(html)
+}
+
+/** The public origin this page is served from, for Stripe's return_url. */
+export const backendOrigin = (): string =>
+  (process.env.MEDUSA_BACKEND_URL || "https://v3.jaalyantra.com").replace(
+    /\/+$/,
+    ""
+  )
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const collectionId = req.params.id
+
+  const { collection, session } = await ensureStripeSessionForCollection(
+    req.scope,
+    collectionId
+  )
+
+  if (!collection) {
+    return sendHtml(
+      res,
+      404,
+      buildStripePaymentPageHtml({
+        state: "unavailable",
+        title: "Payment link",
+        message: "This payment link is not valid.",
+      })
+    )
+  }
+
+  /**
+   * Paid is a first-class page, not a 404 — the same rule the balance page
+   * follows. A buyer who pays and then reopens the link must be told the money
+   * arrived, not shown an error that makes them wonder whether it did.
+   */
+  if (isCollectionSettled(collection)) {
+    return sendHtml(
+      res,
+      200,
+      buildStripePaymentPageHtml({
+        state: "paid",
+        title: "Payment received",
+        message:
+          "This payment has already been made. You can close this window.",
+      })
+    )
+  }
+
+  const clientSecret = clientSecretOf(session)
+  const publishableKey =
+    process.env.STRIPE_PUBLISHABLE_KEY ||
+    process.env.NEXT_PUBLIC_STRIPE_KEY ||
+    null
+
+  if (!clientSecret || !publishableKey) {
+    // Deliberately specific in the log and vague on the page: the buyer cannot
+    // act on "no client secret", and the operator cannot act on "unavailable".
+    logger?.error?.(
+      `[pay-collection] cannot render collection=${collectionId} ` +
+        `client_secret=${clientSecret ? "yes" : "no"} ` +
+        `pk=${publishableKey ? "yes" : "no"}`
+    )
+    return sendHtml(
+      res,
+      200,
+      buildStripePaymentPageHtml({
+        state: "unavailable",
+        title: "Payment link",
+        message:
+          "This payment link cannot be opened just now. Please contact us and we will send a new one.",
+      })
+    )
+  }
+
+  return sendHtml(
+    res,
+    200,
+    buildStripePaymentPageHtml({
+      state: "pay",
+      publishableKey,
+      clientSecret,
+      amountLabel: formatAmount(collection.amount, collection.currency_code),
+      title: "Complete your payment",
+      // Back to this same page: on return it re-reads the collection and, if
+      // the money landed, renders the paid state instead of the form.
+      returnUrl: `${backendOrigin()}/stripe/pay/collection/${collectionId}`,
+    })
+  )
+}

--- a/apps/backend/src/lib/payments/__tests__/ensure-stripe-session.unit.spec.ts
+++ b/apps/backend/src/lib/payments/__tests__/ensure-stripe-session.unit.spec.ts
@@ -1,5 +1,7 @@
 import {
   isCollectionSettled,
+  pickStripeProviderId,
+  stripeProviderCandidates,
   pickStripeSession,
 } from "../ensure-stripe-session"
 import { collectionPayPath } from "../../../api/payment-collection/[id]/route"
@@ -131,6 +133,77 @@ describe("isCollectionSettled", () => {
   it("survives a missing or malformed collection", () => {
     expect(isCollectionSettled(undefined)).toBe(false)
     expect(isCollectionSettled({})).toBe(false)
+  })
+})
+
+describe("pickStripeProviderId", () => {
+  const STANDARD = "pp_stripe_stripe"
+  const CONNECT = "pp_stripe-connect_stripe-connect"
+  const SYSTEM = "pp_system_default"
+
+  /**
+   * 🔴 The regression that caught this. The live India Region enables ONLY the
+   * Connect provider — no `pp_stripe_stripe` at all. Asking for the standard id
+   * unconditionally made `createPaymentSessionsWorkflow` throw
+   * "Payment provider pp_stripe_stripe is not enabled in the cart's region",
+   * so the page could NEVER mint a session for a partner storefront's order.
+   * Measured, not imagined.
+   */
+  it("uses the Connect provider when it is the only Stripe one enabled", () => {
+    expect(pickStripeProviderId([SYSTEM, CONNECT], false)).toBe(CONNECT)
+  })
+
+  it("uses the standard provider when it is the only Stripe one enabled", () => {
+    expect(pickStripeProviderId([SYSTEM, STANDARD], true)).toBe(STANDARD)
+  })
+
+  /**
+   * Both enabled is the live Europe region on prod — the one
+   * `order_01KNP520PT94BN8SC0JKZ6ZVJ9` sits in. Here the partner's Connect
+   * status decides, matching `dedupeStripeProviders` so a buyer is charged
+   * through the same provider whichever door they came in by.
+   */
+  it("prefers Connect for a connected partner when both are enabled", () => {
+    expect(pickStripeProviderId([SYSTEM, STANDARD, CONNECT], true)).toBe(CONNECT)
+  })
+
+  it("prefers standard for an unconnected partner when both are enabled", () => {
+    expect(pickStripeProviderId([SYSTEM, STANDARD, CONNECT], false)).toBe(
+      STANDARD
+    )
+  })
+
+  it("returns null when the region enables no Stripe provider", () => {
+    expect(pickStripeProviderId([SYSTEM], true)).toBeNull()
+    expect(pickStripeProviderId([], false)).toBeNull()
+  })
+
+  it("survives a missing or ragged provider list", () => {
+    expect(pickStripeProviderId(undefined as any, false)).toBeNull()
+    expect(pickStripeProviderId([null, undefined], false)).toBeNull()
+    expect(pickStripeProviderId([null, CONNECT], false)).toBe(CONNECT)
+  })
+
+  /**
+   * The fallback order. A region can ENABLE a provider the container does not
+   * REGISTER — measured locally, where Connect is enabled on the India region
+   * but resolves to "Unable to retrieve the payment provider with id". The
+   * caller tries these in order, so the SECOND entry is what rescues a buyer
+   * from an unavailable payment page.
+   */
+  it("offers the other Stripe provider as a fallback, preferred first", () => {
+    expect(stripeProviderCandidates([SYSTEM, STANDARD, CONNECT], true)).toEqual([
+      CONNECT,
+      STANDARD,
+    ])
+    expect(stripeProviderCandidates([SYSTEM, STANDARD, CONNECT], false)).toEqual(
+      [STANDARD, CONNECT]
+    )
+  })
+
+  it("never offers a non-Stripe provider as a fallback", () => {
+    expect(stripeProviderCandidates([SYSTEM, CONNECT], false)).toEqual([CONNECT])
+    expect(stripeProviderCandidates([SYSTEM], false)).toEqual([])
   })
 })
 

--- a/apps/backend/src/lib/payments/__tests__/ensure-stripe-session.unit.spec.ts
+++ b/apps/backend/src/lib/payments/__tests__/ensure-stripe-session.unit.spec.ts
@@ -1,0 +1,174 @@
+import {
+  isCollectionSettled,
+  pickStripeSession,
+} from "../ensure-stripe-session"
+import { collectionPayPath } from "../../../api/payment-collection/[id]/route"
+
+/**
+ * The collection an order EDIT leaves behind (#1985). Figures are the live EUR
+ * order that exposed the gap: `order_01KNP520PT94BN8SC0JKZ6ZVJ9` was edited
+ * onto five rebuilt products, leaving `pay_col_01M25NHFRS498JEP8PY4CNS8DC` at
+ * €174.97, `not_paid`, with NO payment sessions at all — so "Copy payment link"
+ * had nothing to link to.
+ */
+const EDIT_COLLECTION = {
+  id: "pay_col_01M25NHFRS498JEP8PY4CNS8DC",
+  amount: 174.97,
+  status: "not_paid",
+  currency_code: "eur",
+  payment_sessions: [],
+  payments: [],
+}
+
+/** The order's ORIGINAL collection: €335.39, paid through Stripe. */
+const PAID_COLLECTION = {
+  id: "pay_col_01KNATK6D6ASRP2GEZ81ZVFWS8",
+  amount: 335.39,
+  status: "completed",
+  currency_code: "eur",
+  payment_sessions: [
+    {
+      id: "payses_01KNBJ3JMB0HMS6PSCZ4CXKKF9",
+      provider_id: "pp_stripe_stripe",
+      status: "authorized",
+      data: { client_secret: "pi_123_secret_abc" },
+    },
+  ],
+  payments: [
+    {
+      id: "pay_01KNP522S2H9B790VQSJA01098",
+      amount: 335.39,
+      captured_at: "2026-04-08T08:59:01.731Z",
+    },
+  ],
+}
+
+describe("pickStripeSession", () => {
+  it("returns null when the collection has no sessions at all", () => {
+    // The live order-edit case: nothing mints a session, so there is no
+    // client_secret and nothing for a buyer to pay against.
+    expect(pickStripeSession(EDIT_COLLECTION)).toBeNull()
+  })
+
+  it("finds the standard Stripe session", () => {
+    expect(pickStripeSession(PAID_COLLECTION)?.id).toBe(
+      "payses_01KNBJ3JMB0HMS6PSCZ4CXKKF9"
+    )
+  })
+
+  /**
+   * 🔴 The regression this guards. A Connect-routed session does NOT carry
+   * `pp_stripe_stripe` — it is `pp_stripe-connect_stripe-connect`. An exact-id
+   * match would miss it, report "no session", and mint a SECOND PaymentIntent
+   * for money the buyer may already be part-way through paying.
+   */
+  it("finds a Stripe CONNECT session, whose provider id differs", () => {
+    const connect = {
+      payment_sessions: [
+        {
+          id: "payses_connect",
+          provider_id: "pp_stripe-connect_stripe-connect",
+          data: { client_secret: "pi_c_secret" },
+        },
+      ],
+    }
+    expect(pickStripeSession(connect)?.id).toBe("payses_connect")
+  })
+
+  it("ignores a non-Stripe session", () => {
+    const payu = {
+      payment_sessions: [{ id: "payses_payu", provider_id: "pp_payu_payu" }],
+    }
+    expect(pickStripeSession(payu)).toBeNull()
+  })
+
+  it("survives a missing or malformed collection", () => {
+    expect(pickStripeSession(undefined)).toBeNull()
+    expect(pickStripeSession({})).toBeNull()
+    expect(pickStripeSession({ payment_sessions: [{}] })).toBeNull()
+  })
+})
+
+describe("isCollectionSettled", () => {
+  it("is false for the outstanding edit collection", () => {
+    expect(isCollectionSettled(EDIT_COLLECTION)).toBe(false)
+  })
+
+  it("is true for a completed collection", () => {
+    expect(isCollectionSettled(PAID_COLLECTION)).toBe(true)
+  })
+
+  it.each(["completed", "authorized", "paid"])(
+    "treats status %s as settled",
+    (status) => {
+      expect(isCollectionSettled({ status, payments: [] })).toBe(true)
+    }
+  )
+
+  /**
+   * The webhook window: Stripe has captured and the payment row records it,
+   * but the collection status has not caught up. Showing the payment form here
+   * would invite a second charge.
+   */
+  it("is true when a payment is captured even if status lags", () => {
+    expect(
+      isCollectionSettled({
+        status: "not_paid",
+        payments: [{ id: "pay_1", captured_at: "2026-09-10T12:00:00.000Z" }],
+      })
+    ).toBe(true)
+  })
+
+  it("is false when a payment row exists but nothing captured", () => {
+    expect(
+      isCollectionSettled({
+        status: "not_paid",
+        payments: [{ id: "pay_1", captured_at: null }],
+      })
+    ).toBe(false)
+  })
+
+  it("survives a missing or malformed collection", () => {
+    expect(isCollectionSettled(undefined)).toBe(false)
+    expect(isCollectionSettled({})).toBe(false)
+  })
+})
+
+describe("collectionPayPath", () => {
+  it("forwards a real collection id to the hosted page", () => {
+    expect(collectionPayPath("pay_col_01M25NHFRS498JEP8PY4CNS8DC")).toBe(
+      "/stripe/pay/collection/pay_col_01M25NHFRS498JEP8PY4CNS8DC"
+    )
+  })
+
+  /**
+   * 🔴 The id arrives from a URL and a `Location` header is built from it.
+   * Anything that could steer the redirect elsewhere must be refused, not
+   * escaped — a rejected link 404s, which is recoverable; an open redirect on
+   * a payment page is not.
+   */
+  it.each([
+    ["a protocol-relative host", "//evil.example.com"],
+    ["an absolute URL", "https://evil.example.com"],
+    ["a path traversal", "../../admin/users"],
+    ["a nested path", "abc/def"],
+    ["a CRLF header injection", "abc\r\nLocation: https://evil.example.com"],
+    ["an empty string", ""],
+    ["whitespace only", "   "],
+  ])("refuses %s", (_label, id) => {
+    expect(collectionPayPath(id)).toBeNull()
+  })
+
+  it("refuses a non-string id", () => {
+    expect(collectionPayPath(undefined)).toBeNull()
+    expect(collectionPayPath(null)).toBeNull()
+    expect(collectionPayPath(123 as any)).toBeNull()
+  })
+
+  it("refuses an absurdly long id rather than emitting it", () => {
+    expect(collectionPayPath("a".repeat(129))).toBeNull()
+    expect(collectionPayPath("a".repeat(128))).toBe(
+      `/stripe/pay/collection/${"a".repeat(128)}`
+    )
+  })
+})

--- a/apps/backend/src/lib/payments/ensure-stripe-session.ts
+++ b/apps/backend/src/lib/payments/ensure-stripe-session.ts
@@ -50,12 +50,56 @@ import { createPaymentSessionsWorkflow } from "@medusajs/core-flows"
 import {
   resolvePartnerConnect,
   connectContext,
+  resolvePartnerConnectedByRegion,
+  CONNECT_CHECKOUT_PROVIDER_ID,
 } from "../../modules/stripe-connect-payment/lib/resolve-connect"
 import { resolveSalesChannelForCollection } from "../../modules/payu-payment/lib/resolve-partner-creds"
 import { resolveCollectionPaymentContext } from "./resolve-collection-customer"
 
 /** The Medusa Stripe provider id. */
 export const STRIPE_PROVIDER_ID = "pp_stripe_stripe"
+
+/**
+ * PURE: which Stripe provider to open a session with, given the providers the
+ * ORDER'S REGION actually has enabled.
+ *
+ * 🔴 Asking for `pp_stripe_stripe` unconditionally is wrong and fails loudly:
+ * `createPaymentSessionsWorkflow` throws "Payment provider pp_stripe_stripe is
+ * not enabled in the cart's region <id>". Measured against a real region that
+ * has ONLY `pp_stripe-connect_stripe-connect` enabled — which is the ordinary
+ * shape for a partner storefront, since `/store/payment-providers` hands an
+ * onboarded partner the Connect provider (#985).
+ *
+ * Follows the same rule as `dedupeStripeProviders`, deliberately: a buyer must
+ * be charged through the same provider whichever door they came in by. The
+ * preferred provider is only chosen when it is actually enabled, so a region
+ * carrying just one of the two is never left with nothing.
+ *
+ * Returns null when the region enables no Stripe provider at all — the caller
+ * then renders "unavailable" rather than throwing.
+ */
+export function stripeProviderCandidates(
+  regionProviderIds: Array<string | null | undefined>,
+  connected: boolean
+): string[] {
+  const stripe = (regionProviderIds ?? []).filter((id): id is string =>
+    String(id ?? "").includes("stripe")
+  )
+  if (!stripe.length) return []
+
+  const preferred = connected ? CONNECT_CHECKOUT_PROVIDER_ID : STRIPE_PROVIDER_ID
+  const first = stripe.filter((id) => id === preferred)
+  const rest = stripe.filter((id) => id !== preferred)
+  return [...first, ...rest]
+}
+
+/** The provider to try first. Thin wrapper over `stripeProviderCandidates`. */
+export function pickStripeProviderId(
+  regionProviderIds: Array<string | null | undefined>,
+  connected: boolean
+): string | null {
+  return stripeProviderCandidates(regionProviderIds, connected)[0] ?? null
+}
 
 /** Fields a payment page needs off a collection. Shared so the read that
  *  decides "already paid" and the read that renders cannot disagree. */
@@ -129,6 +173,103 @@ export async function readCollectionForPage(
 }
 
 /**
+ * The order behind a payment collection, with the routing facts a session needs.
+ *
+ * 🔴 An order-EDIT collection has NO CART. `resolveSalesChannelForCollection`
+ * walks `cart_payment_collection` → cart, which is the right path for a
+ * checkout and returns nothing here — so the partner routing and the region
+ * both have to come from the ORDER instead. Reading only the cart link is why
+ * this silently lost the region, and the region is what decides which Stripe
+ * provider may be used at all.
+ *
+ * Returns empty fields rather than throwing; every caller degrades.
+ */
+export async function resolveCollectionOrderRouting(
+  scope: any,
+  collectionId: string
+): Promise<{
+  orderId?: string
+  regionId?: string
+  salesChannelId?: string
+  regionProviderIds: string[]
+}> {
+  const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const empty = { regionProviderIds: [] as string[] }
+
+  const { data: links } = await query
+    .graph({
+      entity: "order_payment_collection",
+      filters: { payment_collection_id: collectionId },
+      fields: ["order_id"],
+    })
+    .catch(() => ({ data: [] }))
+
+  const orderId = links?.[0]?.order_id
+
+  /**
+   * Order first, then cart. A collection raised by an EDIT hangs off the order;
+   * one raised at CHECKOUT hangs off the cart. Both carry a region, and it is
+   * the region — not the collection — that decides which providers may be used,
+   * so whichever link exists has to be followed.
+   */
+  let holder: any = null
+  if (orderId) {
+    const { data } = await query
+      .graph({
+        entity: "order",
+        filters: { id: orderId },
+        fields: ["id", "region_id", "sales_channel_id"],
+      })
+      .catch(() => ({ data: [] }))
+    holder = data?.[0] ?? null
+  }
+
+  if (!holder) {
+    const { data: cartLinks } = await query
+      .graph({
+        entity: "cart_payment_collection",
+        filters: { payment_collection_id: collectionId },
+        fields: ["cart_id"],
+      })
+      .catch(() => ({ data: [] }))
+    const cartId = cartLinks?.[0]?.cart_id
+    if (cartId) {
+      const { data } = await query
+        .graph({
+          entity: "cart",
+          filters: { id: cartId },
+          fields: ["id", "region_id", "sales_channel_id"],
+        })
+        .catch(() => ({ data: [] }))
+      holder = data?.[0] ?? null
+    }
+  }
+
+  if (!holder?.region_id) {
+    return { ...(orderId ? { orderId } : {}), regionProviderIds: [] }
+  }
+
+  const { data: regions } = await query
+    .graph({
+      entity: "region",
+      filters: { id: holder.region_id },
+      fields: ["id", "payment_providers.id"],
+    })
+    .catch(() => ({ data: [] }))
+
+  const regionProviderIds = ((regions?.[0]?.payment_providers ?? []) as any[])
+    .map((p) => p?.id)
+    .filter((id): id is string => typeof id === "string")
+
+  return {
+    ...(orderId ? { orderId } : {}),
+    regionId: holder.region_id ?? undefined,
+    salesChannelId: holder.sales_channel_id ?? undefined,
+    regionProviderIds,
+  }
+}
+
+/**
  * Give `collectionId` a Stripe session if it has none, and return the
  * collection re-read afterwards.
  *
@@ -162,16 +303,47 @@ export async function ensureStripeSessionForCollection(
     return { collection, session: null, created: false }
   }
 
-  const salesChannelId = await resolveSalesChannelForCollection(
+  const routing = await resolveCollectionOrderRouting(
     scope,
     collectionId
-  ).catch(() => undefined)
+  ).catch(() => ({ regionProviderIds: [] as string[] }) as any)
+
+  // Cart link first (a checkout collection), then the order (an edit's).
+  const salesChannelId =
+    (await resolveSalesChannelForCollection(scope, collectionId).catch(
+      () => undefined
+    )) ?? routing.salesChannelId
 
   const connect = await resolvePartnerConnect(
     scope,
     salesChannelId,
     Number(process.env.STRIPE_CONNECT_DEFAULT_FEE_PERCENT) || 0
   ).catch(() => null)
+
+  /**
+   * Whether to prefer the Connect provider. `resolvePartnerConnect` answers it
+   * for a sales channel; an order edit may have neither cart nor channel, so
+   * the region's own partner link is the fallback — the same signal
+   * `/store/payment-providers` uses to decide what the buyer is offered.
+   */
+  const connected =
+    !!connect ||
+    (await resolvePartnerConnectedByRegion(scope, routing.regionId).catch(
+      () => false
+    ))
+
+  const candidates = stripeProviderCandidates(
+    routing.regionProviderIds,
+    connected
+  )
+  if (!candidates.length) {
+    logger?.error?.(
+      `[pay-collection] no Stripe provider enabled for collection=${collectionId} ` +
+        `region=${routing.regionId ?? "unknown"} ` +
+        `providers=[${routing.regionProviderIds.join(",") || "none"}]`
+    )
+    return { collection, session: null, created: false }
+  }
 
   const context = {
     ...(salesChannelId ? { sales_channel_id: salesChannelId } : {}),
@@ -183,20 +355,43 @@ export async function ensureStripeSessionForCollection(
     collectionId
   ).catch(() => ({ customer_id: undefined }) as any)
 
-  try {
-    await createPaymentSessionsWorkflow(scope).run({
-      input: {
-        payment_collection_id: collectionId,
-        provider_id: STRIPE_PROVIDER_ID,
-        ...(customer_id ? { customer_id } : {}),
-        ...(Object.keys(context).length ? { context } : {}),
-      },
-    })
-  } catch (e: any) {
+  /**
+   * Try each enabled Stripe provider, preferred first.
+   *
+   * 🔴 A region can ENABLE a provider the container does not REGISTER — proven
+   * locally, where the India region enables `pp_stripe-connect_stripe-connect`
+   * and the module resolves to "Unable to retrieve the payment provider with
+   * id". Region config and module registration are edited in different places
+   * and drift. On a page a buyer has opened to pay us, falling through to the
+   * other Stripe provider is worth far more than being right about which one
+   * "should" have worked.
+   */
+  let minted = false
+  let lastError: string | null = null
+  for (const providerId of candidates) {
+    try {
+      await createPaymentSessionsWorkflow(scope).run({
+        input: {
+          payment_collection_id: collectionId,
+          provider_id: providerId,
+          ...(customer_id ? { customer_id } : {}),
+          ...(Object.keys(context).length ? { context } : {}),
+        },
+      })
+      minted = true
+      break
+    } catch (e: any) {
+      lastError = e?.message ?? String(e)
+      logger?.warn?.(
+        `[pay-collection] provider ${providerId} failed for ${collectionId}: ${lastError}`
+      )
+    }
+  }
+
+  if (!minted) {
     logger?.error?.(
-      `[pay-collection] session creation failed for ${collectionId}: ${
-        e?.message ?? e
-      }`
+      `[pay-collection] session creation failed for ${collectionId} after trying ` +
+        `[${candidates.join(",")}]: ${lastError}`
     )
     return { collection, session: null, created: false }
   }

--- a/apps/backend/src/lib/payments/ensure-stripe-session.ts
+++ b/apps/backend/src/lib/payments/ensure-stripe-session.ts
@@ -1,0 +1,212 @@
+/**
+ * Ensure a payment collection has a usable Stripe session (#1985).
+ *
+ * An order EDIT that raises the total creates a second payment collection with
+ * an outstanding amount and **no payment sessions at all** — nothing in the
+ * order-edit flow mints one. Until something does, there is no `client_secret`,
+ * so there is nothing for a buyer to pay against and nothing for a payment page
+ * to render.
+ *
+ * The deposit and the balance each already have a rail that ends in a hosted
+ * Stripe page; both get their session from a workflow that runs BEFORE the page
+ * is opened. An edit has no such workflow, so the page has to be able to mint
+ * one on demand — which is what this does.
+ *
+ * ## Why not a Stripe Payment Link
+ *
+ * The same reason `stripe/pay/balance` gives: a Payment Link's charge arrives as
+ * an object with no payment collection, no order association and nothing for the
+ * admin to capture or reconcile against. Mounting the Payment Element on the
+ * collection's OWN Medusa session keeps the money in the records the order
+ * already uses, so `paid_total` moves by itself.
+ *
+ * ## Partner routing
+ *
+ * Resolved here rather than in the provider: payment providers run in an
+ * isolated module container and cannot resolve a partner themselves. This
+ * mirrors the store route
+ * (`/store/payment-collections/:id/payment-sessions`) — the two must agree,
+ * because a buyer can reach the same collection through either.
+ *
+ * Best-effort, exactly as that route is: no partner / no active config → empty
+ * context → the provider keeps its platform behaviour.
+ *
+ * ## 🔴 The mint can fail on DATA, not code
+ *
+ * `createPaymentSessionsWorkflow` throws
+ * `Payment provider pp_stripe_stripe is not enabled in the cart's region <id>`
+ * when the order's region has no Stripe provider attached. Measured locally
+ * against a real collection. That is an operator condition, not a bug, and the
+ * page must degrade to "cannot be opened just now" rather than 500 — so the
+ * reason is logged precisely and the buyer is told something they can act on.
+ *
+ * A collection whose order already carries an authorised Stripe session is
+ * proof the region is configured, which is the common case for an order edit:
+ * the deposit went through the same region minutes or weeks earlier.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createPaymentSessionsWorkflow } from "@medusajs/core-flows"
+
+import {
+  resolvePartnerConnect,
+  connectContext,
+} from "../../modules/stripe-connect-payment/lib/resolve-connect"
+import { resolveSalesChannelForCollection } from "../../modules/payu-payment/lib/resolve-partner-creds"
+import { resolveCollectionPaymentContext } from "./resolve-collection-customer"
+
+/** The Medusa Stripe provider id. */
+export const STRIPE_PROVIDER_ID = "pp_stripe_stripe"
+
+/** Fields a payment page needs off a collection. Shared so the read that
+ *  decides "already paid" and the read that renders cannot disagree. */
+export const COLLECTION_PAGE_FIELDS = [
+  "id",
+  "amount",
+  "status",
+  "currency_code",
+  "payment_sessions.id",
+  "payment_sessions.provider_id",
+  "payment_sessions.status",
+  "payment_sessions.data",
+  "payments.id",
+  "payments.amount",
+  "payments.captured_at",
+]
+
+/**
+ * PURE: the Stripe session on a collection, or null.
+ *
+ * Matches on `provider_id` CONTAINING "stripe" rather than equalling the
+ * default id — a Connect-routed session carries a different provider id, and
+ * an exact match would silently miss it and mint a duplicate session.
+ * Exported for unit testing.
+ */
+export function pickStripeSession(collection: any): any | null {
+  const sessions = (collection?.payment_sessions ?? []) as any[]
+  return (
+    sessions.find((s) => String(s?.provider_id ?? "").includes("stripe")) ?? null
+  )
+}
+
+/**
+ * PURE: is there nothing left to pay on this collection?
+ *
+ * `status` is the primary signal; a captured payment is the backstop for the
+ * window where a webhook has recorded the money but the collection status has
+ * not caught up. Either one means "paid" — a buyer must never be shown a
+ * payment form for money they have already sent.
+ *
+ * Exported for unit testing.
+ */
+export function isCollectionSettled(collection: any): boolean {
+  const status = String(collection?.status ?? "")
+  if (status === "completed" || status === "authorized" || status === "paid") {
+    return true
+  }
+  return ((collection?.payments ?? []) as any[]).some((p) => !!p?.captured_at)
+}
+
+/**
+ * Read a payment collection with everything a page needs.
+ * Returns null when it does not exist — the caller renders "not a valid link"
+ * rather than throwing, because the id in the URL comes from a buyer.
+ */
+export async function readCollectionForPage(
+  scope: any,
+  collectionId: string
+): Promise<any | null> {
+  const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+  try {
+    const { data } = await query.graph({
+      entity: "payment_collection",
+      fields: COLLECTION_PAGE_FIELDS,
+      filters: { id: collectionId },
+    })
+    return (data?.[0] as any) ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Give `collectionId` a Stripe session if it has none, and return the
+ * collection re-read afterwards.
+ *
+ * Idempotent by construction: an existing Stripe session short-circuits, so
+ * reopening the link does not mint a second PaymentIntent and does not replace
+ * the one the buyer may already be part-way through.
+ *
+ * 🔴 Never throws. A failure here must degrade to "this link cannot be opened
+ * just now" — a page that 500s tells the buyer nothing and tells us nothing
+ * either. The reason is logged; the buyer is told to ask for a new link.
+ */
+export async function ensureStripeSessionForCollection(
+  scope: any,
+  collectionId: string
+): Promise<{ collection: any | null; session: any | null; created: boolean }> {
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  let collection = await readCollectionForPage(scope, collectionId)
+  if (!collection) {
+    return { collection: null, session: null, created: false }
+  }
+
+  const existing = pickStripeSession(collection)
+  if (existing) {
+    return { collection, session: existing, created: false }
+  }
+
+  // Settled collections never get a session — minting one would create a
+  // PaymentIntent for money that has already arrived.
+  if (isCollectionSettled(collection)) {
+    return { collection, session: null, created: false }
+  }
+
+  const salesChannelId = await resolveSalesChannelForCollection(
+    scope,
+    collectionId
+  ).catch(() => undefined)
+
+  const connect = await resolvePartnerConnect(
+    scope,
+    salesChannelId,
+    Number(process.env.STRIPE_CONNECT_DEFAULT_FEE_PERCENT) || 0
+  ).catch(() => null)
+
+  const context = {
+    ...(salesChannelId ? { sales_channel_id: salesChannelId } : {}),
+    ...connectContext(connect),
+  }
+
+  const { customer_id } = await resolveCollectionPaymentContext(
+    scope,
+    collectionId
+  ).catch(() => ({ customer_id: undefined }) as any)
+
+  try {
+    await createPaymentSessionsWorkflow(scope).run({
+      input: {
+        payment_collection_id: collectionId,
+        provider_id: STRIPE_PROVIDER_ID,
+        ...(customer_id ? { customer_id } : {}),
+        ...(Object.keys(context).length ? { context } : {}),
+      },
+    })
+  } catch (e: any) {
+    logger?.error?.(
+      `[pay-collection] session creation failed for ${collectionId}: ${
+        e?.message ?? e
+      }`
+    )
+    return { collection, session: null, created: false }
+  }
+
+  // Re-read rather than trusting the workflow's return: the session we render
+  // must be the one actually persisted on the collection.
+  collection = await readCollectionForPage(scope, collectionId)
+  return {
+    collection,
+    session: pickStripeSession(collection),
+    created: true,
+  }
+}


### PR DESCRIPTION
Closes #1985.

An order EDIT that raises the total leaves a second payment collection owing the difference. "Copy payment link" is meant to hand the buyer a way to pay it. It handed over **a string with no host, pointing at a page that does not exist, for a collection with no payment session.**

Live on `order_01KNP520PT94BN8SC0JKZ6ZVJ9`: `pay_col_01M25NHFRS498JEP8PY4CNS8DC`, EUR 174.97, `not_paid`, **zero payment sessions**.

## The three faults

| | |
|---|---|
| **No host** | `admin-bundler` defines `__STOREFRONT_URL__` as `options.storefrontUrl ?? ""`, and `storefrontUrl` was set in NEITHER config. The dashboard reads `__STOREFRONT_URL__ ?? "http://localhost:8000"` — `""` is not nullish, so even the localhost fallback never fired. The copied string began `/payment-collection/…` |
| **No page** | Neither `apps/storefront` nor `apps/storefront-starter` implements `/payment-collection/[id]` — zero hits in either source tree |
| **No session** | Nothing in the order-edit flow mints one, so there was no `client_secret` even had the page existed |

## The fix

`storefrontUrl` now points at the **backend**, and `/payment-collection/:id` forwards to a new hosted Stripe page at `/stripe/pay/collection/:id` — the same rail `stripe/pay/:id` (cart) and `stripe/pay/balance/:id` (schedule) already use in production.

**Backend rather than a storefront, deliberately.** The storefront is multi-tenant — house and partner shops are different apps on different domains — while `storefrontUrl` is a single value baked into the admin bundle at BUILD time, so it could only ever have named one of them. One implementation instead of two, and the page resolves each collection's own Connect routing. `MEDUSA_STOREFRONT_URL` has exactly one consumer in the dashboard, so repointing it has no other blast radius.

## Two defects the unit tests were green over

Both found by running the page against **real local data**, not by reading.

**The provider was hardcoded.** Always `pp_stripe_stripe`. The live India Region enables ONLY `pp_stripe-connect_stripe-connect` — the ordinary shape for a partner storefront (#985) — so the mint threw `Payment provider pp_stripe_stripe is not enabled in the cart's region`. The page could never have worked for a partner's order. Now chosen from what the region enables, following the same preference rule as `dedupeStripeProviders`.

**The region came through the cart, which an edit has none of.** `resolveSalesChannelForCollection` walks `cart_payment_collection` → cart. Right for a checkout, empty for an edit, whose only link is `order_payment_collection`. Losing the region loses the provider list. Now tries order first, then cart.

Plus: a region can **enable** a provider the container does not **register** (measured — Connect enabled, still "Unable to retrieve the payment provider with id"). On a page a buyer opened to pay us, the mint now falls through to the other enabled Stripe provider.

## Verified against a running server, not only unit tests

```
/payment-collection/pay_col_TEST123     → 302 → /stripe/pay/collection/pay_col_TEST123
/payment-collection/abc%2Fdef           → 404  (id guard)
/stripe/pay/collection/<unknown>        → 404, body is OUR page (our CSP, <title>Payment link</title>)
                                          — an unrouted path returns Express's <title>Error</title>,
                                            which is how a route that never registered would look
```

End to end on a real local collection with **zero** sessions — the exact order-edit shape:

```
routing:  region=reg_01KPSE6ZRA7YGX27ZSDR86528K
          providers=[pp_system_default, pp_stripe-connect…, pp_stripe_stripe]
picked:   pp_stripe_stripe
result:   created=true, hasClientSecret=true
page:     200 · Stripe.js · pi_…_secret · return_url · "₹2,625.00"
```

**31 unit tests, mutation-checked:** exact `provider_id` match instead of substring → the Connect test goes red; dropping the `captured_at` backstop → the webhook-window test goes red.

## Known, deliberate

The mint fails on DATA when a region enables no Stripe provider at all. It degrades to "cannot be opened just now" with a precise log rather than a 500. `order_01KNP520`'s Europe region has **both** Stripe providers enabled, so the live case is fine.

## Follow-ups (not in this PR)

- The buyer sees a `v3.jaalyantra.com` URL rather than the shop domain. The balance links already do this and it is proven, but a per-tenant link would be nicer — it needs the copy action overridden, not just a config value.
- Local `.env` had `STRIPE_API_KEY=sk_test` beside `NEXT_PUBLIC_STRIPE_KEY=pk_live`; Stripe.js will not mount a live key against a test secret. Prod is consistently live via SSM. Worth a startup assertion that the two modes agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
