### PR TITLE
fix(pricing): an INR-costed design minted in EUR at ~110x, and production cost now states its currency (#1979)

### DIFF
--- a/apps/backend/integration-tests/http/production-run-cost-currency.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-cost-currency.spec.ts
@@ -1,0 +1,328 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(240000)
+
+/**
+ * What a production run's cost is DENOMINATED IN, end to end (#1979).
+ *
+ * ## The bug this exists to keep out
+ *
+ * A run carried `partner_cost_estimate` as a bare number and `cost_type` saying
+ * whether it was per-unit or total. Nothing said which CURRENCY, and
+ * `RunCostSummary` had no currency field either — so when approval turned a
+ * run's cost into a listed price it had to GUESS. It guessed
+ * `design.cost_currency || <store default> || "inr"`, and the house store's
+ * default is EUR, which made the INR last resort UNREACHABLE. A jacket costed
+ * at ₹2,634.75 was listed as €2,634.75 and the FX fanout propagated that base
+ * into all 11 currencies — ₹291,560, about 110× its cost.
+ *
+ * ## Why these are HTTP tests and not more unit tests
+ *
+ * The unit tests already pin the resolver. What they cannot see is whether the
+ * value SURVIVES the round trip: that the column exists and is migrated, that
+ * the route accepts and normalises it, that `computeRunCostSummary` reads it
+ * back, and that approval writes a price in it. Every one of those is a place
+ * the currency could be dropped while the pure function stays green.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/production-run-cost-currency
+ */
+setupSharedTestSuite(() => {
+  describe("production run cost_currency (#1979)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    const loud = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+      try {
+        return await fn()
+      } catch (e: any) {
+        console.log(`[${label}] ${e.response?.status}`, JSON.stringify(e.response?.data))
+        throw e
+      }
+    }
+
+    async function setup() {
+      const container = getContainer()
+      const unique = Date.now()
+      await createAdminUser(container)
+      const adminHeaders = await getAuthHeaders(api)
+      return { adminHeaders, unique }
+    }
+
+    async function createPartner(unique: number, tag: string) {
+      const email = `ccy-${tag}-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      let login = await api.post("/auth/partner/emailpass", { email, password })
+      const headers = { Authorization: `Bearer ${login.data.token}` }
+
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Ccy Partner ${tag} ${unique}`,
+          handle: `ccy-partner-${tag}-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      login = await api.post("/auth/partner/emailpass", { email, password })
+      return {
+        partnerId: res.data.partner.id,
+        partnerHeaders: { Authorization: `Bearer ${login.data.token}` },
+      }
+    }
+
+    async function createTemplate(adminHeaders: any, unique: number) {
+      const name = `ccy-cutting-${unique}`
+      await api.post(
+        "/admin/task-templates",
+        {
+          name,
+          description: "Cutting",
+          priority: "medium",
+          estimated_duration: 60,
+          required_fields: {},
+          eventable: false,
+          notifiable: false,
+          message_template: "",
+          metadata: { workflow_type: "production_run" },
+          category: `Ccy Test ${unique}`,
+        },
+        adminHeaders
+      )
+      return name
+    }
+
+    /**
+     * A design costed with NO `cost_currency` — the state 45 of the 47 costed
+     * designs on prod are in, and the one that made the guess reachable.
+     */
+    async function createUnstatedDesign(adminHeaders: any, unique: number, tag = "a") {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name: `Ccy Design ${tag} ${unique}`,
+          description: "Design with no stated cost currency",
+          design_type: "Original",
+          status: "In_Development",
+          priority: "Medium",
+          estimated_cost: 850,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      expect(res.data.design.cost_currency ?? null).toBeNull()
+      return res.data.design.id
+    }
+
+    async function completeRun(runId: string, partnerHeaders: any, produced = 10) {
+      await api.post(`/partners/production-runs/${runId}/accept`, {}, { headers: partnerHeaders })
+      await api.post(`/partners/production-runs/${runId}/start`, {}, { headers: partnerHeaders })
+      await api.post(`/partners/production-runs/${runId}/finish`, {}, { headers: partnerHeaders })
+      const res = await api.post(
+        `/partners/production-runs/${runId}/complete`,
+        { produced_quantity: produced },
+        { headers: partnerHeaders }
+      )
+      expect(res.data.production_run.status).toBe("completed")
+    }
+
+    async function oneCompletedRun(adminHeaders: any, unique: number, tag = "a") {
+      const template = await createTemplate(adminHeaders, unique)
+      const designId = await createUnstatedDesign(adminHeaders, unique, tag)
+      const p = await createPartner(unique, tag)
+
+      const createRes = await loud("create-runs", () =>
+        api.post(
+          `/admin/designs/${designId}/production-runs`,
+          {
+            quantity: 10,
+            assignments: [
+              { partner_id: p.partnerId, quantity: 10, template_names: [template] },
+            ],
+          },
+          adminHeaders
+        )
+      )
+      const children = createRes.data.children
+      expect(children).toHaveLength(1)
+      await completeRun(children[0].id, p.partnerHeaders)
+      return { designId, runId: children[0].id as string }
+    }
+
+    const readRun = async (adminHeaders: any, runId: string) =>
+      (await api.get(`/admin/production-runs/${runId}`, adminHeaders)).data
+        .production_run
+
+    const readProduct = async (adminHeaders: any, productId: string) =>
+      (
+        await api.get(
+          `/admin/products/${productId}?fields=*variants,*variants.prices`,
+          adminHeaders
+        )
+      ).data.product
+
+    // ---- the column exists and round-trips -------------------------------
+
+    it("stores the run's cost_currency, normalised", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runId } = await oneCompletedRun(adminHeaders, unique, "store")
+
+      // A new run has never stated one. NULL, not a plausible default.
+      expect((await readRun(adminHeaders, runId)).cost_currency ?? null).toBeNull()
+
+      const res = await loud("set-currency", () =>
+        api.post(
+          `/admin/production-runs/${runId}`,
+          { partner_cost_estimate: 500, cost_type: "total", cost_currency: "  USD " },
+          adminHeaders
+        )
+      )
+      expect(res.status).toBe(200)
+
+      // Trimmed and lowercased on the way in — prices are stored lowercase.
+      expect((await readRun(adminHeaders, runId)).cost_currency).toBe("usd")
+    })
+
+    it("refuses free text, and accepts null to clear it", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runId } = await oneCompletedRun(adminHeaders, unique, "valid")
+
+      /*
+       * 🔴 A free-text currency is how a price ends up labelled "Rupees" and
+       * matched by no region at all. Rejected at the door.
+       */
+      for (const bad of ["rupees", "in", "inrr", "1nr", ""]) {
+        const res = await api.post(
+          `/admin/production-runs/${runId}`,
+          { cost_currency: bad },
+          { ...adminHeaders, validateStatus: () => true }
+        )
+        expect(res.status).toBe(400)
+      }
+
+      await api.post(
+        `/admin/production-runs/${runId}`,
+        { cost_currency: "aud" },
+        adminHeaders
+      )
+      expect((await readRun(adminHeaders, runId)).cost_currency).toBe("aud")
+
+      // null is a real state — "never stated" — not a way of saying INR.
+      const cleared = await api.post(
+        `/admin/production-runs/${runId}`,
+        { cost_currency: null },
+        adminHeaders
+      )
+      expect(cleared.status).toBe(200)
+      expect((await readRun(adminHeaders, runId)).cost_currency ?? null).toBeNull()
+    })
+
+    // ---- the cost summary carries it -------------------------------------
+
+    it("reports the currency on the cost summary, and null when unstated", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runId } = await oneCompletedRun(adminHeaders, unique, "summary")
+
+      /*
+       * 🔴 null, NOT "inr". The fallback belongs to the caller, which has the
+       * design's currency to try next. Defaulting here would hide an unstated
+       * run behind a plausible answer — and hiding it is what made #1979 take
+       * two months and a customer-facing price to notice.
+       */
+      const before = await api.get(
+        `/admin/production-runs/${runId}/cost-summary`,
+        adminHeaders
+      )
+      expect(before.status).toBe(200)
+      expect(before.data.cost_summary.currency ?? null).toBeNull()
+
+      await api.post(
+        `/admin/production-runs/${runId}`,
+        { cost_currency: "usd" },
+        adminHeaders
+      )
+
+      const after = await api.get(
+        `/admin/production-runs/${runId}/cost-summary`,
+        adminHeaders
+      )
+      expect(after.data.cost_summary.currency).toBe("usd")
+    })
+
+    // ---- the whole point: approval prices in it ---------------------------
+
+    /**
+     * 🔴 THE REGRESSION, at HTTP level.
+     *
+     * The design states NO currency, so the old chain fell through to the store
+     * default. The house store's default is EUR — that is what listed ₹2,634.75
+     * as €2,634.75. With the store out of the chain the price must land in INR.
+     */
+    it("does not list an unstated design in the store's default currency", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runId } = await oneCompletedRun(adminHeaders, unique, "fallback")
+
+      const res = await loud("approve-fallback", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: [runId], decision: "approve" },
+          adminHeaders
+        )
+      )
+      const productId = res.data.run_approvals.created_product_ids[0]
+      expect(productId).toBeTruthy()
+
+      const product = await readProduct(adminHeaders, productId)
+      const currencies = (product.variants?.[0]?.prices ?? []).map(
+        (p: any) => String(p.currency_code).toLowerCase()
+      )
+      expect(currencies).toContain("inr")
+      expect(currencies).not.toContain("eur")
+    })
+
+    /**
+     * 🔴 The RUN outranks the design. `resolveApprovalPrice` prefers the run's
+     * actual cost over the design's estimate, so the denomination has to follow
+     * the same record — otherwise the price is valued by one and labelled by
+     * the other.
+     */
+    it("lists in the RUN's currency when the run states one", async () => {
+      const { adminHeaders, unique } = await setup()
+      const { runId } = await oneCompletedRun(adminHeaders, unique, "runwins")
+
+      /*
+       * A costed run: `partner_cost_estimate` gives it a real `cost_per_unit`,
+       * so the price comes from the RUN and not from the design's estimate.
+       */
+      await loud("price-run", () =>
+        api.post(
+          `/admin/production-runs/${runId}`,
+          {
+            partner_cost_estimate: 1000,
+            cost_type: "total",
+            cost_currency: "usd",
+          },
+          adminHeaders
+        )
+      )
+      expect((await readRun(adminHeaders, runId)).cost_currency).toBe("usd")
+
+      const res = await loud("approve-runwins", () =>
+        api.post(
+          "/admin/production-runs/approvals",
+          { run_ids: [runId], decision: "approve" },
+          adminHeaders
+        )
+      )
+      const productId = res.data.run_approvals.created_product_ids[0]
+      expect(productId).toBeTruthy()
+
+      const product = await readProduct(adminHeaders, productId)
+      const currencies = (product.variants?.[0]?.prices ?? []).map(
+        (p: any) => String(p.currency_code).toLowerCase()
+      )
+      expect(currencies).toContain("usd")
+    })
+  })
+})

--- a/apps/backend/src/api/admin/designs/[id]/approve/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/approve/route.ts
@@ -8,11 +8,12 @@ import updateDesignWorkflow from "../../../../../workflows/designs/update-design
 import { createProductFromDesignWorkflow } from "../../../../../workflows/designs/create-product-from-design";
 import { requestVariantPriceFanout } from "../../../../../workflows/fx/fanout-variant-prices";
 import designCustomerLink from "../../../../../links/design-customer-link";
-import {
-  readStoreId,
-  resolveApprovalCurrency,
-} from "../../../../../workflows/production-runs/approve-run-output";
+import { resolveApprovalCurrency } from "../../../../../workflows/production-runs/approve-run-output";
 import { approvalCurrencyWasAssumed } from "../../../../../workflows/production-runs/approval-pricing";
+import {
+  currencyIsSellable,
+  readHouseStore,
+} from "../../../../../workflows/production-runs/house-store";
 
 /**
  * POST /admin/designs/:id/approve
@@ -109,9 +110,22 @@ export async function POST(
       return;
     }
 
+    const houseStore = await readHouseStore(req.scope);
     const approvalCurrency = resolveApprovalCurrency({
       designCurrency: (design as any).cost_currency,
     });
+    if (!currencyIsSellable(approvalCurrency, houseStore)) {
+      /**
+       * A GUARD, never an override — re-denominating a cost to whatever the
+       * store prefers is the #1979 defect itself. This only says the price is
+       * not sellable here, so the condition stops being silent.
+       */
+      logger.warn(
+        `[Admin] Design ${designId} is priced in ${approvalCurrency}, which the house store ` +
+          `does not sell in (enabled: ${houseStore?.currencies.join(", ") || "unknown"}). ` +
+          `The price is correct but unsellable until ${approvalCurrency} is enabled.`
+      );
+    }
     if (approvalCurrencyWasAssumed((design as any).cost_currency)) {
       /**
        * A GUESS, and the common case — 42 of 43 costed designs on prod had no
@@ -175,7 +189,8 @@ export async function POST(
      * skipped, so a re-approval is a no-op.
      */
     try {
-      const storeId = await readStoreId(req.scope)
+      // Already read above for the sellability guard — one query, not two.
+      const storeId = houseStore?.id ?? null
       if (storeId && productResult?.variant_id) {
         await requestVariantPriceFanout(req.scope, {
           storeId,

--- a/apps/backend/src/api/admin/designs/[id]/approve/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/approve/route.ts
@@ -9,10 +9,10 @@ import { createProductFromDesignWorkflow } from "../../../../../workflows/design
 import { requestVariantPriceFanout } from "../../../../../workflows/fx/fanout-variant-prices";
 import designCustomerLink from "../../../../../links/design-customer-link";
 import {
-  readStoreCurrency,
   readStoreId,
   resolveApprovalCurrency,
 } from "../../../../../workflows/production-runs/approve-run-output";
+import { approvalCurrencyWasAssumed } from "../../../../../workflows/production-runs/approval-pricing";
 
 /**
  * POST /admin/designs/:id/approve
@@ -109,6 +109,22 @@ export async function POST(
       return;
     }
 
+    const approvalCurrency = resolveApprovalCurrency({
+      designCurrency: (design as any).cost_currency,
+    });
+    if (approvalCurrencyWasAssumed((design as any).cost_currency)) {
+      /**
+       * A GUESS, and the common case — 42 of 43 costed designs on prod had no
+       * `cost_currency` when #1979 was found. The approval still proceeds
+       * (refusing would block every approval on the platform), but the
+       * assumption is logged rather than living only in a docblock.
+       */
+      logger.warn(
+        `[Admin] Design ${designId} has no cost_currency; assuming ${approvalCurrency}. ` +
+          `If it was not costed in ${approvalCurrency}, the listed price is wrong.`
+      );
+    }
+
     // Create real product/variant from design
     const { result: productResult, errors: productErrors } =
       await createProductFromDesignWorkflow(req.scope).run({
@@ -120,13 +136,15 @@ export async function POST(
            * 🔴 Was hardcoded `"usd"` on a platform that trades in AUD and INR,
            * so every approved design was listed in a currency nobody sells in
            * (#1805). Resolved from the design's own `cost_currency` — what the
-           * work was costed in — with the store default behind it. The rule is
-           * shared with the bulk review so the two paths cannot disagree.
+           * work was costed in — with INR behind it. The rule is shared with
+           * the bulk review so the two paths cannot disagree.
+           *
+           * 🔴 The store default used to sit between the two (#1979). This
+           * store's default is EUR, so an INR-costed design minted in euros
+           * and fanned out to ~110x its cost. A cost is denominated by how it
+           * was COMPUTED, not by where the garment is sold.
            */
-          currency_code: resolveApprovalCurrency({
-            designCurrency: (design as any).cost_currency,
-            storeCurrency: await readStoreCurrency(req.scope),
-          }),
+          currency_code: approvalCurrency,
         },
       });
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-design-cost-currency.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-design-cost-currency.unit.spec.ts
@@ -1,0 +1,98 @@
+import {
+  needsCostCurrency,
+  storedCost,
+} from "../backfill-design-cost-currency-job"
+
+/**
+ * Which designs the #1979 backfill will stamp — its entire blast radius.
+ *
+ * The job fills a blank `cost_currency` on a costed design so approval stops
+ * falling back to the store default (EUR here), which listed INR costs as euros
+ * at ~110x. Two properties matter more than anything else:
+ *
+ *  1. it must never OVERWRITE a currency someone stated, and
+ *  2. it must actually SELECT the rows on prod — which arrive in three shapes.
+ */
+describe("storedCost", () => {
+  it("reads a plain number", () => {
+    expect(storedCost({ estimated_cost: 2634.75 })).toBe(2634.75)
+  })
+
+  it("reads a bigNumber-ish string", () => {
+    // The column is bigNumber-ish and comes back as a string on some paths.
+    expect(storedCost({ estimated_cost: "4000" as any })).toBe(4000)
+  })
+
+  it("reads the { value, precision } object the admin API actually returns", () => {
+    /*
+     * 🔴 The shape observed on prod: `{ value: "4000", precision: 20 }`. A bare
+     * `Number()` on it is NaN, which would score as "no cost" and silently
+     * skip every such row — the job would report success having done nothing.
+     */
+    expect(storedCost({ estimated_cost: { value: "4000", precision: 20 } as any })).toBe(
+      4000
+    )
+  })
+
+  it("treats absent and unparseable as no cost, never NaN", () => {
+    expect(storedCost({})).toBe(0)
+    expect(storedCost({ estimated_cost: null })).toBe(0)
+    expect(storedCost({ estimated_cost: "" as any })).toBe(0)
+    expect(storedCost({ estimated_cost: "abc" as any })).toBe(0)
+    expect(storedCost({ estimated_cost: {} as any })).toBe(0)
+  })
+})
+
+describe("needsCostCurrency", () => {
+  it("selects a costed design with no currency — the 45 on prod", () => {
+    expect(needsCostCurrency({ estimated_cost: 2634.75, cost_currency: null })).toBe(true)
+    expect(needsCostCurrency({ estimated_cost: 2634.75 })).toBe(true)
+    expect(
+      needsCostCurrency({ estimated_cost: { value: "960", precision: 20 } as any })
+    ).toBe(true)
+  })
+
+  it("selects blank-but-not-null currencies", () => {
+    /*
+     * '' is falsy but is not null — the shape that defeated an `is not null`
+     * CHECK elsewhere in this codebase — and "   " is not a statement either.
+     * Both would otherwise be carried into the price as an empty currency code.
+     */
+    expect(needsCostCurrency({ estimated_cost: 100, cost_currency: "" })).toBe(true)
+    expect(needsCostCurrency({ estimated_cost: 100, cost_currency: "   " })).toBe(true)
+  })
+
+  it("🔴 NEVER selects a design that already states a currency", () => {
+    /*
+     * The assertion that makes the job safe to re-run and safe to mis-scope.
+     * The two designs stamped by hand while #1979 was being diagnosed must be
+     * untouchable, and so must a design deliberately costed in another currency.
+     */
+    expect(needsCostCurrency({ estimated_cost: 2634.75, cost_currency: "inr" })).toBe(
+      false
+    )
+    expect(needsCostCurrency({ estimated_cost: 570.4, cost_currency: "aud" })).toBe(false)
+    expect(needsCostCurrency({ estimated_cost: 100, cost_currency: "EUR" })).toBe(false)
+  })
+
+  it("does NOT select a design with no cost", () => {
+    /*
+     * Nothing to denominate. Stamping a currency onto an uncosted design would
+     * state something we do not know — and 83 of the 130 designs on prod are
+     * in exactly that state.
+     */
+    expect(needsCostCurrency({ cost_currency: null })).toBe(false)
+    expect(needsCostCurrency({ estimated_cost: null, cost_currency: null })).toBe(false)
+    expect(needsCostCurrency({ estimated_cost: 0, cost_currency: null })).toBe(false)
+    expect(needsCostCurrency({ estimated_cost: "0" as any, cost_currency: null })).toBe(
+      false
+    )
+  })
+
+  it("does not select a negative or unparseable cost", () => {
+    expect(needsCostCurrency({ estimated_cost: -5, cost_currency: null })).toBe(false)
+    expect(needsCostCurrency({ estimated_cost: "abc" as any, cost_currency: null })).toBe(
+      false
+    )
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-design-cost-currency-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-design-cost-currency-job.ts
@@ -1,0 +1,239 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { DESIGN_MODULE } from "../../../../modules/designs"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — say what a design was costed IN, so approval stops guessing
+ * (#1979).
+ *
+ * `resolveApprovalCurrency` read `designCurrency || storeCurrency || "inr"`.
+ * JYT Medu Store's default is EUR, so a design that never recorded a currency
+ * was listed in euros: a jacket costed at ₹2,634.75 minted as €2,634.75 and
+ * `replay-fx-fanout` propagated that base into all 11 currencies, listing it at
+ * ₹291,560 — about 110× its cost.
+ *
+ * The resolver no longer consults the store, so the fallback is INR and the
+ * mis-pricing has stopped. This job removes the GUESS: a design that states
+ * its currency is not relying on any fallback at all.
+ *
+ * ## Why INR, and why this is an inference rather than a reading
+ *
+ * 🔴 Worth being honest about, because it is the whole risk of this job.
+ * `cost_breakdown` records a `cost_source` per line — `order_history`,
+ * `unit_cost`, `raw_material`, `estimated` — and **not one line records a
+ * currency**. 18 of the 45 candidates on prod have no breakdown at all. So the
+ * currency cannot be READ from the cost's own provenance; it is inferred from
+ * "production is costed in INR" (the unified order carries `currency_assumed:
+ * true` for the same reason).
+ *
+ * That is why the currency is a PARAMETER with an INR default rather than a
+ * constant, and why `design_id` exists: a design costed by someone abroad can
+ * be stamped individually with the right code instead of being swept up.
+ *
+ * ## What keeps it safe
+ *
+ * ⚠️ It only ever fills a BLANK. A design that already states a currency is
+ * never a candidate, so a value someone set by hand — including the two set by
+ * hand while #1979 was being diagnosed — cannot be overwritten by a re-run or
+ * by a mis-scoped one.
+ *
+ * ⚠️ It requires a cost > 0. A design with no cost has nothing to denominate,
+ * and stamping a currency onto it would state something we do not know.
+ *
+ * It writes one field, creates nothing, prices nothing, and touches no product,
+ * payment or order. Safe to re-run: once stamped, a design is no longer blank.
+ *
+ * 🔴 It does NOT re-price the products of designs already approved under the
+ * old EUR behaviour. Those carry a wrong price TODAY and stamping the design
+ * does not correct them — the variant prices are a separate, deliberate repair.
+ */
+const paramsSchema = z.object({
+  /** One design, for a spot check before a full pass — or for a non-INR one. */
+  design_id: z.string().min(1).optional(),
+  /** Bound a first pass; omitted means every design that needs one. */
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+  /**
+   * The currency to stamp. Defaults to INR because production is costed in INR.
+   * A parameter, not a constant, because this is an inference: a design costed
+   * abroad should be stamped individually with `design_id`.
+   */
+  currency: z
+    .string()
+    .trim()
+    .regex(/^[A-Za-z]{3}$/, "currency must be a 3-letter code, e.g. 'inr'")
+    .optional(),
+})
+
+/**
+ * PURE: the stored cost as a number, or 0 when there isn't one.
+ * Exported for tests.
+ *
+ * ⚠️ Three shapes reach this. The column is bigNumber-ish, so it arrives as a
+ * number, as a string (`"4000"`), or as `{ value: "4000", precision: 20 }` —
+ * the last is what the admin API actually returns on prod, and reading it with
+ * a bare `Number()` yields `NaN`, which would silently skip every such row.
+ */
+export function storedCost(design: { estimated_cost?: unknown }): number {
+  let raw: unknown = design?.estimated_cost
+  if (raw && typeof raw === "object" && "value" in (raw as any)) {
+    raw = (raw as any).value
+  }
+  if (raw === null || raw === undefined || raw === "") {
+    return 0
+  }
+  const value = Number(raw)
+  return Number.isFinite(value) ? value : 0
+}
+
+/**
+ * PURE: does this design have a cost but no currency to read it in?
+ * Exported for tests — this is the whole blast radius of the job.
+ *
+ * ⚠️ `""` and `"   "` count as blank. `''` is falsy but is not null (the shape
+ * that defeated an `is not null` CHECK elsewhere in this codebase), and a
+ * whitespace-only code is not a statement of anything either.
+ */
+export function needsCostCurrency(design: {
+  estimated_cost?: unknown
+  cost_currency?: unknown
+}): boolean {
+  if (storedCost(design) <= 0) {
+    return false
+  }
+  return String(design?.cost_currency ?? "").trim() === ""
+}
+
+export const backfillDesignCostCurrencyJob: MaintenanceJob = {
+  id: "backfill-design-cost-currency",
+  label: "Say what a design was costed in (cost_currency)",
+  description:
+    "Stamp cost_currency (default INR) on designs that have an estimated_cost but no currency, so approval stops falling back (#1979). The approve path read `design.cost_currency || store default || inr`, and this store's default is EUR — so an INR-costed design minted in euros and fanned out at ~110x its cost. HONEST CAVEAT: no cost_breakdown line records a currency and many designs have no breakdown at all, so INR is INFERRED from 'production is costed in INR', not read from the data — which is why the currency is a parameter and design_id lets you stamp an individually-costed design with the right code instead. Only ever fills a BLANK: a design that already states a currency can never be overwritten, including by a re-run. Requires a cost > 0, because a design with no cost has nothing to denominate. Writes one field; creates nothing, prices nothing, touches no product, payment or order. Does NOT re-price products already approved under the old EUR behaviour — that is a separate repair.",
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: false,
+      description:
+        "Only this design — for a spot check before a full pass, or to stamp a design costed in something other than the default.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Stop after this many designs. Omit for every design that needs one.",
+    },
+    {
+      name: "currency",
+      type: "string",
+      required: false,
+      description:
+        "3-letter code to stamp. Defaults to 'inr' because production is costed in INR.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+
+    const currency = (parsed.data.currency ?? "inr").trim().toLowerCase()
+    const designService: any = container.resolve(DESIGN_MODULE)
+
+    const designs = (await designService.listDesigns(
+      parsed.data.design_id ? { id: parsed.data.design_id } : {},
+      { take: null }
+    )) as any[]
+
+    if (parsed.data.design_id && !(designs || []).length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Design ${parsed.data.design_id} not found`
+      )
+    }
+
+    const candidates = (designs || []).filter(needsCostCurrency)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    for (const design of candidates) {
+      if (parsed.data.limit && changes.length >= parsed.data.limit) {
+        break
+      }
+
+      try {
+        /**
+         * The `note` carries the evidence, so a dry-run can be ARGUED WITH: the
+         * figure being denominated, the design's status (an already-approved
+         * one may have a wrong price live), and whether any cost provenance
+         * exists at all. A dry-run that lists ids and nothing else can only be
+         * checked by re-deriving it by hand.
+         */
+        const bd = (design as any)?.cost_breakdown
+        const lines = Array.isArray(bd) ? bd : bd?.items
+        const provenance = Array.isArray(lines) && lines.length
+          ? [
+              ...new Set(
+                lines
+                  .map((l: any) => String(l?.cost_source ?? "").trim())
+                  .filter(Boolean)
+              ),
+            ].join("/")
+          : "no cost_breakdown"
+
+        changes.push({
+          entity: "design",
+          id: design.id,
+          field: "cost_currency",
+          before: design.cost_currency ?? null,
+          after: currency,
+          note: `${design.name ?? "(unnamed)"} — cost ${storedCost(
+            design
+          )}, status ${design.status ?? "(none)"}, provenance: ${provenance}`,
+        })
+
+        if (!dry_run) {
+          await designService.updateDesigns({
+            id: design.id,
+            cost_currency: currency,
+          })
+        }
+      } catch (e: any) {
+        // One unreadable design must not strand the rest of the pass.
+        errors.push({ id: design?.id ?? "(unknown)", message: e?.message ?? String(e) })
+      }
+    }
+
+    const approved = changes.filter((c) =>
+      String(c.note ?? "").includes("status Approved")
+    ).length
+
+    const parts: string[] = []
+    parts.push(
+      changes.length
+        ? `${dry_run ? "Would stamp" : "Stamped"} cost_currency=${currency} on ${
+            changes.length
+          } design(s) that had a cost but no currency`
+        : "Every costed design already states a currency"
+    )
+    if (approved) {
+      parts.push(
+        `⚠️ ${approved} of them are already Approved — their products were minted under the old fallback and may carry a wrong price RIGHT NOW; stamping the design does not correct a variant price`
+      )
+    }
+
+    return {
+      job_id: "backfill-design-cost-currency",
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: parts.join(". ") + ".",
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -127,6 +127,7 @@ import { backfillPaymentLineRunProvenanceJob } from "./backfill-payment-line-run
 import { backfillInventoryOrderPaymentLinksJob } from "./backfill-inventory-order-payment-links-job"
 import { backfillSubmissionPaidAtJob } from "./backfill-submission-paid-at-job"
 import { clearUnpriceableDesignCostsJob } from "./clear-unpriceable-design-costs-job"
+import { backfillDesignCostCurrencyJob } from "./backfill-design-cost-currency-job"
 import { recordPaymentLineRunJob } from "./record-payment-line-run-job"
 import { deduplicateTaskTemplateNamesJob } from "./deduplicate-task-template-names-job"
 import { recordManualInventoryCorrectionJob } from "./record-manual-inventory-correction-job"
@@ -6023,6 +6024,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillInventoryOrderPaymentLinksJob,
   backfillSubmissionPaidAtJob,
   clearUnpriceableDesignCostsJob,
+  backfillDesignCostCurrencyJob,
   recordPaymentLineRunJob,
   recordManualInventoryCorrectionJob,
   applyCommittedConsumptionJob,

--- a/apps/backend/src/api/admin/production-runs/[id]/cost-summary/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/cost-summary/route.ts
@@ -217,6 +217,18 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     cost_summary: {
       production_run_id: runId,
       design_id: (run as any).design_id,
+      /**
+       * What every figure below is denominated in (#1979), or null when the run
+       * never stated one — null means UNSTATED, not INR.
+       *
+       * ⚠️ Kept byte-identical to `computeRunCostSummary`'s `currency`, which
+       * the PARTNER route serves. This handler still computes its own totals
+       * rather than calling the shared function that was extracted FROM it, so
+       * the two sides can drift — an integration test caught this field missing
+       * here while the partner side had it.
+       */
+      currency:
+        String((run as any).cost_currency ?? "").trim().toLowerCase() || null,
       status: (run as any).status,
       quantity: (run as any).quantity,
       produced_quantity: (run as any).produced_quantity,

--- a/apps/backend/src/api/admin/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/route.ts
@@ -149,7 +149,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 /**
  * POST /admin/production-runs/:id
  * Update a production run. quantity/role/run_type are only allowed before the
- * run is accepted/started. Cost fields (partner_cost_estimate, cost_type) are
+ * run is accepted/started. Cost fields (partner_cost_estimate, cost_type,
+ * cost_currency) are
  * editable by admins any time except cancelled, since admins may need to
  * record/correct cost after the partner has already begun work.
  *
@@ -302,6 +303,32 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     update.partner_cost_estimate =
       body.partner_cost_estimate === null ? null : Number(body.partner_cost_estimate)
   }
+  if (body.cost_currency !== undefined) {
+    /**
+     * #1979 — the run says what its cost is DENOMINATED IN.
+     *
+     * Without this the cost was a bare number and approval had to guess the
+     * currency when it turned that number into a listed price; it guessed the
+     * store default, and on a EUR store listed ₹2,634.75 as €2,634.75 (~110×).
+     *
+     * `null` clears it back to unstated, which is a real state — approval then
+     * falls back to the design's `cost_currency` and finally to INR. Anything
+     * else must be a 3-letter code: a free-text currency is how you get a
+     * price labelled `"Rupees"` that no region can match.
+     */
+    if (body.cost_currency === null) {
+      update.cost_currency = null
+    } else {
+      const code = String(body.cost_currency).trim().toLowerCase()
+      if (!/^[a-z]{3}$/.test(code)) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          "cost_currency must be a 3-letter currency code (e.g. 'inr'), or null to clear it"
+        )
+      }
+      update.cost_currency = code
+    }
+  }
   if (body.cost_type !== undefined) {
     if (body.cost_type !== "total" && body.cost_type !== "per_unit") {
       throw new MedusaError(
@@ -409,6 +436,14 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const touchesMoney =
     update.partner_cost_estimate !== undefined ||
     update.cost_type !== undefined ||
+    /**
+     * #1979 — stating (or clearing) the run's currency re-denominates every
+     * figure derived from its cost, so a Draft written earlier is now
+     * describing the same numbers in a different unit. It is deliberately NOT
+     * in `touchesPrice` below: saying what a cost was always measured in does
+     * not change what is owed, and must not manufacture a payout claim.
+     */
+    update.cost_currency !== undefined ||
     update.produced_quantity !== undefined ||
     /**
      * 🔴 The agreed quantity belongs here too (#1695). `runPayableAmount` bills

--- a/apps/backend/src/modules/production_runs/cost-summary.ts
+++ b/apps/backend/src/modules/production_runs/cost-summary.ts
@@ -17,6 +17,20 @@ import type EnergyRateService from "../energy_rates/service"
 export type RunCostSummary = {
   production_run_id: string
   design_id: string
+  /**
+   * What every figure below is DENOMINATED IN — the run's own `cost_currency`,
+   * or null when the run never stated one (#1979).
+   *
+   * 🔴 This type used to carry no currency at all. Approval turns `cost_per_unit`
+   * into a listed price, so with no currency here it had to GUESS one, and the
+   * guess was the store's default: a cost of ₹2,634.75 was listed as €2,634.75,
+   * about 110×. A number that becomes money must say what it is measured in.
+   *
+   * ⚠️ null means UNSTATED, not INR. The fallback belongs to the caller
+   * (`resolveApprovalCurrency`), which has the design's currency to try next;
+   * defaulting here would hide an unstated run behind a plausible answer.
+   */
+  currency: string | null
   status: string
   quantity: number
   produced_quantity: number | null
@@ -195,6 +209,13 @@ export async function computeRunCostSummary(
   return {
     production_run_id: runId,
     design_id: (run as any).design_id,
+    /*
+     * Trimmed and lowercased, and `""` collapses to null — '' is falsy but is
+     * not null, and an empty currency code reads as a stated one to any caller
+     * that only checks for null.
+     */
+    currency:
+      String((run as any).cost_currency ?? "").trim().toLowerCase() || null,
     status: (run as any).status,
     quantity: (run as any).quantity,
     produced_quantity: (run as any).produced_quantity ?? null,

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260911070000.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260911070000.ts
@@ -1,0 +1,43 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * #1979 — let a production run SAY what its cost is denominated in.
+ *
+ * The run carried `partner_cost_estimate` as a bare number and `cost_type`
+ * saying whether it was per-unit or total, but nothing said which CURRENCY.
+ * `RunCostSummary` had no currency field either, so approval — which turns a
+ * run's cost into a listed price — had to guess, and guessed the store default.
+ * On a EUR store that listed a cost of ₹2,634.75 as €2,634.75, about 110×.
+ *
+ * Nullable with no default, so every existing run reads as UNSTATED, which is
+ * exactly what they are. Approval then falls back to the design's
+ * `cost_currency` and finally to INR, so behaviour for old runs is unchanged.
+ *
+ * ⚠️ Deliberately NOT backfilled to 'inr' here. A migration that stamps a
+ * currency onto historical rows is asserting something nobody verified; the
+ * `backfill-design-cost-currency` maintenance job exists so that kind of claim
+ * is made by an operator with a dry-run in front of them, not by a schema change.
+ */
+export class Migration20260911070000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      alter table if exists "production_runs"
+        add column if not exists "cost_currency" text null;
+    `);
+  }
+
+  /**
+   * Reversible: without the column every run reads as unstated again and
+   * approval falls back exactly as it did before. It DOES discard whatever
+   * currencies were recorded — acceptable because the fallback chain gives the
+   * same answer for the INR case, which is all of prod today.
+   */
+  override async down(): Promise<void> {
+    this.addSql(`
+      alter table if exists "production_runs"
+        drop column if exists "cost_currency";
+    `);
+  }
+
+}

--- a/apps/backend/src/modules/production_runs/models/production-run.ts
+++ b/apps/backend/src/modules/production_runs/models/production-run.ts
@@ -137,6 +137,25 @@ const ProductionRun = model.define("production_runs", {
   // Cost
   partner_cost_estimate: model.float().nullable(),
   cost_type: model.enum(["per_unit", "total"]).default("total").nullable(),
+  /**
+   * What this run's cost is DENOMINATED IN (#1979).
+   *
+   * 🔴 The cost used to be a bare number with no currency anywhere on the run.
+   * `RunCostSummary` had no currency field either, so when approval turned a
+   * run's cost into a listed price it had to GUESS — and the guess it made was
+   * the store's default. On a EUR store that listed a cost of ₹2,634.75 as
+   * €2,634.75, about 110× the real figure.
+   *
+   * Nullable, and null means "not stated" rather than any particular currency:
+   * every run that existed before this column reads as unstated, which is the
+   * truth about them. Approval falls back to the design's `cost_currency` and
+   * then to INR, so an unstated run behaves exactly as it did.
+   *
+   * ⚠️ Lowercased 3-letter code, matched to how prices are stored. It is the
+   * currency of `partner_cost_estimate` AND of everything `computeRunCostSummary`
+   * derives from the run's consumption logs, because those are the same money.
+   */
+  cost_currency: model.text().nullable(),
 
   // Dispatch state
   dispatch_state: model

--- a/apps/backend/src/workflows/production-runs/__tests__/approval-pricing.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approval-pricing.unit.spec.ts
@@ -106,6 +106,38 @@ describe("resolveApprovalCurrency", () => {
   })
 
   /**
+   * #1979 — the RUN answers first. `resolveApprovalPrice` already prefers the
+   * run's actual cost over the design's estimate, so the denomination has to
+   * follow the same record; otherwise a price is valued by one and labelled by
+   * the other.
+   */
+  it("prefers the RUN's currency over the design's", () => {
+    expect(
+      resolveApprovalCurrency({ runCurrency: "usd", designCurrency: "inr" })
+    ).toBe("usd")
+    expect(resolveApprovalCurrency({ runCurrency: "  USD " })).toBe("usd")
+  })
+
+  it("falls through to the design when the run states nothing", () => {
+    expect(
+      resolveApprovalCurrency({ runCurrency: null, designCurrency: "aud" })
+    ).toBe("aud")
+    expect(
+      resolveApprovalCurrency({ runCurrency: "", designCurrency: "aud" })
+    ).toBe("aud")
+    // whitespace is not a statement either
+    expect(
+      resolveApprovalCurrency({ runCurrency: "   ", designCurrency: "aud" })
+    ).toBe("aud")
+  })
+
+  it("still lands on INR when neither states one", () => {
+    expect(
+      resolveApprovalCurrency({ runCurrency: null, designCurrency: null })
+    ).toBe("inr")
+  })
+
+  /**
    * 🔴 #1979 — THE REGRESSION. The chain was
    * `designCurrency || storeCurrency || "inr"`, and JYT Medu Store's default is
    * EUR, so the INR last resort was unreachable on the only store we sell from.
@@ -160,13 +192,21 @@ describe("resolveApprovalCurrency", () => {
 })
 
 describe("approvalCurrencyWasAssumed", () => {
-  it("is true exactly when the design stated nothing", () => {
+  it("is true exactly when NEITHER the run nor the design stated one", () => {
     expect(approvalCurrencyWasAssumed(null)).toBe(true)
     expect(approvalCurrencyWasAssumed(undefined)).toBe(true)
     expect(approvalCurrencyWasAssumed("")).toBe(true)
     // whitespace is not a statement — tested RAW, before any coercion
     expect(approvalCurrencyWasAssumed("   ")).toBe(true)
+    expect(approvalCurrencyWasAssumed(null, null)).toBe(true)
+    expect(approvalCurrencyWasAssumed("", "  ")).toBe(true)
+  })
+
+  it("is false when EITHER states one", () => {
     expect(approvalCurrencyWasAssumed("inr")).toBe(false)
     expect(approvalCurrencyWasAssumed("EUR")).toBe(false)
+    // 🔴 the run alone is enough — nothing was assumed if the run said it
+    expect(approvalCurrencyWasAssumed(null, "usd")).toBe(false)
+    expect(approvalCurrencyWasAssumed("", "usd")).toBe(false)
   })
 })

--- a/apps/backend/src/workflows/production-runs/__tests__/approval-pricing.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approval-pricing.unit.spec.ts
@@ -13,6 +13,7 @@ import {
   APPROVAL_FALLBACK_CURRENCY,
   APPROVAL_MARKUP,
   resolveApprovalCurrency,
+  approvalCurrencyWasAssumed,
   resolveApprovalPrice,
 } from "../approval-pricing"
 
@@ -101,15 +102,38 @@ describe("resolveApprovalPrice", () => {
 
 describe("resolveApprovalCurrency", () => {
   it("prefers the design's own cost_currency", () => {
-    expect(
-      resolveApprovalCurrency({ designCurrency: "AUD", storeCurrency: "eur" })
-    ).toBe("aud")
+    expect(resolveApprovalCurrency({ designCurrency: "AUD" })).toBe("aud")
   })
 
-  it("falls back to the store default before the last resort", () => {
+  /**
+   * 🔴 #1979 — THE REGRESSION. The chain was
+   * `designCurrency || storeCurrency || "inr"`, and JYT Medu Store's default is
+   * EUR, so the INR last resort was unreachable on the only store we sell from.
+   * A jacket costed at ₹2,634.75 minted as €2,634.75 and fanned out to
+   * ₹291,560 — about 110× its cost.
+   *
+   * The store is no longer asked, so it cannot be passed: this reads
+   * `designCurrency` alone, and an absent one lands on INR however the store is
+   * configured.
+   */
+  it("does not inherit a EUR store default for a design costed in INR", () => {
+    expect(resolveApprovalCurrency({ designCurrency: null })).toBe("inr")
+    expect(resolveApprovalCurrency({ designCurrency: undefined })).toBe("inr")
+    expect(resolveApprovalCurrency({ designCurrency: null })).not.toBe("eur")
+  })
+
+  it("refuses a store default even if one is smuggled in", () => {
+    /*
+     * `storeCurrency` is gone from the input TYPE, which is the real guard —
+     * this proves the runtime ignores it too, so a stale JS caller (or a cast)
+     * cannot resurrect the 110x bug silently.
+     */
     expect(
-      resolveApprovalCurrency({ designCurrency: null, storeCurrency: "EUR" })
-    ).toBe("eur")
+      resolveApprovalCurrency({ designCurrency: null, storeCurrency: "eur" } as any)
+    ).toBe("inr")
+    expect(
+      resolveApprovalCurrency({ designCurrency: "inr", storeCurrency: "eur" } as any)
+    ).toBe("inr")
   })
 
   it("lands on INR, not usd, when nothing states a currency", () => {
@@ -130,8 +154,19 @@ describe("resolveApprovalCurrency", () => {
   it("treats an empty string as unstated", () => {
     // '' is falsy but is not null — the same shape that defeated an
     // `is not null` CHECK constraint elsewhere in this codebase.
-    expect(resolveApprovalCurrency({ designCurrency: "", storeCurrency: "aud" })).toBe(
-      "aud"
-    )
+    expect(resolveApprovalCurrency({ designCurrency: "" })).toBe("inr")
+    expect(resolveApprovalCurrency({ designCurrency: "   " })).toBe("inr")
+  })
+})
+
+describe("approvalCurrencyWasAssumed", () => {
+  it("is true exactly when the design stated nothing", () => {
+    expect(approvalCurrencyWasAssumed(null)).toBe(true)
+    expect(approvalCurrencyWasAssumed(undefined)).toBe(true)
+    expect(approvalCurrencyWasAssumed("")).toBe(true)
+    // whitespace is not a statement — tested RAW, before any coercion
+    expect(approvalCurrencyWasAssumed("   ")).toBe(true)
+    expect(approvalCurrencyWasAssumed("inr")).toBe(false)
+    expect(approvalCurrencyWasAssumed("EUR")).toBe(false)
   })
 })

--- a/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
@@ -29,6 +29,12 @@ const listProductionRuns = jest.fn()
 const updateProductionRuns = jest.fn().mockResolvedValue({})
 const graph = jest.fn()
 const emit = jest.fn().mockResolvedValue(undefined)
+/**
+ * A STABLE logger, not a fresh `jest.fn()` per resolve — otherwise a test can
+ * never see what was logged, and #1979's "the currency was assumed" warning is
+ * the only signal that a price was guessed rather than read.
+ */
+const logger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() }
 
 const container = {
   resolve: (key: string) => {
@@ -36,7 +42,7 @@ const container = {
       return { listProductionRuns, updateProductionRuns }
     }
     if (key === "query") return { graph }
-    if (key === "logger") return { error: jest.fn(), info: jest.fn() }
+    if (key === "logger") return logger
     if (key === "event_bus") return { emit }
     return {}
   },
@@ -111,22 +117,23 @@ describe("resolveApprovalCurrency", () => {
    * AUD and INR.
    */
   it("prefers what the design was costed in", () => {
-    expect(
-      resolveApprovalCurrency({ designCurrency: "INR", storeCurrency: "aud" })
-    ).toBe("inr")
+    expect(resolveApprovalCurrency({ designCurrency: "INR" })).toBe("inr")
   })
 
-  it("falls back to the store, then to INR — never usd (#1914)", () => {
+  it("falls back to INR — never usd (#1914), never the store (#1979)", () => {
     /*
      * "usd" survived the original fix as the last resort, which still
      * mis-priced any design that never recorded a currency. Production is
      * costed in INR (the unified order carries `currency_assumed: true` for
-     * the same reason), so a design with no stated currency was costed in INR
-     * whatever the fallback claimed.
+     * the same reason).
+     *
+     * #1979: the STORE default used to sit in front of that fallback, so on a
+     * EUR store the INR last resort could never be reached and an INR-costed
+     * design minted at ~110x. The store is no longer consulted at all.
      */
-    expect(resolveApprovalCurrency({ storeCurrency: "AUD" })).toBe("aud")
     expect(resolveApprovalCurrency({})).toBe("inr")
     expect(resolveApprovalCurrency({})).not.toBe("usd")
+    expect(resolveApprovalCurrency({ storeCurrency: "EUR" } as any)).toBe("inr")
   })
 })
 
@@ -290,13 +297,55 @@ describe("applyRunApprovals — approving", () => {
     })
   })
 
-  it("falls back to the store's default currency", async () => {
+  /**
+   * 🔴 #1979 — this test used to assert "aud", pinning the bug in place: a
+   * design with no `cost_currency` inherited the STORE's default. On the live
+   * EUR store that minted ₹2,634.75 as €2,634.75, ~110x its cost, and the
+   * INR last resort written for exactly this case was unreachable.
+   *
+   * The store is stubbed as AUD here precisely so a re-introduced
+   * `|| storeCurrency` would turn this red again.
+   */
+  it("ignores the store default for a design that never stated a currency", async () => {
     listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
     stubGraph({ des_1: design("des_1", { cost_currency: null }) }, "aud")
 
     await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
 
-    expect(createProductRun.mock.calls[0][0].input.currency_code).toBe("aud")
+    expect(createProductRun.mock.calls[0][0].input.currency_code).toBe("inr")
+    expect(createProductRun.mock.calls[0][0].input.currency_code).not.toBe("aud")
+  })
+
+  it("says out loud that the currency was assumed", async () => {
+    /*
+     * The price is still written — refusing would block every approval — so
+     * the warning is the only signal that a number was guessed. 42 of 43
+     * costed designs on prod were in this state.
+     */
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { cost_currency: null }) }, "aud")
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    const warned = (logger.warn as jest.Mock).mock.calls
+      .map((c: any[]) => String(c[0]))
+      .filter((m: string) => m.includes("no cost_currency"))
+    expect(warned).toHaveLength(1)
+    expect(warned[0]).toContain("des_1")
+    expect(warned[0]).toContain("inr")
+  })
+
+  it("does not warn when the design stated its currency", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { cost_currency: "inr" }) }, "aud")
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(
+      (logger.warn as jest.Mock).mock.calls
+        .map((c: any[]) => String(c[0]))
+        .filter((m: string) => m.includes("no cost_currency"))
+    ).toHaveLength(0)
   })
 
   /**

--- a/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/approve-run-output.unit.spec.ts
@@ -79,17 +79,33 @@ const design = (id: string, extra: any = {}) => ({
   ...extra,
 })
 
-const stubGraph = (designsById: Record<string, any>, storeCurrency = "aud") => {
+/**
+ * A MULTI-TENANT store table, because that is what prod is: 13 stores, 12 of
+ * them partner tenants carrying `metadata.partner_id`. The partner row is
+ * deliberately FIRST — the read this replaced took `stores[0]`, so a stub with
+ * a single store could never have caught #1979.
+ */
+const stubGraph = (
+  designsById: Record<string, any>,
+  storeCurrency = "aud",
+  houseCurrencies: string[] = ["usd", "inr", "aud", "eur"]
+) => {
   graph.mockImplementation(async ({ entity, filters }: any) => {
     if (entity === "store") {
       return {
         data: [
           {
+            id: "store_partner_first",
+            metadata: { partner_id: "01PARTNER" },
+            supported_currencies: [{ currency_code: "idr", is_default: true }],
+          },
+          {
             id: "store_1",
-            supported_currencies: [
-              { currency_code: "usd", is_default: false },
-              { currency_code: storeCurrency, is_default: true },
-            ],
+            metadata: null,
+            supported_currencies: houseCurrencies.map((c) => ({
+              currency_code: c,
+              is_default: c === storeCurrency,
+            })),
           },
         ],
       }
@@ -314,6 +330,59 @@ describe("applyRunApprovals — approving", () => {
 
     expect(createProductRun.mock.calls[0][0].input.currency_code).toBe("inr")
     expect(createProductRun.mock.calls[0][0].input.currency_code).not.toBe("aud")
+  })
+
+  it("scopes the FX fanout to the HOUSE store, not the first row", async () => {
+    /*
+     * 🔴 `stores[0]` here is a PARTNER tenant. Scoping the fanout to it would
+     * materialise prices against another tenant's currency set (#1979/#1983).
+     */
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { cost_currency: "inr" }) })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    const fanout = emit.mock.calls.filter(
+      (c: any[]) => c[0]?.name === "fx.fanout_requested"
+    )
+    expect(fanout).toHaveLength(1)
+    expect(fanout[0][0].data.store_id).toBe("store_1")
+    expect(fanout[0][0].data.store_id).not.toBe("store_partner_first")
+  })
+
+  it("warns when the price is in a currency the house store cannot sell", async () => {
+    /*
+     * A GUARD, never an override. The live instance: `Le Ciricotte` does not
+     * enable INR at all, so an INR-costed design gets a correct price that the
+     * store cannot actually sell. The currency must NOT be swapped — doing that
+     * silently re-denominates ₹2,634.75 as €2,634.75, which IS #1979.
+     */
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { cost_currency: "inr" }) }, "eur", ["eur", "gbp"])
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    const warned = (logger.warn as jest.Mock).mock.calls
+      .map((c: any[]) => String(c[0]))
+      .filter((m: string) => m.includes("does not sell in"))
+    expect(warned).toHaveLength(1)
+    expect(warned[0]).toContain("inr")
+
+    // and the price it actually wrote is STILL inr — warned, not rewritten
+    expect(createProductRun.mock.calls[0][0].input.currency_code).toBe("inr")
+  })
+
+  it("does not warn when the house store enables the currency", async () => {
+    listProductionRuns.mockResolvedValue([completedRun("run_1", "des_1")])
+    stubGraph({ des_1: design("des_1", { cost_currency: "inr" }) })
+
+    await applyRunApprovals(container, { runIds: ["run_1"], decision: "approve" })
+
+    expect(
+      (logger.warn as jest.Mock).mock.calls
+        .map((c: any[]) => String(c[0]))
+        .filter((m: string) => m.includes("does not sell in"))
+    ).toHaveLength(0)
   })
 
   it("says out loud that the currency was assumed", async () => {

--- a/apps/backend/src/workflows/production-runs/__tests__/house-store.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/house-store.unit.spec.ts
@@ -1,0 +1,126 @@
+import {
+  currencyIsSellable,
+  pickHouseStore,
+  storeCurrencies,
+  storeDefaultCurrency,
+} from "../house-store"
+
+const partner = (id: string, partner_id: string, currencies: string[] = ["inr"]) => ({
+  id,
+  metadata: { partner_id },
+  supported_currencies: currencies.map((c, i) => ({
+    currency_code: c,
+    is_default: i === 0,
+  })),
+})
+
+const house = (id = "store_house", currencies: string[] = ["eur", "inr"]) => ({
+  id,
+  metadata: null,
+  supported_currencies: currencies.map((c, i) => ({
+    currency_code: c,
+    is_default: i === 0,
+  })),
+})
+
+/**
+ * 🔴 The read this replaces was `stores?.[0]` against a 13-row multi-tenant
+ * table, so the currency an approval stamped was a LOTTERY across tenants —
+ * eleven default to INR, one to AUD, two to EUR. That is why 14 approved
+ * products came out in INR and exactly one came out in EUR at ~110× (#1979).
+ */
+describe("pickHouseStore", () => {
+  it("picks the store that is not a partner tenant", () => {
+    const stores = [partner("s1", "p1"), house(), partner("s2", "p2")]
+    expect(pickHouseStore(stores)?.id).toBe("store_house")
+  })
+
+  it("does NOT just take the first row", () => {
+    // The whole defect in one assertion: row order must not decide.
+    const stores = [partner("s_first", "p1"), house("store_house")]
+    expect(pickHouseStore(stores)?.id).not.toBe("s_first")
+  })
+
+  it("returns null when NO store lacks a partner id", () => {
+    // Ambiguous. Guessing here would re-create the bug in a new place.
+    expect(pickHouseStore([partner("s1", "p1"), partner("s2", "p2")])).toBeNull()
+  })
+
+  it("returns null when MORE THAN ONE store lacks a partner id", () => {
+    expect(pickHouseStore([house("h1"), house("h2")])).toBeNull()
+  })
+
+  it("treats a blank or whitespace partner_id as no partner id", () => {
+    /*
+     * '' is falsy but is not null, and "  " is truthy — the pair of shapes that
+     * have defeated guards elsewhere in this codebase. Both mean "not a tenant".
+     */
+    expect(pickHouseStore([{ id: "a", metadata: { partner_id: "" } }])?.id).toBe("a")
+    expect(pickHouseStore([{ id: "b", metadata: { partner_id: "   " } }])?.id).toBe("b")
+  })
+
+  it("survives missing metadata entirely", () => {
+    expect(pickHouseStore([{ id: "a" } as any])?.id).toBe("a")
+    expect(pickHouseStore([])).toBeNull()
+    expect(pickHouseStore(null)).toBeNull()
+  })
+})
+
+describe("storeCurrencies / storeDefaultCurrency", () => {
+  it("lowercases and drops blanks", () => {
+    expect(storeCurrencies(house("h", ["EUR", "inr"]))).toEqual(["eur", "inr"])
+    expect(storeCurrencies({ supported_currencies: [{ currency_code: "  " }] })).toEqual(
+      []
+    )
+    expect(storeCurrencies({})).toEqual([])
+  })
+
+  it("reads the flagged default, not the first entry", () => {
+    const s = {
+      supported_currencies: [
+        { currency_code: "aed", is_default: false },
+        { currency_code: "EUR", is_default: true },
+      ],
+    }
+    // On prod JYT Medu Store lists 'aed' first and defaults to 'eur'.
+    expect(storeDefaultCurrency(s)).toBe("eur")
+    expect(storeDefaultCurrency({ supported_currencies: [] })).toBeNull()
+  })
+})
+
+describe("currencyIsSellable", () => {
+  const jytMedu = { id: "h", currencies: ["aed", "eur", "inr"], defaultCurrency: "eur" }
+  const leCiricotte = { id: "l", currencies: ["eur", "gbp"], defaultCurrency: "eur" }
+
+  it("passes a currency the house store enables", () => {
+    // INR is enabled on JYT Medu Store, so an INR-costed design is sellable.
+    expect(currencyIsSellable("inr", jytMedu)).toBe(true)
+    expect(currencyIsSellable("INR", jytMedu)).toBe(true)
+  })
+
+  it("flags a currency the house store does not enable", () => {
+    // The live instance: Le Ciricotte does not enable INR at all.
+    expect(currencyIsSellable("inr", leCiricotte)).toBe(false)
+  })
+
+  it("🔴 abstains rather than objecting when the house store is unknown", () => {
+    /*
+     * null means "could not read / ambiguous". Returning false there would turn
+     * an unreadable store into a warning about a price that may be perfectly
+     * fine — noise that trains the operator to ignore the real one.
+     */
+    expect(currencyIsSellable("inr", null)).toBe(true)
+    expect(currencyIsSellable("inr", { id: "x", currencies: [], defaultCurrency: null })).toBe(
+      true
+    )
+  })
+
+  it("is a guard and nothing more — it never returns a replacement", () => {
+    /*
+     * Documented as a test because the tempting 'fix' — swapping in the store's
+     * default when the cost currency is not enabled — IS #1979: it silently
+     * re-denominates ₹2,634.75 as €2,634.75.
+     */
+    expect(typeof currencyIsSellable("inr", leCiricotte)).toBe("boolean")
+  })
+})

--- a/apps/backend/src/workflows/production-runs/approval-pricing.ts
+++ b/apps/backend/src/workflows/production-runs/approval-pricing.ts
@@ -111,21 +111,59 @@ export function resolveApprovalPrice(input: {
  * 🔴 The approve route once hardcoded `"usd"` on a platform trading in AUD and
  * INR, so every approved design was listed in a currency nobody sells in. That
  * was fixed to prefer the design's own `cost_currency`, but `"usd"` survived as
- * the last resort — which still mis-prices any design that never recorded one.
+ * the last resort — which still mis-priced any design that never recorded one.
  *
- * The last resort is now **INR**: production is costed in INR (the unified
- * order carries `currency_assumed: true` for exactly this reason), so a design
- * with no stated currency was costed in INR whatever the fallback claimed.
+ * The last resort is **INR**: production is costed in INR (the unified order
+ * carries `currency_assumed: true` for exactly this reason), so a design with
+ * no stated currency was costed in INR whatever the fallback claimed.
  * `RunCostSummary` carries no currency field at all, so the run cannot answer
- * this — which is why the design and the store are still asked first.
+ * this either.
+ *
+ * ── Why the STORE default is not asked (#1979) ────────────────────────────
+ *
+ * It used to sit between the two, as `designCurrency || storeCurrency || "inr"`.
+ * `JYT Medu Store`'s default is EUR, so the INR last resort was UNREACHABLE on
+ * the only store we sell from — the very case it was written for. A design
+ * costed at ₹2,634.75 minted as €2,634.75 and fanned out to **₹291,560**, about
+ * 110× its cost, and `replay-fx-fanout` propagated that base into all 11
+ * currencies. The #1805 fix for the hardcoded `"usd"` had reintroduced the same
+ * bug wearing a different currency.
+ *
+ * 🔑 The rule it violated: **a cost is denominated by how it was COMPUTED, not
+ * by where the garment is SOLD.** `cost_breakdown` line items come from
+ * `cost_source: "order_history"` — rupees — and no amount of selling in Europe
+ * turns them into euros. The store default answers a different question, so it
+ * is not asked here at all; `storeCurrency` is absent from the input type on
+ * purpose, so that re-adding it has to be a deliberate edit rather than a
+ * plausible-looking `||`.
  */
 export const APPROVAL_FALLBACK_CURRENCY = "inr"
 
 export function resolveApprovalCurrency(input: {
   designCurrency?: string | null
-  storeCurrency?: string | null
 }): string {
-  const pick =
-    input.designCurrency || input.storeCurrency || APPROVAL_FALLBACK_CURRENCY
-  return String(pick).trim().toLowerCase()
+  /**
+   * ⚠️ Trimmed BEFORE the choice, not after. `"   "` is truthy, so a trailing
+   * `||` would pick it and the later `.trim()` would hand back `""` — an empty
+   * currency code, which is worse than a guessed one because nothing
+   * downstream reads it as missing. Same family as the `''` that satisfied an
+   * `is not null` CHECK elsewhere in this codebase.
+   */
+  const stated = String(input.designCurrency ?? "").trim()
+  return (stated || APPROVAL_FALLBACK_CURRENCY).toLowerCase()
+}
+
+/**
+ * Whether `resolveApprovalCurrency` had to ASSUME rather than read.
+ *
+ * The fallback is the best available answer, not a known one, and a price whose
+ * currency was guessed is worth saying out loud — 42 of 43 costed designs on
+ * prod carried no `cost_currency` when #1979 was found, so this is the common
+ * case rather than the rare one.
+ *
+ * ⚠️ Tests the RAW field before any coercion: `""` is falsy but not null, the
+ * shape that defeated an `is not null` CHECK elsewhere in this codebase.
+ */
+export function approvalCurrencyWasAssumed(designCurrency?: string | null): boolean {
+  return String(designCurrency ?? "").trim() === ""
 }

--- a/apps/backend/src/workflows/production-runs/approval-pricing.ts
+++ b/apps/backend/src/workflows/production-runs/approval-pricing.ts
@@ -116,8 +116,14 @@ export function resolveApprovalPrice(input: {
  * The last resort is **INR**: production is costed in INR (the unified order
  * carries `currency_assumed: true` for exactly this reason), so a design with
  * no stated currency was costed in INR whatever the fallback claimed.
- * `RunCostSummary` carries no currency field at all, so the run cannot answer
- * this either.
+ * ── The RUN answers first (#1979) ─────────────────────────────────────────
+ *
+ * A production run now states `cost_currency` of its own, and it is asked
+ * BEFORE the design. The design's figure is an estimate typed once; the run's
+ * is what the work actually cost, and `resolveApprovalPrice` already prefers
+ * the run's cost over the design's estimate for exactly that reason. Asking the
+ * design for the currency of a number the RUN supplied would let the two
+ * disagree — a price denominated by one record and valued by another.
  *
  * ── Why the STORE default is not asked (#1979) ────────────────────────────
  *
@@ -140,6 +146,8 @@ export function resolveApprovalPrice(input: {
 export const APPROVAL_FALLBACK_CURRENCY = "inr"
 
 export function resolveApprovalCurrency(input: {
+  /** What the RUN says its cost is in. Wins: it denominates the cost used. */
+  runCurrency?: string | null
   designCurrency?: string | null
 }): string {
   /**
@@ -149,7 +157,9 @@ export function resolveApprovalCurrency(input: {
    * downstream reads it as missing. Same family as the `''` that satisfied an
    * `is not null` CHECK elsewhere in this codebase.
    */
-  const stated = String(input.designCurrency ?? "").trim()
+  const stated =
+    String(input.runCurrency ?? "").trim() ||
+    String(input.designCurrency ?? "").trim()
   return (stated || APPROVAL_FALLBACK_CURRENCY).toLowerCase()
 }
 
@@ -164,6 +174,12 @@ export function resolveApprovalCurrency(input: {
  * ⚠️ Tests the RAW field before any coercion: `""` is falsy but not null, the
  * shape that defeated an `is not null` CHECK elsewhere in this codebase.
  */
-export function approvalCurrencyWasAssumed(designCurrency?: string | null): boolean {
-  return String(designCurrency ?? "").trim() === ""
+export function approvalCurrencyWasAssumed(
+  designCurrency?: string | null,
+  runCurrency?: string | null
+): boolean {
+  return (
+    String(runCurrency ?? "").trim() === "" &&
+    String(designCurrency ?? "").trim() === ""
+  )
 }

--- a/apps/backend/src/workflows/production-runs/approve-run-output.ts
+++ b/apps/backend/src/workflows/production-runs/approve-run-output.ts
@@ -331,8 +331,80 @@ export async function applyRunApprovals(
         throw new Error(`Design not found: ${designId}`)
       }
 
-      currency = resolveCurrency({ designCurrency: design.cost_currency })
-      if (assumedCurrency(design.cost_currency)) {
+      /**
+       * 🔴 The price comes from what the RUN cost, not from an estimate typed
+       * on the design months earlier — and never from `?? 0`.
+       *
+       * `computeRunCostSummary` derives `cost_per_unit` from real consumption
+       * logs (material, energy, labour, partner estimate). A run with no logs
+       * has `null` there and the design's estimate answers instead; a design
+       * with neither is REFUSED below rather than listed at zero, because a
+       * price of 0 is a claim and #1900 caught one on the storefront.
+       *
+       * Costed per run and reduced to the DEAREST, because the product is one
+       * listing for every run of the design: pricing off the cheapest run
+       * would under-price every other unit sold under the same variant.
+       */
+      let runCostPerUnit: number | null = null
+      /**
+       * 🔴 The currency of the run that SUPPLIED the winning cost — not of any
+       * run in the batch. Reducing to the dearest picks one record's number, so
+       * the denomination has to come from that same record or the price is
+       * valued by one run and labelled by another.
+       */
+      let costingRunCurrency: string | null = null
+      for (const r of designRuns) {
+        try {
+          const summary = await computeRunCostSummary(container, r.id)
+          const perUnit = Number(summary?.cost_per_unit)
+          if (Number.isFinite(perUnit) && perUnit > 0 && perUnit > (runCostPerUnit ?? 0)) {
+            runCostPerUnit = perUnit
+            costingRunCurrency = summary?.currency ?? null
+          }
+        } catch {
+          // A run we cannot cost is not a reason to fail the batch; the other
+          // runs and the design's estimate still answer.
+        }
+      }
+
+      /**
+       * #1939 — the approval markup, read rather than compiled. Against the
+       * seeded row (1.4) this is a no-op; the compiled `APPROVAL_MARKUP`
+       * answers for an unconfigured platform.
+       */
+      const priced = resolveApprovalPrice({
+        runCostPerUnit,
+        designEstimatedCost: Number(design.estimated_cost ?? 0),
+        markup: costConfig.approval_markup_multiplier ?? undefined,
+      })
+      if (!priced) {
+        throw new Error(
+          `Cannot price design ${designId}: no run of it has a costed ` +
+            `consumption log and the design has no estimated_cost. Record ` +
+            `consumption or set an estimate — approving would list it at 0.`
+        )
+      }
+      price = priced.price
+      priceSource = priced.source
+      unitCost = priced.cost
+
+      /**
+       * Denominate the price with the record that SUPPLIED it.
+       *
+       * 🔴 Resolved AFTER pricing, deliberately. `resolveApprovalPrice` picks
+       * the run's cost where one exists and the design's estimate where it does
+       * not — so the currency has to follow the same choice. Asking the run for
+       * the currency of a figure that came off the DESIGN would label an
+       * estimate with a denomination it was never expressed in.
+       */
+      const runCurrencyForPrice =
+        priceSource === "run_cost" ? costingRunCurrency : null
+      currency = resolveCurrency({
+        runCurrency: runCurrencyForPrice,
+        designCurrency: design.cost_currency,
+      })
+      if (assumedCurrency(design.cost_currency, runCurrencyForPrice)) {
+
         /**
          * Said out loud because it is a GUESS, and the common case: 42 of 43
          * costed designs on prod had no `cost_currency` when #1979 was found.
@@ -361,54 +433,7 @@ export async function applyRunApprovals(
             `The price is correct but unsellable until ${currency} is enabled.`
         )
       }
-      /**
-       * 🔴 The price comes from what the RUN cost, not from an estimate typed
-       * on the design months earlier — and never from `?? 0`.
-       *
-       * `computeRunCostSummary` derives `cost_per_unit` from real consumption
-       * logs (material, energy, labour, partner estimate). A run with no logs
-       * has `null` there and the design's estimate answers instead; a design
-       * with neither is REFUSED below rather than listed at zero, because a
-       * price of 0 is a claim and #1900 caught one on the storefront.
-       *
-       * Costed per run and reduced to the DEAREST, because the product is one
-       * listing for every run of the design: pricing off the cheapest run
-       * would under-price every other unit sold under the same variant.
-       */
-      let runCostPerUnit: number | null = null
-      for (const r of designRuns) {
-        try {
-          const summary = await computeRunCostSummary(container, r.id)
-          const perUnit = Number(summary?.cost_per_unit)
-          if (Number.isFinite(perUnit) && perUnit > 0) {
-            runCostPerUnit = Math.max(runCostPerUnit ?? 0, perUnit)
-          }
-        } catch {
-          // A run we cannot cost is not a reason to fail the batch; the other
-          // runs and the design's estimate still answer.
-        }
-      }
 
-      /**
-       * #1939 — the approval markup, read rather than compiled. Against the
-       * seeded row (1.4) this is a no-op; the compiled `APPROVAL_MARKUP`
-       * answers for an unconfigured platform.
-       */
-      const priced = resolveApprovalPrice({
-        runCostPerUnit,
-        designEstimatedCost: Number(design.estimated_cost ?? 0),
-        markup: costConfig.approval_markup_multiplier ?? undefined,
-      })
-      if (!priced) {
-        throw new Error(
-          `Cannot price design ${designId}: no run of it has a costed ` +
-            `consumption log and the design has no estimated_cost. Record ` +
-            `consumption or set an estimate — approving would list it at 0.`
-        )
-      }
-      price = priced.price
-      priceSource = priced.source
-      unitCost = priced.cost
 
       const linked = design.products?.[0]
       productExisted = Boolean(linked?.id)

--- a/apps/backend/src/workflows/production-runs/approve-run-output.ts
+++ b/apps/backend/src/workflows/production-runs/approve-run-output.ts
@@ -115,19 +115,18 @@ export {
   resolveApprovalPrice,
 } from "./approval-pricing"
 import { loadCostConfig } from "../../modules/platform-cost-config/read-config"
+import { currencyIsSellable, readHouseStore } from "./house-store"
 
-/** The store the FX fanout is scoped to. Null is survivable; see the call site. */
+/**
+ * The store the FX fanout is scoped to — the HOUSE store, not `stores[0]`.
+ *
+ * 🔴 This used to take the first row of a 13-row, multi-tenant table, so the
+ * fanout could be scoped to an arbitrary partner tenant's currency set (#1979).
+ * See `house-store.ts` for how the house store is identified and why an
+ * ambiguous answer returns null rather than guessing.
+ */
 export async function readStoreId(container: any): Promise<string | null> {
-  try {
-    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
-    const { data: stores = [] } = await query.graph({
-      entity: "store",
-      fields: ["id"],
-    })
-    return stores?.[0]?.id ?? null
-  } catch {
-    return null
-  }
+  return (await readHouseStore(container))?.id ?? null
 }
 
 
@@ -278,7 +277,8 @@ export async function applyRunApprovals(
    * costs the fanout, not the approval: the base price is still written and
    * `replay-fx-fanout` can materialise the rest later.
    */
-  const storeId = await readStoreId(container)
+  const houseStore = await readHouseStore(container)
+  const storeId = houseStore?.id ?? null
   const costConfig = await loadCostConfig(container)
 
   /** design_id → the runs of that design in this batch, in the order given. */
@@ -343,6 +343,22 @@ export async function applyRunApprovals(
         logger?.warn?.(
           `[approve-run-output] design ${designId} has no cost_currency; ` +
             `assuming ${currency}. If it was not costed in ${currency}, its price is wrong.`
+        )
+      }
+      if (!currencyIsSellable(currency, houseStore)) {
+        /**
+         * A GUARD, never an override. The currency stays what the cost was
+         * computed in — re-denominating it to whatever the store prefers is
+         * exactly the #1979 defect. This only says the resulting price is not
+         * sellable here, so it stops being a silent condition: on prod today
+         * INR is enabled on 12 of 13 stores, but `Le Ciricotte` does not
+         * enable it at all.
+         */
+        logger?.warn?.(
+          `[approve-run-output] design ${designId} is priced in ${currency}, ` +
+            `which the house store does not sell in ` +
+            `(enabled: ${houseStore?.currencies.join(", ") || "unknown"}). ` +
+            `The price is correct but unsellable until ${currency} is enabled.`
         )
       }
       /**

--- a/apps/backend/src/workflows/production-runs/approve-run-output.ts
+++ b/apps/backend/src/workflows/production-runs/approve-run-output.ts
@@ -6,6 +6,7 @@ import { computeRunCostSummary } from "../../modules/production_runs/cost-summar
 import { requestVariantPriceFanout } from "../fx/fanout-variant-prices"
 import {
   resolveApprovalCurrency as resolveCurrency,
+  approvalCurrencyWasAssumed as assumedCurrency,
   resolveApprovalPrice,
 } from "./approval-pricing"
 import {
@@ -36,8 +37,10 @@ import updateDesignWorkflow from "../designs/update-design"
  *
  * 🔴 **`currency_code: "usd"` was hardcoded** in the approve route while the
  * platform trades in AUD and INR. At scale that mis-prices a whole batch. The
- * design's own `cost_currency` is the answer; the store default is the
- * fallback (see `resolveApprovalCurrency`).
+ * design's own `cost_currency` is the answer, with INR behind it. The store
+ * default is NOT consulted — on a EUR store it made the INR last resort
+ * unreachable and minted INR costs as euros, ~110x (#1979). See
+ * `resolveApprovalCurrency`.
  *
  * 🔴 **A partial batch is a real outcome and must be said out loud** (#1263).
  * Every run comes back with what happened to it — approved, rejected, skipped
@@ -127,24 +130,6 @@ export async function readStoreId(container: any): Promise<string | null> {
   }
 }
 
-/** The store's default currency, for designs that never recorded their own. */
-export async function readStoreCurrency(container: any): Promise<string | null> {
-  try {
-    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
-    const { data: stores = [] } = await query.graph({
-      entity: "store",
-      fields: ["id", "supported_currencies.currency_code", "supported_currencies.is_default"],
-    })
-    const supported = stores?.[0]?.supported_currencies ?? []
-    const fallback = supported.find((c: any) => c?.is_default) ?? supported[0]
-    return fallback?.currency_code ?? null
-  } catch {
-    // A store we cannot read is not a reason to refuse the batch; the design's
-    // own currency answers for most rows, and `resolveApprovalCurrency` still
-    // has its last resort.
-    return null
-  }
-}
 
 const isDecided = (run: any) => Boolean(run?.approval_decision)
 
@@ -287,8 +272,6 @@ export async function applyRunApprovals(
   }
 
   // ---- 3. Approve: one product per DESIGN, however many runs --------------
-  const storeCurrency = await readStoreCurrency(container)
-
   /**
    * The FX fanout is scoped to a store's `supported_currencies`, so it needs the
    * store id — read once here rather than per design. A store we cannot read
@@ -312,7 +295,12 @@ export async function applyRunApprovals(
     let product_id: string | null = null
     let variant_id: string | null = null
     let productExisted = false
-    let currency = resolveCurrency({ storeCurrency })
+    /**
+     * The pre-read default, used only if the design read below throws. INR
+     * rather than the store's default: production is costed in INR, and a EUR
+     * store default here is what made #1979 a 110x overprice.
+     */
+    let currency = resolveCurrency({})
     let price = 0
     let priceSource: string | null = null
     let unitCost: number | null = null
@@ -343,10 +331,20 @@ export async function applyRunApprovals(
         throw new Error(`Design not found: ${designId}`)
       }
 
-      currency = resolveCurrency({
-        designCurrency: design.cost_currency,
-        storeCurrency,
-      })
+      currency = resolveCurrency({ designCurrency: design.cost_currency })
+      if (assumedCurrency(design.cost_currency)) {
+        /**
+         * Said out loud because it is a GUESS, and the common case: 42 of 43
+         * costed designs on prod had no `cost_currency` when #1979 was found.
+         * The price is still written — refusing the batch over it would stop
+         * approvals platform-wide — but the assumption is now in the log
+         * rather than only in a docblock.
+         */
+        logger?.warn?.(
+          `[approve-run-output] design ${designId} has no cost_currency; ` +
+            `assuming ${currency}. If it was not costed in ${currency}, its price is wrong.`
+        )
+      }
       /**
        * 🔴 The price comes from what the RUN cost, not from an estimate typed
        * on the design months earlier — and never from `?? 0`.

--- a/apps/backend/src/workflows/production-runs/house-store.ts
+++ b/apps/backend/src/workflows/production-runs/house-store.ts
@@ -1,0 +1,121 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * Which store is OURS, and what it can actually sell in (#1979).
+ *
+ * ── Why this exists ───────────────────────────────────────────────────────
+ *
+ * 🔴 `readStoreId` / `readStoreCurrency` both did `stores?.[0]`. This platform
+ * is multi-tenant: there are 13 stores on prod, 12 of them partner tenants. So
+ * "the store" was whichever row the query happened to return first, and the
+ * currency an approval stamped was a LOTTERY across 13 tenants — eleven of them
+ * default to INR, one to AUD, two to EUR. That is why 14 approved products came
+ * out correctly denominated in INR and exactly one came out in EUR at ~110× its
+ * cost. It was never reading "the store default"; it was reading a draw.
+ *
+ * Same family as the `take:1` profile read in #1983: a single-row read against
+ * a table that has since grown more than one row.
+ *
+ * ── How the house store is identified ─────────────────────────────────────
+ *
+ * Every partner tenant carries `metadata.partner_id`. The house store is the
+ * one that does NOT. On prod that is exactly one row (`JYT Medu Store`) and the
+ * other twelve all carry a partner id, so the rule is unambiguous today.
+ *
+ * ⚠️ If it is ever ambiguous — no store without a partner id, or more than one —
+ * this returns `null` rather than guessing. `stores[0]` is what caused the bug;
+ * picking an arbitrary row when the answer is unclear would only re-create it in
+ * a new place. Callers must treat null as "unknown", never as a default.
+ */
+export type HouseStore = {
+  id: string
+  /** Lowercased currency codes the store is able to sell in. */
+  currencies: string[]
+  /** The store's own default, lowercased. NOT the cost currency — see below. */
+  defaultCurrency: string | null
+}
+
+/**
+ * PURE: the one store that is not a partner tenant, or null if that is not a
+ * single unambiguous row. Exported for tests.
+ */
+export function pickHouseStore<T extends { metadata?: any }>(
+  stores: T[] | null | undefined
+): T | null {
+  const houses = (stores ?? []).filter(
+    (s) => !String((s as any)?.metadata?.partner_id ?? "").trim()
+  )
+  return houses.length === 1 ? houses[0] : null
+}
+
+/** PURE: a store's sellable currency codes, lowercased. Exported for tests. */
+export function storeCurrencies(store: any): string[] {
+  return ((store?.supported_currencies ?? []) as any[])
+    .map((c) => String(c?.currency_code ?? "").trim().toLowerCase())
+    .filter(Boolean)
+}
+
+/** PURE: a store's own default currency, lowercased, or null. */
+export function storeDefaultCurrency(store: any): string | null {
+  const found = ((store?.supported_currencies ?? []) as any[]).find(
+    (c) => c?.is_default
+  )
+  const code = String(found?.currency_code ?? "").trim().toLowerCase()
+  return code || null
+}
+
+/**
+ * PURE: can the house store actually sell a price denominated in this currency?
+ * Exported for tests.
+ *
+ * 🔴 This is a GUARD, not a chooser. It never changes the currency — a cost is
+ * denominated by how it was COMPUTED, and silently re-denominating it to
+ * something the store prefers is precisely the #1979 defect. It only answers
+ * whether the resulting price is sellable, so an unsellable one can be said out
+ * loud instead of shipping quietly.
+ *
+ * ⚠️ An UNKNOWN house store (`null`) is not a failure: with nothing to check
+ * against, the honest answer is "no objection", so this returns true. Returning
+ * false would turn "we could not read the store" into a warning about a price
+ * that may be perfectly fine.
+ */
+export function currencyIsSellable(
+  currency: string,
+  house: HouseStore | null
+): boolean {
+  if (!house) {
+    return true
+  }
+  if (!house.currencies.length) {
+    return true
+  }
+  return house.currencies.includes(String(currency ?? "").trim().toLowerCase())
+}
+
+/**
+ * The house store, or null when it cannot be read or is ambiguous.
+ *
+ * Null is survivable everywhere this is used: the FX fanout is skipped and
+ * `replay-fx-fanout` can materialise the prices later, and the sellability
+ * guard abstains. A store we cannot read is not a reason to refuse an approval.
+ */
+export async function readHouseStore(container: any): Promise<HouseStore | null> {
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const { data: stores = [] } = await query.graph({
+      entity: "store",
+      fields: ["id", "metadata", "supported_currencies.*"],
+    })
+    const house = pickHouseStore(stores) as any
+    if (!house?.id) {
+      return null
+    }
+    return {
+      id: house.id,
+      currencies: storeCurrencies(house),
+      defaultCurrency: storeDefaultCurrency(house),
+    }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Closes the pricing half of #1979.

## The bug

`resolveApprovalCurrency` read `designCurrency || storeCurrency || "inr"`. The house store's default is **EUR**, so the INR last resort — written for exactly the case of a design that never recorded a currency — was **unreachable**. A jacket costed at ₹2,634.75 minted as €2,634.75, and `replay-fx-fanout` propagated that base into all 11 currencies: **₹291,560, about 110× its cost.** The #1805 fix for a hardcoded `"usd"` had reintroduced the same bug wearing a different currency.

## What reading production actually showed

**`stores?.[0]` was never "the store".** There are 13 stores on prod and 12 are partner tenants — eleven default to INR, one to AUD, two to EUR. The currency an approval stamped was a **lottery across tenants**. That is why 14 approved products came out correctly in INR and precisely one came out in EUR. Same family as #1983's `take:1`.

I checked all 19 approved-with-no-currency designs: **5 have no product, 14 have one, and 0 carry a EUR-labelled rupee price.** The tweed jacket was the only instance and it was already fixed by hand. **Nothing needs re-pricing.**

Also found: no `cost_breakdown` line records a currency anywhere, and 18 of 45 candidates have no breakdown at all — so "resolve from the cost's own provenance" (suggested in the issue) is not available today.

## The fix

**1. A cost is denominated by how it was COMPUTED, not by where it is sold.** `storeCurrency` is gone from the chain *and from the input type*, so re-adding it must be a deliberate edit rather than a plausible-looking `||`.

**2. The house store, not `stores[0]`.** It is the only store with no `metadata.partner_id`. An ambiguous answer returns **null rather than guessing** — picking an arbitrary row is what caused this. This also means the **FX fanout was being scoped to an arbitrary tenant's currency set**; it is now scoped to the house store.

**3. A sellability GUARD, never an override.** The currency stays what the cost was computed in; the guard only reports whether the house store can sell it. Live instance: INR is enabled on 12 of 13 stores but **not on `Le Ciricotte`**. 🔴 The tempting version — swapping in the store's default when the cost currency is not enabled — *is* #1979. A test pins that the written price is still `inr` after warning.

**4. Production cost now states its currency.** `production_runs.cost_currency`, settable via `POST /admin/production-runs/:id`. The run outranks the design, and the currency is resolved **after** pricing from the run that supplied the *winning* cost — so a price taken off the design's estimate is never labelled with a run's currency.

**5. `backfill-design-cost-currency` maintenance job** for the 45 costed designs with no currency. Fills a **blank only**, requires a cost > 0, and `currency` is a parameter with an INR default because INR is an *inference*, not a reading.

## Two smaller bugs found while pinning it

- `"   "` is truthy, so the old chain picked it and the trailing `.trim()` returned `""` — an **empty currency code**, worse than a guessed one because nothing downstream reads it as missing.
- The **admin** cost-summary route still computes its own totals instead of calling the `computeRunCostSummary` extracted *from* it, so `currency` was present on the partner side and missing on admin. Caught by the integration test; fixed, duplication noted in code.

## Verification

- Reverting the resolver → 3 red; reverting the call site too → 5 red; reverting `pickHouseStore` to `stores[0]` → 6 red.
- The integration regression bites for real: restoring the old chain gives `Expected "inr" / Received ["eur"]` over HTTP.
- **1008 unit tests + 5 new integration tests pass**; sibling `admin-run-output-review` green; `tsc` unchanged at its 84-error baseline.
- The unit stub is now a **multi-tenant** store table with the partner row first — a single-store stub could never have caught this.

## Note

The migration deliberately does **not** backfill `inr`. Stamping a currency onto historical rows is a claim; the maintenance job exists so an operator makes it with a dry-run in front of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp