### PR TITLE
fix(storefront): a cold instance with an unreachable backend no longer 500s (#1993)

### DIFF
--- a/apps/storefront/src/lib/util/__tests__/region-routing.test.ts
+++ b/apps/storefront/src/lib/util/__tests__/region-routing.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  REGION_MAP_UNCONFIGURED,
+  isUnconfiguredRegionsError,
+  pickCountryCode,
+} from "../region-routing"
+
+const mapOf = (...codes: string[]) =>
+  new Map<string, unknown>(codes.map((c) => [c, { id: `reg_${c}` }]))
+
+describe("pickCountryCode — populated map (behaviour must be unchanged)", () => {
+  it("honours an explicit country in the URL", () => {
+    expect(
+      pickCountryCode({
+        urlCountryCode: "gb",
+        regionMap: mapOf("us", "gb"),
+        defaultRegion: "us",
+      })
+    ).toEqual({ countryCode: "gb", degraded: false })
+  })
+
+  it("falls to the Vercel geo header when the URL has no country", () => {
+    expect(
+      pickCountryCode({
+        vercelCountryCode: "gb",
+        regionMap: mapOf("us", "gb"),
+        defaultRegion: "us",
+      }).countryCode
+    ).toBe("gb")
+  })
+
+  it("prefers DEFAULT_REGION over an arbitrary map key", () => {
+    // The ordering that matters: "us" is second in the map, so a first-key
+    // read would answer "gb".
+    expect(
+      pickCountryCode({
+        regionMap: mapOf("gb", "us"),
+        defaultRegion: "us",
+      }).countryCode
+    ).toBe("us")
+  })
+
+  it("ignores a URL country the map does not contain", () => {
+    // A path segment like /products must not be treated as a country.
+    expect(
+      pickCountryCode({
+        urlCountryCode: "products",
+        regionMap: mapOf("us"),
+        defaultRegion: "us",
+      }).countryCode
+    ).toBe("us")
+  })
+
+  it("never reports degraded while the map is populated", () => {
+    expect(
+      pickCountryCode({ regionMap: mapOf("us"), defaultRegion: "us" }).degraded
+    ).toBe(false)
+  })
+})
+
+describe("pickCountryCode — EMPTY map (#1993, the cold-start case)", () => {
+  it("returns DEFAULT_REGION instead of nothing", () => {
+    // Returning undefined is what produced "No valid regions configured" —
+    // a 500 on every route of a cold instance.
+    expect(
+      pickCountryCode({ regionMap: new Map(), defaultRegion: "us" })
+    ).toEqual({ countryCode: "us", degraded: true })
+  })
+
+  it("keeps a buyer on the country they were already on", () => {
+    // A buyer returning to /gb/order/confirmed during an outage should land
+    // where they were, not be bounced to /us.
+    expect(
+      pickCountryCode({
+        urlCountryCode: "gb",
+        regionMap: new Map(),
+        defaultRegion: "us",
+      })
+    ).toEqual({ countryCode: "gb", degraded: true })
+  })
+
+  it("does NOT mistake a path segment for a country code", () => {
+    // 🔑 With no map there is nothing to validate against, so the only test
+    // left is shape. Without it, /products/foo would be rewritten to
+    // /products/products/foo and the buyer's URL becomes nonsense.
+    expect(
+      pickCountryCode({
+        urlCountryCode: "products",
+        regionMap: new Map(),
+        defaultRegion: "us",
+      }).countryCode
+    ).toBe("us")
+  })
+
+  it("uses the Vercel geo header before DEFAULT_REGION", () => {
+    expect(
+      pickCountryCode({
+        vercelCountryCode: "de",
+        regionMap: new Map(),
+        defaultRegion: "us",
+      })
+    ).toEqual({ countryCode: "de", degraded: true })
+  })
+
+  it("reports no country when there is no default either", () => {
+    // The caller still needs to be able to refuse. Inventing a country here
+    // would route every visitor of an unconfigured deploy to a region nobody
+    // chose.
+    expect(
+      pickCountryCode({ regionMap: new Map(), defaultRegion: undefined })
+    ).toEqual({ countryCode: undefined, degraded: true })
+  })
+
+  it("always marks the pick degraded, whichever branch answered", () => {
+    const picks = [
+      pickCountryCode({ urlCountryCode: "gb", regionMap: new Map(), defaultRegion: "us" }),
+      pickCountryCode({ vercelCountryCode: "de", regionMap: new Map(), defaultRegion: "us" }),
+      pickCountryCode({ regionMap: new Map(), defaultRegion: "us" }),
+    ]
+    expect(picks.map((p) => p.degraded)).toEqual([true, true, true])
+  })
+})
+
+describe("isUnconfiguredRegionsError", () => {
+  it("recognises the tagged error", () => {
+    const e = new Error("No regions found.")
+    e.name = REGION_MAP_UNCONFIGURED
+    expect(isUnconfiguredRegionsError(e)).toBe(true)
+  })
+
+  it("does NOT treat an outage as a misconfiguration", () => {
+    // The distinction the whole fix rests on: a dead backend must degrade,
+    // a zero-region backend must stay loud.
+    expect(isUnconfiguredRegionsError(new TypeError("fetch failed"))).toBe(false)
+  })
+
+  it("is not fooled by a matching MESSAGE", () => {
+    // Checked on `name`, which we set, not on prose that gets reworded.
+    expect(isUnconfiguredRegionsError(new Error(REGION_MAP_UNCONFIGURED))).toBe(false)
+  })
+
+  it("tolerates null and undefined", () => {
+    expect(isUnconfiguredRegionsError(null)).toBe(false)
+    expect(isUnconfiguredRegionsError(undefined)).toBe(false)
+  })
+})

--- a/apps/storefront/src/lib/util/region-routing.ts
+++ b/apps/storefront/src/lib/util/region-routing.ts
@@ -1,0 +1,119 @@
+/**
+ * Which country a request routes to — including when the region map is EMPTY
+ * (#1993).
+ *
+ * ## The failure this exists for
+ *
+ * `getRegionMap` fetches `/store/regions` to build a country→region map, and on
+ * failure it rethrew whenever it had no cache to fall back on. A WARM instance
+ * survives on its stale in-process cache; a COLD one — just deployed, just
+ * restarted, or just scaled up — has none, so the rethrow became a **500 on
+ * every single route**. Home, catalogue, checkout, payment links, all of it.
+ *
+ * That is the other half of the #1985 incident. PR #1992 taught the payment
+ * page to tell a buyer the truth — "our side is not responding, your link is
+ * fine" — but that page only renders if middleware lets the request through.
+ * On a cold instance the buyer got a bare 500 and never saw it.
+ *
+ * ## 🔑 The two failures that look identical and must not be treated alike
+ *
+ * - **Unreachable** — the fetch failed, timed out, or answered non-2xx. The
+ *   backend is down or not deployed yet. Nothing about the STOREFRONT is
+ *   wrong, and the honest response is to serve the site and let each page say
+ *   what it cannot load. Degrading here is what makes #1992's work reachable.
+ *
+ * - **Unconfigured** — the backend answered fine and said there are zero
+ *   regions. That is a real misconfiguration in Medusa Admin, by a developer,
+ *   and it should stay LOUD. Degrading it to `DEFAULT_REGION` would route to
+ *   `/us` and render empty pages forever with nobody told why.
+ *
+ * Collapsing the two is the easy mistake: both arrive as "the region map is
+ * empty". They are distinguished at the throw site, not guessed at here.
+ *
+ * ## Why DEFAULT_REGION is not a new invention
+ *
+ * `pickCountryCode` already prefers `DEFAULT_REGION` over an arbitrary map key
+ * when the map is healthy. Using it when the map is empty gives a visitor the
+ * same answer they would have got from an unlisted country — it does not
+ * introduce a new routing rule, it stops one from being unavailable.
+ */
+
+/** Tag carried by the "backend answered, and said zero regions" error. */
+export const REGION_MAP_UNCONFIGURED = "REGION_MAP_UNCONFIGURED"
+
+/**
+ * Was this failure a real misconfiguration rather than an outage?
+ *
+ * Checked on a `name` we set ourselves rather than by matching the message:
+ * a message is prose, it gets reworded, and the reword would silently turn a
+ * loud misconfiguration into a quiet redirect to `/us`.
+ */
+export function isUnconfiguredRegionsError(error: unknown): boolean {
+  return (error as { name?: string } | null)?.name === REGION_MAP_UNCONFIGURED
+}
+
+export type CountryCodePick = {
+  countryCode?: string
+  /**
+   * True when the pick was made with NO region map — the site is being served
+   * on a fallback and pages should not present region-dependent data as if it
+   * were confirmed.
+   */
+  degraded: boolean
+}
+
+/**
+ * Pick the country to route to.
+ *
+ * With a populated map the precedence is unchanged: an explicit country in the
+ * URL, then the Vercel geo header, then `DEFAULT_REGION`, then — last resort —
+ * whatever key the map yields first.
+ *
+ * ⚠️ That last resort is an arbitrary-first-row read, the same shape as the
+ * `take: 1` bugs this codebase keeps finding. It is left alone here because
+ * changing it is a separate decision about a separate case; it only fires when
+ * the map is populated but contains neither the requested country nor the
+ * default.
+ *
+ * With an EMPTY map there is nothing to validate against, so the URL's own
+ * country code is honoured if it looks like one — a buyer returning to
+ * `/gb/order/confirmed` should land where they were, not be bounced to `/us` —
+ * and otherwise `DEFAULT_REGION` is used. Both are marked `degraded`.
+ */
+export function pickCountryCode(args: {
+  urlCountryCode?: string
+  vercelCountryCode?: string
+  regionMap: Map<string, unknown>
+  defaultRegion?: string
+}): CountryCodePick {
+  const { urlCountryCode, vercelCountryCode, regionMap } = args
+  const defaultRegion = args.defaultRegion?.toLowerCase() || undefined
+
+  const mapIsEmpty = regionMap.size === 0
+
+  if (!mapIsEmpty) {
+    if (urlCountryCode && regionMap.has(urlCountryCode)) {
+      return { countryCode: urlCountryCode, degraded: false }
+    }
+    if (vercelCountryCode && regionMap.has(vercelCountryCode)) {
+      return { countryCode: vercelCountryCode, degraded: false }
+    }
+    if (defaultRegion && regionMap.has(defaultRegion)) {
+      return { countryCode: defaultRegion, degraded: false }
+    }
+    const first = regionMap.keys().next().value as string | undefined
+    return { countryCode: first, degraded: false }
+  }
+
+  // Empty map: nothing to validate against, so "looks like a country code" is
+  // the only test available. Two letters — anything else is a path segment
+  // (`products`, `cart`) that must NOT be mistaken for a country, or the
+  // buyer's URL gets rewritten into nonsense.
+  if (urlCountryCode && /^[a-z]{2}$/.test(urlCountryCode)) {
+    return { countryCode: urlCountryCode, degraded: true }
+  }
+  if (vercelCountryCode && /^[a-z]{2}$/.test(vercelCountryCode)) {
+    return { countryCode: vercelCountryCode, degraded: true }
+  }
+  return { countryCode: defaultRegion, degraded: true }
+}

--- a/apps/storefront/src/middleware.ts
+++ b/apps/storefront/src/middleware.ts
@@ -1,6 +1,12 @@
 import { HttpTypes } from "@medusajs/types"
 import { NextRequest, NextResponse } from "next/server"
 
+import {
+  REGION_MAP_UNCONFIGURED,
+  isUnconfiguredRegionsError,
+  pickCountryCode,
+} from "./lib/util/region-routing"
+
 const BACKEND_URL = process.env.MEDUSA_BACKEND_URL
 const PUBLISHABLE_API_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY
 const DEFAULT_REGION = process.env.NEXT_PUBLIC_DEFAULT_REGION || "us"
@@ -128,9 +134,16 @@ async function getRegionMap(cacheId: string) {
       const regions = json.regions as HttpTypes.StoreRegion[] | undefined
 
       if (!regions?.length) {
-        throw new Error(
+        // 🔑 TAGGED, because this is the one region-map failure that must NOT
+        // degrade (#1993). The backend answered; it simply has no regions —
+        // a misconfiguration in Medusa Admin, by a developer. Falling back to
+        // DEFAULT_REGION here would route every visitor to /us and render
+        // empty pages forever with nobody told why.
+        const unconfigured = new Error(
           "No regions found. Please set up regions in your Medusa Admin."
         )
+        unconfigured.name = REGION_MAP_UNCONFIGURED
+        throw unconfigured
       }
 
       regions.forEach((region) => {
@@ -146,12 +159,26 @@ async function getRegionMap(cacheId: string) {
         console.warn(
           `[Middleware] Region fetch failed, using stale cache: ${error.message}`
         )
-      } else {
-        // No cache at all — log and re-throw so the caller can handle it
-        console.error(
-          `[Middleware] Region fetch failed with no cache: ${error.message}`
-        )
+      } else if (isUnconfiguredRegionsError(error)) {
+        // A real misconfiguration: stay loud. See the tag above.
+        console.error(`[Middleware] ${error.message}`)
         throw error
+      } else {
+        // 🔴 #1993: this used to rethrow, which meant a COLD instance — just
+        // deployed, restarted or scaled up — 500'd on EVERY route the moment
+        // the backend was unreachable. A warm one survived on its stale cache,
+        // so "it worked when I tried it" was never evidence the next instance
+        // would.
+        //
+        // It also hid #1992's work: the payment page that tells a buyer "our
+        // side is not responding, your link is fine" only renders if
+        // middleware lets the request through.
+        //
+        // So: serve the site on an empty map and let each page say what it
+        // cannot load.
+        console.error(
+          `[Middleware] Region fetch failed with no cache, serving degraded: ${error.message}`
+        )
       }
     }
   }
@@ -177,15 +204,23 @@ async function getCountryCode(
 
     const urlCountryCode = request.nextUrl.pathname.split("/")[1]?.toLowerCase()
 
-    if (urlCountryCode && regionMap.has(urlCountryCode)) {
-      countryCode = urlCountryCode
-    } else if (vercelCountryCode && regionMap.has(vercelCountryCode)) {
-      countryCode = vercelCountryCode
-    } else if (regionMap.has(DEFAULT_REGION)) {
-      countryCode = DEFAULT_REGION
-    } else if (regionMap.keys().next().value) {
-      countryCode = regionMap.keys().next().value
+    // The precedence itself lives in `lib/util/region-routing` so it can be
+    // tested: the case that matters most — an EMPTY map — is exactly the one
+    // that is hardest to reach through the middleware.
+    const pick = pickCountryCode({
+      urlCountryCode,
+      vercelCountryCode,
+      regionMap,
+      defaultRegion: DEFAULT_REGION,
+    })
+
+    if (pick.degraded) {
+      console.warn(
+        `[Middleware] No region map — serving ${pick.countryCode ?? "(no country)"} degraded`
+      )
     }
+
+    countryCode = pick.countryCode
 
     return countryCode
   } catch (error) {
@@ -276,10 +311,14 @@ export async function middleware(request: NextRequest) {
     // redirect response so they're set before the page even renders.
     captureTrackingParams(request, response)
   } else if (!urlHasCountryCode && !countryCode) {
-    console.log(`[Middleware] → 500: No valid regions`)
-    // Handle case where no valid country code exists (empty regions)
+    // Reachable only when the region map is empty AND no DEFAULT_REGION is
+    // set — i.e. nobody has said where an unrouted visitor should go. Since
+    // #1993 an unreachable backend no longer lands here: it degrades onto
+    // DEFAULT_REGION (which is "us" unless NEXT_PUBLIC_DEFAULT_REGION says
+    // otherwise), so this is a configuration answer, not an outage one.
+    console.log(`[Middleware] → 500: no region map and no DEFAULT_REGION`)
     return new NextResponse(
-      "No valid regions configured. Please set up regions with countries in your Medusa Admin.",
+      "No regions configured and no NEXT_PUBLIC_DEFAULT_REGION set. Set up regions with countries in your Medusa Admin, or set a default region.",
       { status: 500 }
     )
   }


### PR DESCRIPTION
## The defect

`getRegionMap` rethrew whenever the region fetch failed and it had no cache to fall back on. A **warm** instance survives on its stale in-process cache; a **cold** one — just deployed, restarted, or scaled up — has none, so the rethrow became a **500 on every single route**.

It also hid #1992's work. That PR taught the payment page to tell a buyer *"our side is not responding, your link is fine"* — but **that page only renders if middleware lets the request through.** On a cold instance the buyer got a bare 500 and never saw it. A warm storefront degraded honestly; a cold one hard-failed.

## The decision this makes, and why

⚠️ The issue explicitly asked for a deliberate choice between three options rather than one slipped into a PR. **This is option 1 — fall back to `DEFAULT_REGION`.** Reject it cheaply if you disagree; the change is small and self-contained.

- **Option 2 (a dedicated "we're having trouble" page from middleware)** would replace #1992's *specific* honest message with a *generic* one on exactly the route that matters most. It fixes the 500 and undoes the improvement in the same stroke.
- **Option 3 (persist the region map outside the process)** does not help an instance that was never warm, which is the case in the incident. Worth doing, but it is a complement, not a fix.
- **Option 1** lets the request through so each page can degrade honestly one layer up — which is what #1985's "Done when" actually asks for.

And `DEFAULT_REGION` is not a new routing rule: `pickCountryCode` already prefers it over an arbitrary map key when the map is healthy. Using it on an empty map gives a visitor the same answer an unlisted country would have got.

## 🔑 Two failures that look identical and must not be treated alike

Both arrive as *"the region map is empty"*:

- **Unreachable** — fetch failed, timed out, or non-2xx. Nothing about the storefront is wrong. Degrade.
- **Unconfigured** — the backend answered and said **zero regions**. A real misconfiguration, by a developer. Falling back here would route every visitor to `/us` and render empty pages forever with nobody told why. **Stays loud.**

They are separated **at the throw site**, tagged on the error's `name` rather than matched by message prose — because prose gets reworded, and the reword would silently turn a loud misconfiguration into a quiet redirect.

## Verified at runtime, not just in tests

A cold instance in a clean worktree, pointed at a dead backend port — the issue's own repro:

| middleware | `GET /us/payment-collection/…` |
|---|---|
| `main` | **500**, 500, 500 |
| this PR | **200** |

And the 200 is the right page. The buyer sees:

> **We can't load this payment right now.** Something on our side is not responding, so we can't show your payment yet. Your link is fine — please refresh this page in a few minutes and it should work. Nothing has been charged, and your order is unaffected.

That is #1992's message, reachable for the first time on a cold instance. The middleware log shows the whole decision: `Region fetch failed with no cache, serving degraded` → `No region map — serving us degraded` → `NextResponse.next()`. `/gb/store` correctly stays on `gb` rather than being bounced to `/us`.

## 🔴 Honest limitation: this does not make every page survive

`GET /` still returns **500** on a dead backend — but now from the **page's own data fetch**, not from middleware. Only the payment page has been taught to degrade (#1992). Middleware no longer blocks the others from trying; whether they degrade is a separate piece of work per page, and worth its own issue.

So the accurate claim is: **middleware stops being the thing that fails first.** It is not "the storefront now survives a backend outage".

## Tests

`lib/util/region-routing.test.ts` — 15 tests. The precedence moved out of middleware precisely because the case that matters most (an empty map) is the hardest to reach through it.

Two worth calling out:
- **A path segment is not a country code.** With no map there is nothing to validate against, so shape is the only test left. Without it, `/products/foo` would be rewritten to `/products/products/foo`.
- **A buyer stays where they were.** `/gb/order/confirmed` during an outage lands on `gb`, not `/us`.

Full storefront suite: 7 files / 112 tests green. No new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp