### PR TITLE
feat(mcp): admin tools to create and update a sales region

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -566,6 +566,100 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     inputSchema: obj({ id: STR("Region id, e.g. 'reg_...'.") }, ["id"]),
   },
   {
+    name: "list_payment_providers",
+    description:
+      "List the payment providers registered in the container, so a region can be wired to one that actually EXISTS. 🔴 Region-enabled is not container-registered: naming a provider a region cannot resolve gives a buyer a checkout with no way to pay. Note the path — the route is /admin/payments/payment-providers, NOT /admin/payment-providers. Use before create_region / update_region.",
+    method: "GET",
+    path: "/admin/payments/payment-providers",
+    queryParams: ["limit", "offset"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "create_region",
+    description:
+      "Create a sales region: a currency, the countries it covers, and the payment providers a buyer there is offered. Sensitive: requires confirm:true.\n\n🔑 A region is what makes a currency BUYABLE. Prices can exist in a currency with no region — on this platform the FX fanout has been minting aed/cad/chf/cny/gbp prices on every variant that nobody could check out in, because no region sold in them. Creating the region is what turns those existing prices into revenue.\n\n⚠️ A country belongs to exactly ONE region. Passing a country already covered elsewhere MOVES it, changing the currency and tax basis that country is sold in — do that deliberately, not as a side effect of adding a neighbour.\n\n⚠️ Payment providers are the difference between a browsable region and a sellable one. Use `pp_stripe_stripe` for international card payments; `pp_stripe-connect_stripe-connect` is the PARTNER payout configuration and is not what a buyer pays through. Call list_payment_providers first.\n\nA region also needs a SHIPPING OPTION that reaches it before anyone can complete checkout — creating the region alone produces countries that can browse and add to cart but fail at the last step.",
+    method: "POST",
+    path: "/admin/regions",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "currency_code",
+      "countries",
+      "payment_providers",
+      "automatic_taxes",
+      "is_tax_inclusive",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        name: STR("Region name as an operator will recognise it, e.g. 'United Kingdom'."),
+        currency_code: STR("3-letter code, lower-case, e.g. 'gbp'. Must be one the STORE supports, or the FX fanout will never price into it."),
+        countries: {
+          type: "array",
+          description: "Lower-case ISO-2 codes, e.g. ['gb']. Each may belong to only one region; listing one that is already covered MOVES it.",
+          items: { type: "string" },
+        },
+        payment_providers: {
+          type: "array",
+          description: "Provider ids from list_payment_providers, e.g. ['pp_stripe_stripe']. Without one, a buyer reaches checkout with nothing to pay with.",
+          items: { type: "string" },
+        },
+        automatic_taxes: {
+          type: "boolean",
+          description: "Let the tax provider calculate tax for this region.",
+        },
+        is_tax_inclusive: {
+          type: "boolean",
+          description: "Whether prices in this region already include tax.",
+        },
+        metadata: { type: "object", additionalProperties: true },
+      },
+      ["name", "currency_code", "countries"]
+    ),
+  },
+  {
+    name: "update_region",
+    description:
+      "Update a sales region — name, currency, the countries it covers, or its payment providers. Pass only what changes. Sensitive: requires confirm:true.\n\n⚠️ `countries` REPLACES the list wholesale; sending a short list silently drops every country you omitted, and those countries then resolve to no region at all. Read the region first.\n\n⚠️ Moving a country between regions changes the currency and tax basis it is sold in.",
+    method: "POST",
+    path: "/admin/regions/:id",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    previewPath: "/admin/regions/:id",
+    bodyParams: [
+      "name",
+      "currency_code",
+      "countries",
+      "payment_providers",
+      "automatic_taxes",
+      "is_tax_inclusive",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Region id, e.g. 'reg_...'."),
+        name: STR("New region name."),
+        currency_code: STR("3-letter code, lower-case."),
+        countries: {
+          type: "array",
+          description: "REPLACEMENT list of lower-case ISO-2 codes — omitted countries are removed from the region.",
+          items: { type: "string" },
+        },
+        payment_providers: {
+          type: "array",
+          description: "Replacement provider ids, e.g. ['pp_stripe_stripe'].",
+          items: { type: "string" },
+        },
+        automatic_taxes: { type: "boolean" },
+        is_tax_inclusive: { type: "boolean" },
+        metadata: { type: "object", additionalProperties: true },
+      },
+      ["id"]
+    ),
+  },
+  {
     name: "list_sales_channels",
     description:
       "List sales channels (paginated). Supports free-text search via q. A product is only purchasable through a sales channel it is linked to — use this to find a channel id, or to see which storefronts a product can sell through.",


### PR DESCRIPTION
Unblocks opening new sales territories. Needed before South America / Africa regions can be created.

## The blocker

The admin MCP could **list** regions but not create one. Region writes existed only on the *partner* surface (`add_store_region`), which is scoped to partner-owned stores and so cannot touch the house store.

## What this adds

| tool | route |
|---|---|
| `create_region` | `POST /admin/regions` |
| `update_region` | `POST /admin/regions/:id` |
| `list_payment_providers` | `GET /admin/payments/payment-providers` |

## 🔑 Why it matters commercially

A region is what makes a currency **buyable**. The store supports **11 currencies** but only **6 have a region**:

```
priced but UNREACHABLE — no region sells in them:
   aed, cad, chf, cny, gbp
```

The FX fanout has been minting GBP, CAD, AED, CNY and CHF prices on every variant that **nobody can check out in**. Creating the regions is what turns prices that already exist into revenue. (Switzerland is the sharpest case — we shipped there this week, a CHF price exists, and the country sits in the EUR region so that price is dead.)

## ⚠️ The path that would have 404'd

The provider route is `/admin/payments/payment-providers`, **not** the obvious-looking `/admin/payment-providers`. Wrapping the latter is the #1907 failure exactly — a tool that advertises itself, passes every registry test, deploys, and 404s on the first real call.

`registry-routes-exist` catches it, and I verified that by doing it:

```
✕ resolves every tool's path to a real route file exporting its method
+   "list_payment_providers: NO ROUTE FILE for GET /admin/payment-providers"
```

Restored, 7 pass.

## What the tool prose warns about

Two things decide whether a region is *sellable* rather than merely present:

- **`pp_stripe_stripe` is what a buyer pays through.** `pp_stripe-connect_stripe-connect` is the partner payout configuration, not a checkout rail. Naming a provider the container cannot resolve gives a buyer a checkout with nothing to pay with.
- **A region still needs a shipping option that reaches it.** Creating the region alone produces countries that browse and add to cart, then fail at the last step — the same shape as #1982's unfulfillable products.

And two ways these tools can destroy data quietly:

- a country belongs to exactly **one** region, so listing one already covered elsewhere **moves** it, changing the currency and tax basis it is sold in
- `update_region.countries` **replaces** the list wholesale; a short list silently drops every country omitted, leaving them resolving to no region at all

Both are in the descriptions rather than only here.

## Checks

- Both paths were already classified in `tool-slice.ts` (`/admin/regions`→catalog, `/admin/payments`→money), so neither tool loads in an empty slice.
- 285 MCP unit tests pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp