### PR TITLE
chore(deploy): wire PACKLINK_ENABLED so the Packlink provider actually registers in prod

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -223,6 +223,16 @@ secrets:
   DTDC_TRACKING_PASSWORD: /jyt/prod/DTDC_TRACKING_PASSWORD
   DTDC_TRACKING_USERNAME: /jyt/prod/DTDC_TRACKING_USERNAME
   DELHIVERY_API_TOKEN: /jyt/prod/DELHIVERY_API_TOKEN
+
+  # Packlink (EU origin) — registers the provider in medusa-config.prod.ts.
+  # 🔴 This flag is the WHOLE gate: without it `packlink_packlink` is not in the
+  # container at all, so it cannot be attached to a shipping option no matter
+  # what is configured in the UI.
+  # The API KEY and the ORIGIN are deliberately NOT here — they live on a
+  # `socials` platform record (category "shipping", provider "packlink"), which
+  # the provider prefers over these env options, so they rotate in the UI
+  # without a deploy and each partner can hold their own account.
+  PACKLINK_ENABLED: /jyt/prod/PACKLINK_ENABLED
   ENCRYPTION_KEY: /jyt/prod/ENCRYPTION_KEY
   ENCRYPTION_KEY_VERSION: /jyt/prod/ENCRYPTION_KEY_VERSION
   # Etsy OAuth (medusa-plugin-etsy-sync). Without these, the connect URL is built

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -79,6 +79,16 @@ secrets:
   DTDC_TRACKING_PASSWORD: /jyt/prod/DTDC_TRACKING_PASSWORD
   DTDC_TRACKING_USERNAME: /jyt/prod/DTDC_TRACKING_USERNAME
   DELHIVERY_API_TOKEN: /jyt/prod/DELHIVERY_API_TOKEN
+
+  # Packlink (EU origin) — registers the provider in medusa-config.prod.ts.
+  # 🔴 This flag is the WHOLE gate: without it `packlink_packlink` is not in the
+  # container at all, so it cannot be attached to a shipping option no matter
+  # what is configured in the UI.
+  # The API KEY and the ORIGIN are deliberately NOT here — they live on a
+  # `socials` platform record (category "shipping", provider "packlink"), which
+  # the provider prefers over these env options, so they rotate in the UI
+  # without a deploy and each partner can hold their own account.
+  PACKLINK_ENABLED: /jyt/prod/PACKLINK_ENABLED
   ENCRYPTION_KEY: /jyt/prod/ENCRYPTION_KEY
   ENCRYPTION_KEY_VERSION: /jyt/prod/ENCRYPTION_KEY_VERSION
   # Etsy OAuth (medusa-plugin-etsy-sync) — sync jobs run on the worker.


### PR DESCRIPTION
One line of config per service. Everything else for Packlink already exists.

## The gap

The provider shipped in #2005 and the platform record now exists in prod — active, `api_key_present: true`, `origin_country: IT`, `origin_zip: 50022`. But **`PACKLINK_ENABLED` appeared in no copilot manifest**, so it was never set on either service.

`medusa-config.prod.ts:472` gates registration on that flag, so `packlink_packlink` is simply not in the container:

```
list_fulfillment_providers (prod) →
  bluedart_bluedart, delhivery_delhivery, dtdc_dtdc,
  manual_manual, shipglobal_shipglobal, shiprocket_shiprocket
```

Six providers, no Packlink. It cannot be attached to a shipping option no matter what the UI holds — a configured-looking integration that does not exist at runtime.

## The change

`PACKLINK_ENABLED: /jyt/prod/PACKLINK_ENABLED` in **both** manifests.

The SSM parameter is already created — `String`, `"true"`, tagged `copilot-application=jyt` / `copilot-environment=prod`, matching `BLUE_DART_PROVIDER_ENABLED`.

Mirrored onto the worker for the reason already written above the Blue Dart block in that same file: prod runs a **split** server + worker off one `medusa-config.prod.ts`, so a provider registered on only one is a "works on the server, missing on the worker" bug.

## What is deliberately NOT wired

`medusa-config.prod.ts` also reads `PACKLINK_ORIGIN_COUNTRY` and `PACKLINK_ORIGIN_ZIP`. Those are **not** added, because the provider prefers the `socials` platform record over its own options:

```ts
// packlink/service.ts:250-252
String(this.platformOrigin.country ?? opts.origin_country ?? "")
String(this.platformOrigin.zip     ?? opts.origin_zip     ?? "")
```

So origin and the API key rotate in the UI without a deploy, and each partner can hold their own account. Adding env copies would create a second source of truth for the same fact — and the one that loses.

## Why now

Le Ciricotte's flat international prices are **loss-making** against live Packlink quotes from IT 50022:

| lane | cheapest | our flat price | result |
|---|---:|---:|---:|
| GB | €18.19 Poste Italiane | €30.31 | +€12.12 |
| CA | €31.83 brt | €29.85 | −€1.98 |
| CN | €38.33 brt | €30.03 | −€8.30 |
| AE | €82.32 TNT | €30.05 | **−€52.27/parcel** |

Switching it to the calculated option is blocked on this flag.

## Verification

- both manifests parse (`js-yaml`), `PACKLINK_ENABLED` resolves under `secrets:` on each
- `pnpm check:prod-config` parity passes
- SSM parameter read back: `String`, `true`, both copilot tags present

## After merge

Deploy, then confirm `packlink_packlink` appears in `list_fulfillment_providers` **before** touching Le Ciricotte's shipping options. ⚠️ Label booking is still not implemented — `createFulfillment` throws a named error (Packlink slice 2). This enables **rating** only, which is what the calculated option needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
