### PR TITLE
feat: Delhivery scan-push + EPOD webhooks, #891 S3 transfer receipt, and samples/swatch inventory orders

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-samples.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-samples.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * Samples / swatch inventory orders.
+ *
+ * A samples order is created BEFORE anyone knows what will arrive — that is
+ * the whole reason to ask for swatches. So it is the one kind of inventory
+ * order that:
+ *
+ *   1. may be created with NO order lines at all,
+ *   2. stays editable at any status except Cancelled, so the lines can be
+ *      filled in once the box is open,
+ *   3. posts NO stock when those lines are filled — a swatch is reference
+ *      material, not sellable units, and banking it would put zero-value
+ *      stock into a location where it can be counted, reserved and sold,
+ *   4. may name a material that has no catalogue entry yet, creating the
+ *      inventory item as the line is written.
+ *
+ * Every relaxation is checked to NOT leak into ordinary procurement orders.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(90000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Samples / swatch inventory orders", () => {
+    let headers: any
+    let stockLocationId: string
+    let existingItemId: string
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      headers = await getAuthHeaders(api)
+
+      const loc = await api.post(
+        "/admin/stock-locations",
+        {
+          name: "Swatch Shelf",
+          address: {
+            address_1: "1 Sample Rd",
+            city: "Jaipur",
+            province: "RJ",
+            postal_code: "302001",
+            country_code: "in",
+            phone: "9998887771",
+          },
+        },
+        headers
+      )
+      stockLocationId = loc.data.stock_location.id
+
+      const item = await api.post(
+        "/admin/inventory-items",
+        { title: "Known Cotton", sku: `KNOWN-${Date.now()}` },
+        headers
+      )
+      existingItemId = item.data.inventory_item.id
+    })
+
+    const baseOrder = (overrides: any = {}) => ({
+      quantity: 0,
+      total_price: 0,
+      status: "Pending",
+      expected_delivery_date: new Date().toISOString(),
+      order_date: new Date().toISOString(),
+      shipping_address: {},
+      stock_location_id: stockLocationId,
+      ...overrides,
+    })
+
+    const post = (body: any) =>
+      api.post("/admin/inventory-orders", body, headers).catch((e: any) => e.response)
+
+    const fetchOrder = async (id: string) => {
+      const res = await api.get(`/admin/inventory-orders/${id}`, headers)
+      return res.data.inventoryOrder
+    }
+
+    // The HTTP detail route does not hydrate lines by default, so read them
+    // the way the sibling line-persistence spec does.
+    const fetchLines = async (id: string): Promise<any[]> => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id },
+        fields: [
+          "id",
+          "is_sample",
+          "orderlines.id",
+          "orderlines.quantity",
+          "orderlines.price",
+          "orderlines.material_name",
+        ],
+      })
+      return data?.[0]?.orderlines ?? []
+    }
+
+    const putLines = (id: string, body: any) =>
+      api
+        .put(`/admin/inventory-orders/${id}/order-lines`, body, headers)
+        .catch((e: any) => e.response)
+
+    it("creates a sample order with no lines at all", async () => {
+      const res = await post(baseOrder({ is_sample: true }))
+      expect(res.status).toBe(201)
+
+      const order = await fetchOrder(res.data.inventoryOrder.id)
+      expect(order.is_sample).toBe(true)
+      expect(await fetchLines(res.data.inventoryOrder.id)).toHaveLength(0)
+    })
+
+    it("creates a sample order with an explicitly empty line array", async () => {
+      const res = await post(baseOrder({ is_sample: true, order_lines: [] }))
+      expect(res.status).toBe(201)
+    })
+
+    it("STILL refuses an ordinary order with no lines", async () => {
+      // The relaxation must not leak into procurement.
+      const res = await post(baseOrder({ quantity: 5, total_price: 100 }))
+      expect(res.status).toBe(400)
+      expect(JSON.stringify(res.data)).toMatch(/only a sample order/i)
+    })
+
+    it("fills lines in after the box has been delivered, and posts no stock", async () => {
+      const created = await post(baseOrder({ is_sample: true }))
+      const orderId = created.data.inventoryOrder.id
+
+      // Walk it to Delivered the way the box actually arrives.
+      for (const status of ["Processing", "Delivered"]) {
+        const moved = await api
+          .put(`/admin/inventory-orders/${orderId}`, { status }, headers)
+          .catch((e: any) => e.response)
+        expect(moved.status).toBe(200)
+      }
+      expect((await fetchOrder(orderId)).status).toBe("Delivered")
+
+      const filled = await putLines(orderId, {
+        data: { quantity: 1, total_price: 0 },
+        order_lines: [{ inventory_item_id: existingItemId, quantity: 1, price: 0 }],
+      })
+      expect(filled.status).toBe(200)
+
+      expect(await fetchLines(orderId)).toHaveLength(1)
+
+      // 🔑 No stock posted. A swatch is reference material.
+      const levels = await api
+        .get(
+          `/admin/inventory-items/${existingItemId}/location-levels`,
+          headers
+        )
+        .catch((e: any) => e.response)
+      const stocked = (levels.data?.inventory_levels ?? []).reduce(
+        (sum: number, l: any) => sum + Number(l.stocked_quantity || 0),
+        0
+      )
+      expect(stocked).toBe(0)
+    })
+
+    it("STILL refuses to edit an ordinary order past Processing", async () => {
+      const created = await post(
+        baseOrder({
+          quantity: 1,
+          total_price: 10,
+          order_lines: [
+            { inventory_item_id: existingItemId, quantity: 1, price: 10 },
+          ],
+        })
+      )
+      const orderId = created.data.inventoryOrder.id
+
+      await api.put(`/admin/inventory-orders/${orderId}`, { status: "Processing" }, headers)
+      const shipped = await api
+        .put(`/admin/inventory-orders/${orderId}`, { status: "Shipped" }, headers)
+        .catch((e: any) => e.response)
+      // Shipped is reachable; editing from there is not.
+      if (shipped.status === 200) {
+        const blocked = await putLines(orderId, {
+          data: { quantity: 2, total_price: 20 },
+          order_lines: [
+            { inventory_item_id: existingItemId, quantity: 2, price: 10 },
+          ],
+        })
+        expect(blocked.status).toBe(400)
+        expect(JSON.stringify(blocked.data)).toMatch(/Pending' or 'Processing'/)
+      }
+    })
+
+    it("creates the inventory item for a swatch we have never stocked", async () => {
+      const created = await post(baseOrder({ is_sample: true }))
+      const orderId = created.data.inventoryOrder.id
+
+      const filled = await putLines(orderId, {
+        data: { quantity: 1, total_price: 0 },
+        order_lines: [
+          {
+            new_material: { name: "Tangaliya Weave", color: "Indigo" },
+            quantity: 1,
+            price: 0,
+          },
+        ],
+      })
+      expect(filled.status).toBe(200)
+
+      const lines = await fetchLines(orderId)
+      expect(lines).toHaveLength(1)
+
+      // A line's inventory item lives in a module LINK, not a column — so the
+      // proof that the item was really created and attached is the link.
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      // The link is inventory_order_LINE ⇄ inventory_item, so it hangs off the
+      // line, not the order. (A wrong entity/field name here returns an empty
+      // array rather than an error, which reads as "no link" — check the
+      // defineLink before believing it.)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id: orderId },
+        fields: [
+          "id",
+          "orderlines.id",
+          "orderlines.inventory_items.id",
+          "orderlines.inventory_items.title",
+        ],
+      })
+      const linked = data?.[0]?.orderlines?.[0]?.inventory_items ?? []
+      expect(linked).toHaveLength(1)
+      // The colour is folded into the title so gradings stay distinguishable.
+      expect(linked[0].title).toBe("Tangaliya Weave — Indigo")
+    })
+
+    it("refuses new_material alongside an item that was picked", async () => {
+      const created = await post(baseOrder({ is_sample: true }))
+      const orderId = created.data.inventoryOrder.id
+
+      const res = await putLines(orderId, {
+        data: { quantity: 1, total_price: 0 },
+        order_lines: [
+          {
+            inventory_item_id: existingItemId,
+            new_material: { name: "Tangaliya Weave" },
+            quantity: 1,
+            price: 0,
+          },
+        ],
+      })
+      expect(res.status).toBe(400)
+      expect(JSON.stringify(res.data)).toMatch(/duplicate/i)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/shipping-epod-webhook.spec.ts
+++ b/apps/backend/integration-tests/http/shipping-epod-webhook.spec.ts
@@ -1,0 +1,239 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user";
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup";
+
+jest.setTimeout(90000);
+
+/**
+ * Delhivery EPOD webhook — POST /webhooks/shipping/epod?carrier=delhivery.
+ *
+ * The proof-of-delivery sibling of /webhooks/shipping/track. Same token gate,
+ * same ack-before-processing contract. The POD is stored against whichever
+ * shipment owns the AWB, and because Delhivery re-push a corrected POD for the
+ * same AWB, a second push must append rather than overwrite.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv();
+
+  const WEBHOOK_SECRET = "test-shipping-webhook-secret";
+  const STUB_AWB = "STUBAWB123";
+  // A one-byte PDF, base64 — enough to exercise the upload path.
+  const POD_B64 = "JVBERi0xLjQKJUVPRgo=";
+
+  let headers: any;
+  let inventoryItemId: string;
+  let toLocationId: string;
+  let fromLocationId: string;
+
+  let prevEmail: string | undefined;
+  let prevPassword: string | undefined;
+  let prevStub: string | undefined;
+  let prevSecret: string | undefined;
+
+  beforeAll(() => {
+    prevEmail = process.env.SHIPROCKET_EMAIL;
+    prevPassword = process.env.SHIPROCKET_PASSWORD;
+    prevStub = process.env.SHIPROCKET_STUB;
+    prevSecret = process.env.SHIPPING_WEBHOOK_SECRET;
+    process.env.SHIPROCKET_EMAIL = "test@example.example";
+    process.env.SHIPROCKET_PASSWORD = "secret";
+    process.env.SHIPROCKET_STUB = "1";
+    process.env.SHIPPING_WEBHOOK_SECRET = WEBHOOK_SECRET;
+  });
+
+  afterAll(() => {
+    if (prevEmail === undefined) delete process.env.SHIPROCKET_EMAIL;
+    else process.env.SHIPROCKET_EMAIL = prevEmail;
+    if (prevPassword === undefined) delete process.env.SHIPROCKET_PASSWORD;
+    else process.env.SHIPROCKET_PASSWORD = prevPassword;
+    if (prevStub === undefined) delete process.env.SHIPROCKET_STUB;
+    else process.env.SHIPROCKET_STUB = prevStub;
+    if (prevSecret === undefined) delete process.env.SHIPPING_WEBHOOK_SECRET;
+    else process.env.SHIPPING_WEBHOOK_SECRET = prevSecret;
+  });
+
+  beforeEach(async () => {
+    const container = getContainer();
+    await createAdminUser(container);
+    headers = await getAuthHeaders(api);
+
+    const item = await api.post(
+      "/admin/inventory-items",
+      { title: "Tangaliya Weave — Indigo", sku: "OTH-TAN-IND-001" },
+      headers
+    );
+    inventoryItemId = item.data.inventory_item.id;
+
+    const toLoc = await api.post(
+      "/admin/stock-locations",
+      {
+        name: "Surat Warehouse",
+        address: {
+          address_1: "9 Mill Rd",
+          city: "Surat",
+          province: "GJ",
+          postal_code: "395003",
+          country_code: "in",
+          phone: "8887776665",
+        },
+      },
+      headers
+    );
+    toLocationId = toLoc.data.stock_location.id;
+
+    const fromLoc = await api.post(
+      "/admin/stock-locations",
+      {
+        name: "Jaipur Source",
+        address: {
+          address_1: "2 Block Print Bazaar",
+          city: "Jaipur",
+          province: "RJ",
+          postal_code: "302001",
+          country_code: "in",
+          phone: "9998887771",
+        },
+      },
+      headers
+    );
+    fromLocationId = fromLoc.data.stock_location.id;
+  });
+
+  const createOrderWithShipment = async (): Promise<{ orderId: string }> => {
+    const res = await api.post(
+      "/admin/inventory-orders",
+      {
+        order_lines: [{ inventory_item_id: inventoryItemId, quantity: 3, price: 100 }],
+        quantity: 3,
+        total_price: 300,
+        status: "Ready for Delivery",
+        expected_delivery_date: new Date().toISOString(),
+        order_date: new Date().toISOString(),
+        shipping_address: {},
+        stock_location_id: toLocationId,
+        from_stock_location_id: fromLocationId,
+      },
+      headers
+    );
+    expect(res.status).toBe(201);
+    const orderId = res.data.inventoryOrder.id;
+
+    const ship = await api.post(
+      `/admin/inventory-orders/${orderId}/shipment`,
+      { weight_grams: 500 },
+      headers
+    );
+    expect(ship.status).toBe(200);
+    return { orderId };
+  };
+
+  const fetchShipment = async (orderId: string): Promise<any> => {
+    const res = await api.get(`/admin/inventory-orders/${orderId}`, headers);
+    return res.data.inventoryOrder?.shipments?.[0];
+  };
+
+  /** Poll until the async processing lands (the route acks before storing). */
+  const waitFor = async (
+    predicate: () => Promise<boolean>,
+    timeoutMs = 20000
+  ): Promise<boolean> => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (await predicate()) return true;
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    return false;
+  };
+
+  const pushEpod = async (payload: any, token: string | null = WEBHOOK_SECRET) => {
+    const qs = `?carrier=delhivery${token ? `&token=${token}` : ""}`;
+    return api
+      .post(`/webhooks/shipping/epod${qs}`, payload)
+      .catch((e: any) => e.response);
+  };
+
+  it("rejects a bad or missing token with 401", async () => {
+    const bad = await pushEpod({ waybill: STUB_AWB, EPOD: POD_B64 }, "wrong-token");
+    expect(bad.status).toBe(401);
+    const missing = await pushEpod({ waybill: STUB_AWB, EPOD: POD_B64 }, null);
+    expect(missing.status).toBe(401);
+  });
+
+  it("acks an unmatched AWB with 200 rather than erroring", async () => {
+    // The account-level webhook carries PODs for shipments that aren't ours.
+    const res = await pushEpod({ waybill: "UNKNOWNAWB999", EPOD: POD_B64 });
+    expect(res.status).toBe(200);
+  });
+
+  it("acks a push with no document and stores nothing", async () => {
+    const { orderId } = await createOrderWithShipment();
+    const res = await pushEpod({ waybill: STUB_AWB });
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 1500));
+    const shipment = await fetchShipment(orderId);
+    expect(shipment?.metadata?.pod).toBeFalsy();
+  });
+
+  it("stores a base64 POD against the shipment that owns the AWB", async () => {
+    const { orderId } = await createOrderWithShipment();
+
+    const res = await pushEpod({
+      waybill: STUB_AWB,
+      EPOD: POD_B64,
+      orderID: orderId,
+    });
+    expect(res.status).toBe(200);
+
+    const landed = await waitFor(async () => {
+      const s = await fetchShipment(orderId);
+      return Boolean(s?.metadata?.pod?.url);
+    });
+    expect(landed).toBe(true);
+
+    const shipment = await fetchShipment(orderId);
+    expect(shipment.metadata.pod.carrier).toBe("delhivery");
+    // Uploaded to our own store, so the reference does not expire.
+    expect(shipment.metadata.pod.ephemeral).toBe(false);
+    expect(shipment.metadata.pod_documents).toHaveLength(1);
+  });
+
+  it("appends a corrected POD instead of destroying the first", async () => {
+    // Delhivery re-push whenever their audit team uploads a revision; the
+    // superseded document is still evidence of what was shown at delivery.
+    const { orderId } = await createOrderWithShipment();
+
+    await pushEpod({ waybill: STUB_AWB, EPOD: POD_B64 });
+    await waitFor(async () => {
+      const s = await fetchShipment(orderId);
+      return Boolean(s?.metadata?.pod?.url);
+    });
+    const first = (await fetchShipment(orderId)).metadata.pod.url;
+
+    await pushEpod({ waybill: STUB_AWB, EPOD: "JVBERi0xLjQKJSVFT0YK" });
+    const appended = await waitFor(async () => {
+      const s = await fetchShipment(orderId);
+      return (s?.metadata?.pod_documents || []).length === 2;
+    });
+    expect(appended).toBe(true);
+
+    const shipment = await fetchShipment(orderId);
+    expect(shipment.metadata.pod_documents.map((p: any) => p.url)).toContain(first);
+    expect(shipment.metadata.pod.url).not.toBe(first);
+  });
+
+  it("records a carrier link as ephemeral rather than uploading it", async () => {
+    const { orderId } = await createOrderWithShipment();
+    const link = "https://delhivery-pod.s3.amazonaws.com/pod.pdf?sig=abc";
+
+    await pushEpod({ waybill: STUB_AWB, EPOD: link });
+    const landed = await waitFor(async () => {
+      const s = await fetchShipment(orderId);
+      return Boolean(s?.metadata?.pod?.url);
+    });
+    expect(landed).toBe(true);
+
+    const shipment = await fetchShipment(orderId);
+    expect(shipment.metadata.pod.url).toBe(link);
+    // Flagged so it is obvious the reference dies in 7 days.
+    expect(shipment.metadata.pod.ephemeral).toBe(true);
+  });
+});

--- a/apps/backend/src/admin/components/creates/__tests__/create-inventory-order-schema.unit.spec.ts
+++ b/apps/backend/src/admin/components/creates/__tests__/create-inventory-order-schema.unit.spec.ts
@@ -92,3 +92,51 @@ describe("inventoryOrderFormSchema — seeded blank rows (#1671)", () => {
     expect(result.success).toBe(false)
   })
 })
+
+/**
+ * Samples/swatch orders. Ordered precisely because nobody knows what will
+ * arrive, so the create form must accept one with nothing filled in — the
+ * five seeded blank rows and all.
+ */
+describe("a sample order may be created with no items picked", () => {
+  const blankGrid = {
+    ...base,
+    is_sample: true,
+    order_lines: Array.from({ length: 5 }, () => ({ ...BLANK })),
+  }
+
+  it("accepts the untouched grid when is_sample is on", () => {
+    expect(inventoryOrderFormSchema.safeParse(blankGrid).success).toBe(true)
+  })
+
+  it("accepts a sample with an empty grid", () => {
+    expect(
+      inventoryOrderFormSchema.safeParse({ ...blankGrid, order_lines: [] }).success
+    ).toBe(true)
+  })
+
+  it("STILL rejects the untouched grid for a normal order", () => {
+    // The relaxation must not reintroduce the #1671 silent no-op for ordinary
+    // procurement — there, nothing picked is a mistake, not an intent.
+    const parsed = inventoryOrderFormSchema.safeParse({
+      ...blankGrid,
+      is_sample: false,
+    })
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(JSON.stringify(parsed.error.issues)).toMatch(/Pick at least one item/)
+    }
+  })
+
+  it("still validates any row the buyer DID fill in on a sample", () => {
+    // Empty is fine; half-finished is not.
+    const parsed = inventoryOrderFormSchema.safeParse({
+      ...blankGrid,
+      order_lines: [{ inventory_item_id: "iitem_1", quantity: 0, price: 0 }],
+    })
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(JSON.stringify(parsed.error.issues)).toMatch(/Quantity must be at least 1/)
+    }
+  })
+})

--- a/apps/backend/src/admin/components/creates/create-inventory-order-schema.ts
+++ b/apps/backend/src/admin/components/creates/create-inventory-order-schema.ts
@@ -36,7 +36,11 @@ export const inventoryOrderFormSchema = z
       .map((line, index) => ({ line, index }))
       .filter(({ line }) => !!line?.inventory_item_id);
 
-    if (!filledIdx.length) {
+    // A samples/swatch order is created EMPTY on purpose: it is ordered
+    // precisely because nobody knows yet what will arrive, and the lines are
+    // filled in once the box is opened. Every other order still needs
+    // something to order.
+    if (!filledIdx.length && !data.is_sample) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Pick at least one item",

--- a/apps/backend/src/admin/components/creates/create-inventory-order.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order.tsx
@@ -55,6 +55,10 @@ export const CreateInventoryOrderComponent = () => {
     resolver: zodResolver(inventoryOrderFormSchema),
   });
 
+  // A sample order may be created with nothing picked — the lines are filled
+  // in once the swatches arrive — so the Order Lines copy changes to say so.
+  const isSampleOrder = form.watch("is_sample");
+
   const [tab, setTab] = useState<Tab>(Tab.GENERAL);
   const [tabState, setTabState] = useState<TabState>({
     [Tab.GENERAL]: "in-progress",
@@ -413,7 +417,9 @@ export const CreateInventoryOrderComponent = () => {
                       </div>
                     </div>
                     <Text size="small" className="text-ui-fg-subtle">
-                      Add items to your inventory order. The total quantity and price will be calculated automatically.
+                      {isSampleOrder
+                        ? "This is a sample order, so you can leave this empty and create it now — fill in what actually arrived once the swatches are in your hands."
+                        : "Add items to your inventory order. The total quantity and price will be calculated automatically."}
                     </Text>
                   </div>
                   {/* Top search bar removed as requested */}

--- a/apps/backend/src/admin/components/production-runs/goods-transfer-section.tsx
+++ b/apps/backend/src/admin/components/production-runs/goods-transfer-section.tsx
@@ -11,7 +11,7 @@ import {
   Textarea,
   toast,
 } from "@medusajs/ui"
-import { HandTruck, Trash, TruckFast, XCircle } from "@medusajs/icons"
+import { Check, HandTruck, Trash, TruckFast, XCircle } from "@medusajs/icons"
 import { useState } from "react"
 
 import { ActionMenu, type Action } from "../common/action-menu"
@@ -20,6 +20,7 @@ import {
   useCreateGoodsTransfer,
   useDeleteGoodsTransfer,
   useGoodsTransfers,
+  useReceiveGoodsTransfer,
   type AdminGoodsTransfer,
 } from "../../hooks/api/goods-transfers"
 import { useStockLocations } from "../../hooks/api/stock_location"
@@ -126,6 +127,9 @@ export const GoodsTransferSection = ({ runId }: Props) => {
 
   const [cancelling, setCancelling] = useState<AdminGoodsTransfer | null>(null)
   const [cancelReason, setCancelReason] = useState("")
+  const [receiving, setReceiving] = useState<AdminGoodsTransfer | null>(null)
+  const [receivedQty, setReceivedQty] = useState("")
+  const [receiveNotes, setReceiveNotes] = useState("")
   /** The "clear abandoned drafts" confirmation. */
   const [clearingDrafts, setClearingDrafts] = useState(false)
   const [isClearing, setIsClearing] = useState(false)
@@ -153,6 +157,8 @@ export const GoodsTransferSection = ({ runId }: Props) => {
     useCancelGoodsTransfer(runId)
   const { mutateAsync: deleteDraft, isPending: isDeleting } =
     useDeleteGoodsTransfer(runId)
+  const { mutateAsync: receiveTransfer, isPending: isReceiving } =
+    useReceiveGoodsTransfer(runId)
 
   const locationName = (id?: string | null) =>
     locations.find((l: any) => l.id === id)?.name || id || "—"
@@ -259,6 +265,36 @@ export const GoodsTransferSection = ({ runId }: Props) => {
     }
   }
 
+  const handleReceive = async () => {
+    if (!receiving) return
+    // Blank means "all of it" — the common case, and an operator should not
+    // have to retype what the transfer already says.
+    const trimmed = receivedQty.trim()
+    const parsed = trimmed === "" ? undefined : Number(trimmed)
+    if (parsed !== undefined && (Number.isNaN(parsed) || parsed < 0)) {
+      toast.error("Received quantity must be zero or more")
+      return
+    }
+    try {
+      const { receipt } = await receiveTransfer({
+        transferId: receiving.id,
+        received_quantity: parsed,
+        notes: receiveNotes.trim() || undefined,
+      })
+      const moved = receipt.moved
+        ? `stock moved${receipt.reservations_repointed ? `, ${receipt.reservations_repointed} reservation(s) followed` : ""}`
+        : `no stock movement (${receipt.skip_reason})`
+      toast.success(
+        `Received ${receipt.received_quantity} unit(s)${receipt.shortfall ? ` — ${receipt.shortfall} short` : ""} · ${moved}`
+      )
+    } catch (e: any) {
+      toast.error(e?.message || "Could not receive the transfer")
+      return
+    } finally {
+      setReceiving(null)
+    }
+  }
+
   const handleCancel = async () => {
     if (!cancelling) return
     const isBooked = cancelling.status !== "draft"
@@ -347,6 +383,16 @@ export const GoodsTransferSection = ({ runId }: Props) => {
               })
             }
             if (t.status === "draft" || t.status === "in_transit") {
+              // Receipt is the act that moves the stock, so it leads.
+              rowActions.push({
+                icon: <Check />,
+                label: "Receive these goods",
+                onClick: () => {
+                  setReceiving(t)
+                  setReceivedQty(String(t.quantity ?? ""))
+                  setReceiveNotes("")
+                },
+              })
               rowActions.push({
                 icon: t.status === "draft" ? <Trash /> : <XCircle />,
                 label:
@@ -572,6 +618,47 @@ export const GoodsTransferSection = ({ runId }: Props) => {
           </Drawer.Footer>
         </Drawer.Content>
       </Drawer>
+
+      <Prompt open={!!receiving} onOpenChange={(v) => !v && setReceiving(null)}>
+        <Prompt.Content>
+          <Prompt.Header>
+            <Prompt.Title>Receive these goods?</Prompt.Title>
+            <Prompt.Description>
+              This moves the stock from {locationName(receiving?.from_location_id)}{" "}
+              to {locationName(receiving?.to_location_id)} and brings any
+              reservation with it. It cannot be undone — a correction is a new
+              transfer.
+            </Prompt.Description>
+          </Prompt.Header>
+          <div className="flex flex-col gap-y-3 px-6 py-4">
+            <div className="flex flex-col gap-y-1">
+              <Label size="small">Quantity received</Label>
+              <Input
+                type="number"
+                min={0}
+                value={receivedQty}
+                onChange={(e) => setReceivedQty(e.target.value)}
+                placeholder={String(receiving?.quantity ?? "")}
+              />
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                Sent: {receiving?.quantity}. A smaller number is recorded as a
+                shortfall.
+              </Text>
+            </div>
+            <Textarea
+              placeholder="Notes — damage, a partial count (optional)"
+              value={receiveNotes}
+              onChange={(e) => setReceiveNotes(e.target.value)}
+            />
+          </div>
+          <Prompt.Footer>
+            <Prompt.Cancel>Not yet</Prompt.Cancel>
+            <Button onClick={handleReceive} disabled={isReceiving}>
+              Receive
+            </Button>
+          </Prompt.Footer>
+        </Prompt.Content>
+      </Prompt>
 
       <Prompt open={!!cancelling} onOpenChange={(v) => !v && setCancelling(null)}>
         <Prompt.Content>

--- a/apps/backend/src/admin/hooks/api/goods-transfers.ts
+++ b/apps/backend/src/admin/hooks/api/goods-transfers.ts
@@ -100,6 +100,24 @@ export type AdminCancelGoodsTransferPayload = {
   reason?: string
 }
 
+/**
+ * What the receipt actually did. `moved: false` is a normal outcome, not a
+ * failure — a customer leg or a same-location hop has no inventory movement to
+ * make, and the reason says which.
+ */
+export type AdminGoodsTransferReceipt = {
+  transfer_id: string
+  status: "delivered"
+  received_quantity: number
+  moved: boolean
+  skip_reason?: "customer_leg" | "same_location" | "zero_quantity"
+  inventory_item_id?: string
+  from_location_id?: string
+  to_location_id?: string
+  reservations_repointed: number
+  shortfall: number
+}
+
 export const useGoodsTransfers = (
   productionRunId: string,
   options?: Omit<
@@ -183,6 +201,40 @@ export const useCancelGoodsTransfer = (
     mutationFn: async ({ transferId, ...body }) =>
       sdk.client.fetch<{ goods_transfer: AdminGoodsTransfer }>(
         `/admin/production-runs/${productionRunId}/transfers/${transferId}/cancel`,
+        { method: "POST", body }
+      ),
+    ...options,
+    onSuccess: (data, variables, _mutateResult, context) => {
+      invalidate(queryClient, productionRunId)
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+  })
+}
+
+/**
+ * Receive a hop (#891 S3) — the call that actually moves the inventory.
+ *
+ * Deliberately separate from the carrier's "delivered" scan: the scan says a
+ * box arrived, this says a person opened it and counted what was inside.
+ * Omitting `received_quantity` means "all of it", which is the common case.
+ */
+export const useReceiveGoodsTransfer = (
+  productionRunId: string,
+  options?: UseMutationOptions<
+    { goods_transfer: AdminGoodsTransfer; receipt: AdminGoodsTransferReceipt },
+    FetchError,
+    { transferId: string; received_quantity?: number; notes?: string }
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ transferId, ...body }) =>
+      sdk.client.fetch<{
+        goods_transfer: AdminGoodsTransfer
+        receipt: AdminGoodsTransferReceipt
+      }>(
+        `/admin/production-runs/${productionRunId}/transfers/${transferId}/receive`,
         { method: "POST", body }
       ),
     ...options,

--- a/apps/backend/src/api/admin/inventory-orders/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/admin/inventory-orders/__tests__/validators.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   createInventoryOrdersSchema,
   updateInventoryOrdersSchema,
+  updateOrderLineSchema,
 } from "../validators"
 
 describe("inventory-order validators", () => {
@@ -42,5 +43,103 @@ describe("inventory-order validators", () => {
       })
       expect(parsed.is_sample).toBe(false)
     })
+  })
+})
+
+/**
+ * Samples/swatch orders. A sample is ordered precisely because nobody knows
+ * what will arrive, so it must be creatable with NO lines and filled in later.
+ */
+describe("createInventoryOrdersSchema — a sample may start with no lines", () => {
+  const base = {
+    quantity: 0,
+    total_price: 0,
+    status: "Pending" as const,
+    expected_delivery_date: "2026-10-01T00:00:00.000Z",
+    order_date: "2026-09-12T00:00:00.000Z",
+    shipping_address: {},
+    stock_location_id: "sloc_1",
+  }
+
+  it("accepts a sample order with no order_lines at all", () => {
+    const parsed = createInventoryOrdersSchema.safeParse({
+      ...base,
+      is_sample: true,
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.order_lines).toEqual([])
+  })
+
+  it("accepts a sample order with an explicitly empty array", () => {
+    expect(
+      createInventoryOrdersSchema.safeParse({
+        ...base,
+        is_sample: true,
+        order_lines: [],
+      }).success
+    ).toBe(true)
+  })
+
+  it("STILL rejects a non-sample order with no lines", () => {
+    // The relaxation must not leak into ordinary procurement.
+    const parsed = createInventoryOrdersSchema.safeParse({
+      ...base,
+      quantity: 5,
+      is_sample: false,
+      order_lines: [],
+    })
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(JSON.stringify(parsed.error.issues)).toMatch(/only a sample order/)
+    }
+  })
+
+  it("rejects a non-sample order that omits order_lines entirely", () => {
+    expect(
+      createInventoryOrdersSchema.safeParse({ ...base, quantity: 5 }).success
+    ).toBe(false)
+  })
+})
+
+describe("updateOrderLineSchema — naming a material that does not exist yet", () => {
+  it("accepts a line with new_material and no item or variant", () => {
+    const parsed = updateOrderLineSchema.safeParse({
+      new_material: { name: "Tangaliya Weave", color: "Indigo" },
+      quantity: 1,
+      price: 0,
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it("rejects new_material alongside an existing item", () => {
+    // It would create a duplicate of the item that was picked.
+    const parsed = updateOrderLineSchema.safeParse({
+      inventory_item_id: "iitem_1",
+      new_material: { name: "Tangaliya Weave" },
+      quantity: 1,
+      price: 0,
+    })
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(JSON.stringify(parsed.error.issues)).toMatch(/duplicate/)
+    }
+  })
+
+  it("rejects a nameless new_material", () => {
+    expect(
+      updateOrderLineSchema.safeParse({
+        new_material: { name: "" },
+        quantity: 1,
+        price: 0,
+      }).success
+    ).toBe(false)
+  })
+
+  it("still rejects a line that points at nothing at all", () => {
+    const parsed = updateOrderLineSchema.safeParse({ quantity: 1, price: 0 })
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(JSON.stringify(parsed.error.issues)).toMatch(/new_material/)
+    }
   })
 })

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -46,7 +46,13 @@ export const inventoryOrderLineInputSchema = z.object({
 // under Zod v4 (the internal _def shape changed; superRefine no longer exposes
 // the inner schema at that path).
 const inventoryOrdersBaseSchema = z.object({
-  order_lines: z.array(inventoryOrderLineInputSchema).min(1, "At least one order line is required"),
+  /**
+   * Optional, because a SAMPLE order is created before anyone knows what is in
+   * the box (#swatches). A non-sample order still requires at least one line —
+   * enforced in the superRefine below, where `is_sample` is visible. Keeping
+   * the rule there rather than here is what lets the two kinds differ.
+   */
+  order_lines: z.array(inventoryOrderLineInputSchema).optional().default([]),
   // Allow decimal order quantity (sum of line quantities)
   quantity: z.number().nonnegative("Order quantity must be zero or positive"),
   total_price: z.number().nonnegative("Total price must be zero or positive"),
@@ -75,6 +81,22 @@ const inventoryOrdersBaseSchema = z.object({
 
 // Input schema for creating inventory orders
 export const createInventoryOrdersSchema = inventoryOrdersBaseSchema.superRefine((data, ctx) => {
+  // A samples/swatch order legitimately starts empty: the box has to arrive
+  // before anyone can say what is in it, and the lines are filled in
+  // afterwards. Every other order still needs something to order.
+  if (!data.is_sample && (data.order_lines?.length ?? 0) === 0) {
+    // `custom`, not `too_small`: the framework's error formatter regenerates
+    // the message for a typed size issue ("Value for field 'order_lines' too
+    // small…") and throws this wording away, which is the wording that says
+    // WHY it was refused and what the exception is.
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "At least one order line is required (only a sample order may start with none)",
+      path: ["order_lines"],
+    });
+  }
+
   if (!data.is_sample && data.quantity <= 0) {
     ctx.addIssue({
       code: z.ZodIssueCode.too_small,
@@ -197,6 +219,23 @@ export const updateOrderLineSchema = z
     extra_cost: z.number().nonnegative().optional(),
     // Optional batch tag (see inventoryOrderLineInputSchema).
     batch_number: z.number().int().positive().nullish(),
+    /**
+     * A brand-new material named on the spot, for a samples/swatch order.
+     *
+     * A swatch is very often cloth we have never stocked, so there is no
+     * inventory item OR variant to point at yet. Requiring one first would
+     * mean leaving the open box to go create a catalogue entry, which is
+     * exactly when details get lost. Sending `new_material` instead creates the
+     * inventory item (and its raw-material record) as part of writing the line.
+     */
+    new_material: z
+      .object({
+        name: z.string().trim().min(1, "A new material needs a name"),
+        color: z.string().trim().optional(),
+        composition: z.string().trim().optional(),
+        unit_of_measure: z.string().trim().optional(),
+      })
+      .optional(),
     // Explicit removal marker for an existing line: the update workflow
     // soft-deletes the line (by `id`) and dismisses its inventory-item link.
     // Without this key the middleware would strip it and a dropped line would
@@ -217,11 +256,23 @@ export const updateOrderLineSchema = z
     }
     const hasItem = !!val.inventory_item_id && val.inventory_item_id.length > 0;
     const hasVariant = !!val.variant_id && val.variant_id.length > 0;
-    if (!hasItem && !hasVariant) {
+    const hasNewMaterial = !!val.new_material?.name;
+    if (!hasItem && !hasVariant && !hasNewMaterial) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["inventory_item_id"],
-        message: "An order line needs either inventory_item_id or variant_id",
+        message:
+          "An order line needs inventory_item_id, variant_id, or new_material (to create the item as the line is written)",
+      });
+    }
+    // Naming a new material AND pointing at an existing one is ambiguous: it
+    // would silently create a duplicate item beside the one you picked.
+    if (hasNewMaterial && (hasItem || hasVariant)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["new_material"],
+        message:
+          "Send new_material only when the line has no inventory_item_id or variant_id — otherwise it would create a duplicate of the item you picked",
       });
     }
     if (hasItem && hasVariant) {

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1346,7 +1346,9 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         to_stock_location_id: STR(
           "Alias for the destination ('to') stock location — omit if stock_location_id is given."
         ),
-        is_sample: BOOL("Whether this is a sample order (defaults false)."),
+        is_sample: BOOL(
+          "Whether this is a sample/swatch order (defaults false). 🔑 A sample is the ONE kind that may be created with NO `order_lines` and quantity 0 — it is ordered precisely because nobody knows yet what will arrive. Fill the lines in afterwards with update_inventory_order_lines, which stays available at any status except Cancelled and posts no stock."
+        ),
         metadata: { type: "object", description: "Free-form metadata." },
         tax_amount: {
           type: "number",
@@ -1430,6 +1432,8 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "Change an existing inventory order's lines — quantity, per-unit price, per-unit extra_cost (the colour/dye job), batch tag — add new lines, or remove one. Sensitive: requires confirm:true. ALWAYS dry_run first. " +
       "🔑 The `order_lines` array is the DESIRED FINAL STATE of the lines you send: keep an existing line by sending its `id`, add one by omitting `id`, and remove one with `{ id, remove: true }`. ⚠️ EVERY line you keep or add must ALSO carry its `inventory_item_id` (or `variant_id`) — the validator rejects the whole request without it, `id` alone is not enough. Read the ids off get_order/list_inventory_orders and send them back. Do NOT respond to that 400 by dropping the `id`: that stops being an edit and becomes a delete-and-recreate of the line. " +
       "⚠️ `data.quantity` and `data.total_price` are NOT recomputed for you — send the new totals, where total_price is Σ (price + extra_cost) × quantity across the lines you are left with. " +
+      "🔑 SAMPLE/SWATCH orders (`is_sample: true`) are the exception to two rules: they may have started with NO lines at all, and they stay editable at any status except Cancelled — that is the point, since the box has to arrive before anyone can say what is in it. Filling a sample's lines posts NO stock. " +
+      "🔑 For a swatch of cloth we have never stocked, a new line may carry `new_material: { name, color?, composition? }` INSTEAD of inventory_item_id/variant_id — the write creates the inventory item and its raw-material record as the line is written. Send it only when the line names neither an item nor a variant; sending both would duplicate the item you picked. " +
       "Use get_order/list_inventory_orders first to read the current line ids.",
     method: "PUT",
     path: "/admin/inventory-orders/:id/order-lines",
@@ -1477,6 +1481,18 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
                 description: "Per-unit extra charge on top of price (colour/dye job, finishing).",
               },
               batch_number: { type: "number", description: "Optional batch tag." },
+              new_material: {
+                type: "object",
+                description:
+                  "Create the inventory item as the line is written — for a swatch of cloth with no catalogue entry yet. Use INSTEAD of inventory_item_id/variant_id, never alongside one.",
+                properties: {
+                  name: { type: "string", description: "Material name, e.g. 'Tangaliya Weave'." },
+                  color: { type: "string", description: "Colour; folded into the item title so gradings stay distinguishable." },
+                  composition: { type: "string", description: "Fibre composition, if known." },
+                  unit_of_measure: { type: "string", description: "e.g. 'meter'." },
+                },
+                required: ["name"],
+              },
               remove: {
                 type: "boolean",
                 description: "Soft-delete this existing line and dismiss its links. Needs `id`.",

--- a/apps/backend/src/api/admin/production-runs/[id]/transfers/[transferId]/receive/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/transfers/[transferId]/receive/route.ts
@@ -1,0 +1,78 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { FULLFILLED_ORDERS_MODULE } from "../../../../../../../modules/fullfilled_orders"
+import { receiveGoodsTransferWorkflow } from "../../../../../../../workflows/production-runs/receive-goods-transfer"
+
+/**
+ * POST /admin/production-runs/:id/transfers/:transferId/receive
+ *
+ * #891 S3 — the receipt. This is the call that actually moves inventory
+ * between the two locations, and it is the only one that does.
+ *
+ * ## Why receipt is a human act
+ *
+ * A carrier's "delivered" scan means a box reached an address. It does not mean
+ * anyone opened it and counted what was inside, and the two differ often enough
+ * that trusting the scan would write confident wrong numbers into stock. So the
+ * tracking webhook advances the SHIPMENT, and a person calls this to say what
+ * actually arrived — the same split #888 made for inventory orders.
+ *
+ * ## What it does
+ *
+ * - decrements the origin level, increments the destination level
+ * - repoints the run's reservations at the destination, because a reservation
+ *   left behind re-creates the negative this slice exists to remove
+ * - marks the transfer `delivered` with `received_at` / `received_quantity`,
+ *   which is what `resolveRunGoodsLocation` reads to place the next hop and the
+ *   customer leg
+ *
+ * Receiving twice is refused: the goods would move twice. A correction is a new
+ * transfer, not a second receipt.
+ */
+
+const ReceiveSchema = z.object({
+  /**
+   * What was actually counted out of the box. Defaults to the quantity that
+   * was sent — the common case, and the one an operator should not have to
+   * retype. A smaller number is recorded as a shortfall rather than silently
+   * reconciled.
+   */
+  received_quantity: z.number().min(0).optional(),
+  /** Anything worth knowing about the receipt — damage, a partial count. */
+  notes: z.string().trim().max(1000).optional(),
+})
+
+export const POST = async (
+  req: MedusaRequest & { params: { id: string; transferId: string } },
+  res: MedusaResponse
+) => {
+  const { id: runId, transferId } = req.params
+
+  const parsed = ReceiveSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")
+    )
+  }
+
+  const { result } = await receiveGoodsTransferWorkflow(req.scope).run({
+    input: {
+      run_id: runId,
+      transfer_id: transferId,
+      received_quantity: parsed.data.received_quantity,
+      notes: parsed.data.notes ?? null,
+      actor_id: (req as any).auth_context?.actor_id ?? null,
+      actor_type: "user",
+    },
+  })
+
+  const service: any = req.scope.resolve(FULLFILLED_ORDERS_MODULE)
+  const goods_transfer = await service
+    .retrieveGoodsTransfer(transferId)
+    .catch(() => null)
+
+  return res.status(200).json({ goods_transfer, receipt: result })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -1079,6 +1079,19 @@ export default defineMiddlewares({
       middlewares: [],
     },
     {
+      /**
+       * Delhivery EPOD push — the sibling of the tracking route. A base64
+       * proof-of-delivery document is orders of magnitude larger than a status
+       * ping; Medusa's default JSON limit would 413 it and Delhivery would drop
+       * the push (they retry on a timeout, not on a 4xx). 10mb covers a
+       * multi-page scanned delivery sheet.
+       */
+      matcher: "/webhooks/shipping/epod",
+      method: "POST",
+      middlewares: [],
+      bodyParser: { sizeLimit: "10mb" },
+    },
+    {
       // Carrier tracking pushes (Shiprocket — #888). Gated by
       // SHIPPING_WEBHOOK_SECRET (custom header configured in the carrier
       // dashboard; Shiprocket has no HMAC), JSON body parsed normally.

--- a/apps/backend/src/api/webhooks/shipping/epod/route.ts
+++ b/apps/backend/src/api/webhooks/shipping/epod/route.ts
@@ -1,0 +1,95 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { normalizeDelhiveryEpod } from "../../../../modules/shipping-providers/delhivery/client"
+import { storeShipmentPodWorkflow } from "../../../../workflows/orders/store-shipment-pod"
+
+/**
+ * POST /webhooks/shipping/epod?carrier=delhivery
+ *
+ * Electronic proof-of-delivery receiver, the sibling of
+ * `/webhooks/shipping/track`. Delhivery push a POD document once a shipment is
+ * delivered; it is stored against the inventory shipment or core-order
+ * fulfillment that owns the AWB.
+ *
+ * Same gate as the tracking webhook — `SHIPPING_WEBHOOK_SECRET` compared
+ * against `x-webhook-token` / `x-api-key` / `?token=`. Delhivery sign nothing,
+ * so a shared secret configured on their side is the only credential available.
+ *
+ * Same contract too: answer 200 fast, before any processing. A POD can be
+ * several megabytes of base64, and uploading it to our file store takes far
+ * longer than the 500 ms Delhivery allow before they time out and drop the
+ * push.
+ *
+ * Delhivery re-push a POD whenever their audit team uploads a corrected one, so
+ * repeat pushes for one AWB are expected; the workflow appends rather than
+ * overwrites.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const secret = process.env.SHIPPING_WEBHOOK_SECRET
+  if (secret) {
+    const provided =
+      (req.query?.token as string) ||
+      (req.headers["x-webhook-token"] as string) ||
+      (req.headers["x-api-key"] as string) ||
+      ""
+    if (provided !== secret) {
+      logger.warn("[EPOD Webhook] Rejected — bad or missing token")
+      return res.status(401).send("Unauthorized")
+    }
+  } else {
+    logger.warn("[EPOD Webhook] SHIPPING_WEBHOOK_SECRET not set — gate is open")
+  }
+
+  const body = req.body as any
+  const carrier = String((req.query?.carrier as string) || "delhivery")
+
+  // Ack before processing — the upload is far slower than their timeout.
+  res.status(200).send("OK")
+
+  processEpodPush(req.scope, carrier, body).catch((error) => {
+    logger.error("[EPOD Webhook] Failed to process push:", error as Error)
+  })
+}
+
+/** POD payload normalizers by `?carrier=`. Delhivery is the only source today. */
+const NORMALIZERS: Record<string, (body: any) => any> = {
+  delhivery: normalizeDelhiveryEpod,
+}
+
+async function processEpodPush(
+  scope: any,
+  carrier: string,
+  body: any
+): Promise<void> {
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const normalizer = NORMALIZERS[carrier]
+  if (!normalizer) {
+    logger.warn(`[EPOD Webhook] No normalizer for carrier "${carrier}" — push ignored`)
+    return
+  }
+
+  const pod = normalizer(body)
+  if (!pod.awb) {
+    logger.info("[EPOD Webhook] Push without an AWB — ignored (test webhook?)")
+    return
+  }
+
+  const { result } = await storeShipmentPodWorkflow(scope).run({
+    input: { pod: { ...pod, raw: body } },
+  })
+
+  if (!result.matched) {
+    return
+  }
+
+  logger.info(
+    `[EPOD Webhook] AWB ${pod.awb}: POD on ${result.target} ${result.target_id}` +
+      (result.ephemeral
+        ? " (carrier link — EXPIRES in 7 days, not mirrored to our store)"
+        : "")
+  )
+}

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -92,8 +92,13 @@ class InventoryOrderService extends MedusaService({
   ) {
     // Input validation (runs inside the transaction; nothing is created yet, so
     // a throw here simply aborts before any write).
+    // A samples/swatch order may be created empty — the lines are filled in
+    // once the box arrives and someone can see what is actually in it. Every
+    // other kind of order still needs something to order.
     if (!Array.isArray(order_lines) || order_lines.length === 0) {
-      throw new Error("At least one order line is required.");
+      if (!inventory_order.is_sample) {
+        throw new Error("At least one order line is required.");
+      }
     }
     for (const [i, line] of order_lines.entries()) {
       if (inventory_order.is_sample) {

--- a/apps/backend/src/modules/shipping-providers/__tests__/order-partner-origin.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/order-partner-origin.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
-  resolveOrderPartnerId,
+  pickCurrentGoodsLocation,
   resolveOrderShipFromLocation,
+  resolveOrderPartnerId,
 } from "../order-partner-origin"
 import partnerOrderLink from "../../../links/partner-order"
 
@@ -109,6 +110,148 @@ describe("resolveOrderShipFromLocation", () => {
       partners: [],
     })
     const res = await resolveOrderShipFromLocation(containerFor(query), "o1")
-    expect(res).toEqual({ partnerId: null, source: null, locationId: null, actingEmail: null })
+    expect(res).toEqual({
+      partnerId: null,
+      source: null,
+      locationId: null,
+      actingEmail: null,
+      locationSource: null,
+    })
+  })
+})
+
+/**
+ * #891 S4 — the customer leg must ship from where the goods ACTUALLY are.
+ *
+ * Produced output is banked at the producing partner's location; a delivered
+ * goods transfer is the record that it moved. Before S4 nothing on the customer
+ * leg read that, so a jacket received at the finishing warehouse still shipped
+ * from the weaver — re-creating the negative S3 exists to remove, one step on.
+ */
+describe("pickCurrentGoodsLocation", () => {
+  it("takes the location when every run agrees", () => {
+    expect(pickCurrentGoodsLocation(["sloc_b", "sloc_b"])).toEqual({
+      locationId: "sloc_b",
+      reason: "agreed",
+    })
+  })
+
+  it("says nothing when no run has moved", () => {
+    expect(pickCurrentGoodsLocation([null, undefined, ""])).toEqual({
+      locationId: null,
+      reason: "none",
+    })
+    expect(pickCurrentGoodsLocation([])).toEqual({ locationId: null, reason: "none" })
+  })
+
+  it("refuses to choose when runs landed in DIFFERENT places", () => {
+    // The goods really are in two places; picking one would put a confident
+    // wrong address on the label. The partner default is at least the old,
+    // understood behaviour.
+    expect(pickCurrentGoodsLocation(["sloc_b", "sloc_c"])).toEqual({
+      locationId: null,
+      reason: "split",
+    })
+  })
+
+  it("ignores runs that have not moved when the rest agree", () => {
+    // A run still at its origin does not make the order 'split' — only two
+    // different DESTINATIONS do.
+    expect(pickCurrentGoodsLocation([null, "sloc_b"])).toEqual({
+      locationId: "sloc_b",
+      reason: "agreed",
+    })
+  })
+})
+
+describe("resolveOrderShipFromLocation — the goods' current location wins", () => {
+  const PARTNER_GRAPH = {
+    __link__: [{ partner_id: "par_1" }],
+    partners: [
+      {
+        id: "par_1",
+        admins: [{ email: "p@example.com" }],
+        stores: [{ default_sales_channel_id: "sc_partner" }],
+      },
+    ],
+    sales_channels: [
+      {
+        stock_locations: [
+          { id: "sloc_partner", metadata: {}, address: { phone: "1", postal_code: "2" } },
+        ],
+      },
+    ],
+  }
+
+  // A container that resolves the query stub AND the transfers module, so the
+  // goods lookup is exercised rather than swallowed by its own catch.
+  const containerWith = (query: any, transfers: any, logger: any = { warn: jest.fn(), info: jest.fn() }) =>
+    ({
+      resolve: (key: any) => {
+        if (key === "fullfilled_orders") return transfers
+        if (String(key).includes("logger")) return logger
+        return query
+      },
+    }) as any
+
+  it("ships from the transfer destination once the goods have been received", async () => {
+    const query = makeQuery({ ...PARTNER_GRAPH, production_runs: [{ id: "run_1" }] })
+    const transfers = {
+      listGoodsTransfers: jest.fn(async () => [{ to_location_id: "sloc_finishing" }]),
+    }
+    const res = await resolveOrderShipFromLocation(containerWith(query, transfers), "o1")
+    expect(res.locationId).toBe("sloc_finishing")
+    expect(res.locationSource).toBe("goods_transfer")
+  })
+
+  it("falls back to the partner default when no transfer has been received", async () => {
+    const query = makeQuery({ ...PARTNER_GRAPH, production_runs: [{ id: "run_1" }] })
+    const transfers = { listGoodsTransfers: jest.fn(async () => []) }
+    const res = await resolveOrderShipFromLocation(containerWith(query, transfers), "o1")
+    expect(res.locationId).toBe("sloc_partner")
+    expect(res.locationSource).toBe("partner_default")
+  })
+
+  it("falls back to the partner default when the order has no production runs", async () => {
+    // A plain retail order that was never produced to order.
+    const query = makeQuery({ ...PARTNER_GRAPH, production_runs: [] })
+    const transfers = { listGoodsTransfers: jest.fn() }
+    const res = await resolveOrderShipFromLocation(containerWith(query, transfers), "o1")
+    expect(res.locationId).toBe("sloc_partner")
+    expect(transfers.listGoodsTransfers).not.toHaveBeenCalled()
+  })
+
+  it("falls back — and WARNS — when two runs landed in different places", async () => {
+    const query = makeQuery({
+      ...PARTNER_GRAPH,
+      production_runs: [{ id: "run_1" }, { id: "run_2" }],
+    })
+    const transfers = {
+      listGoodsTransfers: jest
+        .fn()
+        .mockResolvedValueOnce([{ to_location_id: "sloc_b" }])
+        .mockResolvedValueOnce([{ to_location_id: "sloc_c" }]),
+    }
+    const logger = { warn: jest.fn(), info: jest.fn() }
+    const res = await resolveOrderShipFromLocation(
+      containerWith(query, transfers, logger),
+      "o1"
+    )
+    expect(res.locationId).toBe("sloc_partner")
+    expect(res.locationSource).toBe("partner_default")
+    expect(logger.warn).toHaveBeenCalled()
+    expect(String(logger.warn.mock.calls[0][0])).toMatch(/DIFFERENT locations/)
+  })
+
+  it("never lets a transfer lookup failure block a label", async () => {
+    // Best-effort throughout: the old behaviour must survive a broken lookup.
+    const query = makeQuery({ ...PARTNER_GRAPH, production_runs: [{ id: "run_1" }] })
+    const transfers = {
+      listGoodsTransfers: jest.fn(async () => {
+        throw new Error("boom")
+      }),
+    }
+    const res = await resolveOrderShipFromLocation(containerWith(query, transfers), "o1")
+    expect(res.locationId).toBe("sloc_partner")
   })
 })

--- a/apps/backend/src/modules/shipping-providers/delhivery/__tests__/normalize-delhivery-epod.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/__tests__/normalize-delhivery-epod.unit.spec.ts
@@ -1,0 +1,55 @@
+import { normalizeDelhiveryEpod } from "../client"
+
+/**
+ * Delhivery's EPOD push, per their EPOD webhook requirement document:
+ * `{ waybill, EPOD, orderID }` with a base64 body. The same hook can be
+ * configured to push a downloadable S3 URL instead, so both are parsed.
+ */
+describe("normalizeDelhiveryEpod", () => {
+  it("reads the documented payload", () => {
+    const out = normalizeDelhiveryEpod({
+      waybill: "1234567890",
+      EPOD: "JVBERi0xLjQK",
+      orderID: "order_123",
+    })
+    expect(out.carrier).toBe("delhivery")
+    expect(out.awb).toBe("1234567890")
+    expect(out.pod_base64).toBe("JVBERi0xLjQK")
+    expect(out.pod_url).toBeUndefined()
+    expect(out.order_ref).toBe("order_123")
+  })
+
+  it("is case-insensitive on the POD key", () => {
+    // Their sample writes `EPOD`; their prose writes `epod`.
+    expect(normalizeDelhiveryEpod({ waybill: "1", epod: "abc" }).pod_base64).toBe("abc")
+    expect(normalizeDelhiveryEpod({ Waybill: "1", Epod: "abc" }).awb).toBe("1")
+  })
+
+  it("distinguishes a downloadable URL from a base64 blob", () => {
+    // Both arrive in the same field. Storing a URL as base64 would persist an
+    // unusable document.
+    const out = normalizeDelhiveryEpod({
+      waybill: "1",
+      EPOD: "https://delhivery-pod.s3.amazonaws.com/x.pdf?sig=1",
+    })
+    expect(out.pod_url).toBe("https://delhivery-pod.s3.amazonaws.com/x.pdf?sig=1")
+    expect(out.pod_base64).toBeUndefined()
+  })
+
+  it("accepts the alternate AWB keys the scan push uses", () => {
+    expect(normalizeDelhiveryEpod({ awb: "2", EPOD: "x" }).awb).toBe("2")
+    expect(normalizeDelhiveryEpod({ wbn: "3", EPOD: "x" }).awb).toBe("3")
+    expect(normalizeDelhiveryEpod({ lrnum: "4", EPOD: "x" }).awb).toBe("4")
+  })
+
+  it("returns an empty AWB for junk rather than throwing", () => {
+    expect(normalizeDelhiveryEpod({}).awb).toBe("")
+    expect(normalizeDelhiveryEpod(null).awb).toBe("")
+    expect(normalizeDelhiveryEpod("nonsense").awb).toBe("")
+  })
+
+  it("keeps the raw payload for the audit trail", () => {
+    const p = { waybill: "1", EPOD: "x" }
+    expect(normalizeDelhiveryEpod(p).raw).toBe(p)
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/delhivery/__tests__/normalize-delhivery-webhook.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/__tests__/normalize-delhivery-webhook.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   delhiveryScanType,
+  delhiveryTimestamp,
   normalizeDelhiveryWebhook,
 } from "../client"
 
@@ -105,5 +106,85 @@ describe("normalizeDelhiveryWebhook", () => {
 
   it("keeps the raw payload for the audit trail", () => {
     expect(normalizeDelhiveryWebhook(push).raw).toBe(push)
+  })
+
+  /**
+   * The payload printed in Delhivery's own webhook requirement document.
+   *
+   * It is flat, its `status` is a bare string, and it carries NO `AWB` or
+   * `Waybill` key — the consignment number rides in `lrnum`. Parsed with only
+   * the nested envelope in mind it yields `awb: ""`, and the webhook route
+   * reads an empty AWB as "ignore this push". A real delivery would have been
+   * dropped with nothing in the log but "test webhook?".
+   */
+  describe("the flat scan push from the requirement document", () => {
+    const flat = {
+      shipment_remark: "Delivered to consignee",
+      location: "Bengaluru_Hub",
+      count: 1,
+      lrnum: "1234567890",
+      mwn: "MWN-1",
+      cl_uuid: "abc",
+      name: "Jaal Yantra Textiles",
+      package_type: "Pre-paid",
+      expected_delivery_date: 1754300000,
+      promised_delivery_date: 1754300000,
+      timestamp: 1754305200,
+      status: "Delivered",
+    }
+
+    it("finds the AWB in lrnum", () => {
+      expect(normalizeDelhiveryWebhook(flat).awb).toBe("1234567890")
+    })
+
+    it("reads a bare-string status", () => {
+      const out = normalizeDelhiveryWebhook(flat)
+      expect(out.current_status).toBe("Delivered")
+      expect(out.estimated_delivery).toBe("2025-08-04T09:33:20.000Z")
+    })
+
+    it("synthesises the single scan as an event", () => {
+      const out = normalizeDelhiveryWebhook(flat)
+      expect(out.events).toHaveLength(1)
+      expect(out.events[0]).toMatchObject({
+        status: "Delivered",
+        location: "Bengaluru_Hub",
+        scan_type: "delivered",
+      })
+      expect(out.events[0].timestamp).toBe("2025-08-04T11:00:00.000Z")
+    })
+
+    it("falls back to the master waybill when there is no lrnum", () => {
+      const { lrnum, ...noLr } = flat
+      expect(normalizeDelhiveryWebhook(noLr).awb).toBe("MWN-1")
+    })
+
+    it("still refuses to invent a delivery from an unknown status", () => {
+      const out = normalizeDelhiveryWebhook({ ...flat, status: "Some new scan", shipment_remark: "" })
+      expect(out.events[0].scan_type).toBe("in_transit")
+    })
+
+    it("does not synthesise an event when there is no AWB to match", () => {
+      // A carrier test-ping must not become a phantom scan on nothing.
+      expect(normalizeDelhiveryWebhook({ status: "Delivered" }).events).toEqual([])
+    })
+  })
+})
+
+describe("delhiveryTimestamp", () => {
+  it("accepts epoch seconds and milliseconds alike", () => {
+    expect(delhiveryTimestamp(1754305200)).toBe("2025-08-04T11:00:00.000Z")
+    expect(delhiveryTimestamp(1754305200000)).toBe("2025-08-04T11:00:00.000Z")
+  })
+
+  it("passes an ISO string through", () => {
+    expect(delhiveryTimestamp("2026-08-04T11:20:00")).toBe("2026-08-04T11:20:00")
+  })
+
+  it("yields empty for nothing, never 1970", () => {
+    expect(delhiveryTimestamp(undefined)).toBe("")
+    expect(delhiveryTimestamp(null)).toBe("")
+    expect(delhiveryTimestamp("")).toBe("")
+    expect(delhiveryTimestamp(0)).toBe("")
   })
 })

--- a/apps/backend/src/modules/shipping-providers/delhivery/client.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/client.ts
@@ -63,6 +63,32 @@ export function delhiveryScanType(
 }
 
 /**
+ * Coerce a Delhivery timestamp into an ISO string.
+ *
+ * The nested track envelope uses ISO strings; the flat scan push uses an epoch
+ * (their sample types it `Number`, and accounts have been seen sending both
+ * seconds and milliseconds). Anything unrecognised yields `""`, which the
+ * tracking timeline treats as "no time recorded" rather than 1970.
+ */
+export function delhiveryTimestamp(value: any): string {
+  if (value == null || value === "") return ""
+
+  const num = typeof value === "number" ? value : Number(value)
+  // A numeric zero/negative is "no time recorded", not 1970 and not the
+  // literal string "0".
+  if (Number.isFinite(num) && String(value).trim() !== "") {
+    if (num <= 0) return ""
+    // Seconds vs milliseconds: anything below ~2001-09-09 in ms is really an
+    // epoch in seconds. Delhivery's sample is unlabelled, so both are accepted.
+    const ms = num < 1e12 ? num * 1000 : num
+    const d = new Date(ms)
+    if (!Number.isNaN(d.getTime())) return d.toISOString()
+  }
+
+  return String(value)
+}
+
+/**
  * Normalize a Delhivery status-push payload into a `TrackingResult`.
  *
  * Pure and exported so the inbound webhook route can parse a push without
@@ -70,11 +96,24 @@ export function delhiveryScanType(
  * webhook route can dispatch on `?carrier=` and feed both into the one sync
  * workflow.
  *
- * Delhivery's push nests everything under `Shipment`, with the current scan in
- * `Shipment.Status` and the history in `Shipment.Scans[].ScanDetail`. Some
- * accounts receive a flatter shape, so both the nested and top-level AWB keys
- * are accepted. An unrecognised payload yields an empty `awb`, which the route
- * already treats as "ignore this push" rather than an error.
+ * TWO shapes are accepted, because Delhivery pushes different ones per account:
+ *
+ *  1. The **nested** envelope, matching their track API — everything under
+ *     `Shipment`, the current scan in `Shipment.Status`, history in
+ *     `Shipment.Scans[].ScanDetail`.
+ *  2. The **flat** scan push printed in their webhook requirement document
+ *     (`{ status, location, timestamp, lrnum, mwn, shipment_remark, ... }`),
+ *     which carries a single scan and no history array.
+ *
+ * Shape 2 matters: it has no `AWB`/`Waybill` key at all, and its `status` is a
+ * bare string rather than an object. Read with only shape 1 in mind it yields
+ * an empty AWB — and the webhook route treats an empty AWB as "ignore this
+ * push", so every delivery update would be dropped in silence with nothing in
+ * the log but "test webhook?". Both shapes are parsed here so whichever the
+ * account is configured for, the AWB is found.
+ *
+ * An unrecognised payload still yields an empty `awb`, which the route already
+ * treats as "ignore this push" rather than an error.
  */
 export function normalizeDelhiveryWebhook(payload: any): {
   carrier: string
@@ -91,38 +130,146 @@ export function normalizeDelhiveryWebhook(payload: any): {
   raw: any
 } {
   const shipment = payload?.Shipment ?? payload?.shipment ?? payload ?? {}
-  const status = shipment?.Status ?? shipment?.status ?? {}
+  const rawStatus = shipment?.Status ?? shipment?.status ?? {}
+
+  // The flat push sends `status` as a string; the nested one as an object.
+  const flatStatus = typeof rawStatus === "string" ? rawStatus : ""
+  const status = typeof rawStatus === "object" && rawStatus ? rawStatus : {}
 
   const awb =
     shipment?.AWB ??
     shipment?.awb ??
     shipment?.Waybill ??
     shipment?.waybill ??
+    shipment?.wbn ??
     payload?.AWB ??
+    payload?.awb ??
     payload?.waybill ??
+    payload?.wbn ??
+    // Flat push: the consignment number rides in `lrnum`, with `mwn` (master
+    // waybill) as the fallback for accounts pushing at master level.
+    shipment?.lrnum ??
+    shipment?.mwn ??
+    payload?.lrnum ??
+    payload?.mwn ??
     ""
 
-  const currentStatus = status?.Status ?? status?.status ?? ""
-  const statusType = status?.StatusType ?? status?.statusType ?? ""
+  const currentStatus =
+    status?.Status ?? status?.status ?? flatStatus ?? ""
+  const statusType =
+    status?.StatusType ??
+    status?.statusType ??
+    shipment?.status_type ??
+    shipment?.StatusType ??
+    shipment?.nsl_code ??
+    ""
 
-  const events = (shipment?.Scans ?? shipment?.scans ?? []).map((s: any) => {
+  const scans = shipment?.Scans ?? shipment?.scans ?? []
+  const events = (Array.isArray(scans) ? scans : []).map((s: any) => {
     const d = s?.ScanDetail ?? s?.scanDetail ?? s ?? {}
     return {
-      timestamp: d?.ScanDateTime ?? d?.StatusDateTime ?? "",
+      timestamp: delhiveryTimestamp(d?.ScanDateTime ?? d?.StatusDateTime),
       status: d?.Scan ?? d?.Instructions ?? d?.ScanType ?? "",
       location: d?.ScannedLocation ?? d?.StatusLocation ?? "",
       scan_type: delhiveryScanType(d?.StatusType ?? d?.ScanType, d?.Scan),
     }
   })
 
+  // The flat push has no history array — it IS one scan. Synthesise the event
+  // so the shipment timeline records it, exactly as the nested shape would.
+  if (!events.length && awb && currentStatus) {
+    events.push({
+      timestamp: delhiveryTimestamp(
+        shipment?.timestamp ?? shipment?.StatusDateTime ?? status?.StatusDateTime
+      ),
+      status: String(currentStatus),
+      location: String(
+        shipment?.location ?? status?.StatusLocation ?? shipment?.StatusLocation ?? ""
+      ),
+      scan_type: delhiveryScanType(
+        statusType,
+        // `shipment_remark` carries the detail ("Delivered to consignee") that
+        // disambiguates a terse status.
+        `${currentStatus} ${shipment?.shipment_remark ?? ""}`.trim()
+      ),
+    })
+  }
+
+  const eta =
+    shipment?.ExpectedDeliveryDate ??
+    shipment?.PromisedDeliveryDate ??
+    shipment?.expected_delivery_date ??
+    shipment?.promised_delivery_date ??
+    null
+
   return {
     carrier: "delhivery",
     awb: String(awb || ""),
     current_status: String(currentStatus || ""),
     current_status_code: statusType ? String(statusType) : undefined,
-    estimated_delivery:
-      shipment?.ExpectedDeliveryDate ?? shipment?.PromisedDeliveryDate ?? null,
+    estimated_delivery: eta == null ? null : delhiveryTimestamp(eta),
     events,
+    raw: payload,
+  }
+}
+
+/**
+ * Normalize a Delhivery EPOD (electronic proof of delivery) push.
+ *
+ * Their requirement document specifies `{ waybill, EPOD, orderID }`, where
+ * `EPOD` is a base64-encoded document. The same webhook can also be configured
+ * to push a downloadable S3 URL (7-day expiry) instead of the blob, so both are
+ * accepted and reported separately — a URL must be fetched before it expires,
+ * a blob is already in hand.
+ *
+ * Key casing is inconsistent across Delhivery's own docs (`EPOD` in the sample,
+ * `epod` elsewhere), so lookups are case-insensitive over the top-level keys.
+ *
+ * Pure, so the webhook route can parse without credentials. An unrecognised
+ * payload yields an empty `awb`, which the route treats as "ignore this push".
+ */
+export function normalizeDelhiveryEpod(payload: any): {
+  carrier: string
+  awb: string
+  /** Base64 document body, when Delhivery pushes the blob. */
+  pod_base64?: string
+  /** Downloadable URL, when Delhivery pushes a link instead (expires in 7 days). */
+  pod_url?: string
+  /** The client order reference Delhivery echoes back, when present. */
+  order_ref?: string
+  raw: any
+}  {
+  const src = payload && typeof payload === "object" ? payload : {}
+
+  // Case-insensitive top-level lookup: `EPOD` vs `epod` differs between
+  // Delhivery's sample payload and their prose.
+  const byLower: Record<string, any> = {}
+  for (const [k, v] of Object.entries(src)) {
+    byLower[k.toLowerCase()] = v
+  }
+  const pick = (...keys: string[]) => {
+    for (const k of keys) {
+      const v = byLower[k]
+      if (v != null && v !== "") return v
+    }
+    return undefined
+  }
+
+  const awb = pick("waybill", "awb", "wbn", "lrnum", "mwn")
+  const pod = pick("epod", "pod", "pod_data", "image")
+  const orderRef = pick("orderid", "order_id", "reference_no", "order_ref")
+
+  const podStr = pod == null ? "" : String(pod)
+  // A URL and a base64 blob arrive in the same field; only a URL starts with a
+  // scheme. Treating a URL as base64 would persist an unusable document.
+  const isUrl = /^https?:\/\//i.test(podStr.trim())
+
+  return {
+    carrier: "delhivery",
+    awb: String(awb ?? ""),
+    pod_base64: !isUrl && podStr ? podStr : undefined,
+    pod_url: isUrl ? podStr.trim() : undefined,
+    order_ref: orderRef == null ? undefined : String(orderRef),
     raw: payload,
   }
 }

--- a/apps/backend/src/modules/shipping-providers/order-partner-origin.ts
+++ b/apps/backend/src/modules/shipping-providers/order-partner-origin.ts
@@ -3,6 +3,7 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 import partnerOrderLink from "../../links/partner-order"
 import { pickPartnerShipFromLocation } from "../../api/partners/lib/ship-from-location"
 import { SHIPROCKET_PICKUP_METADATA_KEY } from "./pickup-locations"
+import { FULLFILLED_ORDERS_MODULE } from "../fullfilled_orders"
 
 /**
  * Resolve the partner that OWNS a core/retail order — and their ship-from stock
@@ -39,6 +40,94 @@ export type OrderShipFromOrigin = OrderPartnerId & {
   locationId: string | null
   /** Acting/notification email for a freshly-registered pickup (#427). */
   actingEmail: string | null
+  /**
+   * Where `locationId` came from (#891 S4). `goods_transfer` means the goods
+   * have physically MOVED since they were produced and the label follows them;
+   * `partner_default` is the pre-S4 behaviour.
+   */
+  locationSource: "goods_transfer" | "partner_default" | null
+}
+
+/** Why a set of production runs did or did not agree on one goods location. */
+export type GoodsLocationVerdict = {
+  locationId: string | null
+  reason: "agreed" | "split" | "none"
+}
+
+/**
+ * PURE: given where each of an order's runs currently holds its goods, what is
+ * the one location the order can ship from? (#891 S4)
+ *
+ * An order can span several production runs, and after S3 each may have been
+ * received somewhere different. A fulfillment has exactly ONE origin, so:
+ *
+ *  - all runs agree → that location
+ *  - they disagree (`split`) → NOTHING. The goods are genuinely in two places
+ *    and no single origin is correct; picking one would put a confident wrong
+ *    address on a label. Falling back to the partner default at least keeps
+ *    the long-standing, understood behaviour instead of inventing a new wrong
+ *    answer, and the split is logged.
+ *  - none has moved → nothing to say; the partner default stands
+ */
+export function pickCurrentGoodsLocation(
+  runLocations: Array<string | null | undefined>
+): GoodsLocationVerdict {
+  const moved = (runLocations || [])
+    .map((l) => (l ? String(l) : ""))
+    .filter(Boolean)
+  if (!moved.length) return { locationId: null, reason: "none" }
+
+  const distinct = Array.from(new Set(moved))
+  if (distinct.length > 1) return { locationId: null, reason: "split" }
+  return { locationId: distinct[0], reason: "agreed" }
+}
+
+/**
+ * Where an order's produced goods physically are NOW (#891 S4).
+ *
+ * Produced output is banked at the producing partner's location, and a
+ * delivered `goods_transfer` is the record that it moved somewhere else. Until
+ * S4 nothing on the customer leg read that, so a jacket received at the
+ * finishing warehouse still shipped from the weaver — which re-creates the very
+ * negative S3 exists to remove, one step further along.
+ *
+ * Only a DELIVERED transfer counts. A booked or in-transit hop means the goods
+ * are between two places, and the origin they left is still the honest answer.
+ *
+ * Best-effort: any miss returns null so the partner default stands.
+ */
+export async function resolveOrderGoodsLocation(
+  container: MedusaContainer,
+  orderId: string
+): Promise<GoodsLocationVerdict> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  try {
+    const { data: runs } = await query.graph({
+      entity: "production_runs",
+      fields: ["id"],
+      filters: { order_id: orderId },
+    })
+    const runIds = (runs ?? []).map((r: any) => r?.id).filter(Boolean)
+    if (!runIds.length) return { locationId: null, reason: "none" }
+
+    const transfers: any = container.resolve(FULLFILLED_ORDERS_MODULE)
+    const landed = await Promise.all(
+      runIds.map(async (runId: string) => {
+        try {
+          const prior = await transfers.listGoodsTransfers(
+            { production_run_id: runId, status: "delivered" },
+            { order: { received_at: "DESC" }, take: 1 }
+          )
+          return prior?.[0]?.to_location_id ?? null
+        } catch {
+          return null
+        }
+      })
+    )
+    return pickCurrentGoodsLocation(landed)
+  } catch {
+    return { locationId: null, reason: "none" }
+  }
 }
 
 /** Read a single order's `sales_channel_id` (null on any error). */
@@ -148,7 +237,13 @@ export async function resolveOrderShipFromLocation(
   try {
     const { partnerId, source } = await resolveOrderPartnerId(container, orderId)
     if (!partnerId) {
-      return { partnerId: null, source: null, locationId: null, actingEmail: null }
+      return {
+        partnerId: null,
+        source: null,
+        locationId: null,
+        actingEmail: null,
+        locationSource: null,
+      }
     }
 
     const { data: partners } = await query.graph({
@@ -163,14 +258,47 @@ export async function resolveOrderShipFromLocation(
     const partner = partners?.[0]
     const partnerChannelId =
       (partner?.stores?.[0]?.default_sales_channel_id as string) ?? null
-    const locationId = await locationForSalesChannel(query, partnerChannelId)
+    const partnerLocationId = await locationForSalesChannel(query, partnerChannelId)
+
+    // #891 S4 — the goods' CURRENT location wins over the partner default.
+    // Output is banked where it was produced, and a delivered goods transfer is
+    // the record that it moved. Shipping from the producing partner after the
+    // goods were received elsewhere is what puts a real garment's origin on the
+    // wrong label, and drives the origin location negative.
+    const goods = await resolveOrderGoodsLocation(container, orderId)
+    if (goods.reason === "split") {
+      // Two runs on one order landed in different places, so no single origin
+      // is correct. Say so loudly and keep the old, understood behaviour rather
+      // than inventing a confident wrong address.
+      try {
+        const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.warn(
+          `[ship-from] order ${orderId}: its production runs' goods are in DIFFERENT locations — no single origin is correct, falling back to the partner default`
+        )
+      } catch {
+        /* logging must never break label generation */
+      }
+    }
+
+    const locationId = goods.locationId ?? partnerLocationId
     return {
       partnerId,
       source,
       locationId,
       actingEmail: (partner?.admins?.[0]?.email as string) ?? null,
+      locationSource: !locationId
+        ? null
+        : goods.locationId
+          ? "goods_transfer"
+          : "partner_default",
     }
   } catch {
-    return { partnerId: null, source: null, locationId: null, actingEmail: null }
+    return {
+      partnerId: null,
+      source: null,
+      locationId: null,
+      actingEmail: null,
+      locationSource: null,
+    }
   }
 }

--- a/apps/backend/src/workflows/inventory_orders/__tests__/deliver-helpers.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/deliver-helpers.unit.spec.ts
@@ -203,3 +203,51 @@ describe("computeAdminDeliveryPosting reads both receipt records (#1613)", () =>
     expect(deliveredRecords).toEqual([{ order_line_id: "ol_1", quantity: 6 }])
   })
 })
+
+/**
+ * Samples/swatch orders (#swatches). A sample order is created EMPTY on
+ * purpose — the box has to arrive before anyone can say what is in it — so it
+ * is the one kind that must stay editable after it ships.
+ */
+describe("evaluateAdminStatusTransition — sample orders", () => {
+  it("stays editable after the box has shipped", () => {
+    expect(() =>
+      evaluateAdminStatusTransition("Shipped", undefined, { isSample: true })
+    ).not.toThrow()
+  })
+
+  it("stays editable after it has been delivered", () => {
+    // This is the whole feature: you fill the lines in once you can see them.
+    expect(() =>
+      evaluateAdminStatusTransition("Delivered", undefined, { isSample: true })
+    ).not.toThrow()
+  })
+
+  it("NEVER posts stock, even on a transition into Delivered", () => {
+    // Swatches are reference material. Posting them would put zero-value units
+    // into a location where they can be counted, reserved and sold.
+    expect(
+      evaluateAdminStatusTransition("Processing", "Delivered", { isSample: true })
+    ).toEqual({ postStock: false })
+  })
+
+  it("is still refused once cancelled", () => {
+    expect(() =>
+      evaluateAdminStatusTransition("Cancelled", undefined, { isSample: true })
+    ).toThrow(/cancelled/i)
+  })
+
+  it("leaves the normal lock untouched for a non-sample order", () => {
+    // The carve-out must not leak: a real order past Processing stays locked,
+    // and a delivery still posts stock.
+    expect(() => evaluateAdminStatusTransition("Shipped", undefined)).toThrow(
+      /Pending' or 'Processing'/
+    )
+    expect(() =>
+      evaluateAdminStatusTransition("Shipped", undefined, { isSample: false })
+    ).toThrow(/Pending' or 'Processing'/)
+    expect(evaluateAdminStatusTransition("Processing", "Delivered")).toEqual({
+      postStock: true,
+    })
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -196,6 +196,12 @@ export const linkInventoryItemsWithLinesStep = createStep(
         inventory_item_id,
       },
     }));
+    // A sample order can have no lines at all, so there may be nothing to
+    // link. Mirrors the guard in `linkVariantsWithLinesStep` below — an empty
+    // `create` call is not worth making.
+    if (!links.length) {
+      return new StepResponse([], []);
+    }
     await remoteLink.create(links);
     return new StepResponse(links, links);
   },

--- a/apps/backend/src/workflows/inventory_orders/lib/__tests__/create-sample-material-lines.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/__tests__/create-sample-material-lines.unit.spec.ts
@@ -1,0 +1,92 @@
+import {
+  materialItemTitle,
+  planNewMaterialLines,
+} from "../create-sample-material-lines"
+
+/**
+ * Samples/swatch orders: a line may name cloth we have never stocked, and the
+ * item is created as the line is written. The guards here all prevent the same
+ * failure — silently minting a duplicate catalogue entry.
+ */
+describe("planNewMaterialLines", () => {
+  it("plans a new line that names a material and points at nothing", () => {
+    const plan = planNewMaterialLines([
+      { new_material: { name: "Tangaliya Weave", color: "Indigo" } },
+    ])
+    expect(plan).toHaveLength(1)
+    expect(plan[0]).toMatchObject({ index: 0, material: { name: "Tangaliya Weave" } })
+  })
+
+  it("skips a line that already points at an inventory item", () => {
+    // Creating an item beside the one the operator picked would duplicate it.
+    expect(
+      planNewMaterialLines([
+        { inventory_item_id: "iitem_1", new_material: { name: "Tangaliya" } },
+      ])
+    ).toEqual([])
+  })
+
+  it("skips a line that names a variant", () => {
+    expect(
+      planNewMaterialLines([
+        { variant_id: "variant_1", new_material: { name: "Tangaliya" } },
+      ])
+    ).toEqual([])
+  })
+
+  it("skips an EXISTING line", () => {
+    // An `id` means the line is already written; it has an item behind it.
+    expect(
+      planNewMaterialLines([{ id: "line_1", new_material: { name: "Tangaliya" } }])
+    ).toEqual([])
+  })
+
+  it("skips a removal", () => {
+    expect(
+      planNewMaterialLines([
+        { remove: true, id: "line_1", new_material: { name: "Tangaliya" } },
+      ])
+    ).toEqual([])
+  })
+
+  it("ignores a blank or whitespace-only name", () => {
+    expect(planNewMaterialLines([{ new_material: { name: "   " } }])).toEqual([])
+    expect(planNewMaterialLines([{ new_material: { name: "" } }])).toEqual([])
+    expect(planNewMaterialLines([{}])).toEqual([])
+  })
+
+  it("trims the name it plans to create", () => {
+    expect(planNewMaterialLines([{ new_material: { name: "  Khadi  " } }])[0].material.name).toBe(
+      "Khadi"
+    )
+  })
+
+  it("reports POSITIONAL indexes so ids land on the right lines", () => {
+    // The caller writes the created item id back by index; an off-by-one here
+    // would attach a material to somebody else's line.
+    const plan = planNewMaterialLines([
+      { inventory_item_id: "iitem_1" },
+      { new_material: { name: "Khadi" } },
+      { id: "line_9" },
+      { new_material: { name: "Ahimsa Silk" } },
+    ])
+    expect(plan.map((p) => p.index)).toEqual([1, 3])
+  })
+})
+
+describe("materialItemTitle", () => {
+  it("folds the colour into the title", () => {
+    // Six items all called "Tangaliya Weave" cannot be told apart in a picker.
+    expect(materialItemTitle({ name: "Tangaliya Weave", color: "Indigo" })).toBe(
+      "Tangaliya Weave — Indigo"
+    )
+  })
+
+  it("uses the bare name when no colour is given", () => {
+    expect(materialItemTitle({ name: "Tangaliya Weave" })).toBe("Tangaliya Weave")
+  })
+
+  it("ignores a blank colour rather than trailing a dash", () => {
+    expect(materialItemTitle({ name: "Khadi", color: "  " })).toBe("Khadi")
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/lib/create-sample-material-lines.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/create-sample-material-lines.ts
@@ -1,0 +1,139 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import { createRawMaterialWorkflow } from "../../raw-materials/create-raw-material"
+
+/**
+ * Create the inventory items for order lines that name a material we have
+ * never stocked.
+ *
+ * This exists for samples/swatch orders. A swatch is very often cloth with no
+ * catalogue entry yet — that is the point of asking for it — so the line has no
+ * `inventory_item_id` and no `variant_id` to give. Requiring one first would
+ * mean walking away from an open box to go create a catalogue record, which is
+ * precisely when the colour name and the composition get lost.
+ *
+ * The item is created and its raw-material record attached in one go, so the
+ * line comes out the same shape as every other line and nothing downstream has
+ * to know it was born here. `createRawMaterialWorkflow` also assigns the SKU.
+ *
+ * ⚠️ No inventory LEVEL is seeded and no stock is posted. A swatch is reference
+ * material, not sellable stock; banking it would put zero-value units into a
+ * location where they can be counted, reserved and sold.
+ */
+
+export type NewMaterialInput = {
+  name: string
+  color?: string
+  composition?: string
+  unit_of_measure?: string
+}
+
+export type MaterialLine = {
+  id?: string
+  remove?: boolean
+  inventory_item_id?: string
+  variant_id?: string
+  new_material?: NewMaterialInput
+}
+
+/**
+ * PURE: which lines are asking for a new material to be created?
+ *
+ * Only NEW lines (no `id`), never removals, and never a line that already
+ * points at something — creating an item beside one the operator picked would
+ * silently duplicate the catalogue entry.
+ *
+ * Returns positional indexes so the caller can write the resulting item ids
+ * back onto the exact lines they came from.
+ */
+export function planNewMaterialLines(
+  lines: MaterialLine[]
+): Array<{ index: number; material: NewMaterialInput }> {
+  const plan: Array<{ index: number; material: NewMaterialInput }> = []
+  lines.forEach((line, index) => {
+    if (line.remove || line.id) return
+    if (line.inventory_item_id || line.variant_id) return
+    const name = line.new_material?.name?.trim()
+    if (!name) return
+    plan.push({ index, material: { ...line.new_material!, name } })
+  })
+  return plan
+}
+
+/**
+ * PURE: the inventory item title for a named material.
+ *
+ * Colour is folded into the title because two swatches of the same cloth in
+ * different colours are different stock, and a catalogue of six items all
+ * called "Tangaliya Weave" cannot be told apart in a picker.
+ */
+export function materialItemTitle(material: NewMaterialInput): string {
+  const name = material.name.trim()
+  const color = material.color?.trim()
+  return color ? `${name} — ${color}` : name
+}
+
+/**
+ * Create an inventory item + raw material for each planned line and return the
+ * new item id by line index.
+ */
+export async function createMaterialsForLines(
+  container: MedusaContainer,
+  lines: MaterialLine[]
+): Promise<Map<number, string>> {
+  const created = new Map<number, string>()
+  const plan = planNewMaterialLines(lines)
+  if (!plan.length) return created
+
+  const inventoryService: any = container.resolve(Modules.INVENTORY)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  for (const { index, material } of plan) {
+    const title = materialItemTitle(material)
+
+    const [item] = await inventoryService.createInventoryItems([
+      {
+        title,
+        // No SKU here — `createRawMaterialWorkflow` generates one, and a
+        // placeholder would have to be unique across the whole catalogue.
+        requires_shipping: true,
+      },
+    ])
+
+    if (!item?.id) {
+      throw new Error(
+        `Could not create an inventory item for the new material "${title}".`
+      )
+    }
+
+    try {
+      await createRawMaterialWorkflow(container as any).run({
+        input: {
+          inventoryId: item.id,
+          rawMaterialData: {
+            name: material.name.trim(),
+            // `composition` is required by the raw-material model; a swatch is
+            // frequently requested precisely because nobody knows it yet, so an
+            // empty string records "not stated" rather than blocking the line.
+            composition: material.composition?.trim() || "",
+            ...(material.color ? { color: material.color.trim() } : {}),
+            ...(material.unit_of_measure
+              ? { unit_of_measure: material.unit_of_measure.trim() }
+              : {}),
+          },
+        },
+      })
+    } catch (e: any) {
+      // The item exists and the line can reference it. Losing the descriptive
+      // record is worth a loud warning, not the loss of what arrived in the box.
+      logger.warn(
+        `[inventory-order] inventory item ${item.id} created for "${title}" but its raw-material record failed: ${e?.message}`
+      )
+    }
+
+    created.set(index, String(item.id))
+  }
+
+  return created
+}

--- a/apps/backend/src/workflows/inventory_orders/lib/deliver-helpers.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/deliver-helpers.ts
@@ -59,9 +59,34 @@ const FIELD_EDIT_STATUSES = new Set(["Pending", "Processing"])
  */
 export const evaluateAdminStatusTransition = (
   current: string | null | undefined,
-  target: string | null | undefined
+  target: string | null | undefined,
+  options?: { isSample?: boolean }
 ): AdminTransitionDecision => {
-  if (!FIELD_EDIT_STATUSES.has(String(current ?? ""))) {
+  const currentStatus = String(current ?? "")
+
+  // A samples/swatch order is the one kind that MUST stay editable after it
+  // arrives: it is created empty on purpose, and the whole point is to fill in
+  // what was in the box once someone has opened it. The Pending/Processing
+  // lock exists to stop an order that already posted stock being edited
+  // underneath itself — a sample never posts stock (see below), so that
+  // reasoning does not apply to it.
+  //
+  // Cancelled is still refused. A cancelled order is not a record anyone
+  // should be adding to.
+  if (options?.isSample) {
+    if (currentStatus === "Cancelled") {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "This sample order is cancelled and can no longer be edited."
+      )
+    }
+    // 🔑 Never posts stock. Swatches are reference material, not sellable
+    // units; posting them would put ~zero-value swatch units into a location
+    // where they can be counted, reserved and sold.
+    return { postStock: false }
+  }
+
+  if (!FIELD_EDIT_STATUSES.has(currentStatus)) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
       "Order can only be updated if status is 'Pending' or 'Processing'."

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -10,6 +10,7 @@ import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/frame
 import type { Link } from "@medusajs/modules-sdk";
 import type { IEventBusModuleService, RemoteQueryFunction, UpdateInventoryLevelInput } from "@medusajs/types";
 import { createInventoryLevelsWorkflow, updateInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows";
+import { createMaterialsForLines } from "./lib/create-sample-material-lines"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import { FULLFILLED_ORDERS_MODULE } from "../../modules/fullfilled_orders";
@@ -107,7 +108,10 @@ export const fetchOriginalOrderStep = createStep(
     // whether stock must be posted.
     const { postStock } = evaluateAdminStatusTransition(
       (originalOrder as any).status,
-      input.data?.status
+      input.data?.status,
+      // A samples/swatch order is created empty and filled in after the box
+      // arrives, so it stays editable past Processing (and never posts stock).
+      { isSample: !!(originalOrder as any).is_sample }
     );
     return new StepResponse({ originalOrder, postStock }, originalOrder); // Save original for compensation
   },
@@ -215,6 +219,24 @@ export const updateOrderLinesStep = createStep(
     const currentOrder = await inventoryOrderService.retrieveInventoryOrder(input.order_id, { relations: ["orderlines"] });
     const currentOrderlines = currentOrder.orderlines || [];
     const byId = new Map<string, any>(currentOrderlines.map((l: any) => [l.id, l]));
+
+    // A samples/swatch line may name a material we have never stocked, with no
+    // item and no variant to point at. Create it first, so every branch below
+    // sees a line of one shape. Done before the variant resolution because a
+    // line carries one form or the other, never both.
+    const materialsCreated = await createMaterialsForLines(
+      container,
+      input.order_lines as any
+    );
+    if (materialsCreated.size) {
+      materialsCreated.forEach((itemId, index) => {
+        const line = input.order_lines[index] as any;
+        if (line) {
+          line.inventory_item_id = itemId;
+          delete line.new_material;
+        }
+      });
+    }
 
     // #1662 — a new line may name an untracked partner variant instead of an
     // item. Establish the inventory item BEFORE anything below reads

--- a/apps/backend/src/workflows/orders/__tests__/store-shipment-pod.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/store-shipment-pod.unit.spec.ts
@@ -1,0 +1,55 @@
+import { appendPodToMetadata, type PodRecord } from "../store-shipment-pod"
+
+const rec = (url: string): PodRecord => ({
+  url,
+  carrier: "delhivery",
+  received_at: "2026-09-12T10:00:00.000Z",
+  ephemeral: false,
+})
+
+/**
+ * Delhivery re-push a POD whenever their audit team uploads a corrected one,
+ * so several PODs for one AWB are normal. A revision must not destroy the
+ * document it replaced — the superseded POD is still evidence of what was
+ * shown at delivery time.
+ */
+describe("appendPodToMetadata", () => {
+  it("records the POD and starts a history", () => {
+    const out = appendPodToMetadata(undefined, rec("https://cdn/pod-1.pdf"))
+    expect(out.pod.url).toBe("https://cdn/pod-1.pdf")
+    expect(out.pod_documents).toHaveLength(1)
+  })
+
+  it("keeps the superseded POD when a revision arrives", () => {
+    const first = appendPodToMetadata({}, rec("https://cdn/pod-1.pdf"))
+    const second = appendPodToMetadata(first, rec("https://cdn/pod-2.pdf"))
+    expect(second.pod.url).toBe("https://cdn/pod-2.pdf")
+    expect(second.pod_documents.map((p: any) => p.url)).toEqual([
+      "https://cdn/pod-1.pdf",
+      "https://cdn/pod-2.pdf",
+    ])
+  })
+
+  it("does not grow the history when the same document is re-pushed", () => {
+    const first = appendPodToMetadata({}, rec("https://cdn/pod-1.pdf"))
+    const retry = appendPodToMetadata(first, rec("https://cdn/pod-1.pdf"))
+    expect(retry.pod_documents).toHaveLength(1)
+  })
+
+  it("preserves unrelated metadata", () => {
+    const out = appendPodToMetadata(
+      { last_webhook: "x", tracking_events: [1, 2] },
+      rec("https://cdn/pod-1.pdf")
+    )
+    expect(out.last_webhook).toBe("x")
+    expect(out.tracking_events).toEqual([1, 2])
+  })
+
+  it("survives a non-array pod_documents left by older data", () => {
+    const out = appendPodToMetadata(
+      { pod_documents: "corrupt" } as any,
+      rec("https://cdn/pod-1.pdf")
+    )
+    expect(out.pod_documents).toHaveLength(1)
+  })
+})

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -456,6 +456,19 @@ export async function createShiprocketShipmentForFulfillment(
           email: input.actingEmail || origin.actingEmail || undefined,
         })
         pickupLocationName = reg.name
+        if (origin.locationSource === "goods_transfer") {
+          // #891 S4 — worth saying out loud: this order is NOT shipping from
+          // the partner that made it, because the goods were received
+          // somewhere else.
+          try {
+            const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+            logger.info(
+              `[ship-from] order ${input.orderId}: shipping from ${origin.locationId} — where a delivered goods transfer left the stock, not the producing partner's default`
+            )
+          } catch {
+            /* logging must never break label generation */
+          }
+        }
       } catch {
         // Best-effort — the #638 fallback (or the guard) handles it cleanly.
       }

--- a/apps/backend/src/workflows/orders/store-shipment-pod.ts
+++ b/apps/backend/src/workflows/orders/store-shipment-pod.ts
@@ -1,0 +1,248 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { uploadFilesWorkflow } from "@medusajs/medusa/core-flows"
+
+import { FULLFILLED_ORDERS_MODULE } from "../../modules/fullfilled_orders"
+
+/**
+ * Store a carrier's proof of delivery against the shipment it belongs to.
+ *
+ * Delhivery's EPOD webhook pushes a document once a shipment is delivered,
+ * either as a base64 blob or as a downloadable URL that EXPIRES AFTER 7 DAYS.
+ * A URL is therefore not durable storage — the blob is uploaded to our own file
+ * store and the resulting permanent URL is what gets recorded. When Delhivery
+ * sends only a link there is nothing to upload, so the link is recorded as-is
+ * and flagged `expires` so it is obvious the reference is perishable.
+ *
+ * An AWB can belong to an inventory shipment or to a core-order fulfillment
+ * (the account-level webhook carries both), so both are tried — inventory
+ * first, mirroring `/webhooks/shipping/track`.
+ *
+ * Idempotency: Delhivery re-pushes a POD whenever their audit team uploads a
+ * corrected one, so MULTIPLE PODs for one AWB are expected and normal. Each is
+ * appended to a `pod_documents` history and the newest becomes `pod`, so a
+ * revision never destroys the document it replaced.
+ */
+
+export type StoreShipmentPodInput = {
+  pod: {
+    carrier: string
+    awb: string
+    pod_base64?: string
+    pod_url?: string
+    order_ref?: string
+    raw?: any
+  }
+}
+
+export type StoreShipmentPodResult = {
+  matched: boolean
+  target?: "inventory_shipment" | "fulfillment"
+  target_id?: string
+  /** The durable URL we recorded (our own, unless Delhivery sent only a link). */
+  pod_url?: string
+  /** True when the recorded URL is Delhivery's own, and will expire. */
+  ephemeral?: boolean
+}
+
+/** One recorded proof-of-delivery document. */
+export type PodRecord = {
+  url: string
+  carrier: string
+  received_at: string
+  ephemeral: boolean
+  order_ref?: string
+}
+
+/**
+ * Append a POD to a metadata blob without losing the ones already there.
+ *
+ * Pure and exported for unit testing. `pod` always points at the newest
+ * document; `pod_documents` keeps the full history, because Delhivery re-pushes
+ * a corrected POD for the same AWB and the superseded one is still evidence.
+ */
+export function appendPodToMetadata(
+  metadata: Record<string, any> | null | undefined,
+  record: PodRecord
+): Record<string, any> {
+  const base = metadata && typeof metadata === "object" ? { ...metadata } : {}
+  const prior = Array.isArray(base.pod_documents) ? base.pod_documents : []
+
+  // A retry of the very same document must not grow the history.
+  const isDuplicate = prior.some(
+    (p: any) => p?.url === record.url && p?.carrier === record.carrier
+  )
+
+  return {
+    ...base,
+    pod: record,
+    pod_documents: isDuplicate ? prior : [...prior, record],
+  }
+}
+
+/** Upload a base64 POD to our file store and return its durable URL. */
+async function uploadPod(
+  container: MedusaContainer,
+  awb: string,
+  base64: string
+): Promise<string | undefined> {
+  // Delhivery does not state the document's MIME type. Their POD is a scanned
+  // delivery sheet delivered as a PDF in every sample we have; a base64 PNG
+  // announces itself with a data-URI prefix, so honour that when present.
+  const dataUri = /^data:([^;]+);base64,/i.exec(base64.trim())
+  const mimeType = dataUri?.[1] || "application/pdf"
+  const content = dataUri ? base64.trim().slice(dataUri[0].length) : base64.trim()
+  const ext = mimeType.split("/")[1]?.split("+")[0] || "pdf"
+
+  const { result } = await uploadFilesWorkflow(container as any).run({
+    input: {
+      files: [
+        {
+          filename: `pod-${awb}-${Date.now()}.${ext}`,
+          mimeType,
+          content,
+          access: "public",
+        },
+      ],
+    },
+  })
+
+  const uploaded = Array.isArray(result)
+    ? result
+    : Array.isArray((result as any)?.files)
+      ? (result as any).files
+      : []
+
+  const file = uploaded[0]
+  return file?.url || file?.location || file?.key
+}
+
+export async function storeShipmentPod(
+  container: MedusaContainer,
+  input: StoreShipmentPodInput
+): Promise<StoreShipmentPodResult> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const pod = input.pod
+
+  const awb = String(pod.awb || "").trim()
+  if (!awb) return { matched: false }
+  if (!pod.pod_base64 && !pod.pod_url) {
+    logger.info(`[EPOD Webhook] AWB ${awb}: push carried no document — ignored`)
+    return { matched: false }
+  }
+
+  // Resolve the durable URL first, so we don't mutate a shipment and then fail
+  // to have anything to point it at.
+  let url = pod.pod_url
+  let ephemeral = true
+  if (pod.pod_base64) {
+    try {
+      const uploaded = await uploadPod(container, awb, pod.pod_base64)
+      if (uploaded) {
+        url = uploaded
+        ephemeral = false
+      }
+    } catch (e: any) {
+      logger.error(
+        `[EPOD Webhook] AWB ${awb}: upload failed (${e?.message}) — falling back to the carrier link`
+      )
+    }
+  }
+
+  if (!url) {
+    logger.error(`[EPOD Webhook] AWB ${awb}: no usable POD URL after upload`)
+    return { matched: false }
+  }
+
+  const record: PodRecord = {
+    url,
+    carrier: pod.carrier || "delhivery",
+    received_at: new Date().toISOString(),
+    ephemeral,
+    order_ref: pod.order_ref,
+  }
+
+  // 1. Inventory shipment (raw-material/partner inbound), matched on the
+  //    `awb` column — same lookup the tracking webhook uses.
+  const fulfilledOrders: any = container.resolve(FULLFILLED_ORDERS_MODULE)
+  const shipments = await fulfilledOrders.listInventoryShipments({ awb })
+  const shipment = (Array.isArray(shipments) ? shipments : [shipments]).filter(
+    Boolean
+  )[0]
+
+  if (shipment) {
+    await fulfilledOrders.updateInventoryShipments({
+      id: shipment.id,
+      metadata: appendPodToMetadata(shipment.metadata, record),
+    })
+    logger.info(
+      `[EPOD Webhook] AWB ${awb}: POD stored on inventory shipment ${shipment.id}`
+    )
+    return {
+      matched: true,
+      target: "inventory_shipment",
+      target_id: shipment.id,
+      pod_url: url,
+      ephemeral,
+    }
+  }
+
+  // 2. Core-order fulfillment, matched on the label's tracking number (the
+  //    only place a retail AWB is queryable).
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+
+  const { data: fulfillments = [] } = await query.graph({
+    entity: "fulfillment",
+    fields: ["id", "metadata", "labels.tracking_number"],
+    filters: { labels: { tracking_number: awb } },
+  })
+
+  const fulfillment = (fulfillments || []).find((f: any) =>
+    (f?.labels || []).some((l: any) => l?.tracking_number === awb)
+  )
+
+  if (!fulfillment) {
+    logger.info(
+      `[EPOD Webhook] AWB ${awb} matched no inventory shipment or core fulfillment — ignored`
+    )
+    return { matched: false }
+  }
+
+  await fulfillmentModule.updateFulfillment(fulfillment.id, {
+    metadata: appendPodToMetadata(fulfillment.metadata, record),
+  })
+  logger.info(
+    `[EPOD Webhook] AWB ${awb}: POD stored on fulfillment ${fulfillment.id}`
+  )
+
+  return {
+    matched: true,
+    target: "fulfillment",
+    target_id: fulfillment.id,
+    pod_url: url,
+    ephemeral,
+  }
+}
+
+const storeShipmentPodStep = createStep(
+  "store-shipment-pod",
+  async (input: StoreShipmentPodInput, { container }) => {
+    const result = await storeShipmentPod(container, input)
+    return new StepResponse(result)
+  }
+)
+
+export const storeShipmentPodWorkflow = createWorkflow(
+  "store-shipment-pod",
+  (input: StoreShipmentPodInput) => {
+    const result = storeShipmentPodStep(input)
+    return new WorkflowResponse(result)
+  }
+)

--- a/apps/backend/src/workflows/production-runs/__tests__/receive-goods-transfer.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/receive-goods-transfer.unit.spec.ts
@@ -1,0 +1,120 @@
+import {
+  assertReceivableTransfer,
+  planTransferMove,
+  transferShortfall,
+} from "../receive-goods-transfer"
+
+/**
+ * #891 S3. Every one of these guards exists because the wrong answer moves
+ * real stock — either minting units that were never made, or driving a
+ * location negative.
+ */
+describe("assertReceivableTransfer", () => {
+  const ok = { id: "gtrf_1", production_run_id: "run_1", status: "in_transit" }
+
+  it("accepts a live transfer on the right run", () => {
+    expect(() => assertReceivableTransfer(ok, "run_1", "gtrf_1")).not.toThrow()
+  })
+
+  it("accepts a draft — a hop can be walked over by hand with no carrier", () => {
+    expect(() =>
+      assertReceivableTransfer({ ...ok, status: "draft" }, "run_1", "gtrf_1")
+    ).not.toThrow()
+  })
+
+  it("refuses a transfer belonging to another run", () => {
+    // Receiving it would move another run's goods.
+    expect(() => assertReceivableTransfer(ok, "run_2", "gtrf_1")).toThrow(
+      /not found on production run run_2/
+    )
+  })
+
+  it("refuses a missing transfer", () => {
+    expect(() => assertReceivableTransfer(null, "run_1", "gtrf_x")).toThrow(
+      /not found/
+    )
+  })
+
+  it("refuses a second receipt", () => {
+    // The whole point: receiving twice moves the same goods twice.
+    expect(() =>
+      assertReceivableTransfer({ ...ok, status: "delivered" }, "run_1", "gtrf_1")
+    ).toThrow(/already been received/)
+  })
+
+  it("refuses a cancelled transfer", () => {
+    expect(() =>
+      assertReceivableTransfer({ ...ok, status: "cancelled" }, "run_1", "gtrf_1")
+    ).toThrow(/cancelled/)
+  })
+})
+
+describe("planTransferMove", () => {
+  const hop = { quantity: 3, from_location_id: "sloc_a", to_location_id: "sloc_b" }
+
+  it("moves the sent quantity by default", () => {
+    const plan = planTransferMove(hop)
+    expect(plan).toMatchObject({ move: true, quantity: 3, to_location_id: "sloc_b" })
+  })
+
+  it("moves what was actually counted when that is given", () => {
+    expect(planTransferMove(hop, 2)).toMatchObject({ move: true, quantity: 2 })
+  })
+
+  it("moves nothing for a customer leg", () => {
+    // No destination = the goods left for a customer. The fulfillment path
+    // already decrements; doing it here too takes the same garment twice.
+    const plan = planTransferMove({ ...hop, to_location_id: null })
+    expect(plan.move).toBe(false)
+    expect(plan.skip_reason).toBe("customer_leg")
+  })
+
+  it("moves nothing when origin and destination are the same location", () => {
+    const plan = planTransferMove({ ...hop, to_location_id: "sloc_a" })
+    expect(plan.move).toBe(false)
+    expect(plan.skip_reason).toBe("same_location")
+  })
+
+  it("moves nothing when nothing arrived", () => {
+    const plan = planTransferMove(hop, 0)
+    expect(plan.move).toBe(false)
+    expect(plan.skip_reason).toBe("zero_quantity")
+  })
+
+  it("treats a zero received count as zero, not as 'unspecified'", () => {
+    // `0` must not fall through to the sent quantity — that would move 3 units
+    // on a receipt that said nothing came.
+    expect(planTransferMove(hop, 0).quantity).toBe(0)
+  })
+
+  it("falls back to the sent quantity for null/undefined/NaN", () => {
+    expect(planTransferMove(hop, null).quantity).toBe(3)
+    expect(planTransferMove(hop, undefined).quantity).toBe(3)
+    expect(planTransferMove(hop, Number.NaN).quantity).toBe(3)
+  })
+
+  it("never moves a negative quantity", () => {
+    expect(planTransferMove(hop, -2).move).toBe(false)
+  })
+})
+
+describe("transferShortfall", () => {
+  it("reports what did not arrive", () => {
+    expect(transferShortfall(5, 3)).toBe(2)
+  })
+
+  it("is zero when everything arrived", () => {
+    expect(transferShortfall(5, 5)).toBe(0)
+  })
+
+  it("never reports a surplus as a negative shortfall", () => {
+    // Receiving more than was sent is a data-entry question; "-2 short" reads
+    // as a surplus nobody can act on.
+    expect(transferShortfall(3, 5)).toBe(0)
+  })
+
+  it("handles missing numbers", () => {
+    expect(transferShortfall(null, null)).toBe(0)
+    expect(transferShortfall(3, null)).toBe(3)
+  })
+})

--- a/apps/backend/src/workflows/production-runs/receive-goods-transfer.ts
+++ b/apps/backend/src/workflows/production-runs/receive-goods-transfer.ts
@@ -1,0 +1,437 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import { FULLFILLED_ORDERS_MODULE } from "../../modules/fullfilled_orders"
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+
+/**
+ * #891 S3 — receiving a goods transfer is what actually moves the inventory.
+ *
+ * Until this slice, a hop could be created and shipped but never received:
+ * nothing in the codebase wrote `goods_transfer.status = "delivered"`. Stock
+ * therefore stayed banked at the producing partner's location forever, and the
+ * customer leg shipped from somewhere the goods were not — which is how a
+ * `-1` appears at one location beside a `+1` at another (the 2026-09-10
+ * incident on iitem_01M25K1PHQ86CQ0SKVDJ47EMCS).
+ *
+ * Receipt is deliberately a HUMAN act, not a carrier event. A carrier's
+ * "delivered" scan means the box arrived; it does not mean anyone opened it and
+ * counted what was inside. That is the same decision #888 made for inventory
+ * orders, and both `inventory_shipment.ts` and `goods_transfer.ts` say so in
+ * their model comments.
+ *
+ * 🔑 The reservation moves with the goods. A transfer that relocates stock but
+ * leaves an order's reservation pointing at the origin reproduces the very
+ * negative this slice exists to prevent, one step later.
+ */
+
+export type ReceiveGoodsTransferInput = {
+  run_id: string
+  transfer_id: string
+  /** What was actually counted. Defaults to the quantity that was sent. */
+  received_quantity?: number
+  notes?: string | null
+  actor_id?: string | null
+  actor_type?: "user" | "partner" | "system"
+}
+
+export type ReceiveGoodsTransferResult = {
+  transfer_id: string
+  status: "delivered"
+  received_quantity: number
+  /** Whether inventory was actually moved, and if not, why not. */
+  moved: boolean
+  skip_reason?: MoveSkipReason
+  inventory_item_id?: string
+  from_location_id?: string
+  to_location_id?: string
+  /** Reservations repointed from the origin to the destination. */
+  reservations_repointed: number
+  shortfall: number
+}
+
+export type MoveSkipReason =
+  | "customer_leg"
+  | "same_location"
+  | "zero_quantity"
+
+export type TransferMovePlan = {
+  move: boolean
+  quantity: number
+  from_location_id: string
+  to_location_id?: string
+  skip_reason?: MoveSkipReason
+}
+
+/**
+ * PURE: may this transfer be received?
+ *
+ * Throws rather than returning false — every caller's only sensible response is
+ * to stop, and a boolean invites one of them not to. Mirrors
+ * `assertReplaceableTransfer`, which guards the other end of the lifecycle.
+ */
+export function assertReceivableTransfer(
+  transfer: { id?: string; production_run_id?: string; status?: string } | null,
+  runId: string,
+  requestedId: string
+): void {
+  if (!transfer || transfer.production_run_id !== runId) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Goods transfer ${requestedId} not found on production run ${runId}.`
+    )
+  }
+  if (transfer.status === "delivered") {
+    // Receiving twice would move the stock twice. The first receipt is the
+    // record; a correction is a new transfer, not a second receipt.
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Transfer ${transfer.id} has already been received — receiving it again would move the same goods twice.`
+    )
+  }
+  if (transfer.status === "cancelled") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Transfer ${transfer.id} is cancelled — goods that were never sent cannot be received.`
+    )
+  }
+}
+
+/**
+ * PURE: what inventory movement does this receipt imply?
+ *
+ * Three cases move NOTHING, and each of them would be a real over- or
+ * under-count if it did:
+ *
+ *  - **customer_leg** — a transfer with no destination is goods leaving for a
+ *    customer. The core fulfillment path already decrements when it ships;
+ *    decrementing here as well would take the same garment out of stock twice.
+ *  - **same_location** — origin and destination are the same stock location.
+ *    A read-then-write of `stocked_quantity` against one level would be a
+ *    no-op at best; it is never a real movement.
+ *  - **zero_quantity** — nothing arrived, so nothing moved. The transfer is
+ *    still marked received, because "the box came and was empty" is a fact
+ *    worth recording.
+ */
+export function planTransferMove(
+  transfer: {
+    quantity?: number | null
+    from_location_id?: string | null
+    to_location_id?: string | null
+  },
+  receivedQuantity?: number | null
+): TransferMovePlan {
+  const sent = Number(transfer.quantity ?? 0)
+  const quantity = Number(
+    receivedQuantity == null || Number.isNaN(Number(receivedQuantity))
+      ? sent
+      : receivedQuantity
+  )
+
+  const from = String(transfer.from_location_id || "")
+  const to = transfer.to_location_id ? String(transfer.to_location_id) : undefined
+
+  const base = { quantity, from_location_id: from, to_location_id: to }
+
+  if (!to) return { ...base, move: false, skip_reason: "customer_leg" }
+  if (from && from === to) return { ...base, move: false, skip_reason: "same_location" }
+  if (!(quantity > 0)) return { ...base, move: false, skip_reason: "zero_quantity" }
+
+  return { ...base, move: true }
+}
+
+/**
+ * PURE: the difference between what was sent and what was counted.
+ *
+ * Never negative — receiving MORE than was sent is a data-entry question, not a
+ * shortfall, and reporting it as `-2` short would read as a surplus nobody can
+ * act on.
+ */
+export function transferShortfall(
+  sentQuantity?: number | null,
+  receivedQuantity?: number | null
+): number {
+  const sent = Number(sentQuantity ?? 0)
+  const received = Number(receivedQuantity ?? 0)
+  return Math.max(0, sent - received)
+}
+
+/** Resolve the inventory item the run's output is banked as. */
+async function resolveRunInventoryItem(
+  container: MedusaContainer,
+  run: { variant_id?: string | null; design_id?: string | null }
+): Promise<string | undefined> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Same resolution order as `stockFinishedGoodsStep` — the run's own variant
+  // wins, the design lookup is the fallback for runs that predate the column.
+  let variantId: string | undefined = run.variant_id ?? undefined
+  if (!variantId && run.design_id) {
+    const { data } = await query.graph({
+      entity: "design_product_variant",
+      filters: { design_id: run.design_id },
+      fields: ["product_variant_id"],
+    })
+    variantId = data?.[0]?.product_variant_id
+  }
+  if (!variantId) return undefined
+
+  const { data: variantInventory } = await query.graph({
+    entity: "product_variant_inventory_item",
+    filters: { variant_id: variantId },
+    fields: ["inventory_item_id"],
+  })
+  return variantInventory?.[0]?.inventory_item_id
+}
+
+/**
+ * Move `quantity` of `inventoryItemId` from one location to the other.
+ *
+ * Read-then-absolute-write, because this codebase has no `adjustInventory` —
+ * which is exactly why the origin side is clamped at zero. An origin level that
+ * is already short must not be driven negative by a receipt; the shortfall is
+ * reported instead.
+ */
+async function moveInventory(
+  container: MedusaContainer,
+  inventoryItemId: string,
+  fromLocationId: string,
+  toLocationId: string,
+  quantity: number
+): Promise<void> {
+  const inventoryService: any = container.resolve(Modules.INVENTORY)
+
+  const [originLevel] = await inventoryService.listInventoryLevels({
+    inventory_item_id: inventoryItemId,
+    location_id: fromLocationId,
+  })
+  if (originLevel) {
+    await inventoryService.updateInventoryLevels(originLevel.id, {
+      stocked_quantity: Math.max(
+        0,
+        (originLevel.stocked_quantity || 0) - quantity
+      ),
+    })
+  }
+
+  const [destinationLevel] = await inventoryService.listInventoryLevels({
+    inventory_item_id: inventoryItemId,
+    location_id: toLocationId,
+  })
+  if (destinationLevel) {
+    await inventoryService.updateInventoryLevels(destinationLevel.id, {
+      stocked_quantity: (destinationLevel.stocked_quantity || 0) + quantity,
+    })
+  } else {
+    await inventoryService.createInventoryLevels({
+      inventory_item_id: inventoryItemId,
+      location_id: toLocationId,
+      stocked_quantity: quantity,
+    })
+  }
+}
+
+/**
+ * Repoint the run's reservations at the destination.
+ *
+ * A reservation is held at a LOCATION. Move the stock and leave the reservation
+ * behind, and the origin now owes a unit it no longer has while the destination
+ * holds one nothing has claimed — the same negative, one step later.
+ *
+ * Quantities are deliberately NOT adjusted on a short receipt. The goods that
+ * did arrive are at the destination, so that is where the claim belongs;
+ * reconciling a shortfall is a separate decision, and silently shrinking a
+ * customer's reservation here would make it invisible.
+ */
+async function repointReservations(
+  container: MedusaContainer,
+  productionRunId: string,
+  inventoryItemId: string,
+  fromLocationId: string,
+  toLocationId: string
+): Promise<number> {
+  const inventoryService: any = container.resolve(Modules.INVENTORY)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const reservations = await inventoryService.listReservationItems({
+    inventory_item_id: inventoryItemId,
+    location_id: fromLocationId,
+  })
+
+  // `metadata` is JSON, so the run filter happens in-app — the same reason the
+  // partner reservation list filters in-app.
+  const mine = (Array.isArray(reservations) ? reservations : []).filter(
+    (r: any) => String(r?.metadata?.production_run_id || "") === productionRunId
+  )
+
+  let moved = 0
+  for (const reservation of mine) {
+    try {
+      await inventoryService.updateReservationItems({
+        id: reservation.id,
+        location_id: toLocationId,
+      })
+      moved++
+    } catch (e: any) {
+      // The stock has already moved; a reservation left behind is a reportable
+      // inconsistency, not a reason to unwind a physical receipt.
+      logger.error(
+        `[goods-transfer] reservation ${reservation.id} could not follow the goods to ${toLocationId}: ${e?.message}`
+      )
+    }
+  }
+  return moved
+}
+
+/** Put the receipt on the run's timeline. Best-effort — never unwinds the move. */
+async function recordReceiptActivity(
+  container: MedusaContainer,
+  run: { id: string; partner_id?: string | null },
+  transfer: any,
+  result: ReceiveGoodsTransferResult,
+  notes?: string | null
+): Promise<void> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+    const summary =
+      `${result.received_quantity} unit${result.received_quantity === 1 ? "" : "s"} received` +
+      (result.shortfall ? ` (${result.shortfall} short)` : "") +
+      (result.moved ? "" : ` — inventory not moved (${result.skip_reason})`)
+
+    await runService.createProductionRunActivities({
+      production_run_id: run.id,
+      activity_type: "lifecycle_event",
+      kind: "goods_transfer_received",
+      actor_type: "system",
+      actor_id: null,
+      partner_id: run.partner_id ?? null,
+      channel: null,
+      message_id: null,
+      template_name: null,
+      recipient: null,
+      summary,
+      payload: {
+        goods_transfer_id: transfer.id,
+        from_location_id: result.from_location_id ?? null,
+        to_location_id: result.to_location_id ?? null,
+        quantity: Number(transfer.quantity ?? 0),
+        received_quantity: result.received_quantity,
+        shortfall: result.shortfall,
+        moved: result.moved,
+        skip_reason: result.skip_reason ?? null,
+        reservations_repointed: result.reservations_repointed,
+        notes: notes ?? null,
+      },
+      occurred_at: new Date(),
+    })
+  } catch (e: any) {
+    logger.error(
+      `[goods-transfer] transfer ${transfer.id} received but timeline write failed: ${e?.message}`
+    )
+  }
+}
+
+export async function receiveGoodsTransfer(
+  container: MedusaContainer,
+  input: ReceiveGoodsTransferInput
+): Promise<ReceiveGoodsTransferResult> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+  const transferService: any = container.resolve(FULLFILLED_ORDERS_MODULE)
+
+  const [transfer] = await transferService.listGoodsTransfers({
+    id: input.transfer_id,
+  })
+  assertReceivableTransfer(transfer, input.run_id, input.transfer_id)
+
+  const run = await runService.retrieveProductionRun(input.run_id)
+
+  const plan = planTransferMove(transfer, input.received_quantity)
+  const shortfall = transferShortfall(transfer.quantity, plan.quantity)
+
+  const result: ReceiveGoodsTransferResult = {
+    transfer_id: transfer.id,
+    status: "delivered",
+    received_quantity: plan.quantity,
+    moved: false,
+    skip_reason: plan.skip_reason,
+    from_location_id: plan.from_location_id,
+    to_location_id: plan.to_location_id,
+    reservations_repointed: 0,
+    shortfall,
+  }
+
+  if (plan.move && plan.to_location_id) {
+    const inventoryItemId = await resolveRunInventoryItem(container, run)
+    if (!inventoryItemId) {
+      // The receipt is still real — it just cannot be expressed as an inventory
+      // movement, so say so loudly rather than reporting a move that never was.
+      logger.warn(
+        `[goods-transfer] transfer ${transfer.id} received but no inventory item resolves from run ${run.id} — stock not moved`
+      )
+    } else {
+      await moveInventory(
+        container,
+        inventoryItemId,
+        plan.from_location_id,
+        plan.to_location_id,
+        plan.quantity
+      )
+      result.moved = true
+      result.inventory_item_id = inventoryItemId
+      result.reservations_repointed = await repointReservations(
+        container,
+        String(transfer.production_run_id),
+        inventoryItemId,
+        plan.from_location_id,
+        plan.to_location_id
+      )
+    }
+  }
+
+  await transferService.updateGoodsTransfers({
+    id: transfer.id,
+    status: "delivered",
+    received_at: new Date(),
+    received_quantity: plan.quantity,
+    ...(input.notes ? { notes: input.notes } : {}),
+  })
+
+  await recordReceiptActivity(container, run, transfer, result, input.notes)
+
+  logger.info(
+    `[goods-transfer] ${transfer.id} received: ${result.received_quantity} unit(s)` +
+      (result.moved
+        ? ` moved ${plan.from_location_id} → ${plan.to_location_id}, ${result.reservations_repointed} reservation(s) repointed`
+        : ` (no inventory movement: ${result.skip_reason ?? "unresolved item"})`)
+  )
+
+  return result
+}
+
+const receiveGoodsTransferStep = createStep(
+  "receive-goods-transfer",
+  async (input: ReceiveGoodsTransferInput, { container }) => {
+    const result = await receiveGoodsTransfer(container, input)
+    return new StepResponse(result)
+  }
+)
+
+export const receiveGoodsTransferWorkflow = createWorkflow(
+  "receive-goods-transfer",
+  (input: ReceiveGoodsTransferInput) => {
+    const result = receiveGoodsTransferStep(input)
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
Three independent pieces of work from one session. They share no code; split on review if that is easier.

---

## 1. Delhivery webhooks — and the payload that would have been dropped in silence

**Delhivery's own webhook requirement document prints a default scan-push payload that our normalizer could not read.**

```json
{"shipment_remark","location","count","lrnum","mwn","cl_uuid","name",
 "package_type","expected_delivery_date","promised_delivery_date","timestamp","status"}
```

Flat, `status` a bare string, and **no waybill key at all** — the consignment number rides in `lrnum`. `normalizeDelhiveryWebhook` was written against the nested track envelope, so a live "Delivered" push produced `awb: ""`, `current_status: ""`, `events: []`. `/webhooks/shipping/track` reads an empty AWB as *"ignore this push"*. Every delivery update would have been discarded with nothing in the log but `"Push without an AWB — ignored (test webhook?)"`.

Verified by running the documented payload through the real function before changing anything.

**Scan push** (route already existed, #888):
- parses BOTH the nested track envelope and the flat documented shape; AWB from `waybill`/`awb`/`wbn`/`lrnum`/`mwn`
- the flat push carries one scan and no history array, so it is synthesised into an event — but only when there is an AWB to hang it on, so a carrier test-ping never becomes a phantom scan
- new `delhiveryTimestamp` normalises their epoch (seconds *or* milliseconds) to ISO. A non-positive epoch is "no time recorded", not 1970 and not the string `"0"` (a real bug found on the way)

**EPOD** (new): `POST /webhooks/shipping/epod?carrier=delhivery`
- same token gate and ack-before-processing contract as the tracking route — a base64 POD takes far longer to store than the 500 ms Delhivery allow before they time out and drop the push
- `store-shipment-pod` resolves the AWB to an inventory shipment or a core fulfillment. Delhivery's own S3 links **expire after 7 days**, so a base64 blob is uploaded to our file store and the durable URL is kept; a bare link is recorded and flagged `ephemeral`
- their audit team re-pushes a **corrected** POD for the same AWB, so PODs are APPENDED to a `pod_documents` history — a revision never destroys the document it replaced
- 10mb body limit; the default JSON limit would 413 the push, and Delhivery retry on a timeout, not on a 4xx

Mutation-checked: removing the `lrnum` fallback turns four of the new tests red.

**Ops tail (not in this PR):** the two filled requirement documents go to `lastmile-integration@delhivery.com` with the account POC in copy. They quote 4–5 business days.

---

## 2. #891 S3 — receiving a transfer moves the stock, and the reservation with it

Until now **nothing in the codebase could write `goods_transfer.status = "delivered"`**. A hop could be planned, booked and shipped but never received, so stock stayed banked at the producing partner's location forever and the customer leg shipped from somewhere the goods were not.

`POST /admin/production-runs/:id/transfers/:transferId/receive`:
- decrements the origin level (clamped at zero — this codebase has no `adjustInventory`, every adjustment is a read-then-absolute-write), increments or creates the destination level
- 🔑 **repoints the run's reservations at the destination.** A transfer that moves stock but leaves the reservation behind re-creates the same negative one step later: the origin owes a unit it no longer has while the destination holds one nothing has claimed
- marks the transfer `delivered` with `received_at` / `received_quantity`, which `resolveRunGoodsLocation` already reads

**Receipt is a human act.** A carrier's "delivered" scan means a box reached an address, not that anyone opened it and counted — the same split #888 made for inventory orders. The tracking webhook still advances only the shipment.

**Three cases mark the transfer received but move NO inventory**, because each would be a real miscount:

| case | why |
|---|---|
| `customer_leg` | no destination; the fulfillment path already decrements, so doing it here takes the same garment out of stock twice |
| `same_location` | origin and destination are the same stock location |
| `zero_quantity` | nothing arrived |

A second receipt is refused outright. Quantities are deliberately **not** reconciled on a short receipt: the goods that did arrive are at the destination, and silently shrinking a customer's reservation would hide the shortfall.

The admin Receive action is wired up — the timeline kind `goods_transfer_received` and the green badge were already waiting for it.

**Still open on #891: S4** — the customer leg's ship-from must read the goods' *current* location, not the producing partner's default. Without it the receipt is recorded but a fulfillment can still ship from the wrong place.

---

## 3. Samples / swatch inventory orders

A samples order is placed precisely because nobody knows yet what will turn up. The platform could not express that: **three** independent gates each demanded at least one line at create time, and a **fourth** locked the order against edits past `Processing` — so the one moment you finally *can* say what is in the box was the moment you were no longer allowed to.

Built on the existing **`is_sample`** boolean rather than a new discriminator. It was already a real column with an index and a create-form switch, and its validation already relaxed the quantity rule for samples. **No migration.**

A sample order now:
- may be created with **no lines** (every other kind still requires one — enforced in the superRefine, where `is_sample` is visible)
- stays editable at **any status except Cancelled**
- posts **no stock** when the lines are filled. Swatches are reference material; banking them would put zero-value units into a location where they can be counted, reserved and sold
- may name a material with no catalogue entry at all — `new_material: { name, color?, composition? }` creates the inventory item and its raw-material record as the line is written, because otherwise an unknown swatch cannot be entered until you walk away from the open box, which is exactly when the colour and composition get lost

Every relaxation is pinned as **not** leaking into ordinary procurement: a non-sample order with no lines is still refused, the #1671 blank-grid guard still fires, editing a normal order past `Processing` is still locked, and a normal delivery still posts stock.

Two things that bit during the work and are now commented in place:
- a `z.ZodIssueCode.too_small` issue has its message **regenerated** by the framework's error formatter — the wording that says *why* is thrown away. Use `custom` when the message matters.
- an order line's inventory item lives in a module **link on the LINE** (`inventory_order_line ⇄ inventory_item`), not a column and not a link on the order. Querying the wrong one returns `[]`, which reads convincingly as "no link was made".

**Not built:** an inline "new material" control in the admin line-edit grid — `new_material` is API/MCP only for now. The MCP tool descriptions document both.

---

## Testing

- **Full unit suite: 587 suites / 6982 tests green** (was 585/6936 on main)
- Integration, run against a real database:
  - `inventory-order-samples.spec.ts` — 7/7 (new)
  - `shipping-epod-webhook.spec.ts` — 6/6 (new)
  - regression: `inventory-orders-api`, `inventory-order-line-update-persistence`, `shipping-tracking-webhook`, `production-run-transfer-carrier` — 4 suites / 46 tests green
- Typecheck clean on every new and modified file

Closes nothing outright. Advances #891 (S3 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
