### PR TITLE
fix(ops): replay-fx-fanout queues the fanout instead of running it on the request path (#1996)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/replay-fx-fanout.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/replay-fx-fanout.unit.spec.ts
@@ -1,5 +1,8 @@
 import {
+  chunkPriceIds,
   collectHouseStoreTargets,
+  collectStoreTargets,
+  FX_FANOUT_JOB_BATCH_SIZE,
   MAX_FX_FANOUT_PARTNER_SCAN,
   planPriceSetFanout,
   previewFanoutCurrencies,
@@ -7,6 +10,7 @@ import {
   type FanoutPriceRow,
 } from "../fanout-fx-job"
 import { getMaintenanceJob, MAINTENANCE_JOBS } from "../registry"
+import { FX_FANOUT_REQUESTED } from "../../../../../workflows/fx/fanout-variant-prices"
 
 /**
  * Pure preview/plan logic for the `replay-fx-fanout` Data Plumbing job. The
@@ -115,7 +119,7 @@ describe("replay-fx-fanout — registration", () => {
     const names = replayFxFanoutJob.params.map((p) => p.name)
     // include_house_stores joined in when the job was extended past partner
     // stores; the list is asserted exactly so a new param is a deliberate edit.
-    expect(names).toEqual(["partner_id", "limit", "include_house_stores"])
+    expect(names).toEqual(["partner_id", "limit", "offset", "include_house_stores"])
     expect(replayFxFanoutJob.params.every((p) => p.required === false)).toBe(true)
     expect(MAX_FX_FANOUT_PARTNER_SCAN).toBe(5000)
   })
@@ -265,5 +269,237 @@ describe("replay-fx-fanout — include_house_stores param", () => {
 
   it("says in its description that house stores are covered", () => {
     expect(replayFxFanoutJob.description.toLowerCase()).toContain("house")
+  })
+})
+
+/**
+ * #1996 — apply QUEUES, it does not fan out.
+ *
+ * The job used to run `fanoutPricesWorkflow` once per source price on the HTTP
+ * request path. On 2026-09-11 that timed out five times in a row while
+ * succeeding server-side every time (264 → 202 → … → 0 remaining), which is
+ * indistinguishable from failure; and it was the last caller still doing the
+ * thing that OOM-killed prod twice on 2026-08-19. These cases pin the new
+ * contract: emit FX_FANOUT_REQUESTED in bounded batches, return immediately,
+ * and never claim more than "queued".
+ */
+describe("replay-fx-fanout — chunkPriceIds (the batch ceiling)", () => {
+  it("never emits a batch larger than the ceiling", () => {
+    const ids = Array.from({ length: 264 }, (_, i) => `price_${i}`)
+    const batches = chunkPriceIds(ids)
+    expect(batches).toHaveLength(Math.ceil(264 / FX_FANOUT_JOB_BATCH_SIZE))
+    expect(batches.every((b) => b.length <= FX_FANOUT_JOB_BATCH_SIZE)).toBe(true)
+    // Nothing dropped and nothing duplicated — a ceiling that loses work is
+    // worse than no ceiling.
+    expect(batches.flat()).toEqual(ids)
+  })
+
+  it("returns no batches for no work, so an empty run wakes no worker", () => {
+    expect(chunkPriceIds([])).toEqual([])
+  })
+
+  it("clamps a nonsense size to 1 rather than looping forever", () => {
+    expect(chunkPriceIds(["a", "b"], 0)).toEqual([["a"], ["b"]])
+  })
+})
+
+describe("replay-fx-fanout — apply emits instead of running the fanout", () => {
+  /**
+   * One partner, one store, `sourceCount` inr-priced variants. The store
+   * supports inr/eur/usd, so every price plans a fanout of two currencies.
+   */
+  const fakeScope = (sourceCount: number, opts: { busThrows?: boolean } = {}) => {
+    const emitted: any[] = []
+    const graphCalls: any[] = []
+
+    const priceSets = Array.from({ length: sourceCount }, (_, i) => ({
+      product: {
+        variants: [
+          {
+            price_set: {
+              id: `pset_${i}`,
+              prices: [{ id: `price_${i}`, currency_code: "inr" }],
+            },
+          },
+        ],
+      },
+    }))
+
+    const query = {
+      graph: async (args: any) => {
+        graphCalls.push(args)
+        if (args.entity === "partners") {
+          return {
+            data: [
+              {
+                id: "partner_1",
+                name: "P1",
+                stores: [
+                  {
+                    id: "store_1",
+                    name: "S1",
+                    default_sales_channel_id: "sc_1",
+                    supported_currencies: [
+                      { currency_code: "inr" },
+                      { currency_code: "eur" },
+                      { currency_code: "usd" },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }
+        }
+        if (args.entity === "sales_channel") {
+          return { data: [{ id: "sc_1", products_link: priceSets }] }
+        }
+        throw new Error(`unexpected entity ${args.entity}`)
+      },
+    }
+
+    const eventBus = {
+      emit: async (event: any) => {
+        if (opts.busThrows) throw new Error("redis unreachable")
+        emitted.push(event)
+      },
+    }
+
+    const container = {
+      resolve: (key: string) => {
+        if (key === "query") return query
+        if (key === "logger") return { info: () => {}, warn: () => {} }
+        if (key === "event_bus") return eventBus
+        throw new Error(`unexpected resolve ${key}`)
+      },
+    }
+
+    return { container, emitted, graphCalls }
+  }
+
+  it("hands every source price to the worker in bounded batches and returns", async () => {
+    const { container, emitted } = fakeScope(120)
+
+    const result = await replayFxFanoutJob.run(container, {
+      dry_run: false,
+      params: { partner_id: "partner_1" },
+    })
+
+    // Assert on what the bus actually received, after the call — an
+    // expectation inside the mock would be swallowed by the job's catch.
+    expect(emitted).toHaveLength(Math.ceil(120 / FX_FANOUT_JOB_BATCH_SIZE))
+    expect(emitted.every((e) => e.name === FX_FANOUT_REQUESTED)).toBe(true)
+    expect(emitted.every((e) => e.data.store_id === "store_1")).toBe(true)
+    expect(
+      emitted.every((e) => e.data.price_ids.length <= FX_FANOUT_JOB_BATCH_SIZE)
+    ).toBe(true)
+    expect(emitted.flatMap((e) => e.data.price_ids)).toHaveLength(120)
+
+    expect(result.applied).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("says QUEUED in the summary — `applied: true` here does not mean done", async () => {
+    const { container } = fakeScope(3)
+
+    const result = await replayFxFanoutJob.run(container, {
+      dry_run: false,
+      params: { partner_id: "partner_1" },
+    })
+
+    // The weakened guarantee has to be in words the operator reads, not left
+    // to be inferred from a boolean that still says `applied`.
+    expect(result.summary).toContain("QUEUED")
+    expect(result.summary).toMatch(/not yet fanned out/i)
+    // …and it must name the way to confirm completion, because the preview
+    // reporting 0 is the only completion signal there is.
+    expect(result.summary).toMatch(/dry_run/i)
+  })
+
+  it("records an error and does NOT claim a queue when the bus is unreachable", async () => {
+    const { container, emitted } = fakeScope(3, { busThrows: true })
+
+    const result = await replayFxFanoutJob.run(container, {
+      dry_run: false,
+      params: { partner_id: "partner_1" },
+    })
+
+    // requestVariantPriceFanout never throws, so without its queued flag this
+    // run would report a successful hand-off of everything.
+    expect(emitted).toEqual([])
+    expect(result.applied).toBe(false)
+    expect(result.errors?.length).toBe(1)
+    expect(result.errors?.[0].message).toContain("could not queue")
+  })
+
+  it("emits nothing on a dry run — the preview stays read-only", async () => {
+    const { container, emitted } = fakeScope(3)
+
+    const result = await replayFxFanoutJob.run(container, {
+      dry_run: true,
+      params: { partner_id: "partner_1" },
+    })
+
+    expect(emitted).toEqual([])
+    expect(result.applied).toBe(false)
+    // The preview is the completion signal, so it must still list the real
+    // change set rather than a count.
+    expect(result.changes).toHaveLength(3)
+    expect(result.changes[0].after).toBe("eur, usd")
+  })
+
+  it("reports the same change set in both modes, so apply shows what it handed over", async () => {
+    const preview = await replayFxFanoutJob.run(fakeScope(2).container, {
+      dry_run: true,
+      params: { partner_id: "partner_1" },
+    })
+    const applied = await replayFxFanoutJob.run(fakeScope(2).container, {
+      dry_run: false,
+      params: { partner_id: "partner_1" },
+    })
+
+    expect(applied.changes.map((c) => c.id)).toEqual(preview.changes.map((c) => c.id))
+    expect(applied.changes.map((c) => c.after)).toEqual(preview.changes.map((c) => c.after))
+    // The note is where the two differ: queued vs would-queue.
+    expect(applied.changes[0].note).toMatch(/queued/i)
+  })
+})
+
+describe("replay-fx-fanout — limit is a window, offset makes it a cursor", () => {
+  const fakeQuery = () => {
+    const calls: any[] = []
+    return {
+      calls,
+      graph: async (args: any) => {
+        calls.push(args)
+        return { data: [] }
+      },
+    }
+  }
+
+  it("passes offset as skip with a deterministic order", async () => {
+    const query = fakeQuery()
+    await collectStoreTargets(query, undefined, 100, 250)
+
+    expect(query.calls[0].pagination).toEqual({
+      take: 100,
+      skip: 250,
+      // Without a stable sort, page 2 is not "the partners after page 1" —
+      // it is an arbitrary window that can repeat or skip rows.
+      order: { id: "ASC" },
+    })
+  })
+
+  it("defaults to offset 0 so the existing call shape is unchanged", async () => {
+    const query = fakeQuery()
+    await collectStoreTargets(query, undefined, 10)
+    expect(query.calls[0].pagination.skip).toBe(0)
+  })
+
+  it("warns in the param description that limit alone repeats page one", () => {
+    const limit = replayFxFanoutJob.params.find((p) => p.name === "limit")
+    expect(limit!.description).toMatch(/first n/i)
+    const offset = replayFxFanoutJob.params.find((p) => p.name === "offset")
+    expect(offset!.type).toBe("number")
+    expect(offset!.required).toBe(false)
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/fanout-fx-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/fanout-fx-job.ts
@@ -1,7 +1,7 @@
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 
-import fanoutPricesWorkflow from "../../../../workflows/fx/fanout-prices"
+import { requestVariantPriceFanout } from "../../../../workflows/fx/fanout-variant-prices"
 import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
 
 /**
@@ -12,7 +12,10 @@ import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./
  * This is the guarded, UI-runnable version of
  * `src/scripts/fanout-existing-variant-prices.ts` — same enumeration
  * (partner → store → default sales channel → variants → price rows), same
- * idempotent `fanoutPricesWorkflow` per non-auto price.
+ * idempotent fanout per non-auto price. It differs from the script in WHERE
+ * the fanout runs: the script is a CLI process that can block as long as it
+ * likes, this job is an HTTP request and so hands the work to the worker
+ * instead (see below).
  *
  * Why it's needed even though every write path now fans out inline: prices
  * created before that wiring landed (or before a store gained a new supported
@@ -21,18 +24,81 @@ import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./
  *
  * Dry-run previews, per source price, exactly which currencies a fanout would
  * ADD — computed purely from the price_set's existing currencies vs the store's
- * supported currencies (no writes, no FX calls). Apply runs the workflow and
- * reports what it actually created.
+ * supported currencies (no writes, no FX calls).
+ *
+ * ⚠️ APPLY QUEUES, IT DOES NOT FAN OUT (#1996).
+ *
+ * This job used to call `fanoutPricesWorkflow` once per source price, inline,
+ * on the HTTP request path. Two consequences, both observed:
+ *
+ *  1. It timed out. Opening the 7 new sales regions on 2026-09-11 needed 1,331
+ *     price rows; five successive applies all returned "The operation timed
+ *     out" **while succeeding server-side** (264 → 202 → … → 0 remaining). A
+ *     timeout is indistinguishable from a failure, so the only way to learn
+ *     the true state was to re-run the preview and watch the count fall.
+ *  2. It was the last caller still doing the thing that OOM-killed prod twice
+ *     on 2026-08-19 (exit 137). Every other write path emits
+ *     FX_FANOUT_REQUESTED so the work lands on the WORKER; this one did not.
+ *     It survived only because the load happened to be split across five
+ *     timed-out calls instead of arriving as one.
+ *
+ * So apply now emits FX_FANOUT_REQUESTED in bounded batches and returns
+ * immediately. `applied: true` therefore means QUEUED, not done — which the
+ * summary says in words, because a weaker guarantee that is only implied is
+ * how "a check that never ran reads as a pass" happens.
+ *
+ * Confirmation is the preview: re-run with dry_run and it reports 0 source
+ * prices when the worker has finished.
  */
 
 /** Hard cap on partners scanned in one call — bounds the per-request blast
  *  radius (each partner fans out every price on every store product). */
 export const MAX_FX_FANOUT_PARTNER_SCAN = 5000
 
+/**
+ * Source price ids per FX_FANOUT_REQUESTED event.
+ *
+ * This is the job's half of a two-part ceiling, and neither half is optional:
+ *
+ *   - HERE: a batch bounds the size of one event payload and one unit of
+ *     redelivery. A single event carrying all 1,331 prices would make the
+ *     retry granularity "everything", which is how a partial failure becomes a
+ *     full replay.
+ *   - IN THE SUBSCRIBER: `FANOUT_MAX_CONCURRENCY` (4) bounds how many
+ *     workflow runs are actually in flight. THAT is the memory ceiling; the
+ *     batch size is not, because a batch is processed with that concurrency,
+ *     not all at once.
+ *
+ * Emission itself is sequential — one awaited `emit` at a time — so this job
+ * never has more than one bus call outstanding either. The 2026-08-19 kill
+ * came from a docblock that CLAIMED bounded concurrency (`Promise.allSettled`,
+ * which bounds nothing); `replay-fx-fanout.unit.spec.ts` exercises the batch
+ * ceiling rather than trusting this comment.
+ */
+export const FX_FANOUT_JOB_BATCH_SIZE = 50
+
+/**
+ * PURE: split ids into batches of at most `size`, preserving order.
+ * Exported so the ceiling is testable without an event bus.
+ */
+export function chunkPriceIds(ids: string[], size = FX_FANOUT_JOB_BATCH_SIZE): string[][] {
+  const bounded = Math.max(1, Math.floor(size))
+  const out: string[][] = []
+  for (let i = 0; i < ids.length; i += bounded) out.push(ids.slice(i, i + bounded))
+  return out
+}
+
 const fanoutFxParamsSchema = z.object({
   /** Restrict the replay to a single partner (default: all partners). */
   partner_id: z.string().min(1).optional(),
-  /** Max partners to scan in one call (1..MAX_FX_FANOUT_PARTNER_SCAN). */
+  /**
+   * WINDOW SIZE, not "the next N to do".
+   *
+   * ⚠️ `limit` bounds PARTNERS and, on its own, always takes the FIRST N in a
+   * stable id order. Once those partners are clean it reports "0 changes"
+   * forever while later partners are still outstanding — which reads exactly
+   * like completion. Page with `offset` if you scope a long run this way.
+   */
   limit: z
     .number()
     .int()
@@ -40,6 +106,8 @@ const fanoutFxParamsSchema = z.object({
     .max(MAX_FX_FANOUT_PARTNER_SCAN)
     .optional()
     .default(1000),
+  /** Partners to skip before the window starts — makes `limit` a real cursor. */
+  offset: z.number().int().min(0).optional().default(0),
   /**
    * Also replay the HOUSE store(s) — the ones no partner owns. On by default:
    * omitting them is what left admin-side products (custom-design products in
@@ -124,10 +192,11 @@ type StoreTarget = {
 /** Walk partners → stores → default sales channel, collecting the targets we
  *  can fan out. Stores without a default channel or supported currencies are
  *  skipped (nothing to fan out). */
-async function collectStoreTargets(
+export async function collectStoreTargets(
   query: any,
   partnerId: string | undefined,
-  limit: number
+  limit: number,
+  offset = 0
 ): Promise<{ targets: StoreTarget[]; skippedStores: number }> {
   const partnerGraphArgs: Record<string, unknown> = {
     entity: "partners",
@@ -139,7 +208,10 @@ async function collectStoreTargets(
       "stores.default_sales_channel_id",
       "stores.supported_currencies.currency_code",
     ],
-    pagination: { take: limit },
+    // `order` is what makes `offset` mean anything: without a deterministic
+    // sort, page 2 is not "the partners after page 1" — it is an arbitrary
+    // window that may repeat or skip rows between calls.
+    pagination: { take: limit, skip: offset, order: { id: "ASC" } },
   }
   if (partnerId) partnerGraphArgs.filters = { id: partnerId }
 
@@ -286,7 +358,7 @@ export const replayFxFanoutJob: MaintenanceJob = {
   id: "replay-fx-fanout",
   label: "Replay FX price fanout",
   description:
-    `Materialise auto-converted variant prices in every currency of the owning store's supported_currencies, for products whose prices were created before FX fanout ran (or before the store gained the currency). Fixes products that read "not available" in non-native regions (e.g. an INR-priced product showing unavailable in the EUR region). Dry-run previews, per source price, exactly which currencies would be added — no writes, no FX calls. Apply runs the idempotent fanout workflow (skips currencies that already exist + auto-derived source rows). Covers partner stores AND the house store(s) — the ones no partner owns, where admin-side custom-design products live; those were previously unreachable by this job, so prices written there had no repair path at all. Optionally scope to one partner_id (which excludes house stores). Scans up to 'limit' partners per call (default 1000, max ${MAX_FX_FANOUT_PARTNER_SCAN}).`,
+    `Materialise auto-converted variant prices in every currency of the owning store's supported_currencies, for products whose prices were created before FX fanout ran (or before the store gained the currency). Fixes products that read "not available" in non-native regions (e.g. an INR-priced product showing unavailable in the EUR region). Dry-run previews, per source price, exactly which currencies would be added — no writes, no FX calls. APPLY QUEUES THE WORK AND RETURNS: it emits fx.fanout_requested in batches of up to ${FX_FANOUT_JOB_BATCH_SIZE} so the idempotent fanout runs on the WORKER, so 'applied' here means QUEUED, not done — re-run the dry run to confirm completion (it reports 0 source prices when the worker has finished). It used to run every fanout inline on the request path, which timed out on large replays while still succeeding server-side, and was the last caller doing the thing that OOM-killed prod on 2026-08-19. Covers partner stores AND the house store(s) — the ones no partner owns, where admin-side custom-design products live; those were previously unreachable by this job, so prices written there had no repair path at all. Optionally scope to one partner_id (which excludes house stores). Scans up to 'limit' partners per call (default 1000, max ${MAX_FX_FANOUT_PARTNER_SCAN}).`,
   params: [
     {
       name: "partner_id",
@@ -298,7 +370,14 @@ export const replayFxFanoutJob: MaintenanceJob = {
       name: "limit",
       type: "number",
       required: false,
-      description: `Max partners to scan in one call (default 1000, max ${MAX_FX_FANOUT_PARTNER_SCAN})`,
+      description: `WINDOW size over partners, not "the next N to do" (default 1000, max ${MAX_FX_FANOUT_PARTNER_SCAN}). On its own it always takes the FIRST N in id order, so once those are clean it reports 0 changes forever while later partners are still outstanding. Page with offset.`,
+    },
+    {
+      name: "offset",
+      type: "number",
+      required: false,
+      description:
+        "Partners to skip before the window starts (default 0) — this is what makes 'limit' a real cursor rather than a repeat of page one.",
     },
     {
       name: "include_house_stores",
@@ -316,12 +395,12 @@ export const replayFxFanoutJob: MaintenanceJob = {
         parsed.error.issues.map((i) => i.message).join("; ")
       )
     }
-    const { partner_id, limit, include_house_stores } = parsed.data
+    const { partner_id, limit, offset, include_house_stores } = parsed.data
 
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
 
-    const partnerScan = await collectStoreTargets(query, partner_id, limit)
+    const partnerScan = await collectStoreTargets(query, partner_id, limit, offset)
 
     // `partner_id` is an explicit request for ONE partner, so house stores are
     // not silently added to it. Otherwise they are part of "replay everything".
@@ -338,13 +417,19 @@ export const replayFxFanoutJob: MaintenanceJob = {
     const errors: Array<{ id: string; message: string }> = []
     let sourcesWithWork = 0
     let currenciesPlanned = 0
-    let created = 0
+    let queued = 0
+    let batchesEmitted = 0
     let storesScanned = 0
 
     for (const target of targets) {
       try {
         const priceSets = await collectStorePriceSets(query, target.channelId)
         storesScanned++
+
+        // Source prices this store would hand to the worker. Collected per
+        // store because FX_FANOUT_REQUESTED is keyed on store_id — the store's
+        // supported_currencies are what the fanout converts INTO.
+        const storePriceIds: string[] = []
 
         for (const ps of priceSets) {
           const plan = planPriceSetFanout({
@@ -356,48 +441,41 @@ export const replayFxFanoutJob: MaintenanceJob = {
             sourcesWithWork++
             currenciesPlanned += item.add.length
 
-            if (dry_run) {
-              changes.push({
-                entity: "price",
-                id: item.source_price_id,
-                field: "fanout_currencies",
-                before: item.source_currency,
-                after: item.add.join(", "),
-              })
-              continue
-            }
+            // The change set is identical in both modes on purpose: apply
+            // reports exactly what it HANDED OVER, in the same shape the
+            // preview said it would. Nothing here claims the fanout ran.
+            changes.push({
+              entity: "price",
+              id: item.source_price_id,
+              field: "fanout_currencies",
+              before: item.source_currency,
+              after: item.add.join(", "),
+              note: dry_run
+                ? `store ${target.storeId} — would queue`
+                : `store ${target.storeId} — queued for the worker, not yet fanned out`,
+            })
 
-            // Apply: run the idempotent fanout for this source price.
-            try {
-              const { result } = await fanoutPricesWorkflow(container).run({
-                input: {
-                  source_price_id: item.source_price_id,
-                  store_id: target.storeId,
-                },
-              })
-              const createdCount = result?.created_count ?? 0
-              created += createdCount
-              if (createdCount > 0) {
-                changes.push({
-                  entity: "price",
-                  id: item.source_price_id,
-                  field: "fanout_currencies",
-                  before: item.source_currency,
-                  after: String(createdCount),
-                })
-              }
-              for (const e of result?.errors ?? []) {
-                errors.push({
-                  id: item.source_price_id,
-                  message: `${e.currency}: ${e.error}`,
-                })
-              }
-            } catch (err: any) {
-              errors.push({
-                id: item.source_price_id,
-                message: err?.message ?? String(err),
-              })
-            }
+            if (!dry_run) storePriceIds.push(item.source_price_id)
+          }
+        }
+
+        // Apply: hand the work to the worker in bounded batches, one awaited
+        // emit at a time. Nothing is fanned out on this request path (#1996).
+        for (const batch of chunkPriceIds(storePriceIds)) {
+          const outcome = await requestVariantPriceFanout(container, {
+            storeId: target.storeId,
+            priceIds: batch,
+          })
+          if (outcome.queued) {
+            batchesEmitted++
+            queued += batch.length
+          } else {
+            // The emit never throws, so a dead bus would otherwise be
+            // reported as a successful queue of everything.
+            errors.push({
+              id: target.storeId,
+              message: `could not queue ${batch.length} price(s): ${outcome.reason ?? "unknown"}`,
+            })
           }
         }
       } catch (err: any) {
@@ -414,14 +492,19 @@ export const replayFxFanoutJob: MaintenanceJob = {
         } would gain ${currenciesPlanned} auto-converted price(s)${
           skippedStores ? ` (${skippedStores} store(s) skipped: no channel / <2 currencies)` : ""
         }.`
-      : `Fanned out ${created} auto-converted price(s) from ${sourcesWithWork} source price(s) across ${storesScanned} store(s)${
+      : `QUEUED — not yet fanned out. ${queued} source price(s) across ${storesScanned} store(s)${
           houseStoresScanned ? ` (incl. ${houseStoresScanned} house)` : ""
-        }${errors.length ? `, ${errors.length} error(s)` : ""}.`
+        } handed to the worker in ${batchesEmitted} batch(es) of up to ${FX_FANOUT_JOB_BATCH_SIZE}; they will gain up to ${currenciesPlanned} auto-converted price(s). This job does NOT wait for the fanout — re-run it with dry_run to confirm, it reports 0 source prices when the worker is done${
+          errors.length ? `. ${errors.length} batch/store error(s)` : ""
+        }.`
 
     return {
       job_id: replayFxFanoutJob.id,
       dry_run,
-      applied: !dry_run && created > 0,
+      // ⚠️ WEAKER THAN IT LOOKS: `applied` means the fanout was QUEUED, not
+      // performed. The summary says so in words rather than leaving it to be
+      // inferred from this flag.
+      applied: !dry_run && queued > 0,
       summary,
       changes,
       errors,

--- a/apps/backend/src/workflows/fx/fanout-variant-prices.ts
+++ b/apps/backend/src/workflows/fx/fanout-variant-prices.ts
@@ -216,11 +216,24 @@ export type FxFanoutRequestedPayload = {
  * Never throws. If the event bus itself is unreachable the fanout is skipped
  * and logged — exactly the pre-existing "worst case is no auto-prices"
  * contract, and never a failed save for the partner.
+ *
+ * It RETURNS whether the enqueue actually happened, because "never throws"
+ * and "succeeded" are not the same thing. A save path is right to ignore that
+ * (the fanout is best-effort there), but a caller that REPORTS what it did —
+ * the `replay-fx-fanout` maintenance job — must not print "queued 264" when
+ * the bus was unreachable and nothing was queued at all.
  */
+export type RequestVariantPriceFanoutResult = {
+  /** true only when the event was handed to the bus without error. */
+  queued: boolean
+  /** set when nothing was emitted: "empty" (no ids) or the bus error message. */
+  reason?: string
+}
+
 export async function requestVariantPriceFanout(
   scope: any,
   input: FanoutVariantPricesInput
-): Promise<void> {
+): Promise<RequestVariantPriceFanoutResult> {
   const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
   const payload: FxFanoutRequestedPayload = {
     store_id: input.storeId,
@@ -229,15 +242,19 @@ export async function requestVariantPriceFanout(
   }
 
   // Nothing to fan out — don't wake the worker for an empty job.
-  if (!payload.price_ids?.length && !payload.variant_ids?.length) return
+  if (!payload.price_ids?.length && !payload.variant_ids?.length) {
+    return { queued: false, reason: "empty" }
+  }
 
   try {
     const eventBus: any = scope.resolve(Modules.EVENT_BUS)
     await eventBus.emit({ name: FX_FANOUT_REQUESTED, data: payload })
+    return { queued: true }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     logger?.warn?.(
       `[fanout] could not enqueue FX fanout for store ${input.storeId}: ${message}`
     )
+    return { queued: false, reason: message }
   }
 }


### PR DESCRIPTION
Closes #1996.

## The problem

`replay-fx-fanout`'s apply ran `fanoutPricesWorkflow` **once per source price, inline, on the HTTP request path**. Two consequences, both observed in prod:

1. **It timed out.** Opening the 7 new sales regions on 2026-09-11 needed 1,331 price rows. Five successive applies all returned `The operation timed out` — **while succeeding server-side every time** (264 → 202 → … → 0 remaining). A timeout is indistinguishable from a failure; the only way to learn the true state was to re-run the preview and watch the count fall.
2. **It was the last caller still doing the thing that OOM-killed prod twice on 2026-08-19** (exit 137). Every other write path emits `FX_FANOUT_REQUESTED` so the fanout lands on the worker. This one did not. It survived only because the load arrived as five timed-out calls instead of one.

## The fix

Apply emits `FX_FANOUT_REQUESTED` in batches of up to `FX_FANOUT_JOB_BATCH_SIZE` (50) price ids, one awaited emit at a time, and returns. Two-part ceiling, neither half optional:

| where | bounds |
|---|---|
| this job | event payload size and the unit of redelivery |
| the subscriber | `FANOUT_MAX_CONCURRENCY` (4) — **this** is the memory ceiling |

**The weakened guarantee is stated, not implied.** `applied: true` now means **QUEUED**, and the summary says so in words plus how to confirm: re-run the preview, it reports 0 source prices when the worker is done. The change set is identical in both modes, so apply reports exactly what it handed over.

`requestVariantPriceFanout` now returns whether the enqueue happened. It still never throws — but *never throws* and *succeeded* are not the same thing, and without that flag a dead event bus would be reported as a successful queue of everything.

## Also fixed: the `limit` trap

`limit` bounded partners and always took the **first N**, so once the leading partners were clean it reported "0 changes" forever while later ones were still outstanding — which reads exactly like completion. It now takes an `offset` and a deterministic `id ASC` order, making it a real cursor, and the param description says what it is.

## Tests

Added to `replay-fx-fanout.unit.spec.ts` (28 pass, 741 in the maintenance-job suite):

- batch ceiling — nothing over 50, nothing dropped or duplicated
- apply emits `FX_FANOUT_REQUESTED` and runs no workflow; assertions read `emitted` **after** the call, not inside the mock
- dry run emits nothing and still returns the real change set (it is the completion signal)
- a throwing event bus → an error recorded, `applied: false`, no phantom queue
- `offset`/`order` reach `pagination`

**Mutation-checked**: removing the batch ceiling and faking the `queued` flag each turned a test red.

## Not in this PR

The queued fanout still has no first-class progress record in `ops_maintenance_run` — the preview remains the completion signal, and the summary now says so rather than leaving an operator to infer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp