### PR TITLE
fix(storefront): stop telling buyers their payment link is invalid when WE are down (#1985)

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(checkout)/payment-collection/[id]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/payment-collection/[id]/page.tsx
@@ -49,9 +49,38 @@ export default async function PaymentCollectionPage(props: {
   params: Promise<{ id: string; countryCode: string }>
 }) {
   const { id } = await props.params
-  const prepared = await preparePaymentCollection(id)
+  const result = await preparePaymentCollection(id)
 
-  if (!prepared) {
+  /**
+   * 🔴 "Down" and "dead link" are DIFFERENT PAGES.
+   *
+   * Both used to render "This payment link is not valid", because every failure
+   * collapsed to null. That sentence sends a buyer whose link is perfectly fine
+   * off to ask for a replacement they do not need — and the replacement will
+   * fail in exactly the same way, because the fault is ours. Observed live when
+   * the storefront deployed ahead of the backend.
+   */
+  if (result.state === "unavailable") {
+    return (
+      <Shell>
+        <Heading level="h1" className="text-2xl-semi">
+          We can&apos;t load this payment right now
+        </Heading>
+        <Text className="text-ui-fg-subtle">
+          Something on our side is not responding, so we can&apos;t show your
+          payment yet. Your link is fine — please refresh this page in a few
+          minutes and it should work.
+        </Text>
+        <Text className="text-ui-fg-subtle txt-small">
+          Nothing has been charged, and your order is unaffected. If it still
+          won&apos;t load after a few tries, reply to your order email and we
+          will sort it out.
+        </Text>
+      </Shell>
+    )
+  }
+
+  if (result.state === "not_found") {
     return (
       <Shell>
         <Heading level="h1" className="text-2xl-semi">
@@ -65,7 +94,7 @@ export default async function PaymentCollectionPage(props: {
     )
   }
 
-  const { payment_collection: pc, order, settled } = prepared
+  const { payment_collection: pc, order, settled } = result.prepared
   const amountLabel = convertToLocale({
     amount: Number(pc.amount) || 0,
     currency_code: pc.currency_code,

--- a/apps/storefront/src/lib/data/payment-collections.ts
+++ b/apps/storefront/src/lib/data/payment-collections.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { sdk } from "@lib/config"
+import { classifyPrepareFailure } from "@lib/util/payment-collection-error"
 
 /**
  * The buyer-facing view of an outstanding payment collection (#1985).
@@ -50,6 +51,26 @@ export type PreparedPaymentCollection = {
 }
 
 /**
+ * The three things that can happen, kept apart.
+ *
+ * 🔴 This used to be `PreparedPaymentCollection | null`, and `null` meant BOTH
+ * "that link is dead" and "our backend is down" — so the page told a paying
+ * customer their link was invalid when the fault was ours. A single nullable
+ * cannot express whose fault it is, which is why this is a discriminated union
+ * rather than an extra boolean beside the old return.
+ *
+ * ⚠️ The failure arms are spelled out as SEPARATE members rather than the
+ * tidier `{ state: PrepareFailure }`. A member whose discriminant is itself a
+ * union does not discriminate: narrowing `state === "unavailable"` and then
+ * `state === "not_found"` never eliminates that single member, so the `ok` arm
+ * is never reached and `result.prepared` does not typecheck.
+ */
+export type PreparedPaymentCollectionResult =
+  | { state: "ok"; prepared: PreparedPaymentCollection }
+  | { state: "not_found" }
+  | { state: "unavailable" }
+
+/**
  * Fetch the collection and ensure it has a Stripe session.
  *
  * 🔴 POST, not GET, and `cache: "no-store"`. The backend mints a Stripe
@@ -57,18 +78,33 @@ export type PreparedPaymentCollection = {
  * would create intents on hover. It is idempotent server-side (an existing
  * session short-circuits), but the method still has to say what it does.
  *
- * Returns null when the id is not a live collection, so the page can render
- * "this link is not valid" rather than throwing a 500 at a buyer.
+ * Never throws: a buyer holding a payment link must get a page that explains
+ * itself, not a 500. But it no longer flattens every failure into one — see
+ * `classifyPrepareFailure` for why only a 404 may blame the link.
  */
 export async function preparePaymentCollection(
   id: string
-): Promise<PreparedPaymentCollection | null> {
+): Promise<PreparedPaymentCollectionResult> {
   try {
-    return await sdk.client.fetch<PreparedPaymentCollection>(
+    const prepared = await sdk.client.fetch<PreparedPaymentCollection>(
       `/store/payment-collections/${id}/prepare`,
       { method: "POST", cache: "no-store" }
     )
-  } catch {
-    return null
+    return { state: "ok", prepared }
+  } catch (error) {
+    const state = classifyPrepareFailure(error)
+    /*
+     * 🔴 The old bare `catch {}` swallowed the outage as well as the message.
+     * "The storefront deployed before the backend" was invisible in the logs —
+     * the only evidence it happened at all was a customer saying their link did
+     * not work. An outage on a payment page has to leave a trace.
+     */
+    if (state === "unavailable") {
+      console.error(
+        `[payment-collection] prepare failed for ${id} — treating as UNAVAILABLE (ours, not the buyer's):`,
+        error
+      )
+    }
+    return { state }
   }
 }

--- a/apps/storefront/src/lib/data/payment-collections.ts
+++ b/apps/storefront/src/lib/data/payment-collections.ts
@@ -100,8 +100,16 @@ export async function preparePaymentCollection(
      * not work. An outage on a payment page has to leave a trace.
      */
     if (state === "unavailable") {
+      /*
+       * ⚠️ `id` is passed as an ARGUMENT against `%s`, never interpolated into
+       * the format string. It comes straight off the URL path, so a `%d` in the
+       * link would be read as a format specifier — garbling the line and
+       * consuming the `error` argument, so the outage we are trying to record
+       * would be the thing that vanished. CodeQL caught this one (CWE-134).
+       */
       console.error(
-        `[payment-collection] prepare failed for ${id} — treating as UNAVAILABLE (ours, not the buyer's):`,
+        "[payment-collection] prepare failed for %s — treating as UNAVAILABLE (ours, not the buyer's):",
+        id,
         error
       )
     }

--- a/apps/storefront/src/lib/util/__tests__/payment-collection-error.test.ts
+++ b/apps/storefront/src/lib/util/__tests__/payment-collection-error.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { classifyPrepareFailure } from "../payment-collection-error"
+
+/**
+ * 🔴 The page used to render "This payment link is not valid" for EVERY
+ * failure, including our own outages — telling a paying customer their link was
+ * bad when the fault was ours. Observed live when the storefront deployed ahead
+ * of the backend.
+ *
+ * Only a 404 from `prepare` may blame the link; that is the single status the
+ * backend uses for an id that is not a live collection.
+ */
+describe("classifyPrepareFailure", () => {
+  it("blames the link ONLY on a 404", () => {
+    expect(classifyPrepareFailure({ status: 404 })).toBe("not_found")
+    // The SDK's FetchError carries status as a number; a string must still work
+    // rather than silently falling through to "unavailable".
+    expect(classifyPrepareFailure({ status: "404" })).toBe("not_found")
+  })
+
+  it("🔴 treats a connection failure — which has NO status — as ours", () => {
+    /*
+     * THE CASE THIS EXISTS FOR. The SDK only builds a FetchError from a real
+     * HTTP response; when the backend is unreachable the underlying fetch
+     * throws a bare TypeError with no status. Reading that as "not found" is
+     * exactly the bug.
+     */
+    expect(classifyPrepareFailure(new TypeError("fetch failed"))).toBe(
+      "unavailable"
+    )
+    expect(classifyPrepareFailure(new Error("ECONNREFUSED"))).toBe("unavailable")
+    expect(classifyPrepareFailure({})).toBe("unavailable")
+    expect(classifyPrepareFailure(undefined)).toBe("unavailable")
+    expect(classifyPrepareFailure(null)).toBe("unavailable")
+  })
+
+  it("treats a server error as ours", () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(classifyPrepareFailure({ status })).toBe("unavailable")
+    }
+  })
+
+  it("does not blame the link for other 4xx", () => {
+    /*
+     * A 401/403 means our publishable key or CORS is misconfigured, and a 400
+     * means we sent a bad request — the buyer's link is fine in all of them.
+     * Being wrong towards "try again shortly" costs minutes; being wrong the
+     * other way costs the sale.
+     */
+    for (const status of [400, 401, 403, 405, 429]) {
+      expect(classifyPrepareFailure({ status })).toBe("unavailable")
+    }
+  })
+})

--- a/apps/storefront/src/lib/util/payment-collection-error.ts
+++ b/apps/storefront/src/lib/util/payment-collection-error.ts
@@ -1,0 +1,52 @@
+/**
+ * Telling "your link is wrong" apart from "our backend is down" (#1985 / #1979
+ * slice 1b).
+ *
+ * ## Why this exists
+ *
+ * `preparePaymentCollection` used to be `try { … } catch { return null }`, and
+ * the page rendered one message for null:
+ *
+ * > This payment link is not valid.
+ *
+ * That sentence is a lie in every case except one. A backend that is down,
+ * unreachable, mid-deploy, or 500ing produces exactly the same `null` as a
+ * genuinely dead link — so we told a paying customer their link was bad when
+ * the fault was ours. It was observed live: the storefront deployed before the
+ * backend, and a perfectly valid link read as invalid.
+ *
+ * ⚠️ It is also the worst possible lie to tell HERE. The buyer's next move is
+ * to give up or to email asking for a new link, and the link they have is fine
+ * — so the "fix" cannot work and the money does not arrive.
+ *
+ * ## The one case that really is the link's fault
+ *
+ * `POST /store/payment-collections/:id/prepare` answers **404** — and only 404
+ * — for an id that is not a live collection:
+ *
+ * ```ts
+ * res.status(404).json({ message: "This payment link is not valid." })
+ * ```
+ *
+ * So 404 is the ONLY status that may blame the link. Everything else is ours
+ * until proven otherwise, which is the safe direction to be wrong in: telling
+ * someone "try again shortly" when their link is genuinely dead costs a few
+ * minutes, while telling them "your link is invalid" when our backend is
+ * restarting costs the sale.
+ */
+export type PrepareFailure = "not_found" | "unavailable"
+
+/**
+ * PURE: whose fault a failed `prepare` was. Exported for tests.
+ *
+ * ⚠️ A genuinely unreachable backend does NOT produce a `FetchError`. The
+ * Medusa JS SDK only constructs one from a real HTTP response; when the
+ * connection itself fails, the underlying `fetch` throws a `TypeError`
+ * ("fetch failed") with **no `status` at all**. So "no status" is the shape of
+ * the exact outage this function was written for, and it must read as
+ * `unavailable` — never as a missing link.
+ */
+export function classifyPrepareFailure(error: unknown): PrepareFailure {
+  const status = Number((error as { status?: unknown })?.status)
+  return status === 404 ? "not_found" : "unavailable"
+}


### PR DESCRIPTION
Slice 1b of the sequenced plan.

## The bug

`preparePaymentCollection` was `try { … } catch { return null }`, and the page rendered one sentence for `null`:

> This payment link is not valid.

That is a lie in every case but one. A backend that is **down, unreachable, mid-deploy or 500ing** produced the same `null` as a genuinely dead link — so we told a paying customer their link was bad when the fault was ours. **Observed live:** the storefront deployed ahead of the backend and a valid link read as invalid.

🔴 It is also the worst possible lie to tell *here*. The buyer's next move is to give up or to ask for a replacement link — and the link they hold is fine, so the "fix" cannot work and the money never arrives.

## The fix

- `preparePaymentCollection` returns a discriminated result (`ok` / `not_found` / `unavailable`) instead of collapsing to `null`. A single nullable cannot express *whose fault it is*.
- **Only a 404 may blame the link** — the one status `POST /store/payment-collections/:id/prepare` uses for an id that is not a live collection. Everything else is ours until proven otherwise: being wrong towards "try again shortly" costs minutes, being wrong the other way costs the sale.
- ⚠️ **A genuinely unreachable backend produces no status at all.** The SDK only builds a `FetchError` from a real HTTP response, so a dead connection throws a bare `TypeError("fetch failed")`. "No status" is the signature of the very outage this exists for and must read as `unavailable`.
- The old bare `catch {}` swallowed the outage as well as the message — "deployed before the backend" was invisible in the logs, the only evidence being a customer saying their link didn't work. `unavailable` now logs.

## Verified by RENDERING, not by reasoning

This page has form for passing every non-visual check while being broken on screen (the dead Pay button). Same URL both times, only the backend's behaviour differing — a local proxy that breaks **only** the `prepare` route, so regions still resolve:

| backend | rendered |
|---|---|
| real **404** | "This payment link is not valid." |
| up, `prepare` **503** | "We can't load this payment right now … **Your link is fine** — refresh in a few minutes" |

That is slice 1b's "Done when" satisfied.

## 🔴 Known gap, deliberately NOT fixed here

A **cold** storefront whose backend is fully unreachable still 500s before any page renders: `getRegionMap` in `src/middleware.ts` **rethrows** when it has no cached region map. Found by rendering — my first attempt against a dead backend returned HTTP 500, not my new branch.

It is storefront-wide (every route, not just payment) and fixing it means choosing a default country code, so it is a separate call rather than something to slip into this PR. A **warm** storefront survives on its stale region cache and does reach the page above — which is the live shape that was observed.

## Notes

- The failure arms are spelled out separately rather than the tidier `{ state: PrepareFailure }`: a member whose discriminant is itself a union does not discriminate, so the `ok` arm was unreachable and `result.prepared` did not typecheck.
- The classifier lives in `lib/util/`, not the `"use server"` module, because such a file may only export async functions.
- 4 new unit tests; 36 storefront tests pass. `tsc` gains 2 errors, both instances of the repo's existing 805-strong `TS2786` `@types/react` duplicate class (two more `<Text>` elements); `next.config.js` sets `ignoreBuildErrors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp