### PR TITLE
feat(mcp): a tool to link a carrier to a warehouse, and defaultQuery

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -529,6 +529,9 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     method: "GET",
     path: "/admin/stock-locations",
     queryParams: ["limit", "offset", "q"],
+    // Core's default field set omits the provider links, so without this the
+    // answer to "can this warehouse ship with X?" is invisible here (#2023).
+    defaultQuery: { fields: "+fulfillment_providers.id,+fulfillment_providers.is_enabled" },
     inputSchema: obj({ ...PAGINATION }),
   },
   {
@@ -538,7 +541,57 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     method: "GET",
     path: "/admin/stock-locations/:id",
     pathParams: ["id"],
+    defaultQuery: { fields: "+fulfillment_providers.id,+fulfillment_providers.is_enabled" },
     inputSchema: obj({ id: STR("Stock location id, e.g. 'sloc_...'.") }, ["id"]),
+  },
+  /**
+   * Linking a CARRIER to a WAREHOUSE (#2023).
+   *
+   * `list_fulfillment_providers` answers "is this provider registered?" - a
+   * process-wide fact. `POST /admin/shipping-options` gates on a different one:
+   * is the provider linked to the stock location behind the zone. Packlink was
+   * `is_enabled: true` and linked to ZERO locations for a day, so every attempt
+   * to create an option on it 400'd while the prescribed check kept passing.
+   */
+  {
+    name: "set_location_fulfillment_providers",
+    description:
+      "Attach or detach fulfillment providers on ONE stock location — which carriers that warehouse may ship with. Sensitive: requires confirm:true. " +
+      "🔴 THIS IS THE FACT `POST /admin/shipping-options` ACTUALLY GATES ON. A provider can be registered and `is_enabled: true` in list_fulfillment_providers and still be linked to NO location, in which case creating a shipping option on it fails with `Providers (x) are not enabled for the service location`. Global registration and per-location enablement are different things, and only this one reaches a zone. " +
+      "🔑 `add` and `remove` are DELTAS, not a replacement set — unlike a shipping option's `prices`, a provider you leave out keeps whatever state it had. So adding one carrier never silently detaches another. " +
+      "Read the current links first with get_stock_location, which now returns them; the response here reports them too, so the change is verifiable without a second call.",
+    method: "POST",
+    path: "/admin/stock-locations/:id/fulfillment-providers",
+    pathParams: ["id"],
+    bodyParams: ["add", "remove"],
+    // The route refetches the location through core's default field set, which
+    // omits the links this tool exists to change - so a bare response could not
+    // show whether the write took.
+    defaultQuery: { fields: "+fulfillment_providers.id,+fulfillment_providers.is_enabled" },
+    write: true,
+    sensitive: true,
+    previewPath: "/admin/stock-locations/:id",
+    sideEffects:
+      "Takes effect immediately: a newly-linked provider becomes selectable for shipping options in zones on this location's fulfillment set, and quoting starts hitting that carrier. Removing one does not delete existing shipping options that name it — those stop being offerable instead.",
+    nextSteps: ["get_stock_location", "create_shipping_option"],
+    inputSchema: obj(
+      {
+        id: STR("Stock location id, e.g. 'sloc_...'. From list_stock_locations."),
+        add: {
+          type: "array",
+          description:
+            "Provider ids to LINK, e.g. ['packlink_packlink']. Each must appear in list_fulfillment_providers — that is necessary but not sufficient, which is why this tool exists.",
+          items: { type: "string" },
+        },
+        remove: {
+          type: "array",
+          description:
+            "Provider ids to UNLINK. Leaves every provider not named here untouched.",
+          items: { type: "string" },
+        },
+      },
+      ["id"]
+    ),
   },
   // ---- Id producers: readers for the ids other tools demand --------------
   // Regions, sales channels and payment submissions were all demanded by
@@ -685,7 +738,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "create_shipping_option",
     description:
-      "Create a shipping option — a rate a buyer can pick at checkout, or a quote-only row. Sensitive: requires confirm:true. Call list_shipping_options on the target `service_zone_id` first: options are what make a zone SELLABLE, and a second one competing with an existing rate is usually not what was wanted. 🔴 `prices` is REQUIRED even for `price_type: \"calculated\"` — send `[]` there; the carrier quotes, so a price row would be a second answer to the same question. 🔑 A FLAT option with no price in the cart's currency is simply not offered; a CALCULATED one has no prices and so is offered EVERYWHERE the zone reaches. That asymmetry is the whole trap: the only way to confine a calculated option to particular lanes is a `rules` entry, and a rule can only name a context key something actually publishes (`enabled_in_store`, `is_return`, `quote_id`, `cart_currency_code` — see the setShippingOptionsContext hook). ⚠️ A rule naming a key nobody publishes does not fail: the matcher stringifies the absent value to \"undefined\", so the option is EXCLUDED from every cart and looks merely unpopular. Exactly one of `type` or `type_id`. The `provider_id` must be registered AND enabled — check list_fulfillment_providers, since a provider configured in only one medusa-config file does not exist in prod.",
+      "Create a shipping option — a rate a buyer can pick at checkout, or a quote-only row. Sensitive: requires confirm:true. Call list_shipping_options on the target `service_zone_id` first: options are what make a zone SELLABLE, and a second one competing with an existing rate is usually not what was wanted. 🔴 `prices` is REQUIRED even for `price_type: \"calculated\"` — send `[]` there; the carrier quotes, so a price row would be a second answer to the same question. 🔑 A FLAT option with no price in the cart's currency is simply not offered; a CALCULATED one has no prices and so is offered EVERYWHERE the zone reaches. That asymmetry is the whole trap: the only way to confine a calculated option to particular lanes is a `rules` entry, and a rule can only name a context key something actually publishes (`enabled_in_store`, `is_return`, `quote_id`, `cart_currency_code` — see the setShippingOptionsContext hook). ⚠️ A rule naming a key nobody publishes does not fail: the matcher stringifies the absent value to \"undefined\", so the option is EXCLUDED from every cart and looks merely unpopular. Exactly one of `type` or `type_id`. 🔴 The `provider_id` must be registered AND LINKED TO THIS ZONE'S STOCK LOCATION — two different facts, and list_fulfillment_providers only sees the first. It reports `is_enabled: true` for a provider attached to no location at all, and this route then fails with `Providers (x) are not enabled for the service location`. Check the location itself with get_stock_location and link it with set_location_fulfillment_providers (#2023). Registration is still worth confirming, since a provider configured in only one medusa-config file does not exist in prod.",
     method: "POST",
     path: "/admin/shipping-options",
     write: true,

--- a/apps/backend/src/lib/mcp-core/__tests__/default-query.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/default-query.unit.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * `defaultQuery` — query params a tool always sends (#2023).
+ *
+ * ── Why this exists ───────────────────────────────────────────────────────────
+ *
+ * Core's default field set for `/admin/stock-locations` omits
+ * `fulfillment_providers`. So `set_location_fulfillment_providers` — a tool
+ * whose entire job is changing those links — would answer with a body that
+ * cannot show whether the link took, unless the caller happened to pass
+ * `fields`. Leaving the read-back to the model's discretion is how a write goes
+ * unverified, so the tool declares it and the dispatcher always sends it.
+ *
+ * The rule is one-directional: it FILLS a gap, never pins a value. A caller who
+ * asks for different fields must win, or the default becomes a ceiling.
+ */
+import { dispatchMcpTool } from "../dispatch"
+import type { McpContext, McpToolDef } from "../types"
+import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
+
+const ctx = { baseUrl: "http://localhost:9000", surface: "admin" } as McpContext
+
+/** dry_run returns the planned request without touching a route. */
+const planOf = async (tools: McpToolDef[], name: string, args: Record<string, unknown> = {}) => {
+  const r: any = await dispatchMcpTool(ctx, tools, name, { ...args, dry_run: true })
+  expect(r.ok).toBe(true)
+  return r.plan
+}
+
+const READ: McpToolDef = {
+  name: "read_thing",
+  description: "x",
+  method: "GET",
+  path: "/admin/things",
+  queryParams: ["limit", "fields"],
+  defaultQuery: { fields: "+a.b", order: "-created_at" },
+  inputSchema: { type: "object", properties: {} },
+}
+
+const NO_DEFAULT: McpToolDef = {
+  name: "plain_thing",
+  description: "x",
+  method: "GET",
+  path: "/admin/things",
+  queryParams: ["limit"],
+  inputSchema: { type: "object", properties: {} },
+}
+
+describe("defaultQuery", () => {
+  it("is sent when the caller asks for nothing", async () => {
+    const plan = await planOf([READ], "read_thing")
+    expect(plan.query).toEqual({ fields: "+a.b", order: "-created_at" })
+  })
+
+  it("merges with, rather than replaces, caller-supplied params", async () => {
+    const plan = await planOf([READ], "read_thing", { limit: 5 })
+    expect(plan.query).toEqual({ fields: "+a.b", order: "-created_at", limit: 5 })
+  })
+
+  it("LOSES to a caller-supplied value for the same key", async () => {
+    // The default must widen a request, never cap it: a caller who names their
+    // own `fields` has to get exactly those.
+    const plan = await planOf([READ], "read_thing", { fields: "id" })
+    expect(plan.query.fields).toBe("id")
+    expect(plan.query.order).toBe("-created_at")
+  })
+
+  it("leaves a tool without one completely unchanged", async () => {
+    const plan = await planOf([NO_DEFAULT], "plain_thing", { limit: 2 })
+    expect(plan.query).toEqual({ limit: 2 })
+  })
+
+  it("omits the query block entirely when there is nothing to send", async () => {
+    const plan = await planOf([NO_DEFAULT], "plain_thing")
+    expect(plan.query).toBeUndefined()
+  })
+})
+
+describe("the stock-location tools carry it for real", () => {
+  const find = (n: string) => {
+    const t = ADMIN_MCP_TOOLS.find((x) => x.name === n)
+    // Without this the assertions below would vacuously pass on a renamed tool.
+    expect(t).toBeDefined()
+    return t as McpToolDef
+  }
+
+  it.each([
+    "list_stock_locations",
+    "get_stock_location",
+    "set_location_fulfillment_providers",
+  ])("%s asks for the provider links", (name) => {
+    expect(find(name).defaultQuery?.fields).toContain("fulfillment_providers")
+  })
+
+  it("asks for them ADDITIVELY, so the address fields survive", () => {
+    // A bare `fields=fulfillment_providers.id` REPLACES core's defaults, which
+    // would strip the addresses these tools are also relied on for. The `+`
+    // prefix appends instead.
+    for (const name of ["list_stock_locations", "get_stock_location"]) {
+      const fields = find(name).defaultQuery!.fields
+      for (const part of fields.split(",")) {
+        expect(part.startsWith("+")).toBe(true)
+      }
+    }
+  })
+
+  it("reaches the planned request for the write tool", async () => {
+    const plan = await planOf(ADMIN_MCP_TOOLS, "set_location_fulfillment_providers", {
+      id: "sloc_1",
+      add: ["packlink_packlink"],
+    })
+    expect(plan.path).toBe("/admin/stock-locations/sloc_1/fulfillment-providers")
+    expect(plan.query.fields).toContain("fulfillment_providers")
+    expect(plan.body).toEqual({ add: ["packlink_packlink"] })
+  })
+
+  it("treats add/remove as deltas — neither is required", async () => {
+    // `remove` alone is a legitimate call; requiring both would make detaching
+    // a carrier impossible without naming one to keep.
+    const plan = await planOf(ADMIN_MCP_TOOLS, "set_location_fulfillment_providers", {
+      id: "sloc_1",
+      remove: ["packlink_packlink"],
+    })
+    expect(plan.body).toEqual({ remove: ["packlink_packlink"] })
+  })
+})

--- a/apps/backend/src/lib/mcp-core/__tests__/product-tool-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/product-tool-field-coverage.unit.spec.ts
@@ -54,6 +54,15 @@ const coreShippingOptionValidators = require("@medusajs/medusa/api/admin/shippin
 const { AdminCreateShippingOption, AdminUpdateShippingOption } =
   coreShippingOptionValidators
 
+/**
+ * The generic link-body validator core registers on every `add`/`remove` link
+ * route, including `/admin/stock-locations/:id/fulfillment-providers` (#2023).
+ * Bound here so the day core grows the shape, the tool that wraps it fails
+ * rather than quietly dropping the new field.
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { createLinkBody } = require("@medusajs/medusa/api/utils/validators")
+
 import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
 import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
 import type { McpToolDef } from "../types"
@@ -209,6 +218,16 @@ const CASES: Array<{
     tool: findTool(ADMIN_MCP_TOOLS, "update_shipping_option"),
     validator: AdminUpdateShippingOption,
     what: "core route, core validator",
+  },
+  {
+    key: "admin:set_location_fulfillment_providers",
+    tool: findTool(ADMIN_MCP_TOOLS, "set_location_fulfillment_providers"),
+    validator: createLinkBody(),
+    // Two fields is the whole contract, so the default floor of 6 would fail a
+    // correct tool. Stating it here keeps the sanity check meaningful instead
+    // of disabling it.
+    minFields: 2,
+    what: "core route, core's generic link validator — { add?, remove? }",
   },
 ]
 

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -86,6 +86,13 @@ const NO_ROUTE_VALIDATOR = new Set<string>([
    * reported `ok: true` and dropped (#1348). Verified by reading the handler,
    * not inferred from the absence of a matcher.
    */
+  /**
+   * Wraps the CORE link route, whose body validator is core's generic
+   * `createLinkBody()` ({ add?, remove? }) registered in core's own
+   * middlewares — nothing in this repo binds it. The contract is asserted
+   * directly in `product-tool-field-coverage.unit.spec.ts` (#2023).
+   */
+  "admin:set_location_fulfillment_providers",
   "admin:revoke_quote",
   /**
    * The partner twin (#1517), for the same reason and verified the same way:

--- a/apps/backend/src/lib/mcp-core/dispatch.ts
+++ b/apps/backend/src/lib/mcp-core/dispatch.ts
@@ -277,7 +277,8 @@ export async function dispatchMcpTool(
     return fail(`Missing required parameter: ${sub.missing}`)
   }
   const path = sub.path as string
-  const query = pick(def.queryParams, args)
+  // Caller-supplied values win, so `defaultQuery` only ever fills a gap (#2023).
+  const query = { ...(def.defaultQuery ?? {}), ...pick(def.queryParams, args) }
   const body = pick(def.bodyParams, args)
   const method = def.method ?? "GET"
 

--- a/apps/backend/src/lib/mcp-core/types.ts
+++ b/apps/backend/src/lib/mcp-core/types.ts
@@ -41,6 +41,20 @@ export type McpToolDef = {
   pathParams?: string[]
   /** Argument keys forwarded to the route as query-string params. */
   queryParams?: string[]
+  /**
+   * Query params ALWAYS sent, whether or not the caller asked (#2023).
+   *
+   * For a route whose default field set omits the very thing the tool exists to
+   * show. `/admin/stock-locations` does not return `fulfillment_providers`
+   * unless `fields` names it, so a tool that links a carrier to a warehouse
+   * would answer with a body that cannot show whether the link took. Relying on
+   * the model to pass `fields` makes the read-back optional, which is how a
+   * write goes unverified.
+   *
+   * A caller-supplied value for the same key WINS, so this widens a default
+   * without ever pinning one.
+   */
+  defaultQuery?: Record<string, string>
   /** Argument keys assembled into the JSON request body (write tools only). */
   bodyParams?: string[]
   /** Non-GET tool: gated behind the write flag on the server. */


### PR DESCRIPTION
Closes #2023.

Switching Le Ciricotte to live Packlink rates (#2010's recipe) failed on:

```
400: Providers (packlink_packlink) are not enabled for the service location
```

`packlink_packlink` was registered and `is_enabled: true`, and linked to **zero
stock locations** — it shipped in #2005, reached prod in #2007, and nothing ever
wired it to anything. It had never been usable anywhere.

## The trap this closes

`create_shipping_option` told you to verify the provider with
`list_fulfillment_providers`. That answers a **process-wide** question — is it
registered? — while `POST /admin/shipping-options` gates on a **per-location**
one: is it linked to the stock location behind this zone. So the prescribed
check passes while the route 400s, and nothing on the tool surface could show
why. Same family as a green check from an instrument that doesn't measure the
thing.

## What's here

**`set_location_fulfillment_providers`** — wraps the core link route
`POST /admin/stock-locations/:id/fulfillment-providers` (`createLinkBody`).

`add`/`remove` are **deltas**: unlike a shipping option's `prices`, a provider
you leave out keeps whatever state it had. The description says so outright,
because the two tools an operator would use in the same sitting disagree on
that, and guessing wrong on the other one deletes rows.

**`create_shipping_option`'s description** now names the per-location fact and
the tool that changes it, rather than the check that cannot answer it.

**`defaultQuery`** — query params a tool always sends. Core's default field set
for `/admin/stock-locations` omits `fulfillment_providers`, so all three
stock-location tools would answer with a body that cannot show the links they
exist to read or change. Two properties matter:

- **A caller-supplied key wins.** The default fills a gap; it must never become
  a ceiling on what someone can ask for.
- **Fields are `+`-prefixed**, so they append to core's defaults rather than
  replacing them — a bare `fields=fulfillment_providers.id` would strip the
  addresses these tools are also relied on for.

## Tests

`default-query.unit.spec.ts`, 11 tests: the merge, the precedence rule, the
untouched-tool case, and that the write tool's planned request really carries
both the fields and a delta body.

**Mutation-checked** — reverting the one-line merge in `dispatch.ts` turns 4 of
the 11 red; restoring it returns all 11 to green. The new tool is also bound to
core's imported `createLinkBody()` in `product-tool-field-coverage`, so a field
core adds later fails the build instead of being silently dropped.

MCP unit suites: **37 suites / 689 tests** green. `tsc` unchanged against the
main baseline (84 pre-existing errors, 0 from these files).

## Already done on prod, by hand

The link itself was applied over curl so the loss-making lanes could be fixed
today — Le Ciricotte Warehouse now reads
`['manual_manual', 'packlink_packlink']`, and both #2010 writes then succeeded.
This PR is what stops the next person needing a curl.

⚠️ **Every other partner warehouse still has no Packlink link**, and most have
`providers: []` entirely — the next non-Indian lane hits the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp
