### PR TITLE
feat(storefront): pay an order edit's balance on cicilabel.com, with the order shown (#1985)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -53,11 +53,15 @@ module.exports = defineConfig({
      * consumer in the dashboard — `copy-payment-link.tsx`, which builds
      * `${storefrontUrl}/payment-collection/:id?order_id=:order`.
      *
-     * It is deliberately the BACKEND, not a storefront. Our storefront is
-     * multi-tenant (the house shop and partner shops are different apps on
-     * different domains) and a single build-time constant could only ever name
-     * one of them. `/payment-collection/:id` on this backend forwards to the
-     * hosted Stripe page, which resolves each collection's own partner routing.
+     * It names the SHOP, so a buyer lands on the storefront they bought from
+     * and sees the order they are topping up. `apps/storefront` serves
+     * cicilabel.com and implements `/payment-collection/:id`.
+     *
+     * ⚠️ Single build-time constant, one value for every tenant. Partner shops
+     * live on their own domains, so a partner order's link still points at the
+     * house shop. The backend keeps its own `/payment-collection/:id` redirect
+     * to the hosted Stripe page as a fallback for links already sent and for
+     * any tenant this cannot name — see #1985.
      *
      * 🔴 Left unset, `@medusajs/admin-bundler` defines it as `""` — and the
      * dashboard's `__STOREFRONT_URL__ ?? "http://localhost:8000"` does NOT
@@ -65,9 +69,7 @@ module.exports = defineConfig({
      * `||` rather than `??` here for the same reason.
      */
     storefrontUrl:
-      process.env.MEDUSA_STOREFRONT_URL ||
-      process.env.MEDUSA_BACKEND_URL ||
-      "https://v3.jaalyantra.com",
+      process.env.MEDUSA_STOREFRONT_URL || "https://cicilabel.com",
     
   },
   featureFlags: {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -55,11 +55,15 @@ module.exports = defineConfig({
      * consumer in the dashboard — `copy-payment-link.tsx`, which builds
      * `${storefrontUrl}/payment-collection/:id?order_id=:order`.
      *
-     * It is deliberately the BACKEND, not a storefront. Our storefront is
-     * multi-tenant (the house shop and partner shops are different apps on
-     * different domains) and a single build-time constant could only ever name
-     * one of them. `/payment-collection/:id` on this backend forwards to the
-     * hosted Stripe page, which resolves each collection's own partner routing.
+     * It names the SHOP, so a buyer lands on the storefront they bought from
+     * and sees the order they are topping up. `apps/storefront` serves
+     * cicilabel.com and implements `/payment-collection/:id`.
+     *
+     * ⚠️ Single build-time constant, one value for every tenant. Partner shops
+     * live on their own domains, so a partner order's link still points at the
+     * house shop. The backend keeps its own `/payment-collection/:id` redirect
+     * to the hosted Stripe page as a fallback for links already sent and for
+     * any tenant this cannot name — see #1985.
      *
      * 🔴 Left unset, `@medusajs/admin-bundler` defines it as `""` — and the
      * dashboard's `__STOREFRONT_URL__ ?? "http://localhost:8000"` does NOT
@@ -67,9 +71,7 @@ module.exports = defineConfig({
      * `||` rather than `??` here for the same reason.
      */
     storefrontUrl:
-      process.env.MEDUSA_STOREFRONT_URL ||
-      process.env.MEDUSA_BACKEND_URL ||
-      "https://v3.jaalyantra.com",
+      process.env.MEDUSA_STOREFRONT_URL || "https://cicilabel.com",
     vite: () => ({
       resolve: {
         alias: {

--- a/apps/backend/src/api/store/payment-collections/[id]/prepare/route.ts
+++ b/apps/backend/src/api/store/payment-collections/[id]/prepare/route.ts
@@ -60,6 +60,15 @@ export function summariseOrderLine(item: any) {
  */
 export function summariseOrder(order: any) {
   if (!order) return null
+  /**
+   * `summary` is where the money actually lives. `paid_total` and
+   * `pending_difference` are what let the page say "you paid X, an update took
+   * the order to Y, so Z is outstanding" instead of showing a bare amount the
+   * buyer has to take on trust. Measured on the live order that prompted this:
+   * total 510.36, paid_total 335.39, pending_difference 174.97 — and 174.97 is
+   * exactly the collection's amount.
+   */
+  const summary = (order.summary ?? {}) as Record<string, any>
   return {
     id: order.id,
     display_id: order.display_id ?? null,
@@ -68,6 +77,9 @@ export function summariseOrder(order: any) {
     created_at: order.created_at ?? null,
     total: order.total ?? null,
     item_total: order.item_total ?? null,
+    paid_total: summary.paid_total ?? null,
+    pending_difference: summary.pending_difference ?? null,
+    original_order_total: summary.original_order_total ?? null,
     items: ((order.items ?? []) as any[]).map(summariseOrderLine),
   }
 }
@@ -105,6 +117,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
           "created_at",
           "total",
           "item_total",
+          "summary",
           "items.id",
           "items.title",
           "items.variant_title",

--- a/apps/backend/src/api/store/payment-collections/[id]/prepare/route.ts
+++ b/apps/backend/src/api/store/payment-collections/[id]/prepare/route.ts
@@ -1,0 +1,142 @@
+/**
+ * POST /store/payment-collections/:id/prepare — everything the storefront's
+ * payment-collection page needs, in one call (#1985).
+ *
+ * An order EDIT that raises the total leaves a second payment collection owing
+ * the difference, with NO payment sessions — nothing in the edit flow mints
+ * one. This route makes that collection payable: it ensures a Stripe session
+ * exists and returns the collection alongside a minimal summary of the order
+ * the money belongs to, so the buyer can see WHAT they are paying for rather
+ * than a bare amount.
+ *
+ * ## Why POST and not GET
+ *
+ * Ensuring a session creates a Stripe PaymentIntent. A GET that mints one would
+ * be triggered by link prefetchers, crawlers and preview bots — every hover
+ * over the link would bill a little more Stripe API traffic and litter the
+ * account with abandoned intents. The write is explicit, so the method is.
+ *
+ * ## What it deliberately does NOT accept
+ *
+ * The admin's copy-link carries `?order_id=…`, and this route ignores it. The
+ * order is derived from the COLLECTION server-side; trusting an order id from a
+ * URL would let one payment link report another order's contents.
+ *
+ * ## Exposure
+ *
+ * The collection id is the credential, exactly as it is for the deposit's
+ * hosted page, the balance page and a PayU link — an unguessable ULID handed to
+ * one buyer. The order summary is therefore kept to what a buyer already knows
+ * from their own confirmation email: display id, currency, totals and line
+ * titles/quantities. No addresses, no customer record, no payment history.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  ensureStripeSessionForCollection,
+  isCollectionSettled,
+  resolveCollectionOrderRouting,
+} from "../../../../../lib/payments/ensure-stripe-session"
+
+/** PURE: the buyer-safe shape of an order line. Exported for unit testing. */
+export function summariseOrderLine(item: any) {
+  return {
+    id: item?.id,
+    title: item?.title ?? null,
+    variant_title: item?.variant_title ?? null,
+    thumbnail: item?.thumbnail ?? null,
+    quantity: Number(item?.quantity) || 0,
+    unit_price: item?.unit_price ?? null,
+    total: item?.total ?? null,
+  }
+}
+
+/**
+ * PURE: the buyer-safe shape of the order behind a collection.
+ *
+ * Allow-list, never a delete-list: a field added to the order later must not
+ * appear here by default. Exported for unit testing.
+ */
+export function summariseOrder(order: any) {
+  if (!order) return null
+  return {
+    id: order.id,
+    display_id: order.display_id ?? null,
+    currency_code: order.currency_code ?? null,
+    email: order.email ?? null,
+    created_at: order.created_at ?? null,
+    total: order.total ?? null,
+    item_total: order.item_total ?? null,
+    items: ((order.items ?? []) as any[]).map(summariseOrderLine),
+  }
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const collectionId = req.params.id
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { collection, session } = await ensureStripeSessionForCollection(
+    req.scope,
+    collectionId
+  )
+
+  if (!collection) {
+    res.status(404).json({ message: "This payment link is not valid." })
+    return
+  }
+
+  const routing = await resolveCollectionOrderRouting(
+    req.scope,
+    collectionId
+  ).catch(() => ({ regionProviderIds: [] }) as any)
+
+  let order: any = null
+  if (routing.orderId) {
+    const { data } = await query
+      .graph({
+        entity: "order",
+        filters: { id: routing.orderId },
+        fields: [
+          "id",
+          "display_id",
+          "currency_code",
+          "email",
+          "created_at",
+          "total",
+          "item_total",
+          "items.id",
+          "items.title",
+          "items.variant_title",
+          "items.thumbnail",
+          "items.quantity",
+          "items.unit_price",
+          "items.total",
+        ],
+      })
+      .catch(() => ({ data: [] }))
+    order = data?.[0] ?? null
+  }
+
+  res.status(200).json({
+    payment_collection: {
+      id: collection.id,
+      amount: collection.amount,
+      currency_code: collection.currency_code,
+      status: collection.status,
+      // Only the Stripe session, and only the fields the Payment Element needs.
+      // The raw session `data` carries provider internals a buyer has no use
+      // for; `client_secret` is the one field that must cross.
+      payment_session: session
+        ? {
+            id: session.id,
+            provider_id: session.provider_id,
+            status: session.status,
+            client_secret: (session.data as any)?.client_secret ?? null,
+          }
+        : null,
+    },
+    settled: isCollectionSettled(collection),
+    order: summariseOrder(order),
+  })
+}

--- a/apps/storefront/src/app/[countryCode]/(checkout)/payment-collection/[id]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/payment-collection/[id]/page.tsx
@@ -1,0 +1,180 @@
+import { Heading, Text } from "@medusajs/ui"
+import type { Metadata } from "next"
+
+import { preparePaymentCollection } from "@lib/data/payment-collections"
+import { convertToLocale } from "@lib/util/money"
+import PayCollectionForm from "@modules/checkout/components/payment-collection/pay-collection-form"
+import StripeWrapper from "@modules/checkout/components/payment-wrapper/stripe-wrapper"
+import { loadStripe } from "@stripe/stripe-js"
+
+/**
+ * `/payment-collection/:id` — the buyer pays what an order EDIT left owing
+ * (#1985).
+ *
+ * This is the page the admin's "Copy payment link" button points at. It used to
+ * point nowhere: `storefrontUrl` was unset, so the copied string had no host,
+ * and no storefront implemented this route in either of our two apps.
+ *
+ * ## Why it lives here rather than on the backend
+ *
+ * The buyer should land on the shop they bought from, see the order they are
+ * topping up, and pay in the shop's own chrome — not on an admin hostname. The
+ * backend keeps a `/payment-collection/:id` redirect as a fallback for links
+ * already sent.
+ *
+ * ## The id is the credential
+ *
+ * Unguessable ULID, handed to one buyer — the same model as the deposit page,
+ * the balance page and a PayU link. The route is `noindex` via the checkout
+ * layout, and the backend returns only order fields the buyer already has in
+ * their confirmation email. `?order_id=` on the incoming link is IGNORED: the
+ * order is derived from the collection server-side, so one link can never
+ * report another order's contents.
+ */
+export const metadata: Metadata = {
+  title: "Complete your payment",
+  robots: { index: false, follow: false },
+}
+
+// Money is live and a stale "unpaid" page invites a second payment.
+export const dynamic = "force-dynamic"
+
+const stripeKey =
+  process.env.NEXT_PUBLIC_STRIPE_KEY ||
+  process.env.NEXT_PUBLIC_MEDUSA_PAYMENTS_PUBLISHABLE_KEY
+
+const medusaAccountId = process.env.NEXT_PUBLIC_MEDUSA_PAYMENTS_ACCOUNT_ID
+const stripePromise = stripeKey
+  ? loadStripe(
+      stripeKey,
+      medusaAccountId ? { stripeAccount: medusaAccountId } : undefined
+    )
+  : null
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="content-container flex justify-center py-12">
+      <div className="w-full max-w-2xl flex flex-col gap-y-8">{children}</div>
+    </div>
+  )
+}
+
+export default async function PaymentCollectionPage(props: {
+  params: Promise<{ id: string; countryCode: string }>
+}) {
+  const { id } = await props.params
+  const prepared = await preparePaymentCollection(id)
+
+  if (!prepared) {
+    return (
+      <Shell>
+        <Heading level="h1" className="text-2xl-semi">
+          Payment link
+        </Heading>
+        <Text className="text-ui-fg-subtle">
+          This payment link is not valid. If you were sent it recently, please
+          reply to your order email and we will send a new one.
+        </Text>
+      </Shell>
+    )
+  }
+
+  const { payment_collection: pc, order, settled } = prepared
+  const amountLabel = convertToLocale({
+    amount: Number(pc.amount) || 0,
+    currency_code: pc.currency_code,
+  })
+
+  /**
+   * Paid is a first-class page, not an error. A buyer who pays and reopens the
+   * link from their email must be told the money arrived, not shown a form that
+   * makes them wonder whether it did — or worse, pay twice.
+   */
+  if (settled) {
+    return (
+      <Shell>
+        <Heading level="h1" className="text-2xl-semi">
+          Payment received
+        </Heading>
+        <Text className="text-ui-fg-subtle">
+          {amountLabel} has already been paid
+          {order?.display_id ? ` on order #${order.display_id}` : ""}. There is
+          nothing more to do — you can close this window.
+        </Text>
+      </Shell>
+    )
+  }
+
+  const clientSecret = pc.payment_session?.client_secret ?? null
+  const canPay = Boolean(clientSecret && stripePromise && stripeKey)
+
+  return (
+    <Shell>
+      <div>
+        <Heading level="h1" className="text-2xl-semi mb-2">
+          Complete your payment
+        </Heading>
+        <Text className="text-ui-fg-subtle">
+          {order?.display_id
+            ? `An update to order #${order.display_id} leaves ${amountLabel} to pay.`
+            : `There is ${amountLabel} to pay.`}
+        </Text>
+      </div>
+
+      {order && order.items.length > 0 && (
+        <div className="rounded-lg border border-ui-border-base divide-y divide-ui-border-base">
+          {order.items.map((item) => (
+            <div key={item.id} className="flex items-center gap-x-4 p-4">
+              {item.thumbnail && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={item.thumbnail}
+                  alt=""
+                  className="h-14 w-14 rounded object-cover bg-ui-bg-subtle"
+                />
+              )}
+              <div className="flex-1 min-w-0">
+                <Text className="txt-medium-plus text-ui-fg-base truncate">
+                  {item.title}
+                </Text>
+                {item.variant_title && (
+                  <Text className="txt-small text-ui-fg-subtle truncate">
+                    {item.variant_title}
+                  </Text>
+                )}
+              </div>
+              <Text className="txt-small text-ui-fg-subtle shrink-0">
+                × {item.quantity}
+              </Text>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between border-t border-ui-border-base pt-4">
+        <Text className="txt-medium-plus text-ui-fg-base">Amount due now</Text>
+        <Text className="txt-medium-plus text-ui-fg-base">{amountLabel}</Text>
+      </div>
+
+      {canPay ? (
+        /* StripeWrapper mounts <Elements>. PayCollectionForm calls useStripe()
+           and useElements(), which THROW outside it — so it is only ever
+           rendered as its child, never conditionally inside itself. */
+        <StripeWrapper
+          paymentSession={
+            { data: { client_secret: clientSecret } } as any
+          }
+          stripeKey={stripeKey}
+          stripePromise={stripePromise}
+        >
+          <PayCollectionForm amountLabel={amountLabel} />
+        </StripeWrapper>
+      ) : (
+        <Text className="text-ui-fg-subtle">
+          This payment link cannot be opened just now. Please reply to your order
+          email and we will send a new one.
+        </Text>
+      )}
+    </Shell>
+  )
+}

--- a/apps/storefront/src/app/[countryCode]/(checkout)/payment-collection/[id]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/payment-collection/[id]/page.tsx
@@ -91,6 +91,36 @@ export default async function PaymentCollectionPage(props: {
     )
   }
 
+  /**
+   * 🔴 Only show the order's own figures when they are in the SAME currency as
+   * the amount due. A collection is normally in its order's currency, but when
+   * they disagree the breakdown becomes nonsense a buyer cannot challenge:
+   * caught in a local render showing "Order total ₹22,401.80 / Already paid
+   * −₹22,401.80 / Amount due SGD 109.00" — three numbers that do not reconcile
+   * and two currencies. Rather than convert (we have no rate here and inventing
+   * one on a payment page is worse), drop the context rows and let the amount
+   * due stand alone.
+   */
+  const sameCurrency =
+    !!order?.currency_code &&
+    order.currency_code.toLowerCase() === pc.currency_code?.toLowerCase()
+
+  const money = (v: number | null | undefined) =>
+    v == null || !sameCurrency
+      ? null
+      : convertToLocale({
+          amount: Number(v),
+          currency_code: pc.currency_code,
+        })
+
+  const orderDate = order?.created_at
+    ? new Date(order.created_at).toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      })
+    : null
+
   const clientSecret = pc.payment_session?.client_secret ?? null
   // Only the secret is decidable on the server; whether Stripe.js loads is a
   // client fact, so PayCollectionWrapper owns that half.
@@ -104,13 +134,34 @@ export default async function PaymentCollectionPage(props: {
         </Heading>
         <Text className="text-ui-fg-subtle">
           {order?.display_id
-            ? `An update to order #${order.display_id} leaves ${amountLabel} to pay.`
-            : `There is ${amountLabel} to pay.`}
+            ? `Order #${order.display_id}${
+                orderDate ? ` · placed ${orderDate}` : ""
+              }`
+            : "Outstanding balance"}
+        </Text>
+      </div>
+
+      {/* Say WHY money is owed before asking for it. A buyer who already paid
+          once and then receives a link for more will assume a double charge
+          unless the page accounts for both figures. */}
+      <div className="rounded-lg border border-ui-border-base bg-ui-bg-subtle p-4">
+        <Text className="txt-medium-plus text-ui-fg-base mb-1">
+          This is an outstanding balance on your order
+        </Text>
+        <Text className="txt-small text-ui-fg-subtle">
+          {order
+            ? `Your order was updated after it was placed, which increased the total. Everything you have already paid is credited below — only the remaining ${amountLabel} is due now.`
+            : `Only the remaining ${amountLabel} is due now. Anything already paid on this order is not charged again.`}
         </Text>
       </div>
 
       {order && order.items.length > 0 && (
         <div className="rounded-lg border border-ui-border-base divide-y divide-ui-border-base">
+          <div className="px-4 py-3">
+            <Text className="txt-small-plus text-ui-fg-base">
+              What is in your order
+            </Text>
+          </div>
           {order.items.map((item) => (
             <div key={item.id} className="flex items-center gap-x-4 p-4">
               {item.thumbnail && (
@@ -139,9 +190,27 @@ export default async function PaymentCollectionPage(props: {
         </div>
       )}
 
-      <div className="flex items-center justify-between border-t border-ui-border-base pt-4">
-        <Text className="txt-medium-plus text-ui-fg-base">Amount due now</Text>
-        <Text className="txt-medium-plus text-ui-fg-base">{amountLabel}</Text>
+      <div className="flex flex-col gap-y-2 border-t border-ui-border-base pt-4">
+        {money(order?.total) && (
+          <div className="flex items-center justify-between">
+            <Text className="txt-small text-ui-fg-subtle">Order total</Text>
+            <Text className="txt-small text-ui-fg-subtle">
+              {money(order?.total)}
+            </Text>
+          </div>
+        )}
+        {money(order?.paid_total) && (
+          <div className="flex items-center justify-between">
+            <Text className="txt-small text-ui-fg-subtle">Already paid</Text>
+            <Text className="txt-small text-ui-fg-subtle">
+              − {money(order?.paid_total)}
+            </Text>
+          </div>
+        )}
+        <div className="flex items-center justify-between border-t border-ui-border-base pt-2 mt-1">
+          <Text className="txt-medium-plus text-ui-fg-base">Amount due now</Text>
+          <Text className="txt-medium-plus text-ui-fg-base">{amountLabel}</Text>
+        </div>
       </div>
 
       {canPay ? (

--- a/apps/storefront/src/app/[countryCode]/(checkout)/payment-collection/[id]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/payment-collection/[id]/page.tsx
@@ -3,9 +3,7 @@ import type { Metadata } from "next"
 
 import { preparePaymentCollection } from "@lib/data/payment-collections"
 import { convertToLocale } from "@lib/util/money"
-import PayCollectionForm from "@modules/checkout/components/payment-collection/pay-collection-form"
-import StripeWrapper from "@modules/checkout/components/payment-wrapper/stripe-wrapper"
-import { loadStripe } from "@stripe/stripe-js"
+import PayCollectionWrapper from "@modules/checkout/components/payment-collection/pay-collection-wrapper"
 
 /**
  * `/payment-collection/:id` — the buyer pays what an order EDIT left owing
@@ -38,18 +36,6 @@ export const metadata: Metadata = {
 
 // Money is live and a stale "unpaid" page invites a second payment.
 export const dynamic = "force-dynamic"
-
-const stripeKey =
-  process.env.NEXT_PUBLIC_STRIPE_KEY ||
-  process.env.NEXT_PUBLIC_MEDUSA_PAYMENTS_PUBLISHABLE_KEY
-
-const medusaAccountId = process.env.NEXT_PUBLIC_MEDUSA_PAYMENTS_ACCOUNT_ID
-const stripePromise = stripeKey
-  ? loadStripe(
-      stripeKey,
-      medusaAccountId ? { stripeAccount: medusaAccountId } : undefined
-    )
-  : null
 
 function Shell({ children }: { children: React.ReactNode }) {
   return (
@@ -106,7 +92,9 @@ export default async function PaymentCollectionPage(props: {
   }
 
   const clientSecret = pc.payment_session?.client_secret ?? null
-  const canPay = Boolean(clientSecret && stripePromise && stripeKey)
+  // Only the secret is decidable on the server; whether Stripe.js loads is a
+  // client fact, so PayCollectionWrapper owns that half.
+  const canPay = Boolean(clientSecret)
 
   return (
     <Shell>
@@ -157,18 +145,13 @@ export default async function PaymentCollectionPage(props: {
       </div>
 
       {canPay ? (
-        /* StripeWrapper mounts <Elements>. PayCollectionForm calls useStripe()
-           and useElements(), which THROW outside it — so it is only ever
-           rendered as its child, never conditionally inside itself. */
-        <StripeWrapper
-          paymentSession={
-            { data: { client_secret: clientSecret } } as any
-          }
-          stripeKey={stripeKey}
-          stripePromise={stripePromise}
-        >
-          <PayCollectionForm amountLabel={amountLabel} />
-        </StripeWrapper>
+        /* Everything Stripe is client-side — see pay-collection-wrapper.tsx.
+           A `loadStripe()` Promise cannot cross the RSC boundary, and when it
+           silently fails to, the page renders a dead Pay button with no error. */
+        <PayCollectionWrapper
+          clientSecret={clientSecret as string}
+          amountLabel={amountLabel}
+        />
       ) : (
         <Text className="text-ui-fg-subtle">
           This payment link cannot be opened just now. Please reply to your order

--- a/apps/storefront/src/lib/data/payment-collections.ts
+++ b/apps/storefront/src/lib/data/payment-collections.ts
@@ -1,0 +1,68 @@
+"use server"
+
+import { sdk } from "@lib/config"
+
+/**
+ * The buyer-facing view of an outstanding payment collection (#1985).
+ *
+ * An order EDIT that raises the total leaves a second payment collection owing
+ * the difference. The admin's "Copy payment link" hands the buyer a link to
+ * this collection; the page it opens is the only place they can pay it.
+ */
+export type PreparedPaymentCollection = {
+  payment_collection: {
+    id: string
+    amount: number
+    currency_code: string
+    status: string
+    payment_session: {
+      id: string
+      provider_id: string
+      status: string
+      client_secret: string | null
+    } | null
+  }
+  settled: boolean
+  order: {
+    id: string
+    display_id: number | null
+    currency_code: string | null
+    email: string | null
+    created_at: string | null
+    total: number | null
+    item_total: number | null
+    items: Array<{
+      id: string
+      title: string | null
+      variant_title: string | null
+      thumbnail: string | null
+      quantity: number
+      unit_price: number | null
+      total: number | null
+    }>
+  } | null
+}
+
+/**
+ * Fetch the collection and ensure it has a Stripe session.
+ *
+ * 🔴 POST, not GET, and `cache: "no-store"`. The backend mints a Stripe
+ * PaymentIntent when the collection has no session — a cached or prefetched GET
+ * would create intents on hover. It is idempotent server-side (an existing
+ * session short-circuits), but the method still has to say what it does.
+ *
+ * Returns null when the id is not a live collection, so the page can render
+ * "this link is not valid" rather than throwing a 500 at a buyer.
+ */
+export async function preparePaymentCollection(
+  id: string
+): Promise<PreparedPaymentCollection | null> {
+  try {
+    return await sdk.client.fetch<PreparedPaymentCollection>(
+      `/store/payment-collections/${id}/prepare`,
+      { method: "POST", cache: "no-store" }
+    )
+  } catch {
+    return null
+  }
+}

--- a/apps/storefront/src/lib/data/payment-collections.ts
+++ b/apps/storefront/src/lib/data/payment-collections.ts
@@ -31,6 +31,12 @@ export type PreparedPaymentCollection = {
     created_at: string | null
     total: number | null
     item_total: number | null
+    /** What has already been captured on this order. */
+    paid_total: number | null
+    /** What the order still owes — equals the collection's amount. */
+    pending_difference: number | null
+    /** The total before the edit that created this balance. */
+    original_order_total: number | null
     items: Array<{
       id: string
       title: string | null

--- a/apps/storefront/src/modules/checkout/components/payment-collection/pay-collection-form.tsx
+++ b/apps/storefront/src/modules/checkout/components/payment-collection/pay-collection-form.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { Button, Text } from "@medusajs/ui"
+import { PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js"
+import { useState } from "react"
+
+/**
+ * The Payment Element and Pay button for an outstanding payment collection
+ * (#1985).
+ *
+ * 🔴 `useStripe()` / `useElements()` THROW outside an `<Elements>` provider —
+ * not return null, throw — and a throw here takes the whole page down, not just
+ * the button. So this component is only ever rendered by the page INSIDE
+ * `StripeWrapper`. A `stripeReady` check placed inside this component would sit
+ * below the hooks and be reached too late; the guard has to be at the mount
+ * site. That mistake killed the checkout page once already.
+ */
+export default function PayCollectionForm({
+  amountLabel,
+}: {
+  amountLabel: string
+}) {
+  const stripe = useStripe()
+  const elements = useElements()
+  const [submitting, setSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [paid, setPaid] = useState(false)
+
+  const handlePay = async () => {
+    setSubmitting(true)
+    setErrorMessage(null)
+
+    if (!stripe || !elements) {
+      setSubmitting(false)
+      return
+    }
+
+    /**
+     * Back to THIS page. On return it re-reads the collection and renders the
+     * paid state, so a buyer who pays through a redirect method (iDEAL,
+     * Bancontact, 3DS) lands somewhere that confirms the money arrived rather
+     * than on a form asking for it again.
+     */
+    const returnUrl = `${window.location.origin}${window.location.pathname}`
+
+    const { error, paymentIntent } = await stripe.confirmPayment({
+      elements,
+      confirmParams: { return_url: returnUrl },
+      redirect: "if_required",
+    })
+
+    // A declined card and an authorised-but-uncaptured intent both arrive as
+    // `error`. Only the genuinely failed ones are the buyer's problem.
+    if (error) {
+      const pi = error.payment_intent
+      if (pi && (pi.status === "requires_capture" || pi.status === "succeeded")) {
+        setPaid(true)
+        return
+      }
+      setErrorMessage(error.message || "That payment could not be completed.")
+      setSubmitting(false)
+      return
+    }
+
+    if (
+      paymentIntent &&
+      (paymentIntent.status === "requires_capture" ||
+        paymentIntent.status === "succeeded")
+    ) {
+      setPaid(true)
+      return
+    }
+
+    setSubmitting(false)
+  }
+
+  if (paid) {
+    return (
+      <div className="rounded-lg border border-ui-border-base bg-ui-bg-subtle p-6">
+        <Text className="txt-medium-plus text-ui-fg-base mb-1">
+          Payment received
+        </Text>
+        <Text className="txt-small text-ui-fg-subtle">
+          Thank you — {amountLabel} has been paid. You can close this window; a
+          confirmation follows by email.
+        </Text>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <PaymentElement options={{ layout: "accordion" }} />
+
+      {errorMessage && (
+        <Text
+          className="txt-small text-ui-fg-error"
+          data-testid="payment-collection-error"
+        >
+          {errorMessage}
+        </Text>
+      )}
+
+      <Button
+        size="large"
+        isLoading={submitting}
+        disabled={!stripe || !elements || submitting}
+        onClick={handlePay}
+        data-testid="pay-collection-button"
+      >
+        Pay {amountLabel}
+      </Button>
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/checkout/components/payment-collection/pay-collection-wrapper.tsx
+++ b/apps/storefront/src/modules/checkout/components/payment-collection/pay-collection-wrapper.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { Elements } from "@stripe/react-stripe-js"
+import { loadStripe } from "@stripe/stripe-js"
+import { Text } from "@medusajs/ui"
+
+import PayCollectionForm from "./pay-collection-form"
+
+/**
+ * Mounts Stripe for the payment-collection page (#1985).
+ *
+ * 🔴 This file exists because `loadStripe()` CANNOT live in the page.
+ *
+ * The page is a server component. Calling `loadStripe()` there runs it on the
+ * server and yields a Promise wrapping a browser-only Stripe object, which
+ * cannot cross the RSC boundary as a prop. Nothing throws and nothing is logged
+ * — `<Elements>` simply never initialises, `useStripe()` returns null, and the
+ * page renders a permanently DISABLED Pay button with no card form and no
+ * error. It looked completely fine in SSR HTML: correct title, correct amount,
+ * `client_secret` present in the payload. Only opening it in a browser showed
+ * the form was missing.
+ *
+ * So the boundary is here: the server passes a plain STRING, and everything
+ * Stripe happens client-side. This mirrors `payment-wrapper/index.tsx`, which
+ * is `"use client"` for exactly the same reason.
+ */
+const stripeKey =
+  process.env.NEXT_PUBLIC_STRIPE_KEY ||
+  process.env.NEXT_PUBLIC_MEDUSA_PAYMENTS_PUBLISHABLE_KEY
+
+const medusaAccountId = process.env.NEXT_PUBLIC_MEDUSA_PAYMENTS_ACCOUNT_ID
+
+const stripePromise = stripeKey
+  ? loadStripe(
+      stripeKey,
+      medusaAccountId ? { stripeAccount: medusaAccountId } : undefined
+    )
+  : null
+
+export default function PayCollectionWrapper({
+  clientSecret,
+  amountLabel,
+}: {
+  clientSecret: string
+  amountLabel: string
+}) {
+  /**
+   * A missing key is an operator problem, not a buyer problem. `StripeWrapper`
+   * THROWS on it, which would take the page down; here it degrades to a line
+   * the buyer can act on. (Local dev hit exactly this: an empty
+   * `NEXT_PUBLIC_STRIPE_KEY=` line, which `grep -q` and `||` both read as
+   * "present".)
+   */
+  if (!stripePromise || !stripeKey) {
+    return (
+      <Text className="text-ui-fg-subtle">
+        This payment link cannot be opened just now. Please reply to your order
+        email and we will send a new one.
+      </Text>
+    )
+  }
+
+  return (
+    <Elements options={{ clientSecret }} stripe={stripePromise}>
+      <PayCollectionForm amountLabel={amountLabel} />
+    </Elements>
+  )
+}


### PR DESCRIPTION
Follow-up to #1987. That fix worked, but it sent buyers to **v3.jaalyantra.com** — an admin hostname — and showed them nothing but an amount. This puts the page on the shop they bought from, with the order they are topping up.

`apps/storefront` is the live cicilabel.com storefront (the repo's own codebase map says so — NOT the `-starter` submodule).

## What's here

- **`POST /store/payment-collections/:id/prepare`** — one call returning the collection, a buyer-safe order summary, and a Stripe session, minting one when the collection has none.
- **`/[countryCode]/(checkout)/payment-collection/[id]`** — the page: order number and date, an explanation of *why* money is owed, the order's lines, a Order total / Already paid / Amount due breakdown, and Stripe's Payment Element.
- **`storefrontUrl` → `https://cicilabel.com`**.

The backend's `/payment-collection/:id` redirect from #1987 stays as a fallback for links already sent.

## 🔴 Two defects found only by opening it in a browser

**The Pay button was dead.** `page.tsx` is a server component and called `loadStripe()` at module scope, passing the Promise to a client component. It cannot cross the RSC boundary. **Nothing throws and nothing logs** — `<Elements>` never initialises, `useStripe()` returns null, and `disabled={!stripe}` is permanently true.

Every non-visual check passed: 200, correct title, correct amount, `pi_…_secret` in the payload, `prepare` returning 200 in the console, zero Stripe warnings. SSR HTML cannot show a client-side mount, so "the secret is in the payload" only ever proved the server did its half. `pay-collection-wrapper.tsx` is now `"use client"` and the server passes a plain string — the same reason `payment-wrapper/index.tsx` has always been a client component.

**Mixed currencies produced nonsense.** A render with a deliberately mismatched link showed `Order total ₹22,401.80 / Already paid −₹22,401.80 / Amount due SGD 109.00` — three numbers that don't reconcile, in two currencies, on a page asking for money. The order's figures now render only when its currency matches the collection's. No FX conversion: we have no rate here and inventing one on a payment page is worse than saying less.

## Decisions

**POST, not GET.** Ensuring a session mints a Stripe PaymentIntent; a GET would be fired by link prefetchers and preview bots, minting intents on hover.

**`?order_id=` is ignored.** The admin link carries it; the order is derived from the collection server-side. Trusting an order id from a URL would let one payment link report another order's contents.

**The order summary is an allow-list.** Display id, currency, totals, line titles/quantities/thumbnails — what the buyer already has in their confirmation email. No addresses, no customer record, no payment history. A field added to the order later does not appear by default.

## Verified in Chrome, three renders

| | |
|---|---|
| `/in/…` INR ₹2,625.00 | UPI + Card accordion, billing fields, Pay button **enabled** |
| `/sg/…` SGD 109.00 | Card + Link, card number / expiry / CVC — also the existing-session path, nothing minted |
| `/sg/…` order-linked | "Order #29 · placed 1 July 2026", the balance explanation, 3 lines, totals breakdown |

Middleware redirect verified too: `/payment-collection/<id>?order_id=x` → **307** → `/in/payment-collection/<id>?order_id=x`, path and query preserved.

The order-linked render needed a temporary `order_payment_collection` row in the local dev DB (no local collection had an order link). It was deleted afterwards; the table is back to its original 3 rows.

## Note

`tsc` reports pre-existing TS2786 React-types errors across this app (920, hitting `not-found.tsx` and `constants.tsx` too). The new files add no new class of error, and there is no `typecheck` script — CI builds with `next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
