### PR TITLE
feat(shipping): shipping-option write tools + a currency-gatable rule context

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -673,6 +673,213 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       id: STR("A specific shipping option id."),
     }),
   },
+  /**
+   * The two shipping-option WRITES.
+   *
+   * Until these existed there was no way to create or amend a shipping option
+   * except the admin UI: no tool wrapped either route, and an authenticated
+   * curl at prod is refused by the permission classifier. So "the flat rate is
+   * loss-making, switch the lane to live rates" was a change nobody could
+   * actually make from here.
+   */
+  {
+    name: "create_shipping_option",
+    description:
+      "Create a shipping option — a rate a buyer can pick at checkout, or a quote-only row. Sensitive: requires confirm:true. Call list_shipping_options on the target `service_zone_id` first: options are what make a zone SELLABLE, and a second one competing with an existing rate is usually not what was wanted. 🔴 `prices` is REQUIRED even for `price_type: \"calculated\"` — send `[]` there; the carrier quotes, so a price row would be a second answer to the same question. 🔑 A FLAT option with no price in the cart's currency is simply not offered; a CALCULATED one has no prices and so is offered EVERYWHERE the zone reaches. That asymmetry is the whole trap: the only way to confine a calculated option to particular lanes is a `rules` entry, and a rule can only name a context key something actually publishes (`enabled_in_store`, `is_return`, `quote_id`, `cart_currency_code` — see the setShippingOptionsContext hook). ⚠️ A rule naming a key nobody publishes does not fail: the matcher stringifies the absent value to \"undefined\", so the option is EXCLUDED from every cart and looks merely unpopular. Exactly one of `type` or `type_id`. The `provider_id` must be registered AND enabled — check list_fulfillment_providers, since a provider configured in only one medusa-config file does not exist in prod.",
+    method: "POST",
+    path: "/admin/shipping-options",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "service_zone_id",
+      "shipping_profile_id",
+      "provider_id",
+      "price_type",
+      "type",
+      "type_id",
+      "prices",
+      "rules",
+      "data",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        name: STR("Shown to the buyer at checkout, e.g. 'International (Packlink)'."),
+        service_zone_id: STR("Service zone this option serves, e.g. 'serzo_...'. From list_shipping_options or the zone's fulfillment set."),
+        shipping_profile_id: STR("Shipping profile id, e.g. 'sp_...'. From list_shipping_profiles — ⚠️ there is more than one, so do not take whichever comes back first (#1983)."),
+        provider_id: STR("Fulfillment provider, e.g. 'manual_manual', 'packlink_packlink'. Must appear enabled in list_fulfillment_providers."),
+        price_type: {
+          type: "string",
+          enum: ["flat", "calculated"],
+          description:
+            "'flat' prices from the `prices` rows; 'calculated' asks the provider per cart. A calculated option is only as good as its provider's calculatePrice — one that cannot quote a lane falls back or throws.",
+        },
+        type: obj(
+          {
+            label: STR("Short label, e.g. 'International'."),
+            description: STR("What this option is."),
+            code: STR("Stable code, unique per option, e.g. 'international-packlink-Y49EF4ZP'."),
+          },
+          ["label", "code"]
+        ),
+        type_id: STR("Reuse an existing shipping option type instead of creating one. Exactly one of `type` / `type_id`."),
+        prices: {
+          type: "array",
+          description:
+            "Price rows — REQUIRED by the validator; send `[]` for a calculated option. Each row is either { currency_code, amount } or { region_id, amount }, optionally with `rules` (free-shipping bands: only `item_total` is a legal attribute and its `value` is a NUMBER).",
+          items: {
+            type: "object",
+            properties: {
+              currency_code: STR("Lower-case 3-letter code, e.g. 'gbp'. Mutually exclusive with region_id."),
+              region_id: STR("Region id. Mutually exclusive with currency_code."),
+              amount: { type: "number", description: "Amount in the currency's own units, as the admin UI shows it." },
+              rules: {
+                type: "array",
+                description: "Bands, e.g. free shipping between two basket totals.",
+                items: obj(
+                  {
+                    attribute: { type: "string", enum: ["item_total"], description: "Only 'item_total' is accepted." },
+                    operator: { type: "string", description: "gte | lte | gt | lt | eq." },
+                    value: { type: "number", description: "A NUMBER, not a string." },
+                  },
+                  ["attribute", "operator", "value"]
+                ),
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+        rules: {
+          type: "array",
+          description:
+            "Who the option is offered to. `{ attribute: 'enabled_in_store', operator: 'eq', value: 'true' }` makes it visible in a cart; 'false' hides it from every cart while leaving it quotable. Values are STRINGS even when they read as booleans or currencies.",
+          items: obj(
+            {
+              attribute: STR("Context key, e.g. 'enabled_in_store', 'is_return', 'cart_currency_code'."),
+              operator: STR("eq | ne | in | nin | gt | gte | lt | lte."),
+              value: {
+                description: "A string, or an array of strings for `in`/`nin`.",
+                anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+              },
+            },
+            ["attribute", "operator", "value"]
+          ),
+        },
+        data: {
+          type: "object",
+          additionalProperties: true,
+          description:
+            "Provider-specific settings, handed to the provider verbatim on every quote — e.g. Packlink's parcel defaults (`default_weight_kg`, `default_length_cm`, …) and `flat_fallback_amounts`. This is how one option differs from another on the SAME provider.",
+        },
+        metadata: { type: "object", additionalProperties: true },
+      },
+      ["name", "service_zone_id", "shipping_profile_id", "provider_id", "price_type", "prices"]
+    ),
+    sideEffects:
+      "A store-enabled option is offered at checkout immediately. If its provider cannot createFulfillment, orders that pick it cannot be fulfilled from the admin — check before enabling one.",
+    nextSteps: ["list_shipping_options", "update_shipping_option"],
+  },
+  {
+    name: "update_shipping_option",
+    description:
+      "Amend an existing shipping option — its name, provider, price type, provider `data`, prices or rules. Sensitive: requires confirm:true. 🔴🔴 `prices` REPLACES THE WHOLE SET. A row you leave out is DELETED, not left alone — the same shape as a variant price save that hard-deleted 11 rows. So to change ONE currency, read the option with list_shipping_options first and re-send EVERY price you intend to keep, each with its `id`, including the free-shipping bands and their `rules`. Omit `prices` entirely and the set is untouched; that is the safe call when you only mean to rename or repoint something. 🔑 `rules` behaves the same way, so omit it unless you mean to rewrite the rule set. ⚠️ Removing a currency's price row does not disable the option — it makes it unofferable in THAT currency only, which is exactly how you hand a lane over to a calculated option without touching the others.",
+    method: "POST",
+    path: "/admin/shipping-options/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/shipping-options/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "provider_id",
+      "shipping_profile_id",
+      "price_type",
+      "type",
+      "type_id",
+      "prices",
+      "rules",
+      "data",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Shipping option id, e.g. 'so_...'."),
+        name: STR("New name shown at checkout."),
+        provider_id: STR("Repoint at a different fulfillment provider."),
+        shipping_profile_id: STR("Move to a different shipping profile."),
+        price_type: {
+          type: "string",
+          enum: ["flat", "calculated"],
+          description:
+            "⚠️ Turning a flat option calculated makes its price rows meaningless — including any free-shipping bands, which then simply stop applying. Usually you want a SECOND, calculated option instead.",
+        },
+        type: obj(
+          {
+            label: STR("Short label."),
+            description: STR("What this option is."),
+            code: STR("Stable code."),
+          },
+          ["label", "code"]
+        ),
+        type_id: STR("Reuse an existing type. Only one of `type` / `type_id`."),
+        prices: {
+          type: "array",
+          description:
+            "🔴 THE REPLACEMENT SET, not a patch. Re-send every row you are keeping WITH its `id` (and its `rules`, which are likewise replaced per row). Omit the field to leave prices alone.",
+          items: {
+            type: "object",
+            properties: {
+              id: STR("Existing price row id — carry it to keep that row rather than mint a new one."),
+              currency_code: STR("Lower-case 3-letter code."),
+              region_id: STR("Region id. Mutually exclusive with currency_code."),
+              amount: { type: "number", description: "Amount in the currency's own units." },
+              rules: {
+                type: "array",
+                description: "Bands for this row. Only `item_total`, and `value` is a NUMBER.",
+                items: obj(
+                  {
+                    attribute: { type: "string", enum: ["item_total"], description: "Only 'item_total' is accepted." },
+                    operator: STR("gte | lte | gt | lt | eq."),
+                    value: { type: "number", description: "A NUMBER, not a string." },
+                  },
+                  ["attribute", "operator", "value"]
+                ),
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+        rules: {
+          type: "array",
+          description:
+            "The replacement rule set. Carry each existing rule's `id` to keep it. Omit the field to leave rules alone.",
+          items: obj(
+            {
+              id: STR("Existing rule id — omit to create a new rule."),
+              attribute: STR("Context key, e.g. 'enabled_in_store', 'cart_currency_code'."),
+              operator: STR("eq | ne | in | nin | gt | gte | lt | lte."),
+              value: {
+                description: "A string, or an array of strings for `in`/`nin`.",
+                anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+              },
+            },
+            ["attribute", "operator", "value"]
+          ),
+        },
+        data: {
+          type: "object",
+          additionalProperties: true,
+          description: "Provider settings, replaced wholesale — re-send the keys you are keeping.",
+        },
+        metadata: { type: "object", additionalProperties: true },
+      },
+      ["id"]
+    ),
+    sideEffects:
+      "Takes effect on the next cart that lists options. Dropping a price row makes the option unofferable in that currency; existing orders are unaffected.",
+    nextSteps: ["list_shipping_options"],
+  },
   {
     name: "list_shipping_profiles",
     description:

--- a/apps/backend/src/lib/mcp-core/__tests__/product-tool-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/product-tool-field-coverage.unit.spec.ts
@@ -42,12 +42,31 @@ const { UpdateProduct, UpdateProductVariant, CreateProductVariant } =
  * the tool unbound there. This spec binds it directly instead.
  */
 const { AdminLinkProductOptions } = coreProductValidators
+/**
+ * The shipping-option validators, likewise registered by core's own middleware
+ * config rather than this repo's. Bound here for the same reason as the batch
+ * route above: `route-validator-field-coverage` can only say "core owns this
+ * one", and a write tool nobody checks against its contract is how `weight`
+ * went missing from a third of a catalogue.
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const coreShippingOptionValidators = require("@medusajs/medusa/api/admin/shipping-options/validators")
+const { AdminCreateShippingOption, AdminUpdateShippingOption } =
+  coreShippingOptionValidators
 
 import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
 import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
 import type { McpToolDef } from "../types"
 
-/** Keys a zod object validator accepts. */
+/**
+ * Keys a zod object validator accepts.
+ *
+ * ⚠️ Both shipping-option validators are `.refine()`d — "exactly one of `type`
+ * / `type_id`" — and on THIS zod that still yields a ZodObject with a populated
+ * `.shape` (checked: 11 keys). On a zod where `.refine()` wraps the object, it
+ * would not, and every assertion below would pass over an empty set instead.
+ * The `minFields` sanity floor is what catches that, not this function.
+ */
 const acceptedKeys = (schema: any): string[] =>
   Object.keys(schema?.shape ?? schema?._def?.shape?.() ?? {})
 
@@ -178,6 +197,18 @@ const CASES: Array<{
     validator: AdminLinkProductOptions,
     what: "the batch route is the only one core exposes for editing an option's values (#1907)",
     minFields: 3,
+  },
+  {
+    key: "admin:create_shipping_option",
+    tool: findTool(ADMIN_MCP_TOOLS, "create_shipping_option"),
+    validator: AdminCreateShippingOption,
+    what: "core route, core validator — and a .strict() one, so a stray field is a 400 on every call",
+  },
+  {
+    key: "admin:update_shipping_option",
+    tool: findTool(ADMIN_MCP_TOOLS, "update_shipping_option"),
+    validator: AdminUpdateShippingOption,
+    what: "core route, core validator",
   },
 ]
 

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -69,6 +69,17 @@ import { buildToolInputSchema } from "../schema"
  */
 const NO_ROUTE_VALIDATOR = new Set<string>([
   /**
+   * Both wrap CORE shipping-option routes, whose validators core registers in
+   * its own middleware config — so nothing in this repo's `middlewares.ts`
+   * binds them and there is nothing here to match against. Not unchecked: the
+   * contract check for these two lives in
+   * `product-tool-field-coverage.unit.spec.ts`, which imports
+   * `AdminCreateShippingOption` / `AdminUpdateShippingOption` directly and
+   * asserts field coverage in both directions.
+   */
+  "admin:create_shipping_option",
+  "admin:update_shipping_option",
+  /**
    * The revoke route takes NO body — it works entirely off the `:id` in the
    * path. Nothing to bind, and nothing advertised: the tool declares no
    * `bodyParams`, because a field the route never reads would be accepted,

--- a/apps/backend/src/workflows/hooks/__tests__/shipping-options-currency-context.unit.spec.ts
+++ b/apps/backend/src/workflows/hooks/__tests__/shipping-options-currency-context.unit.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * The shipping-options rule context must carry the cart's currency.
+ *
+ * A calculated option has no price rows, so nothing confines it to a lane the
+ * way a missing flat price confines a flat option. A `cart_currency_code` rule
+ * is the only gate — and a rule naming a key the context does not publish does
+ * not error, it simply matches nothing, on every cart, forever. So the one
+ * thing worth asserting is that the key is REALLY in the returned context, and
+ * on every branch the hook can take.
+ */
+jest.mock("@medusajs/medusa/core-flows", () => ({
+  listShippingOptionsForCartWorkflow: { hooks: { setShippingOptionsContext: jest.fn() } },
+  listShippingOptionsForCartWithPricingWorkflow: {
+    hooks: { setShippingOptionsContext: jest.fn() },
+  },
+}))
+
+import {
+  listShippingOptionsForCartWorkflow,
+  listShippingOptionsForCartWithPricingWorkflow,
+} from "@medusajs/medusa/core-flows"
+
+import "../quote-shipping-options-context"
+
+/** The handler both workflows were registered with. */
+const handler = (): any =>
+  (listShippingOptionsForCartWorkflow.hooks.setShippingOptionsContext as jest.Mock)
+    .mock.calls[0][0]
+
+/**
+ * The hook returns a `StepResponse`; core reads the value through
+ * `getResult()`, which is the `output` side of it. Reading the wrong side is
+ * how this file's subject once threw its own answer away.
+ */
+const run = async (
+  cart: any,
+  container: any = { resolve: () => ({ listPartnerQuotes: async () => [] }) }
+) => {
+  const res: any = await handler()({ cart }, { container })
+  return res?.output ?? res
+}
+
+describe("setShippingOptionsContext — cart_currency_code", () => {
+  it("registers on BOTH list workflows", () => {
+    // Wiring only one produces a cart that can be shown an option and is then
+    // told the option is invalid.
+    expect(
+      listShippingOptionsForCartWorkflow.hooks.setShippingOptionsContext
+    ).toHaveBeenCalled()
+    expect(
+      listShippingOptionsForCartWithPricingWorkflow.hooks.setShippingOptionsContext
+    ).toHaveBeenCalled()
+  })
+
+  it("publishes the cart's currency, lower-cased", async () => {
+    const out = await run({ id: "cart_1", currency_code: "GBP" })
+    expect(out.cart_currency_code).toBe("gbp")
+  })
+
+  it("still publishes the currency when the quote lookup THROWS", async () => {
+    // A failed quote lookup says nothing about the currency. Dropping the key
+    // here would hide every currency-gated option on an unrelated error.
+    const container = {
+      resolve: () => ({
+        listPartnerQuotes: async () => {
+          throw new Error("db gone")
+        },
+      }),
+    }
+    const out = await run({ id: "cart_1", currency_code: "aed" }, container)
+    expect(out.cart_currency_code).toBe("aed")
+    expect(out.quote_id).toBe("none")
+  })
+
+  it("publishes the currency even with no cart id", async () => {
+    const out = await run({ currency_code: "cad" })
+    expect(out.cart_currency_code).toBe("cad")
+  })
+
+  it("falls back to 'none' rather than omitting the key", async () => {
+    // An ABSENT key and a key that matches nothing are different failures: an
+    // absent one is stringified to "undefined" and would make a `ne` rule
+    // match; "none" is simply a currency that does not exist.
+    const out = await run({ id: "cart_1" })
+    expect(out.cart_currency_code).toBe("none")
+  })
+
+  it("still resolves the quote id — the currency did not displace it", async () => {
+    const container = {
+      resolve: () => ({ listPartnerQuotes: async () => [{ id: "quo_7" }] }),
+    }
+    const out = await run({ id: "cart_1", currency_code: "eur" }, container)
+    expect(out).toEqual({ quote_id: "quo_7", cart_currency_code: "eur" })
+  })
+})

--- a/apps/backend/src/workflows/hooks/quote-shipping-options-context.ts
+++ b/apps/backend/src/workflows/hooks/quote-shipping-options-context.ts
@@ -77,13 +77,54 @@ import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
  * plain variant backs the storefront's option list. Wiring only one produces a
  * cart that can be given the option and is then told the option is invalid.
  */
+/**
+ * The cart's currency, as a rule-matchable context key.
+ *
+ * ## Why core cannot already do this
+ *
+ * `currency_code` reaches core's shipping-option listing twice, and only one of
+ * them is the one a rule reads. It is in `calculated_price.context`, where it
+ * picks WHICH price applies, and it is absent from the `context` object that
+ * `isContextValid` matches rules against — that one carries `is_return`,
+ * `enabled_in_store` and whatever this hook returns, and nothing else. So a
+ * rule `currency_code eq gbp` on a stock Medusa matches nothing, everywhere.
+ *
+ * ## Why a calculated option needs it
+ *
+ * A FLAT option is confined to the currencies it has price rows for: no row,
+ * no offer. A CALCULATED option has no price rows at all — that is the point —
+ * so nothing confines it, and it is offered in every currency the zone reaches
+ * the moment it exists. A rule is the only gate there is.
+ *
+ * That matters when the provider behind it can quote but not BOOK. Packlink
+ * rates Le Ciricotte's EU-origin lanes and throws a named error on
+ * `createFulfillment`; letting it appear on the five lanes that a manual option
+ * already serves would trade a working checkout for an unfulfillable one, to no
+ * gain. `cart_currency_code in [gbp,cad,aed,cny]` keeps it on the four lanes
+ * that had no live quote at all.
+ *
+ * 🔑 Named `cart_currency_code`, not `currency_code`, on purpose: core already
+ * spends the bare name on the pricing context, and one word meaning two things
+ * a few lines apart is how someone later writes the rule that silently matches
+ * nothing.
+ */
+const cartCurrency = (cart: any): string => {
+  // Both list workflows fetch `currency_code` and `validatePresenceOfStep`
+  // requires it, so this is populated on every real cart. The fallback is not
+  // decoration: an absent key excludes the option, and a currency-gated option
+  // that quietly vanishes is the failure this file already documents once.
+  const code = cart?.currency_code
+  return typeof code === "string" && code ? code.toLowerCase() : "none"
+}
+
 const setQuoteShippingContext = async (
   { cart }: { cart: any },
   { container }: { container: any }
 ) => {
+  const cart_currency_code = cartCurrency(cart)
   const cartId = cart?.id
   if (!cartId) {
-    return new StepResponse({ quote_id: "none" })
+    return new StepResponse({ quote_id: "none", cart_currency_code })
   }
 
   try {
@@ -95,12 +136,18 @@ const setQuoteShippingContext = async (
     const quoteId = rows?.[0]?.id
     // The literal "none" matters: the rule compares `${contextValue}` against
     // its value, so this is simply a string no quote id can equal.
-    return new StepResponse({ quote_id: quoteId ? String(quoteId) : "none" })
+    return new StepResponse({
+      quote_id: quoteId ? String(quoteId) : "none",
+      cart_currency_code,
+    })
   } catch {
     // Shipping options must not 500 because a lookup failed. Falling back to
     // "none" hides the quote option, which fails toward showing the buyer
     // fewer options rather than toward offering someone else's freight.
-    return new StepResponse({ quote_id: "none" })
+    // The currency still goes out: it is read off the cart, so a quote lookup
+    // that failed says nothing about it, and dropping it here would hide every
+    // currency-gated option on an unrelated error.
+    return new StepResponse({ quote_id: "none", cart_currency_code })
   }
 }
 


### PR DESCRIPTION
Le Ciricotte's four newest lanes — GB, CA, AE, CN — are priced by hand, and
three of the four sell shipping below cost: **CA −€1.98, CN −€8.30, AE −€52.27
per parcel** against live Packlink quotes. The provider that can quote them
shipped in #2005 and reached prod in #2007. Nothing then connected the two,
because there was **no way to write a shipping option from here**: no MCP tool
wrapped either route, and an authenticated curl at prod is refused by the
permission classifier. This is that missing path, plus the one core gap that
makes a calculated option safe to turn on.

## 1. Two shipping-option write tools

`create_shipping_option` and `update_shipping_option`, wrapping
`POST /admin/shipping-options` and `POST /admin/shipping-options/:id`.

The prose carries the two things that bite:

- **`prices` REPLACES the whole set.** A row left out is deleted, not left
  alone — the same shape as the variant price save that hard-deleted 11 rows.
  The option this PR exists to amend carries 14 rows including **five
  free-shipping bands**, so the tool says outright: re-send every keeper with
  its `id`, or omit `prices` entirely.
- **`prices` is required even when it is meaningless.** The validator demands
  the key for a `calculated` option; the answer is `[]`.

## 2. `cart_currency_code` in the shipping-options rule context

The asymmetry that makes this necessary: a **flat** option is confined to the
currencies it has price rows for — no row, no offer. A **calculated** option has
no price rows at all, so nothing confines it, and it is offered in every
currency its zone reaches the moment it exists.

Core cannot gate that today. `currency_code` reaches the listing twice and only
one of them is the one a rule reads: it is in `calculated_price.context`, where
it picks which price applies, and it is **absent** from the `context` object
`isContextValid` matches rules against — that one carries `is_return`,
`enabled_in_store` and whatever `setShippingOptionsContext` returns, full stop.
So `currency_code eq gbp` on a stock Medusa matches nothing, everywhere, and
says nothing while doing it.

The hook now publishes `cart_currency_code`. Deliberately not the bare name:
core already spends that on the pricing context a few lines away, and one word
meaning two things is how someone later writes the rule that silently matches
nothing.

### Why the gate earns its keep

Packlink **quotes but cannot book** — `createFulfillment` throws a named error;
label booking is the next slice. Letting it appear on the five lanes a manual
option already serves would trade a working checkout for an unfulfillable order,
for nothing. And core's `calculateShippingOptionsPricesStep` has no try/catch:
a provider that throws takes down the **entire option list** for that cart, not
just its own row. The currency rule bounds that blast radius to the four lanes
that have no live quote at all today.

## Tests

- `shipping-options-currency-context.unit.spec.ts` — 6 tests, covering both
  workflow registrations and every branch the hook can take, including the
  `catch`: a failed quote lookup says nothing about the currency, so dropping
  the key there would hide every currency-gated option on an unrelated error.
  **Mutation-checked**: removing `cart_currency_code` from the success path
  turns 3 of the 6 red.
- The existing `registry-routes-exist` guard covers both new tools —
  **mutation-checked** by pointing one at `/admin/shipping-options-bogus` and
  watching it fail with the tool named.
- Full MCP registry suite: 19 suites / 285 tests green. Slice and tier
  classification are inherited: `/admin/shipping-options` already maps to
  `catalog`, and the tier derives from `sensitive: true`.

## What this PR does NOT do

It changes no production data. The prod write needs these tools deployed and a
fresh session (the MCP tool list loads at session start), and the recipe is in
the issue. Packlink label booking remains unimplemented.

---

## The prod write this unblocks (needs these tools deployed + a fresh session)

Service zone `serzo_01KXBTAPP5EWCMVAPP12F3SD52` ("International Zone
(Y49EF4ZP)"), Le Ciricotte. All four lanes have **zero orders** today
(GB/CA/AE/CN regions were created 2026-09-11), so the switch is reversible with
nothing in flight.

**1 — create the calculated option**

```json
{
  "name": "International (Packlink)",
  "service_zone_id": "serzo_01KXBTAPP5EWCMVAPP12F3SD52",
  "shipping_profile_id": "sp_01JNQG1MNPH0Z8E0S6EQVJM593",
  "provider_id": "packlink_packlink",
  "price_type": "calculated",
  "prices": [],
  "type": {
    "label": "International",
    "description": "Live carrier rates from Italy (Packlink)",
    "code": "international-packlink-Y49EF4ZP"
  },
  "rules": [
    { "attribute": "enabled_in_store", "operator": "eq", "value": "true" },
    { "attribute": "is_return", "operator": "eq", "value": "false" },
    { "attribute": "cart_currency_code", "operator": "in",
      "value": ["gbp", "cad", "aed", "cny"] }
  ],
  "data": {
    "default_weight_kg": 1,
    "default_length_cm": 30,
    "default_width_cm": 25,
    "default_height_cm": 10,
    "flat_fallback_amounts": { "gbp": 26, "cad": 55, "aed": 380, "cny": 325 }
  }
}
```

**2 — strip the four loss-making rows** from `so_01KXBTAPSYKX3K6R5VH8ZQ4TTT`,
re-sending the other **ten** with their ids: `inr 3200`, `eur 35`, `usd 39`,
`idr 550000`, `aud 55`, and the five `0` bands (inr 25000-30000, eur 300-360,
usd 350-420, idr 5000000-6000000, aud 450-540). Omit `rules`.

### ⚠️ The fallback figures are mine, not the founder's

`flat_fallback_amounts` is **not optional**: core's
`calculateShippingOptionsPricesStep` has no try/catch, so a provider that throws
takes down the whole option list for that cart, and the provider throws when it
cannot quote and has no fallback. A Packlink timeout would mean "no shipping
available" at checkout.

The numbers above are derived, not chosen: live cheapest × the 1.2 margin,
converted at the FX the option's own existing rows imply (every one of them set
relative to €35 — gbp 0.743, cad 1.371, aed 3.657, cny 6.686), then rounded up,
because a fallback fires exactly when we are blind.

| lane | live cheapest | × 1.2 | implied local | set |
|---|---:|---:|---:|---:|
| GB | €18.19 | €21.83 | £16.22 | **26** (kept — the existing number is already profitable) |
| CA | €31.83 | €38.20 | C$52.36 | **55** |
| AE | €82.32 | €98.78 | AED 361 | **380** |
| CN | €38.33 | €46.00 | ¥307 | **325** |

Overwrite them with real numbers if these are wrong — they are the price a buyer
pays whenever Packlink cannot answer.

### 🔴 Packlink still cannot book a label

`createFulfillment` throws a named error. With zero orders on these lanes the
gap is theoretical today, but the FIRST order that picks this option cannot be
fulfilled from the admin: core takes the provider from the order's shipping
method and there is no picker. Label booking is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
