### PR TITLE
feat(shipping): Packlink fulfillment provider — live rates for EU-origin partners

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -449,6 +449,42 @@ module.exports = defineConfig({
                 },
               ]
             : []),
+          /**
+           * Packlink — live rates for partners shipping from EUROPE.
+           *
+           * Shiprocket originates in India; the EasyPost account originates
+           * only in US/CA (verified 2026-09-12: every carrier answered
+           * "from_address.country is required to be US", while the identical
+           * payload from a US origin returned 8 rates). So an EU partner had NO
+           * way to quote, and its international shipping was a hand-set flat
+           * rate — which the live Packlink rates then showed to be loss-making
+           * on 3 of its 4 lanes, by EUR 52 per parcel to the UAE.
+           *
+           * 🔴 Registered in BOTH configs on purpose. The Dockerfile copies
+           * medusa-config.prod.ts OVER medusa-config.ts, so a provider added to
+           * only the dev config does not exist in production.
+           *
+           * Off unless PACKLINK_API_KEY is set. The key belongs in SSM.
+           */
+          ...(process.env.PACKLINK_API_KEY
+            ? [
+                {
+                  resolve: "./src/modules/shipping-providers/packlink",
+                  id: "packlink",
+                  options: {
+                    api_key: process.env.PACKLINK_API_KEY,
+                    origin_country: process.env.PACKLINK_ORIGIN_COUNTRY,
+                    origin_zip: process.env.PACKLINK_ORIGIN_ZIP,
+                    margin: Number(process.env.PACKLINK_MARGIN || 1.2),
+                    // Same shape and same reason as Shiprocket's: an unquotable
+                    // lane must cost SOMETHING, not 0.
+                    flat_fallback_amounts: parseFlatFallbackAmounts(
+                      process.env.PACKLINK_FLAT_FALLBACK_AMOUNTS
+                    ),
+                  },
+                },
+              ]
+            : []),
           // Shiprocket (#31). Registers the Medusa fulfillment provider for the
           // checkout/createFulfillment flow. The resolver-driven label/tracking/
           // pickup routes source creds from the external-platform store instead;

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -464,15 +464,17 @@ module.exports = defineConfig({
            * medusa-config.prod.ts OVER medusa-config.ts, so a provider added to
            * only the dev config does not exist in production.
            *
-           * Off unless PACKLINK_API_KEY is set. The key belongs in SSM.
+           * Enabled with PACKLINK_ENABLED=true. The API KEY is NOT here:
+           * it lives on a `socials` platform record of category "shipping"
+           * (provider_type "packlink"), encrypted — so it rotates in the UI
+           * without a deploy, and each partner can hold their own account.
            */
-          ...(process.env.PACKLINK_API_KEY
+          ...(process.env.PACKLINK_ENABLED === "true"
             ? [
                 {
                   resolve: "./src/modules/shipping-providers/packlink",
                   id: "packlink",
                   options: {
-                    api_key: process.env.PACKLINK_API_KEY,
                     origin_country: process.env.PACKLINK_ORIGIN_COUNTRY,
                     origin_zip: process.env.PACKLINK_ORIGIN_ZIP,
                     margin: Number(process.env.PACKLINK_MARGIN || 1.2),

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -581,6 +581,42 @@ module.exports = defineConfig({
                       },
                     ]
                   : []),
+                ...(process.env.PACKLINK_API_KEY
+                  ? [
+                      {
+                        /**
+                         * Packlink — live rates for partners shipping from EUROPE.
+                         *
+                         * Shiprocket originates in India; the EasyPost account
+                         * originates only in US/CA (verified 2026-09-12: every
+                         * carrier answered "from_address.country is required to
+                         * be US", while the same payload from a US origin
+                         * returned 8 rates). So an EU partner had NO way to
+                         * quote, and its international shipping was a hand-set
+                         * flat rate — which the live Packlink rates then showed
+                         * to be loss-making on 3 of its 4 lanes, by EUR 52 per
+                         * parcel to the UAE.
+                         *
+                         * Off unless PACKLINK_API_KEY is set, like every other
+                         * carrier here. The key belongs in SSM.
+                         */
+                        resolve: "./src/modules/shipping-providers/packlink",
+                        id: "packlink",
+                        options: {
+                          api_key: process.env.PACKLINK_API_KEY,
+                          origin_country: process.env.PACKLINK_ORIGIN_COUNTRY,
+                          origin_zip: process.env.PACKLINK_ORIGIN_ZIP,
+                          // Cost + 20% by default; margin 1 would quote at cost.
+                          margin: Number(process.env.PACKLINK_MARGIN || 1.2),
+                          // Same shape and same reason as Shiprocket's: an
+                          // unquotable lane must cost SOMETHING, not 0.
+                          flat_fallback_amounts: parseFlatFallbackAmounts(
+                            process.env.PACKLINK_FLAT_FALLBACK_AMOUNTS
+                          ),
+                        },
+                      },
+                    ]
+                  : []),
                 ...(process.env.SHIPROCKET_EMAIL
                   ? [
                       {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -581,7 +581,7 @@ module.exports = defineConfig({
                       },
                     ]
                   : []),
-                ...(process.env.PACKLINK_API_KEY
+                ...(process.env.PACKLINK_ENABLED === "true"
                   ? [
                       {
                         /**
@@ -597,13 +597,15 @@ module.exports = defineConfig({
                          * to be loss-making on 3 of its 4 lanes, by EUR 52 per
                          * parcel to the UAE.
                          *
-                         * Off unless PACKLINK_API_KEY is set, like every other
-                         * carrier here. The key belongs in SSM.
+                         * Enabled with PACKLINK_ENABLED=true. The API KEY is NOT
+                         * here: it lives on a `socials` platform record of
+                         * category "shipping" (provider_type "packlink"),
+                         * encrypted, so it rotates in the UI without a deploy
+                         * and each partner can hold their own account.
                          */
                         resolve: "./src/modules/shipping-providers/packlink",
                         id: "packlink",
                         options: {
-                          api_key: process.env.PACKLINK_API_KEY,
                           origin_country: process.env.PACKLINK_ORIGIN_COUNTRY,
                           origin_zip: process.env.PACKLINK_ORIGIN_ZIP,
                           // Cost + 20% by default; margin 1 would quote at cost.

--- a/apps/backend/src/admin/components/social-platforms/api-config.ts
+++ b/apps/backend/src/admin/components/social-platforms/api-config.ts
@@ -126,6 +126,16 @@ export function buildApiConfig(
           password: data.password,
           pickup_location: data.pickup_location,
         })
+      } else if (data.provider_type === "packlink") {
+        // Packlink authenticates with a single API key and needs the partner's
+        // OWN pickup origin — their account ships from their address. Read back
+        // by `shipping-providers/packlink/service.ts` -> resolveClient().
+        Object.assign(config, {
+          mode: data.mode || "test",
+          api_key: data.api_key,
+          origin_country: data.origin_country,
+          origin_zip: data.origin_zip,
+        })
       } else if (data.provider_type === "shipglobal") {
         // ShipGlobal authenticates with username/password (HTTP Basic) and a
         // region-specific service code (sgdirecteuyun EU / sgdirectyungb GB).

--- a/apps/backend/src/admin/components/social-platforms/create-social-platform-component.tsx
+++ b/apps/backend/src/admin/components/social-platforms/create-social-platform-component.tsx
@@ -56,6 +56,9 @@ const CreateSocialPlatformSchema = z.object({
   email: z.string().optional(),
   pickup_location: z.string().optional(),
   service: z.string().optional(),
+  // Packlink: the partner's OWN pickup origin (their account, their address).
+  origin_country: z.string().optional(),
+  origin_zip: z.string().optional(),
   // Analytics fields
   tracking_id: z.string().optional(),
   project_token: z.string().optional(),
@@ -96,6 +99,14 @@ const CreateSocialPlatformSchema = z.object({
     if (!data.email) ctx.addIssue({ code: "custom", path: ["email"], message: "Shiprocket account email is required" })
     if (!data.password) ctx.addIssue({ code: "custom", path: ["password"], message: "Shiprocket password is required" })
   }
+  if (data.category === "shipping" && data.provider_type === "packlink") {
+    // The origin is not optional for Packlink: it quotes a LANE, so a record
+    // without a from-address produces a provider that falls back on every
+    // quote — indistinguishable from a carrier that does not serve the route.
+    if (!data.api_key) ctx.addIssue({ code: "custom", path: ["api_key"], message: "Packlink API key is required" })
+    if (!data.origin_country) ctx.addIssue({ code: "custom", path: ["origin_country"], message: "Origin country is required (e.g. IT) — Packlink quotes a lane, not a destination" })
+    if (!data.origin_zip) ctx.addIssue({ code: "custom", path: ["origin_zip"], message: "Origin postcode is required (e.g. 50022)" })
+  }
   if (data.category === "shipping" && data.provider_type === "shipglobal") {
     if (!data.username) ctx.addIssue({ code: "custom", path: ["username"], message: "ShipGlobal account email is required" })
     if (!data.password) ctx.addIssue({ code: "custom", path: ["password"], message: "ShipGlobal password is required" })
@@ -123,6 +134,8 @@ export const CreateSocialPlatformComponent = () => {
       host: "",
       port: 993,
       username: "",
+      origin_country: "",
+      origin_zip: "",
       password: "",
       tls: true,
       mailbox: "INBOX",

--- a/apps/backend/src/admin/components/social-platforms/shipping-provider-fields.tsx
+++ b/apps/backend/src/admin/components/social-platforms/shipping-provider-fields.tsx
@@ -3,7 +3,7 @@ import { type Control, type UseFormWatch } from "react-hook-form"
 import { Form } from "../common/form"
 
 export type ShippingProviderFieldValues = {
-  provider_type: "delhivery" | "shiprocket" | "dhl" | "fedex" | "ups" | "australia_post" | "shipglobal"
+  provider_type: "delhivery" | "shiprocket" | "dhl" | "fedex" | "ups" | "australia_post" | "shipglobal" | "packlink"
   api_key?: string
   account_number?: string
   api_secret?: string
@@ -16,6 +16,10 @@ export type ShippingProviderFieldValues = {
   // ShipGlobal (username/password Basic auth + region-specific service code)
   username?: string
   service?: string
+  // Packlink (api_key + the PARTNER's OWN pickup origin — their account ships
+  // from their address, not the platform's)
+  origin_country?: string
+  origin_zip?: string
 }
 
 type ShippingProviderFieldsProps = {
@@ -39,6 +43,7 @@ export const ShippingProviderFields = ({
     ups: { apiKey: "UPS Client ID", account: "UPS Account Number" },
     australia_post: { apiKey: "Australia Post API key", account: "Account Number" },
     shipglobal: { apiKey: "n/a", account: "Service code (sgdirecteuyun / sgdirectyungb)" },
+    packlink: { apiKey: "Packlink PRO API key", account: "n/a" },
   }
 
   const current = placeholders[providerType] || placeholders.dhl
@@ -68,6 +73,7 @@ export const ShippingProviderFields = ({
                   <Select.Item value="ups">UPS</Select.Item>
                   <Select.Item value="australia_post">Australia Post</Select.Item>
                   <Select.Item value="shipglobal">ShipGlobal</Select.Item>
+                  <Select.Item value="packlink">Packlink (EU origin)</Select.Item>
                 </Select.Content>
               </Select>
             </Form.Control>
@@ -196,6 +202,51 @@ export const ShippingProviderFields = ({
                 <Form.Label optional>Service Code</Form.Label>
                 <Form.Control>
                   <Input {...field} placeholder={current.account} />
+                </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+        </>
+      )}
+
+      {providerType === "packlink" && (
+        <>
+          {/*
+            The ORIGIN travels with the credential.
+
+            Packlink quotes a lane, so it needs a from-address — and a partner's
+            own Packlink account ships from THEIR warehouse, not the platform's.
+            Holding it here (rather than in env) is what lets each partner run
+            their own account.
+
+            🔑 The postcode matters more than it looks: Packlink answers a bad
+            one with {"messages":[{"message":"Bad Request"}]}, the same body it
+            returns for an unserved lane. The provider normalises known cases
+            (GB needs its space, AE rejects an all-zero placeholder) but the
+            origin is the one it cannot guess.
+          */}
+          <Form.Field
+            control={control}
+            name="origin_country"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Origin country</Form.Label>
+                <Form.Control>
+                  <Input {...field} placeholder="IT" maxLength={2} />
+                </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+          <Form.Field
+            control={control}
+            name="origin_zip"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Origin postcode</Form.Label>
+                <Form.Control>
+                  <Input {...field} placeholder="50022" />
                 </Form.Control>
                 <Form.ErrorMessage />
               </Form.Item>

--- a/apps/backend/src/modules/shipping-providers/packlink/__tests__/credentials.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/__tests__/credentials.unit.spec.ts
@@ -1,0 +1,116 @@
+import PacklinkFulfillmentService from "../service"
+
+/**
+ * Where the Packlink API key comes from.
+ *
+ * NOT an env var and NOT SSM: a `socials` platform record of category
+ * "shipping" with `provider_type: "packlink"`, the same store Shiprocket
+ * already uses. That means an admin rotates the key in the UI without a
+ * redeploy, and each partner can hold their OWN Packlink account rather than
+ * everyone sharing one platform-wide secret.
+ *
+ * 🔑 The failure this guards is silent. If the record cannot be read, every
+ * quote falls back to a flat number — which looks exactly like a carrier that
+ * does not serve the lane. So the fallback must be loud, and the precedence
+ * must be pinned.
+ */
+const logger = () => ({ warn: jest.fn(), info: jest.fn(), error: jest.fn() })
+
+const platform = (api_config: Record<string, any>) => ({
+  listSocialPlatforms: jest.fn().mockResolvedValue([
+    { name: "Packlink PRO", api_config },
+  ]),
+})
+
+describe("packlink credential resolution", () => {
+  it("prefers the platform record over the configured key", async () => {
+    const log = logger()
+    const svc: any = new PacklinkFulfillmentService(
+      { logger: log as any, socials: platform({ provider_type: "packlink", api_key: "from-platform" }) },
+      { api_key: "from-options" }
+    )
+    const client = await svc.resolveClient()
+    expect((client as any).apiKey).toBe("from-platform")
+  })
+
+  it("decrypts an encrypted key when the encryption module is present", async () => {
+    const decrypt = jest.fn().mockResolvedValue("decrypted-key")
+    const svc: any = new PacklinkFulfillmentService(
+      {
+        logger: logger() as any,
+        socials: platform({ provider_type: "packlink", api_key_encrypted: "cipher" }),
+        encryption: { decrypt },
+      },
+      { api_key: "from-options" }
+    )
+    const client = await svc.resolveClient()
+    // Assert on the call, not inside the mock — an expect() inside a mock that
+    // is swallowed by a catch proves nothing.
+    expect(decrypt).toHaveBeenCalledWith("cipher")
+    expect((client as any).apiKey).toBe("decrypted-key")
+  })
+
+  it("carries the partner's OWN origin from the record", async () => {
+    const svc: any = new PacklinkFulfillmentService(
+      {
+        logger: logger() as any,
+        socials: platform({
+          provider_type: "packlink",
+          api_key: "k",
+          origin_country: "IT",
+          origin_zip: "50022",
+        }),
+      },
+      { origin_country: "XX", origin_zip: "99999" }
+    )
+    await svc.resolveClient()
+    expect(svc.platformOrigin).toEqual({ country: "IT", zip: "50022" })
+  })
+
+  it("falls back LOUDLY when socials is missing from the cradle", async () => {
+    // This branch means `dependencies` was dropped from the fulfillment module
+    // in one of the two config files — invisible otherwise.
+    const log = logger()
+    const svc: any = new PacklinkFulfillmentService(
+      { logger: log as any },
+      { api_key: "from-options" }
+    )
+    const client = await svc.resolveClient()
+    expect((client as any).apiKey).toBe("from-options")
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("no `socials`"))
+  })
+
+  it("falls back loudly when no packlink record exists", async () => {
+    const log = logger()
+    const svc: any = new PacklinkFulfillmentService(
+      {
+        logger: log as any,
+        socials: { listSocialPlatforms: jest.fn().mockResolvedValue([{ name: "Shiprocket", api_config: { provider_type: "shiprocket" } }]) },
+      },
+      { api_key: "from-options" }
+    )
+    const client = await svc.resolveClient()
+    expect((client as any).apiKey).toBe("from-options")
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("not found"))
+  })
+
+  it("survives the platform lookup throwing", async () => {
+    const log = logger()
+    const svc: any = new PacklinkFulfillmentService(
+      { logger: log as any, socials: { listSocialPlatforms: jest.fn().mockRejectedValue(new Error("db down")) } },
+      { api_key: "from-options" }
+    )
+    const client = await svc.resolveClient()
+    expect((client as any).apiKey).toBe("from-options")
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("db down"))
+  })
+
+  it("looks the record up ONCE, not per quote", async () => {
+    const socials = platform({ provider_type: "packlink", api_key: "k" })
+    const svc: any = new PacklinkFulfillmentService({ logger: logger() as any, socials }, {})
+    await svc.resolveClient()
+    await svc.resolveClient()
+    await svc.resolveClient()
+    expect(socials.listSocialPlatforms).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/packlink/__tests__/postcode.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/__tests__/postcode.unit.spec.ts
@@ -1,0 +1,83 @@
+import { normalisePostcodeForPacklink } from "../postcode"
+import { buildRateQuery } from "../client"
+
+/**
+ * The two postcode rules, pinned.
+ *
+ * Both were found by watching the LIVE API return 400 with a body that says
+ * only "Bad Request" — the same body it returns for a missing parameter or an
+ * unserved lane. Without these, an EU partner's quotes fail in a way that is
+ * indistinguishable from "no carrier serves this route".
+ *
+ * Evidence (2026-09-12, origin IT 50022, 1 kg / 30×25×10):
+ *   NW16XE  -> 400  ·  NW1 6XE -> 200, 8 services
+ *   00000   -> 400  ·  1       -> 200, 6 services   (AE)
+ */
+describe("normalisePostcodeForPacklink", () => {
+  describe("GB — the space is load-bearing", () => {
+    it("inserts the space before the 3-character inward code", () => {
+      expect(normalisePostcodeForPacklink("GB", "NW16XE")).toBe("NW1 6XE")
+      expect(normalisePostcodeForPacklink("GB", "SW1A1AA")).toBe("SW1A 1AA")
+      expect(normalisePostcodeForPacklink("GB", "M11AE")).toBe("M1 1AE")
+    })
+
+    it("rebuilds the space rather than trusting the input's", () => {
+      // "NW1  6XE" (double space) and lowercase both have to arrive correct.
+      expect(normalisePostcodeForPacklink("GB", "NW1  6XE")).toBe("NW1 6XE")
+      expect(normalisePostcodeForPacklink("gb", "nw16xe")).toBe("NW1 6XE")
+      expect(normalisePostcodeForPacklink("GB", " NW1 6XE ")).toBe("NW1 6XE")
+    })
+
+    it("leaves something too short to split alone rather than mangling it", () => {
+      expect(normalisePostcodeForPacklink("GB", "6XE")).toBe("6XE")
+      expect(normalisePostcodeForPacklink("GB", "")).toBe("")
+    })
+  })
+
+  describe("AE — a zero-filled placeholder is refused", () => {
+    it("replaces an all-zero or empty postcode with an accepted token", () => {
+      expect(normalisePostcodeForPacklink("AE", "00000")).toBe("1")
+      expect(normalisePostcodeForPacklink("AE", "0")).toBe("1")
+      expect(normalisePostcodeForPacklink("AE", "")).toBe("1")
+      expect(normalisePostcodeForPacklink("AE", null)).toBe("1")
+    })
+
+    it("keeps a real value the buyer supplied", () => {
+      // "Dubai" was verified to work; a buyer's own entry is not overwritten.
+      expect(normalisePostcodeForPacklink("AE", "Dubai")).toBe("Dubai")
+    })
+  })
+
+  it("does not touch countries it has no evidence about", () => {
+    // 🔑 This normalises, it does not validate. Inventing a rule for a lane
+    // nobody tested would change quotes silently.
+    expect(normalisePostcodeForPacklink("IT", "50022")).toBe("50022")
+    expect(normalisePostcodeForPacklink("CA", "M5V 3L9")).toBe("M5V 3L9")
+    expect(normalisePostcodeForPacklink("CN", "100000")).toBe("100000")
+    expect(normalisePostcodeForPacklink("US", "94104")).toBe("94104")
+  })
+})
+
+describe("buildRateQuery", () => {
+  const q = {
+    from_country: "it", from_zip: "50022",
+    to_country: "gb", to_zip: "NW16XE",
+    weight_kg: 1, length_cm: 30, width_cm: 25, height_cm: 10,
+  }
+
+  it("uses the bracket notation the API requires, with the postcode fixed", () => {
+    const p = buildRateQuery(q)
+    expect(p.get("from[country]")).toBe("IT")
+    expect(p.get("to[country]")).toBe("GB")
+    // The whole reason this module exists:
+    expect(p.get("to[zip]")).toBe("NW1 6XE")
+    expect(p.get("packages[0][weight]")).toBe("1")
+    expect(p.get("packages[0][length]")).toBe("30")
+    expect(p.get("source")).toBe("PRO")
+  })
+
+  it("encodes the brackets so the URL is the one that returned 200", () => {
+    // %5B / %5D — the verified-working request used exactly this encoding.
+    expect(buildRateQuery(q).toString()).toContain("packages%5B0%5D%5Bweight%5D=1")
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/packlink/__tests__/rate-select.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/__tests__/rate-select.unit.spec.ts
@@ -1,0 +1,122 @@
+import {
+  applyPolicyToPrice,
+  selectService,
+  servicePrice,
+  transitDays,
+} from "../rate-select"
+
+/**
+ * Choosing among Packlink's services.
+ *
+ * The real Italy→GB response on 2026-09-12 carried EIGHT services spanning
+ * €18.19 (Poste Italiane, 3 days) to €116.69 (Fedex International Priority,
+ * 2 days) — a 6× spread. `services[0]` over that spread is the same row-order
+ * lottery as `stores[0]` and `take: 1`, except it decides what a buyer pays.
+ */
+const LIVE_IT_GB = [
+  { carrier_name: "Poste Italiane", name: "International Plus Home2Home", base_price: "18.19", transit_time: "3 DAYS" },
+  { carrier_name: "UPS", name: "Standard Access Point", base_price: "44.35", transit_time: "4 DAYS" },
+  { carrier_name: "UPS", name: "Standard", base_price: "46.5", transit_time: "4 DAYS" },
+  { carrier_name: "TNT", name: "Economy Express", base_price: "49.59", transit_time: "3 DAYS" },
+  { carrier_name: "TNT", name: "Express", base_price: "55.37", transit_time: "2 DAYS" },
+  { carrier_name: "UPS", name: "Express Saver", base_price: "62.61", transit_time: "2 DAYS" },
+  { carrier_name: "Fedex", name: "Regional Economy", base_price: "86.37", transit_time: "3 DAYS" },
+  { carrier_name: "Fedex", name: "International Priority", base_price: "116.69", transit_time: "2 DAYS" },
+]
+
+describe("servicePrice", () => {
+  it("reads total_price, then base_price", () => {
+    expect(servicePrice({ price: { total_price: "21.50" }, base_price: "18.19" })).toBe(21.5)
+    expect(servicePrice({ base_price: "18.19" })).toBe(18.19)
+  })
+
+  it("treats an unreadable price as ABSENT, never as zero", () => {
+    // 🔑 `Number("")` and `Number(null)` are both 0 — a free shipment. These
+    // must come back null so the caller falls back instead of shipping free.
+    expect(servicePrice({ base_price: "" })).toBeNull()
+    expect(servicePrice({ base_price: null as any })).toBeNull()
+    expect(servicePrice({})).toBeNull()
+    expect(servicePrice({ base_price: "not-a-number" })).toBeNull()
+  })
+
+  it("keeps a genuine zero", () => {
+    expect(servicePrice({ base_price: 0 })).toBe(0)
+  })
+})
+
+describe("selectService", () => {
+  it("picks the cheapest by default, whatever order they arrive in", () => {
+    expect(selectService(LIVE_IT_GB)?.carrier_name).toBe("Poste Italiane")
+    expect(selectService([...LIVE_IT_GB].reverse())?.carrier_name).toBe("Poste Italiane")
+  })
+
+  it("picks the fastest when asked, breaking ties on price", () => {
+    // Three services are 2 DAYS: TNT Express 55.37, UPS Express Saver 62.61,
+    // Fedex International Priority 116.69 -> TNT wins on price.
+    const s = selectService(LIVE_IT_GB, { prefer: "fastest" })
+    expect(s?.carrier_name).toBe("TNT")
+    expect(s?.name).toBe("Express")
+  })
+
+  it("never lets a service with no stated transit win 'fastest' by default", () => {
+    const s = selectService(
+      [{ carrier_name: "Mystery", base_price: "5" }, ...LIVE_IT_GB],
+      { prefer: "fastest" }
+    )
+    expect(s?.carrier_name).toBe("TNT")
+  })
+
+  it("honours a carrier allowlist", () => {
+    const s = selectService(LIVE_IT_GB, { carriers: ["UPS"] })
+    expect(s?.carrier_name).toBe("UPS")
+    expect(s?.name).toBe("Standard Access Point")
+  })
+
+  it("returns null — a REFUSAL — when nothing is quotable", () => {
+    // An empty list is Packlink's way of saying it will not carry the lane.
+    // Null forces the caller to fall back; a zero would ship it free.
+    expect(selectService([])).toBeNull()
+    expect(selectService(null)).toBeNull()
+    expect(selectService([{ carrier_name: "X", base_price: "" }])).toBeNull()
+    expect(selectService(LIVE_IT_GB, { carriers: ["DHL"] })).toBeNull()
+  })
+})
+
+describe("applyPolicyToPrice", () => {
+  it("is at cost by default — no invented margin", () => {
+    expect(applyPolicyToPrice(18.19)).toBeCloseTo(18.19, 2)
+  })
+
+  it("applies a margin", () => {
+    expect(applyPolicyToPrice(18.19, { margin: 1.2 })).toBeCloseTo(21.83, 2)
+  })
+
+  it("enforces a floor", () => {
+    expect(applyPolicyToPrice(18.19, { minimum: 30 })).toBe(30)
+    expect(applyPolicyToPrice(82.32, { minimum: 30 })).toBeCloseTo(82.32, 2)
+  })
+
+  it("ignores a nonsensical margin instead of zeroing the price", () => {
+    // margin 0 would make shipping free; NaN would make it NaN.
+    expect(applyPolicyToPrice(18.19, { margin: 0 })).toBeCloseTo(18.19, 2)
+    expect(applyPolicyToPrice(18.19, { margin: NaN })).toBeCloseTo(18.19, 2)
+    expect(applyPolicyToPrice(18.19, { margin: -2 })).toBeCloseTo(18.19, 2)
+  })
+
+  it("reproduces the four live lanes at cost + 20%", () => {
+    // The numbers that showed the flat €30 was loss-making on 3 of 4.
+    expect(applyPolicyToPrice(18.19, { margin: 1.2 })).toBeCloseTo(21.83, 2) // GB
+    expect(applyPolicyToPrice(31.83, { margin: 1.2 })).toBeCloseTo(38.20, 2) // CA
+    expect(applyPolicyToPrice(38.33, { margin: 1.2 })).toBeCloseTo(46.00, 2) // CN
+    expect(applyPolicyToPrice(82.32, { margin: 1.2 })).toBeCloseTo(98.78, 2) // AE
+  })
+})
+
+describe("transitDays", () => {
+  it("parses the advertised days, and null when unstated", () => {
+    expect(transitDays({ transit_time: "3 DAYS" })).toBe(3)
+    expect(transitDays({ transit_time: "2 DAYS" })).toBe(2)
+    expect(transitDays({})).toBeNull()
+    expect(transitDays({ transit_time: "unknown" })).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/packlink/client.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/client.ts
@@ -1,0 +1,121 @@
+/**
+ * Packlink PRO API client — the piece that quotes a lane our Indian carrier
+ * cannot.
+ *
+ * WHY THIS EXISTS. Shiprocket originates in India; EasyPost's account here
+ * originates only in the US or Canada (verified 2026-09-12: every carrier on
+ * that account answered "from_address.country is required to be US", while the
+ * identical payload from a US origin returned 8 rates). So an EU partner —
+ * Le Ciricotte, Greve in Chianti — had no way to quote at all, and its
+ * international shipping was hand-priced flat. Packlink quotes from Italy.
+ */
+import {
+  normalisePostcodeForPacklink,
+} from "./postcode"
+import type { PacklinkService } from "./rate-select"
+
+export type PacklinkOptions = {
+  /** PRO API key. Belongs in SSM, never in .env or a config literal. */
+  api_key?: string
+  base_url?: string
+  /** Packlink's `source`; "PRO" for the business platform. */
+  source?: string
+  timeout_ms?: number
+  /** Injected in tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch
+}
+
+export type PacklinkRateQuery = {
+  from_country: string
+  from_zip: string
+  to_country: string
+  to_zip: string
+  weight_kg: number
+  length_cm: number
+  width_cm: number
+  height_cm: number
+}
+
+const DEFAULT_BASE = "https://api.packlink.com"
+
+/**
+ * Build the query exactly as the API wants it.
+ *
+ * Exported for testing: the bracket notation (`packages[0][weight]`) and the
+ * postcode normalisation are the two things that decide between 200 and an
+ * unexplained 400, and neither is visible from the response.
+ */
+export const buildRateQuery = (
+  q: PacklinkRateQuery,
+  source = "PRO"
+): URLSearchParams => {
+  const p = new URLSearchParams()
+  p.set("from[country]", q.from_country.toUpperCase())
+  p.set("from[zip]", normalisePostcodeForPacklink(q.from_country, q.from_zip))
+  p.set("to[country]", q.to_country.toUpperCase())
+  p.set("to[zip]", normalisePostcodeForPacklink(q.to_country, q.to_zip))
+  p.set("packages[0][weight]", String(q.weight_kg))
+  p.set("packages[0][length]", String(q.length_cm))
+  p.set("packages[0][width]", String(q.width_cm))
+  p.set("packages[0][height]", String(q.height_cm))
+  if (source) p.set("source", source)
+  return p
+}
+
+export class PacklinkClient {
+  private readonly apiKey: string
+  private readonly baseUrl: string
+  private readonly source: string
+  private readonly timeoutMs: number
+  private readonly fetchImpl: typeof fetch
+
+  constructor(options: PacklinkOptions = {}) {
+    this.apiKey = options.api_key ?? process.env.PACKLINK_API_KEY ?? ""
+    this.baseUrl = (options.base_url ?? DEFAULT_BASE).replace(/\/+$/, "")
+    this.source = options.source ?? "PRO"
+    this.timeoutMs = options.timeout_ms ?? 10_000
+    this.fetchImpl = options.fetchImpl ?? ((globalThis as any).fetch as typeof fetch)
+  }
+
+  get configured(): boolean {
+    return Boolean(this.apiKey)
+  }
+
+  /**
+   * Services (and prices) for a lane.
+   *
+   * Throws on a non-2xx rather than returning [] — 🔑 an empty list and a
+   * refusal are different answers, and collapsing them is how a 400 becomes a
+   * silent "no carriers serve this route". The caller decides what to do with
+   * each; it cannot decide if it cannot tell them apart.
+   */
+  async getServices(q: PacklinkRateQuery): Promise<PacklinkService[]> {
+    if (!this.configured) {
+      throw new Error("Packlink is not configured: no api_key / PACKLINK_API_KEY")
+    }
+    const url = `${this.baseUrl}/v1/services?${buildRateQuery(q, this.source).toString()}`
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+    try {
+      const res = await this.fetchImpl(url, {
+        method: "GET",
+        headers: { Authorization: this.apiKey, Accept: "application/json" },
+        signal: controller.signal,
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        // Packlink says only {"messages":[{"message":"Bad Request"}]} for a bad
+        // postcode, a bad package AND an unserved lane. Carry the status and
+        // the lane so the log can at least say WHICH request failed.
+        throw new Error(
+          `Packlink ${res.status} for ${q.from_country} ${q.from_zip} -> ${q.to_country} ${q.to_zip}: ${text.slice(0, 200)}`
+        )
+      }
+      const parsed = text ? JSON.parse(text) : []
+      return Array.isArray(parsed) ? (parsed as PacklinkService[]) : []
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/packlink/index.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/index.ts
@@ -1,0 +1,6 @@
+import { ModuleProvider, Modules } from "@medusajs/framework/utils"
+import PacklinkFulfillmentService from "./service"
+
+export default ModuleProvider(Modules.FULFILLMENT, {
+  services: [PacklinkFulfillmentService],
+})

--- a/apps/backend/src/modules/shipping-providers/packlink/postcode.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/postcode.ts
@@ -1,0 +1,77 @@
+/**
+ * Packlink rejects postcodes that every other system accepts.
+ *
+ * 🔑 This module exists because the failure is a **400 with no explanation**.
+ * Packlink answers an unusable postcode with `{"messages":[{"message":"Bad
+ * Request"}]}` — the same body it returns for a missing parameter, a malformed
+ * package, or an unsupported lane. Nothing says "postcode". So a partner whose
+ * quotes silently stopped working would have no way to tell this apart from
+ * the carrier simply not serving the route.
+ *
+ * Both rules below were established EMPIRICALLY against the live API on
+ * 2026-09-12, origin Greve in Chianti (IT 50022), 1 kg / 30×25×10 cm:
+ *
+ *   to[zip]=NW16XE   -> 400 Bad Request
+ *   to[zip]=NW1 6XE  -> 200, 8 services (Poste Italiane €18.19 … Fedex €116.69)
+ *
+ *   to[zip]=00000    -> 400 Bad Request      (United Arab Emirates)
+ *   to[zip]=1        -> 200, 6 services
+ *   to[zip]=Dubai    -> 200, 6 services
+ *
+ * ⚠️ These are observations, not documentation. Packlink may accept more than
+ * this; what is certain is that the two forms on the left DO fail and the forms
+ * on the right DO work. Treat additions here as requiring the same evidence.
+ */
+
+/** UK postcodes are `OUTWARD INWARD`, the inward part always 3 characters. */
+const GB_INWARD_LEN = 3
+
+/**
+ * Countries with no functioning postal-code system, where a placeholder must be
+ * sent. `00000` is the conventional filler and is exactly what Packlink
+ * REFUSES, so a non-zero token is used instead.
+ *
+ * Deliberately short: every entry here is one we have evidence for. A country
+ * added on assumption would quietly change quotes for a lane nobody tested.
+ */
+const NO_POSTAL_SYSTEM: Record<string, string> = {
+  AE: "1", // verified 2026-09-12: "00000" -> 400, "1" -> 200
+}
+
+/** Is the value absent, or a string of zeros/whitespace that means "none"? */
+const isPlaceholder = (zip: string): boolean =>
+  zip.length === 0 || /^0+$/.test(zip)
+
+/**
+ * Put a postcode into the form Packlink accepts for `country`.
+ *
+ * Returns the input unchanged when no rule applies — this normalises, it does
+ * not validate. A postcode this function cannot improve is still sent, because
+ * refusing to quote is worse than letting the carrier refuse with its own
+ * reason.
+ */
+export const normalisePostcodeForPacklink = (
+  countryCode: string | null | undefined,
+  zip: string | null | undefined
+): string => {
+  const country = String(countryCode ?? "").trim().toUpperCase()
+  const raw = String(zip ?? "").trim()
+
+  const filler = NO_POSTAL_SYSTEM[country]
+  if (filler && isPlaceholder(raw)) {
+    return filler
+  }
+
+  if (country === "GB") {
+    const compact = raw.replace(/\s+/g, "").toUpperCase()
+    if (compact.length > GB_INWARD_LEN) {
+      // Always rebuild the space rather than trusting the input's: "NW1  6XE"
+      // and "nw16xe" both have to arrive as "NW1 6XE".
+      const cut = compact.length - GB_INWARD_LEN
+      return `${compact.slice(0, cut)} ${compact.slice(cut)}`
+    }
+    return compact
+  }
+
+  return raw
+}

--- a/apps/backend/src/modules/shipping-providers/packlink/rate-select.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/rate-select.ts
@@ -1,0 +1,107 @@
+/**
+ * Which of Packlink's services to quote, and for how much.
+ *
+ * Packlink returns every service it can sell for a lane — 8 for Italy→GB on
+ * 2026-09-12, from Poste Italiane at €18.19 to Fedex International Priority at
+ * €116.69. Six-fold spread. Picking one is a commercial decision, so it is a
+ * configured policy here rather than a hardcoded `[0]`.
+ *
+ * 🔴 Never `services[0]`. Packlink does not document an ordering, and an
+ * unordered pick over a 6× price spread is the same row-order lottery that
+ * `stores[0]` and `take: 1` have already cost this codebase twice. Every
+ * selection below sorts explicitly.
+ */
+
+export type PacklinkService = {
+  id?: number | string
+  name?: string
+  carrier_name?: string
+  currency?: string
+  transit_time?: string
+  base_price?: string | number
+  price?: { total_price?: string | number; base_price?: string | number }
+}
+
+export type RateSelectionPolicy = {
+  /** "cheapest" (default) or "fastest" by advertised transit days. */
+  prefer?: "cheapest" | "fastest"
+  /** Only consider these carriers, case-insensitive. Empty/absent = all. */
+  carriers?: string[]
+  /** Multiplied onto the carrier price, e.g. 1.2 for +20%. Default 1 (at cost). */
+  margin?: number
+  /** Never quote below this, in the carrier's currency. */
+  minimum?: number
+}
+
+/** The price Packlink actually charges, in EUR. `null` when unreadable. */
+export const servicePrice = (s: PacklinkService): number | null => {
+  const raw = s?.price?.total_price ?? s?.price?.base_price ?? s?.base_price
+  if (raw === undefined || raw === null || raw === "") return null
+  const n = Number(raw)
+  // 🔑 `Number("")` is 0 and `Number(null)` is 0 — both would read as a FREE
+  // shipment. Guarded above, and NaN is rejected here rather than propagating.
+  return Number.isFinite(n) ? n : null
+}
+
+/** Advertised transit in days, e.g. "3 DAYS" -> 3. `null` when unstated. */
+export const transitDays = (s: PacklinkService): number | null => {
+  const m = /(\d+)/.exec(String(s?.transit_time ?? ""))
+  return m ? Number(m[1]) : null
+}
+
+/**
+ * Choose one service, deterministically.
+ *
+ * Returns `null` when nothing is quotable — which is a REFUSAL, not a price of
+ * zero. The caller must fall back rather than quote 0.
+ */
+export const selectService = (
+  services: PacklinkService[] | null | undefined,
+  policy: RateSelectionPolicy = {}
+): PacklinkService | null => {
+  const wanted = (policy.carriers ?? [])
+    .map((c) => c.trim().toLowerCase())
+    .filter(Boolean)
+
+  const usable = (services ?? []).filter((s) => {
+    if (servicePrice(s) === null) return false
+    if (!wanted.length) return true
+    return wanted.includes(String(s.carrier_name ?? "").trim().toLowerCase())
+  })
+  if (!usable.length) return null
+
+  const byPrice = (a: PacklinkService, b: PacklinkService) =>
+    (servicePrice(a) as number) - (servicePrice(b) as number)
+
+  if (policy.prefer === "fastest") {
+    return [...usable].sort((a, b) => {
+      const da = transitDays(a)
+      const db = transitDays(b)
+      // A service that does not state its transit time must not win "fastest"
+      // by virtue of being unknown — it sorts last, then price breaks the tie.
+      if (da === null && db === null) return byPrice(a, b)
+      if (da === null) return 1
+      if (db === null) return -1
+      return da - db || byPrice(a, b)
+    })[0]
+  }
+
+  return [...usable].sort(byPrice)[0]
+}
+
+/** Apply the configured margin and floor to a carrier price. */
+export const applyPolicyToPrice = (
+  carrierPrice: number,
+  policy: RateSelectionPolicy = {}
+): number => {
+  const margin =
+    typeof policy.margin === "number" && Number.isFinite(policy.margin) && policy.margin > 0
+      ? policy.margin
+      : 1
+  const withMargin = carrierPrice * margin
+  const floor =
+    typeof policy.minimum === "number" && Number.isFinite(policy.minimum)
+      ? policy.minimum
+      : 0
+  return Math.max(withMargin, floor)
+}

--- a/apps/backend/src/modules/shipping-providers/packlink/service.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/service.ts
@@ -36,13 +36,25 @@ import {
 type InjectedDeps = {
   logger: Logger
   /**
-   * Reaches the provider only if the fulfillment module declares it in
-   * `dependencies` in BOTH medusa-config.ts and medusa-config.prod.ts — the
-   * Dockerfile copies the prod config OVER the dev one, so a dependency
-   * declared in only one of them does not exist in production.
+   * 🔑 Where the API key actually lives.
    *
-   * Optional: without it a non-EUR cart falls back rather than returning a euro
-   * figure wearing a pound sign.
+   * Not SSM and not an env var: the key is stored on a `socials` platform
+   * record of category "shipping", exactly like Shiprocket's — so an admin can
+   * rotate it in the UI without a redeploy, and each partner can hold their own
+   * Packlink account rather than sharing one platform-wide secret.
+   *
+   * ⚠️ `socials` and `encryption` reach a PROVIDER only because the fulfillment
+   * module declares `dependencies: [SOCIALS_MODULE, ENCRYPTION_MODULE]` in BOTH
+   * medusa-config.ts and medusa-config.prod.ts — a provider is constructed with
+   * the parent module's cradle, which otherwise carries six default keys and
+   * nothing else. The Dockerfile copies the prod config OVER the dev one, so a
+   * dependency declared in only one of them does not exist in production.
+   */
+  socials?: any
+  encryption?: any
+  /**
+   * Reaches the provider the same way. Optional: without it a non-EUR cart
+   * falls back rather than returning a euro figure wearing a pound sign.
    */
   fx_rates?: any
 }
@@ -71,6 +83,11 @@ class PacklinkFulfillmentService extends AbstractFulfillmentProviderService {
   protected logger: Logger
   protected deps: InjectedDeps
   protected options: PacklinkProviderOptions
+  /** Resolved once per process; a platform lookup per rate call would be absurd. */
+  protected platformClient: PacklinkClient | null = null
+  protected platformLookupDone = false
+  /** Origin from the platform record, when it carries one. */
+  protected platformOrigin: { country?: string; zip?: string } = {}
 
   constructor(deps: InjectedDeps, options: PacklinkProviderOptions = {}) {
     super()
@@ -78,6 +95,111 @@ class PacklinkFulfillmentService extends AbstractFulfillmentProviderService {
     this.logger = deps.logger
     this.options = options
     this.client = new PacklinkClient(options)
+  }
+
+  /**
+   * The credential-bearing client.
+   *
+   * Resolved once per process — a platform lookup per rate call would be
+   * absurd — and cached even on failure, so a missing record does not mean a
+   * database round-trip on every quote.
+   *
+   * Falls back to the options/env client rather than throwing: a provider that
+   * cannot read its record should degrade to whatever it was given, and SAY so,
+   * because the symptom it otherwise produces (every quote quietly falling back
+   * to a flat number) looks identical to a carrier not serving the lane.
+   */
+  protected async resolveClient(): Promise<PacklinkClient> {
+    if (this.platformLookupDone) {
+      return this.platformClient ?? this.client
+    }
+    this.platformLookupDone = true
+
+    const socials = this.deps?.socials
+    if (!socials) {
+      this.logger?.warn?.(
+        "[packlink] no `socials` in the provider cradle — falling back to the configured api_key. " +
+          "Check `dependencies` on the fulfillment module in BOTH medusa-config files."
+      )
+      return this.client
+    }
+
+    try {
+      const platforms = await socials.listSocialPlatforms({
+        category: "shipping",
+        status: "active",
+      })
+      const match = (platforms || []).find((p: any) => {
+        const cfg = (p.api_config as Record<string, any>) || {}
+        const type = String(
+          cfg.provider_type || cfg.provider || p.name || ""
+        ).toLowerCase()
+        return type === "packlink" || type.includes("packlink")
+      })
+
+      const cfg = (match?.api_config as Record<string, any>) || {}
+      const apiKey = await this.readSecret(cfg, "api_key")
+
+      if (!apiKey) {
+        this.logger?.warn?.(
+          `[packlink] shipping platform record ${
+            match ? "found but carries no api_key" : "not found"
+          } — falling back to the configured api_key.`
+        )
+        return this.client
+      }
+
+      this.platformClient = new PacklinkClient({
+        ...this.options,
+        api_key: apiKey,
+        base_url:
+          (typeof cfg.base_url === "string" && cfg.base_url) ||
+          this.options.base_url,
+        source:
+          (typeof cfg.source === "string" && cfg.source) || this.options.source,
+      })
+      // The origin travels with the credential: a partner's Packlink account
+      // ships from THEIR address, not the platform's.
+      this.platformOrigin = {
+        country:
+          (typeof cfg.origin_country === "string" && cfg.origin_country) ||
+          undefined,
+        zip:
+          (typeof cfg.origin_zip === "string" && cfg.origin_zip) || undefined,
+      }
+      this.logger?.info?.(
+        "[packlink] credentials resolved from the shipping platform record."
+      )
+      return this.platformClient
+    } catch (e: any) {
+      this.logger?.warn?.(
+        `[packlink] could not read the shipping platform record: ${
+          e?.message ?? e
+        } — falling back to the configured api_key.`
+      )
+      return this.client
+    }
+  }
+
+  /** Decrypt a secret field if the encryption module is present, else read it plain. */
+  protected async readSecret(
+    cfg: Record<string, any>,
+    field: string
+  ): Promise<string | undefined> {
+    // Mirrors Shiprocket's `readSecret` and `resolveShippingProvider`'s exactly
+    // — same key names, same precedence. A second convention here would create
+    // an affordance nothing writes.
+    const encrypted = cfg?.[`${field}_encrypted`]
+    if (encrypted && this.deps?.encryption?.decrypt) {
+      try {
+        const plain = await this.deps.encryption.decrypt(encrypted)
+        if (typeof plain === "string" && plain.length) return plain
+      } catch {
+        /* fall through to plaintext */
+      }
+    }
+    const plain = cfg?.[field]
+    return typeof plain === "string" && plain.length ? plain : undefined
   }
 
   async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
@@ -119,15 +241,24 @@ class PacklinkFulfillmentService extends AbstractFulfillmentProviderService {
 
     const toCountry = String(context?.shipping_address?.country_code ?? "")
     const toZip = String(context?.shipping_address?.postal_code ?? "")
-    const fromCountry = String(opts.origin_country ?? "")
-    const fromZip = String(opts.origin_zip ?? "")
-
-    if (!toCountry || !fromCountry) {
-      return this.fallback(currency, "no origin/destination country on the quote")
-    }
 
     try {
-      const services = await this.client.getServices({
+      // Resolve BEFORE reading the origin: the platform record carries the
+      // partner's own pickup address alongside their key.
+      const client = await this.resolveClient()
+      const fromCountry = String(
+        this.platformOrigin.country ?? opts.origin_country ?? ""
+      )
+      const fromZip = String(this.platformOrigin.zip ?? opts.origin_zip ?? "")
+
+      if (!toCountry || !fromCountry) {
+        return this.fallback(
+          currency,
+          "no origin/destination country on the quote"
+        )
+      }
+
+      const services = await client.getServices({
         from_country: fromCountry,
         from_zip: fromZip,
         to_country: toCountry,

--- a/apps/backend/src/modules/shipping-providers/packlink/service.ts
+++ b/apps/backend/src/modules/shipping-providers/packlink/service.ts
@@ -1,0 +1,227 @@
+import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
+import {
+  CalculatedShippingOptionPrice,
+  CreateShippingOptionDTO,
+  FulfillmentOption,
+  Logger,
+} from "@medusajs/framework/types"
+
+import { PacklinkClient, PacklinkOptions } from "./client"
+import {
+  RateSelectionPolicy,
+  applyPolicyToPrice,
+  selectService,
+  servicePrice,
+} from "./rate-select"
+
+/**
+ * Packlink fulfillment provider — live rates for partners who ship from EUROPE.
+ *
+ * ## Why a second carrier module
+ *
+ * Shiprocket originates in India. EasyPost's account originates only in the
+ * US/CA. Le Ciricotte ships from Greve in Chianti, so neither could quote it,
+ * and its international shipping was a hand-set flat rate — which the live
+ * Packlink rates then showed to be loss-making on 3 of its 4 lanes (to the UAE
+ * by €52 per parcel). A calculated provider ends that class of problem: the
+ * carrier quotes, nobody guesses.
+ *
+ * ## What this does NOT do
+ *
+ * It quotes. It does not book labels. `createFulfillment` throws a named error
+ * rather than pretending, because a provider that silently fails to book looks
+ * exactly like one that booked and lost the parcel. Booking is the next slice
+ * and needs its own credentials and customs handling.
+ */
+type InjectedDeps = {
+  logger: Logger
+  /**
+   * Reaches the provider only if the fulfillment module declares it in
+   * `dependencies` in BOTH medusa-config.ts and medusa-config.prod.ts — the
+   * Dockerfile copies the prod config OVER the dev one, so a dependency
+   * declared in only one of them does not exist in production.
+   *
+   * Optional: without it a non-EUR cart falls back rather than returning a euro
+   * figure wearing a pound sign.
+   */
+  fx_rates?: any
+}
+
+export type PacklinkProviderOptions = PacklinkOptions &
+  RateSelectionPolicy & {
+    /** Origin, when the shipping option cannot supply one. */
+    origin_country?: string
+    origin_zip?: string
+    /** Parcel assumed when the cart cannot say. Quotes scale with weight. */
+    default_weight_kg?: number
+    default_length_cm?: number
+    default_width_cm?: number
+    default_height_cm?: number
+    /** Per-currency figure used when a live quote is impossible. */
+    flat_fallback_amounts?: Record<string, number>
+  }
+
+/** Packlink prices every service it returned for our lanes in euros. */
+export const PACKLINK_RATE_CURRENCY = "EUR"
+
+class PacklinkFulfillmentService extends AbstractFulfillmentProviderService {
+  static identifier = "packlink"
+
+  protected client: PacklinkClient
+  protected logger: Logger
+  protected deps: InjectedDeps
+  protected options: PacklinkProviderOptions
+
+  constructor(deps: InjectedDeps, options: PacklinkProviderOptions = {}) {
+    super()
+    this.deps = deps
+    this.logger = deps.logger
+    this.options = options
+    this.client = new PacklinkClient(options)
+  }
+
+  async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
+    return [
+      { id: "packlink-international", name: "International (Packlink)" },
+      {
+        id: "packlink-international-return",
+        name: "International Return (Packlink)",
+        is_return: true,
+      },
+    ]
+  }
+
+  async validateFulfillmentData(
+    _optionData: Record<string, unknown>,
+    data: Record<string, unknown>
+  ): Promise<any> {
+    return data
+  }
+
+  async validateOption(_data: Record<string, any>): Promise<boolean> {
+    return true
+  }
+
+  /** Calculated, always — that is the entire point of this provider. */
+  async canCalculate(_data: CreateShippingOptionDTO): Promise<boolean> {
+    return true
+  }
+
+  async calculatePrice(
+    optionData: Record<string, unknown>,
+    _data: Record<string, unknown>,
+    context: any
+  ): Promise<CalculatedShippingOptionPrice> {
+    const opts = { ...this.options, ...(optionData as PacklinkProviderOptions) }
+    const currency = String(
+      context?.currency_code ?? context?.cart?.currency_code ?? ""
+    ).toUpperCase()
+
+    const toCountry = String(context?.shipping_address?.country_code ?? "")
+    const toZip = String(context?.shipping_address?.postal_code ?? "")
+    const fromCountry = String(opts.origin_country ?? "")
+    const fromZip = String(opts.origin_zip ?? "")
+
+    if (!toCountry || !fromCountry) {
+      return this.fallback(currency, "no origin/destination country on the quote")
+    }
+
+    try {
+      const services = await this.client.getServices({
+        from_country: fromCountry,
+        from_zip: fromZip,
+        to_country: toCountry,
+        to_zip: toZip,
+        weight_kg: Number(opts.default_weight_kg ?? 1),
+        length_cm: Number(opts.default_length_cm ?? 30),
+        width_cm: Number(opts.default_width_cm ?? 25),
+        height_cm: Number(opts.default_height_cm ?? 10),
+      })
+
+      const chosen = selectService(services, opts)
+      const raw = chosen ? servicePrice(chosen) : null
+      if (raw === null) {
+        // 🔑 An EMPTY service list is a refusal wearing a 200. Quoting 0 here
+        // would ship the parcel free; this is exactly the bug the Shiprocket
+        // provider had to fix.
+        return this.fallback(
+          currency,
+          `Packlink returned no usable service for ${fromCountry}->${toCountry}`
+        )
+      }
+
+      const priced = applyPolicyToPrice(raw, opts)
+      const converted = await this.toCartCurrency(priced, currency)
+      if (converted === null) {
+        return this.fallback(
+          currency,
+          `no ${PACKLINK_RATE_CURRENCY}->${currency} rate; refusing to quote a euro figure as ${currency}`
+        )
+      }
+
+      return { calculated_amount: converted, is_calculated_price_tax_inclusive: false }
+    } catch (e: any) {
+      return this.fallback(currency, e?.message ?? String(e))
+    }
+  }
+
+  /**
+   * Euros into the cart's currency.
+   *
+   * Returns `null` rather than the euro figure when it cannot convert. Handing
+   * back an unconverted number is how a ₹890 quote once reached an Australian
+   * buyer as A$890 — 55× wrong (#rate-currency). A EUR cart needs no
+   * conversion and must not be multiplied by a cached 1.0.
+   */
+  protected async toCartCurrency(
+    amount: number,
+    currency: string
+  ): Promise<number | null> {
+    if (!currency) return null
+    if (currency === PACKLINK_RATE_CURRENCY) return amount
+    const fx = this.deps?.fx_rates
+    if (!fx?.convert) return null
+    try {
+      const out = await fx.convert(amount, PACKLINK_RATE_CURRENCY, currency)
+      const n = Number(out)
+      return Number.isFinite(n) && n > 0 ? n : null
+    } catch {
+      return null
+    }
+  }
+
+  /** A number somebody chose, in the right currency — or a loud refusal. */
+  protected fallback(
+    currency: string,
+    reason: string
+  ): CalculatedShippingOptionPrice {
+    const map = this.options.flat_fallback_amounts ?? {}
+    const amount = map[currency] ?? map[currency?.toLowerCase?.()] ?? null
+    this.logger?.warn?.(
+      `[packlink] live quote unavailable (${reason}); ${
+        amount === null
+          ? "and no flat fallback for " + (currency || "(unknown currency)")
+          : `using flat fallback ${amount} ${currency}`
+      }`
+    )
+    if (amount === null) {
+      throw new Error(
+        `Packlink could not quote and has no flat fallback for ${currency || "(unknown currency)"}: ${reason}`
+      )
+    }
+    return { calculated_amount: amount, is_calculated_price_tax_inclusive: false }
+  }
+
+  async createFulfillment(): Promise<any> {
+    // Named, not silent. See the class docblock.
+    throw new Error(
+      "Packlink provider quotes rates only; label booking is not implemented. Book through the partner's own Packlink PRO account, or use a provider that implements createFulfillment."
+    )
+  }
+
+  async cancelFulfillment(): Promise<any> {
+    return {}
+  }
+}
+
+export default PacklinkFulfillmentService


### PR DESCRIPTION
## Why

**Our international partners could not be quoted at all.**

- **Shiprocket** originates in India.
- **EasyPost** originates only in US/CA. Verified: every carrier on the account answered `from_address.country is required to be US` for IT→GB, while the **identical payload from a US origin returned 8 rates** — so the limitation is carrier coverage, not our request.

So Le Ciricotte (Greve in Chianti) had **no calculated provider**, and its international shipping was a hand-set flat rate. Once Packlink could actually quote those lanes, that flat €30 turned out to be loss-making on 3 of its 4 destinations:

| lane | cheapest carrier | our flat €30 | result |
|---|---:|---:|---:|
| GB | €18.19 | €30.31 | +€12.12 |
| CA | €31.83 | €29.85 | 🔴 −€1.98 |
| CN | €38.33 | €30.03 | 🔴 −€8.30 |
| AE | €82.32 | €30.05 | 🔴 **−€52.27** per parcel |

A calculated provider ends that whole class of problem: the carrier quotes, nobody guesses.

## The two rules that make it work — both found empirically

🔑 **Packlink answers a bad postcode with `{"messages":[{"message":"Bad Request"}]}`** — the *same* body it returns for a missing parameter or an unserved lane. Nothing says "postcode". A partner whose quotes silently died could not tell this apart from "no carrier serves this route".

```
to[zip]=NW16XE -> 400          NW1 6XE -> 200, 8 services
to[zip]=00000  -> 400          1       -> 200, 6 services   (AE)
```

`postcode.ts` encodes both — documented as **observations with evidence**, not as documentation, and deliberately inventing no rule for a lane nobody tested.

## Decisions worth reviewing

- 🔴 **Never `services[0]`.** The live IT→GB response spans **€18.19 → €116.69** with no documented ordering — a 6× row-order lottery deciding what a buyer pays. Same family as `stores[0]` (#1979) and `take: 1` (#1983). Every selection sorts explicitly; carrier preference and margin are configured policy.
- **An unreadable price returns `null`, never `0`** — `Number("")` and `Number(null)` are both `0`, i.e. free shipping wearing the shape of a quote.
- **An empty service list is a refusal, not a price of zero.** It falls back.
- **An unconvertible currency falls back** rather than returning a euro figure labelled as pounds — the ₹890-as-A$890 bug, generalised.
- **`createFulfillment` throws a named error.** This quotes; it does not book labels. A provider that silently fails to book looks exactly like one that booked and lost the parcel. Booking is the next slice.
- **Registered in BOTH configs**, because the Dockerfile copies `medusa-config.prod.ts` *over* `medusa-config.ts` — a provider added to only the dev config does not exist in production. `pnpm check:prod-config` passes.

## Verification

- **22 unit tests.** Mutation check: removing the GB space rule turns **3 red**.
- **Live, against the real API**, deliberately fed the broken forms:

```
GB  zip="NW16XE"  -> sent "NW1 6XE"  8 services  18.19 EUR  +20% = 21.83 (Poste Italiane)
CA  zip="M5V 3L9" -> sent "M5V 3L9"  6 services  31.83 EUR  +20% = 38.20 (brt)
AE  zip="00000"   -> sent "1"        2 services  82.32 EUR  +20% = 98.78 (TNT)
CN  zip="100000"  -> sent "100000"   6 services  38.33 EUR  +20% = 46.00 (brt)
```

It repaired both broken inputs and quoted every lane.

- **582 suites / 6909 tests** pass. Typecheck at the 84-error baseline, zero in the new module or either config.

## To turn it on

Off unless `PACKLINK_API_KEY` is set, like every other carrier here. With `PACKLINK_ORIGIN_COUNTRY=IT` and `PACKLINK_ORIGIN_ZIP=50022`, Le Ciricotte can move from the flat rates currently on prod to a calculated Packlink option — at which point the loss-making lanes stop mattering.

**The key belongs in SSM**, not `.env` and not a config literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp