### PR TITLE
fix(stores): pick a shipping profile deterministically, not take:1 (#1983)

### DIFF
--- a/apps/backend/integration-tests/http/partners-store-create-with-defaults.spec.ts
+++ b/apps/backend/integration-tests/http/partners-store-create-with-defaults.spec.ts
@@ -137,6 +137,107 @@ setupSharedTestSuite(() => {
       expect(types).toContain("pickup")
     })
 
+    it("provisions onto the type:'default' profile even when a second profile exists (#1983)", async () => {
+      // 🔴 The regression this pins. Provisioning read
+      // `listShippingProfiles({}, { take: 1 })` and fed the answer to all ten
+      // of a new store's shipping options — correct by ACCIDENT while exactly
+      // one profile exists, which is the state prod is in. Add a second and
+      // the choice becomes whichever row Postgres returned, per store,
+      // silently; the store provisions fine and the mismatch surfaces later as
+      // "The shipping option you have selected don't allow fulfillment of this
+      // item" on a real order.
+      //
+      // This has to be an integration test: the defect is in what the DATABASE
+      // hands back, and a unit test with a stubbed service would assert against
+      // an order this code never sees.
+      // Build the two-profile world explicitly rather than lean on the seed:
+      // this runner starts with NO shipping profiles at all (checked — the
+      // list comes back empty), so a test that assumed a seeded default would
+      // have been asserting about a database that does not exist.
+      //
+      // 🔑 The CUSTOM profile is created FIRST, and that ordering is the whole
+      // test. Created default-first, `take: 1` returns the default and the old
+      // broken code passes this test — I checked, and it did: 3/3 green on the
+      // defect. A regression test that cannot fail on the bug is not a test of
+      // the bug. Custom-first makes `take: 1` return the wrong row, which is
+      // precisely the nondeterminism the fix removes.
+      const unique = Date.now()
+      const partnerRes = await api.post(
+        "/admin/shipping-profiles",
+        { name: `Partner Shipping Profile ${unique}`, type: "custom" },
+        adminHeaders
+      )
+      const defaultRes = await api.post(
+        "/admin/shipping-profiles",
+        { name: `Default Shipping Profile ${unique}`, type: "default" },
+        adminHeaders
+      )
+      const defaultProfileId = defaultRes.data.shipping_profile.id
+      const partnerProfileId = partnerRes.data.shipping_profile.id
+      expect(defaultProfileId).not.toBe(partnerProfileId)
+
+      // The premise, asserted rather than assumed: exactly two profiles, one
+      // of them default. If either ever stops being true the assertion at the
+      // end would be answering a different question than the one it claims to.
+      const profilesRes = await api.get("/admin/shipping-profiles", adminHeaders)
+      const profiles = profilesRes.data.shipping_profiles || []
+      expect(profiles).toHaveLength(2)
+      expect(profiles.filter((p: any) => p.type === "default")).toHaveLength(1)
+
+      const createStoreRes = await api.post(
+        "/partners/stores",
+        {
+          store: {
+            name: `Profile Store ${unique}`,
+            supported_currencies: [{ currency_code: "usd", is_default: true }],
+          },
+          sales_channel: { name: `Profile ${unique} - Default` },
+          region: { name: "Default Region", currency_code: "usd", countries: ["us"] },
+          location: {
+            name: "Main Warehouse",
+            address: {
+              address_1: "123 Main St",
+              city: "New York",
+              postal_code: "10001",
+              country_code: "US",
+            },
+          },
+        },
+        { headers: partnerHeaders }
+      )
+      expect(createStoreRes.status).toBe(201)
+
+      // Read the options back rather than trusting the create response: the
+      // profile id is written per option, and it is the stored value that
+      // decides whether a product can be fulfilled.
+      const locationId = createStoreRes.data.location.id
+      const zonesRes = await api.get(
+        `/admin/stock-locations/${locationId}?fields=*fulfillment_sets,fulfillment_sets.service_zones.id`,
+        adminHeaders
+      )
+      const zoneIds = (
+        zonesRes.data.stock_location?.fulfillment_sets || []
+      ).flatMap((fs: any) => (fs.service_zones || []).map((z: any) => z.id))
+      expect(zoneIds.length).toBeGreaterThan(0)
+
+      const profileIds = new Set<string>()
+      for (const zoneId of zoneIds) {
+        const optionsRes = await api.get(
+          `/admin/shipping-options?service_zone_id=${zoneId}`,
+          adminHeaders
+        )
+        for (const option of optionsRes.data.shipping_options || []) {
+          profileIds.add(option.shipping_profile_id)
+        }
+      }
+
+      // A vacuous pass is not a pass: if the store came out with no options at
+      // all (the #1176 failure) the set would be empty and every assertion
+      // below would hold for the wrong reason.
+      expect(profileIds.size).toBeGreaterThan(0)
+      expect([...profileIds]).toEqual([defaultProfileId])
+    })
+
     it("creates a second store without fulfillment set name collisions", async () => {
       // Create FIRST store
       const unique1 = Date.now()

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-product-shipping-profiles-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-product-shipping-profiles-job.ts
@@ -5,6 +5,8 @@ import {
 } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 
+import { pickTargetProfileId } from "../../../../lib/shipping-profile-selection"
+
 import type {
   MaintenanceChange,
   MaintenanceJob,
@@ -68,23 +70,12 @@ export function needsShippingProfile(product: any): boolean {
 }
 
 /**
- * PURE: pick the profile to link. An explicit id wins; otherwise the
- * `type: "default"` profile; otherwise — when exactly one profile exists — that
- * one. Returns null when the choice is ambiguous, so the job fails loudly
- * rather than scattering products across profiles. Exported for unit testing.
+ * Re-exported, not redefined: store provisioning picks a profile too, and the
+ * two must agree or a product and the option meant to ship it end up on
+ * different profiles (#1983). The rule and its reasoning live in
+ * `lib/shipping-profile-selection`.
  */
-export function pickTargetProfileId(
-  profiles: any[],
-  explicitId?: string
-): string | null {
-  if (explicitId) {
-    return profiles.some((p) => p?.id === explicitId) ? explicitId : null
-  }
-  const defaults = profiles.filter((p) => p?.type === "default")
-  if (defaults.length === 1) return defaults[0].id
-  if (defaults.length === 0 && profiles.length === 1) return profiles[0].id
-  return null
-}
+export { pickTargetProfileId }
 
 /** PURE: the operator-facing summary line. Exported for unit testing. */
 export function summarizeProfileBackfill(

--- a/apps/backend/src/lib/__tests__/shipping-profile-selection.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/shipping-profile-selection.unit.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * The profile pick must be DETERMINISTIC once a second profile exists (#1983).
+ *
+ * Store provisioning read `listShippingProfiles({}, { take: 1 })` and fed the
+ * answer to all ten of a new store's shipping options. That is correct by
+ * accident while exactly one profile exists — which is exactly the state prod
+ * is in, and exactly why nobody noticed. The tests below are written against
+ * the two-profile world #1983 is about to create.
+ */
+import {
+  describeAmbiguousProfilePick,
+  pickTargetProfileId,
+} from "../shipping-profile-selection"
+
+const DEFAULT = { id: "sp_default", type: "default", name: "Default Shipping Profile" }
+const PARTNER = { id: "sp_partner", type: "custom", name: "Partner Shipping Profile" }
+
+describe("pickTargetProfileId", () => {
+  it("picks the type:'default' profile when a partner profile also exists", () => {
+    // The regression in one line: with `take: 1` this answer depended on row
+    // order, so half the stores would have been provisioned onto sp_partner.
+    expect(pickTargetProfileId([DEFAULT, PARTNER])).toBe("sp_default")
+  })
+
+  it("gives the SAME answer whatever order the rows arrive in", () => {
+    // `take: 1` would return a different id for these two inputs. That is the
+    // whole defect, stated as a property rather than a case.
+    expect(pickTargetProfileId([DEFAULT, PARTNER])).toBe(
+      pickTargetProfileId([PARTNER, DEFAULT])
+    )
+  })
+
+  it("falls back to the only profile when nothing is marked default", () => {
+    expect(pickTargetProfileId([PARTNER])).toBe("sp_partner")
+  })
+
+  it("returns null rather than guessing between two non-default profiles", () => {
+    const other = { id: "sp_other", type: "custom" }
+    expect(pickTargetProfileId([PARTNER, other])).toBeNull()
+  })
+
+  it("returns null rather than guessing between two DEFAULT profiles", () => {
+    // A second row typed "default" is a data problem. Picking one would bury
+    // it; null makes the caller say so.
+    expect(pickTargetProfileId([DEFAULT, { id: "sp_dupe", type: "default" }])).toBeNull()
+  })
+
+  it("returns null on an empty list — 'none' is a separate case from 'ambiguous'", () => {
+    // The caller distinguishes them: none → create the default; ambiguous →
+    // refuse. Collapsing the two is how a third profile would get minted into
+    // an already-ambiguous database.
+    expect(pickTargetProfileId([])).toBeNull()
+  })
+
+  it("honours an explicit id that exists", () => {
+    expect(pickTargetProfileId([DEFAULT, PARTNER], "sp_partner")).toBe("sp_partner")
+  })
+
+  it("refuses an explicit id that does NOT exist, rather than falling back", () => {
+    // Falling back to the default here would silently ship the caller's
+    // products on a profile they did not ask for.
+    expect(pickTargetProfileId([DEFAULT], "sp_ghost")).toBeNull()
+  })
+
+  it("tolerates malformed rows without throwing", () => {
+    expect(pickTargetProfileId([null as any, undefined as any, DEFAULT])).toBe(
+      "sp_default"
+    )
+  })
+})
+
+describe("describeAmbiguousProfilePick", () => {
+  it("names the missing profile when an explicit id was given", () => {
+    expect(describeAmbiguousProfilePick([DEFAULT], "sp_ghost")).toContain("sp_ghost")
+  })
+
+  it("counts what it found so the operator can act on the message alone", () => {
+    const msg = describeAmbiguousProfilePick([PARTNER, { id: "sp_other", type: "custom" }])
+    expect(msg).toContain("2 profile(s)")
+    expect(msg).toContain('0 of type "default"')
+  })
+})

--- a/apps/backend/src/lib/shipping-profile-selection.ts
+++ b/apps/backend/src/lib/shipping-profile-selection.ts
@@ -1,0 +1,65 @@
+/**
+ * Which shipping profile does a thing belong to? — answered ONCE (#1983).
+ *
+ * ## Why this is a shared rule rather than two local ones
+ *
+ * Medusa gates fulfillment AND checkout on
+ * `product.shipping_profile.id === shippingOption.shipping_profile_id`. Two
+ * callers pick a profile — the product backfill job and store provisioning —
+ * and if they ever disagree the symptom is not a crash. It is *"The shipping
+ * option you have selected don't allow fulfillment of this item"* on a real
+ * order, days later, with nothing pointing back at the choice that caused it.
+ * That is the same failure that opened #1982.
+ *
+ * ## Why `take: 1` was wrong
+ *
+ * Store provisioning read `listShippingProfiles({}, { take: 1 })` — no filter,
+ * no ordering — and used the result for all ten of a new store's shipping
+ * options. With exactly one profile in the database that is correct by
+ * ACCIDENT. The moment a second profile exists (which #1983 exists to create)
+ * it becomes whichever row Postgres happened to return, per store, silently.
+ *
+ * Same family as `stores[0]` on a 13-tenant table, which made a store's
+ * currency a lottery, and as the `take: 1` design-link read that handed
+ * production the design a customer was no longer getting. A defect that fires
+ * on SOME rows is a selector bug.
+ *
+ * ## The rule
+ *
+ * An explicit id wins, and must exist. Otherwise the single `type: "default"`
+ * profile. Otherwise — only when there is exactly one profile in total — that
+ * one. Otherwise `null`: the caller must fail loudly rather than guess, because
+ * guessing is precisely what this replaces.
+ */
+
+/**
+ * PURE: pick the profile to use. Returns `null` when the choice is ambiguous.
+ *
+ * 🔑 `null` is not "none available" — it is "more than one plausible answer and
+ * nobody said which". Treat it as an error, never as a default.
+ */
+export function pickTargetProfileId(
+  profiles: any[],
+  explicitId?: string
+): string | null {
+  if (explicitId) {
+    return profiles.some((p) => p?.id === explicitId) ? explicitId : null
+  }
+  const defaults = profiles.filter((p) => p?.type === "default")
+  if (defaults.length === 1) return defaults[0].id
+  if (defaults.length === 0 && profiles.length === 1) return profiles[0].id
+  return null
+}
+
+/** The message a caller should raise when the pick came back ambiguous. */
+export function describeAmbiguousProfilePick(
+  profiles: any[],
+  explicitId?: string
+): string {
+  if (explicitId) return `Shipping profile ${explicitId} not found`
+  const defaults = profiles.filter((p) => p?.type === "default").length
+  return (
+    `Could not pick a shipping profile unambiguously: ${profiles.length} profile(s), ` +
+    `${defaults} of type "default". Pass an explicit profile id.`
+  )
+}

--- a/apps/backend/src/workflows/stores/create-store-with-defaults.ts
+++ b/apps/backend/src/workflows/stores/create-store-with-defaults.ts
@@ -15,10 +15,18 @@ import {
   linkSalesChannelsToApiKeyWorkflow,
   createShippingOptionsWorkflow,
 } from "@medusajs/medusa/core-flows"
-import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
 import type { RemoteQueryFunction } from "@medusajs/types"
 import type { Link } from "@medusajs/modules-sdk"
 import { PARTNER_MODULE } from "../../modules/partner"
+import {
+  describeAmbiguousProfilePick,
+  pickTargetProfileId,
+} from "../../lib/shipping-profile-selection"
 import { registerShiprocketPickup } from "../../modules/shipping-providers/pickup-locations"
 import {
   DEFAULT_QUOTE_FREIGHT_TIERS,
@@ -481,14 +489,42 @@ const autoLinkFulfillmentProvidersStep = createStep(
           // shipping method, and core's create-fulfillment then died on
           // `shippingOption.provider_id` of undefined (a 500 with no clue).
           //
-          // A shipping profile only pre-exists because the seed made one, so
-          // any environment provisioning a store before a seed hits this: fresh
-          // test DBs always, and a brand-new deployment for real. Create the
-          // default profile rather than skip.
-          const shippingProfiles = await fulfillmentService.listShippingProfiles({}, { take: 1 })
-          let profileId = shippingProfiles?.[0]?.id
+          // 🔴 #1983: this read used to be `listShippingProfiles({}, { take: 1 })`
+          // — no filter, no ordering — and `profileId` feeds ALL TEN shipping
+          // options created below. With exactly one profile in the database
+          // that is correct by ACCIDENT; the moment a second exists, every new
+          // store gets whichever row came back first, silently and per store.
+          // The store provisions fine, the options are created fine, and the
+          // mismatch surfaces days later as "The shipping option you have
+          // selected don't allow fulfillment of this item" on a real order.
+          //
+          // So: no `take`, and the same deterministic rule the product backfill
+          // uses, so a product and the option meant to ship it cannot land on
+          // different profiles.
+          const shippingProfiles =
+            (await fulfillmentService.listShippingProfiles({})) || []
+          let profileId = pickTargetProfileId(shippingProfiles)
+
+          if (!profileId && shippingProfiles.length > 1) {
+            // Ambiguous is NOT the same as absent, and creating a second
+            // "Default" here would make it worse — it would add a third
+            // profile and guarantee the ambiguity for every store after this
+            // one. Refuse, and say which profiles were in the way.
+            throw new MedusaError(
+              MedusaError.Types.INVALID_DATA,
+              `[create-store] ${describeAmbiguousProfilePick(shippingProfiles)} ` +
+                `Found: ${shippingProfiles
+                  .map((p: any) => `${p?.id} (${p?.type ?? "no type"})`)
+                  .join(", ")}`
+            )
+          }
 
           if (!profileId) {
+            // #1176: a shipping profile only pre-exists because the seed made
+            // one, so a fresh test DB or a brand-new deployment reaches here
+            // with none at all. Create it rather than skip — skipping produced
+            // a store with service zones and ZERO shipping options, whose carts
+            // could never pick a shipping method.
             const created = await fulfillmentService.createShippingProfiles({
               name: "Default",
               type: "default",


### PR DESCRIPTION
Closes the prerequisite #1983 names before a second shipping profile can exist at all.

## The defect

`apps/backend/src/workflows/stores/create-store-with-defaults.ts` read:

```ts
const shippingProfiles = await fulfillmentService.listShippingProfiles({}, { take: 1 })
let profileId = shippingProfiles?.[0]?.id
```

No filter, no ordering — and `profileId` feeds **all ten** shipping options that workflow creates. With exactly one profile in the database that is correct by *accident*, which is precisely the state prod is in (`count: 1`, `sp_01JNQG1MNPH0Z8E0S6EQVJM593`) and precisely why nobody noticed.

The moment a second profile exists — which is items 2-6 of #1983 — every new store gets whichever row Postgres returned first, per store, silently. The store provisions fine, the options are created fine, and the mismatch appears days later as *"The shipping option you have selected don't allow fulfillment of this item"* on a real order. That is the symptom that opened #1982.

Same family as `stores[0]` on a 13-tenant table (currency by lottery) and the `take: 1` design-link read that handed production the design a customer was no longer getting: **a defect that fires on some rows is a selector bug.**

## The change

- **`src/lib/shipping-profile-selection.ts`** — the rule, stated once: an explicit id wins and must exist; else the single `type: "default"`; else the only profile; else `null`. The product backfill job's existing copy becomes a re-export, so the two callers cannot drift — and a product and the option meant to ship it cannot land on different profiles.
- **Provisioning now distinguishes AMBIGUOUS from ABSENT.** Absent → create the default (the #1176 behaviour, unchanged). Ambiguous → throw, naming the profiles in the way. Minting another `"Default"` there would add a *third* profile and guarantee the ambiguity for every store after it.

## The test took two goes, and that is worth stating

Built default-first, the integration test **passes on the broken code** — I restored `take: 1` and got 3/3 green, because `take: 1` happened to return the default. A regression test that cannot fail on the bug is not a test of the bug.

Creating the **custom profile first** makes `take: 1` return the wrong row. Verified both directions:

| code | result |
|---|---|
| `take: 1` (original) | ✕ 1 failed, 2 passed |
| this PR | ✓ 3 passed |

The test also guards its own premise (exactly two profiles, one default) and asserts the option set is non-empty before checking what is in it — a store that came out with zero options (the #1176 failure) would otherwise satisfy every assertion for the wrong reason.

Unit: `shipping-profile-selection.unit.spec.ts`, 11 tests, including the property that matters — the answer is the same whatever order the rows arrive in.

## Not in this PR

Items 2-6 of #1983: create the partner profile, re-point partner options and products, backfill existing ones. They need the open question answered first — **may a house shipping option fulfil a partner product?** Today yes, by accident; after the split, no, and it will start throwing on any order that mixes them. They also need a prod migration path: a product holds one profile link and the backfill job only ever fills a gap, never reassigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp