### PR TITLE
fix(#2009): a samples parcel declares real contents, not an empty manifest

### DIFF
--- a/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
@@ -1,11 +1,15 @@
 import {
   buildInventoryOrderShipmentInput,
   DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS,
+  DEFAULT_SAMPLE_DECLARED_VALUE,
   missingDestinationAddressFields,
   normalizeDimensionsCm,
   resolveInventoryDestinationAddress,
+  SAMPLE_SHIPMENT_ITEM_NAME,
+  SAMPLE_SHIPMENT_ITEM_SKU,
   type InventoryOrderForShipment,
 } from "../lib/inventory-order-shipment"
+import { readEnvDeclaredValue } from "../create-inventory-order-shipment"
 
 describe("normalizeDimensionsCm (breadth → width for the courier)", () => {
   it("maps breadth to the canonical width the client reads", () => {
@@ -103,11 +107,128 @@ describe("buildInventoryOrderShipmentInput (#772)", () => {
   })
 
   it("falls back to a default pickup ('') and 'Warehouse' name / IN country on a bare order", () => {
-    const input = buildInventoryOrderShipmentInput({ id: "x", orderlines: [] })
+    // A sample order, because a bare NON-sample order now throws (#2009) and
+    // this case is about the pickup/name/country fallbacks, not the manifest.
+    const input = buildInventoryOrderShipmentInput({
+      id: "x",
+      orderlines: [],
+      is_sample: true,
+    })
     expect(input.pickup_location_name).toBe("")
     expect(input.to.name).toBe("Warehouse")
     expect(input.to.country).toBe("IN")
-    expect(input.items).toEqual([])
+  })
+})
+
+describe("buildInventoryOrderShipmentInput empty manifests (#2009)", () => {
+  const sampleOrder: InventoryOrderForShipment = {
+    id: "inv_sample_1",
+    is_sample: true,
+    total_price: 0,
+    metadata: {},
+    orderlines: [],
+  }
+
+  it("synthesises one contents line for a sample order with no lines", () => {
+    const input = buildInventoryOrderShipmentInput(sampleOrder, { pickupLocationName: "wh" })
+    expect(input.items).toEqual([
+      {
+        name: SAMPLE_SHIPMENT_ITEM_NAME,
+        sku: SAMPLE_SHIPMENT_ITEM_SKU,
+        quantity: 1,
+        unit_price: DEFAULT_SAMPLE_DECLARED_VALUE,
+      },
+    ])
+  })
+
+  it("declares the nominal value, never the sample order's own 0", () => {
+    const input = buildInventoryOrderShipmentInput(sampleOrder, {})
+    expect(input.sub_total).toBe(DEFAULT_SAMPLE_DECLARED_VALUE)
+    expect(input.sub_total).toBeGreaterThan(0)
+  })
+
+  it("ranks explicit call value > order metadata > deployment default > nominal", () => {
+    const withMeta = { ...sampleOrder, metadata: { declared_value: 420 } }
+    // Every rung present: the explicit call value wins.
+    expect(
+      buildInventoryOrderShipmentInput(withMeta, {
+        sampleDeclaredValue: 750,
+        defaultSampleDeclaredValue: 300,
+      }).sub_total
+    ).toBe(750)
+    // No call value: the ORDER's own figure beats the deployment default —
+    // whoever typed it knows what is in this parcel.
+    expect(
+      buildInventoryOrderShipmentInput(withMeta, { defaultSampleDeclaredValue: 300 })
+        .sub_total
+    ).toBe(420)
+    // Neither: the deployment default (SSM) applies.
+    expect(
+      buildInventoryOrderShipmentInput(sampleOrder, { defaultSampleDeclaredValue: 300 })
+        .sub_total
+    ).toBe(300)
+    // Nothing at all: the compiled-in nominal.
+    expect(buildInventoryOrderShipmentInput(sampleOrder, {}).sub_total).toBe(
+      DEFAULT_SAMPLE_DECLARED_VALUE
+    )
+  })
+
+  it("ignores non-positive / unparseable values at every rung", () => {
+    expect(
+      buildInventoryOrderShipmentInput(
+        { ...sampleOrder, metadata: { declared_value: 0 } },
+        { defaultSampleDeclaredValue: 0, sampleDeclaredValue: -5 }
+      ).sub_total
+    ).toBe(DEFAULT_SAMPLE_DECLARED_VALUE)
+  })
+
+  it("the compiled-in nominal matches the seeded SSM figure (500)", () => {
+    // These two are deliberately the same number: an unset parameter must not
+    // silently change what a customs officer reads off the label.
+    expect(DEFAULT_SAMPLE_DECLARED_VALUE).toBe(500)
+  })
+
+  it("honours metadata.is_sample when the column is absent (unified-order mirror)", () => {
+    const input = buildInventoryOrderShipmentInput(
+      { id: "inv_2", metadata: { is_sample: true }, orderlines: [] },
+      {}
+    )
+    expect(input.items).toHaveLength(1)
+  })
+
+  it("prices a COD sample parcel at the declared value, not 0", () => {
+    const input = buildInventoryOrderShipmentInput(
+      { ...sampleOrder, metadata: { payment_mode: "cod" } },
+      {}
+    )
+    expect(input.cod_amount).toBe(DEFAULT_SAMPLE_DECLARED_VALUE)
+  })
+
+  it("leaves a sample order that HAS lines completely alone", () => {
+    const input = buildInventoryOrderShipmentInput(
+      {
+        ...sampleOrder,
+        total_price: 300,
+        orderlines: [{ id: "l1", quantity: 2, price: 150, metadata: { title: "Swatch", sku: "SW-1" } }],
+      },
+      {}
+    )
+    expect(input.items).toEqual([{ name: "Swatch", sku: "SW-1", quantity: 2, unit_price: 150 }])
+    expect(input.sub_total).toBe(300)
+  })
+
+  it("THROWS on a non-sample order with no lines rather than booking an empty manifest", () => {
+    expect(() =>
+      buildInventoryOrderShipmentInput({ id: "inv_3", orderlines: [] }, {})
+    ).toThrow(/nothing to ship/i)
+  })
+
+  it("THROWS when every delivered quantity is zero (same empty manifest, other door)", () => {
+    expect(() =>
+      buildInventoryOrderShipmentInput(baseOrder, {
+        deliveredQuantities: { ol_1: 0, ol_2: 0 },
+      })
+    ).toThrow(/nothing to ship/i)
   })
 })
 
@@ -191,5 +312,19 @@ describe("resolveInventoryDestinationAddress (#772 to-location fill)", () => {
       "pincode",
       "phone",
     ])
+  })
+})
+
+describe("readEnvDeclaredValue (SSM → workflow, #2009)", () => {
+  it("reads a positive numeric value", () => {
+    expect(readEnvDeclaredValue({ SAMPLE_SHIPMENT_DECLARED_VALUE: "500" })).toBe(500)
+  })
+
+  it("returns undefined for unset, blank, non-numeric or non-positive values", () => {
+    for (const raw of [undefined, "", "   ", "abc", "0", "-100"]) {
+      expect(
+        readEnvDeclaredValue({ SAMPLE_SHIPMENT_DECLARED_VALUE: raw } as any)
+      ).toBeUndefined()
+    }
   })
 })

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
@@ -44,6 +44,24 @@ import {
  * thrown when no pickup can be resolved so the UI shows an actionable message.
  */
 
+/**
+ * Env var holding the deployment's nominal declared value for a samples parcel
+ * (#2009). Seeded into SSM at `/jyt/<env>/SAMPLE_SHIPMENT_DECLARED_VALUE` and
+ * injected by ECS at task start, so the figure can be changed with a parameter
+ * edit plus a service restart rather than a code deploy.
+ */
+export const SAMPLE_DECLARED_VALUE_ENV = "SAMPLE_SHIPMENT_DECLARED_VALUE"
+
+/** The env value, or undefined when unset, unparseable or not positive. */
+export function readEnvDeclaredValue(
+  env: NodeJS.ProcessEnv = process.env
+): number | undefined {
+  const raw = env[SAMPLE_DECLARED_VALUE_ENV]
+  if (raw == null || String(raw).trim() === "") return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
 export type CreateInventoryOrderShipmentInput = {
   orderId: string
   /** Defaults to "shiprocket". */
@@ -63,6 +81,12 @@ export type CreateInventoryOrderShipmentInput = {
    * picks the earliest slot.
    */
   pickupDate?: string
+  /**
+   * Declared value for the contents line synthesised when a SAMPLE order has no
+   * lines yet (#2009). Falls back to the order's `metadata.declared_value`, then
+   * to `DEFAULT_SAMPLE_DECLARED_VALUE`.
+   */
+  sampleDeclaredValue?: number
 }
 
 export async function createInventoryOrderShipment(
@@ -228,6 +252,12 @@ export async function createInventoryOrderShipment(
     preferredCourierId: input.preferredCourierId,
     taxId,
     deliveredQuantities: input.deliveredQuantities,
+    sampleDeclaredValue: input.sampleDeclaredValue,
+    // The deployment's nominal declared value for a samples parcel (#2009),
+    // read here rather than in the pure builder. Unset/garbage → the builder's
+    // compiled-in DEFAULT_SAMPLE_DECLARED_VALUE, which is deliberately the same
+    // figure; this exists so the number can be changed without a deploy.
+    defaultSampleDeclaredValue: readEnvDeclaredValue(),
   })
   const result = await provider.createShipment(shipmentInput)
 

--- a/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
@@ -1,3 +1,5 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
 import type {
   CreateShipmentInput,
   Dimensions,
@@ -20,6 +22,62 @@ import type {
  */
 
 export const DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS = 500
+
+/**
+ * Contents line synthesised for a samples/swatch order (#2009).
+ *
+ * A sample order is created EMPTY on purpose (#2006): the box is ordered before
+ * anyone knows what is in it, and the lines are filled in on arrival by
+ * `create-sample-material-lines`. That is the right shape for procurement and
+ * the wrong shape for a carrier — every carrier wants a contents line to raise a
+ * waybill, and `items: []` either 400s on a field the operator never filled in
+ * or, worse, books a manifest that describes nothing.
+ *
+ * The substitution lives HERE, at the carrier boundary, and nowhere else: no
+ * placeholder row is written to the order. A real line is not inert —
+ * `resolveLineItemDesignId`, production-run creation and the payout path all
+ * read lines and would treat a placeholder as goods sold.
+ */
+export const SAMPLE_SHIPMENT_ITEM_NAME = "Fabric samples / swatches"
+export const SAMPLE_SHIPMENT_ITEM_SKU = "SAMPLE-SWATCH"
+
+/**
+ * Last-resort nominal per-parcel declared value for a samples shipment, in the
+ * order's currency (major units).
+ *
+ * A sample order's `total_price` is legitimately 0, and 0 is not a legal customs
+ * value. The operative figure is the `SAMPLE_SHIPMENT_DECLARED_VALUE` SSM
+ * parameter, resolved by the workflow and passed in as
+ * `opts.defaultSampleDeclaredValue`; this constant only applies when that is
+ * unset, so the two are kept in step deliberately. Set 2026-09-13.
+ */
+export const DEFAULT_SAMPLE_DECLARED_VALUE = 500
+
+const isSampleOrder = (order: InventoryOrderForShipment): boolean =>
+  order.is_sample === true || order.metadata?.is_sample === true
+
+/**
+ * Explicit per-call value → the order's own metadata → the deployment default
+ * (SSM) → the compiled-in nominal.
+ *
+ * A per-ORDER value outranks the deployment default: someone who typed a value
+ * for this parcel knows more about what is in it than the environment does.
+ */
+const sampleDeclaredValue = (
+  order: InventoryOrderForShipment,
+  opts: BuildInventoryShipmentOpts
+): number => {
+  const candidates = [
+    opts.sampleDeclaredValue,
+    order.metadata?.declared_value,
+    opts.defaultSampleDeclaredValue,
+  ]
+  for (const c of candidates) {
+    const n = Number(c)
+    if (Number.isFinite(n) && n > 0) return n
+  }
+  return DEFAULT_SAMPLE_DECLARED_VALUE
+}
 
 /**
  * Normalize a loose L/B/H dimensions payload onto the canonical `Dimensions`
@@ -68,6 +126,12 @@ export type InventoryOrderForShipment = {
   metadata?: Record<string, any> | null
   shipping_address?: Record<string, any> | null
   orderlines?: InventoryOrderLineForShipment[] | null
+  /**
+   * A samples/swatch order (#2006), legitimately created with no lines. The
+   * column is authoritative; `metadata.is_sample` is honoured as a fallback
+   * because the unified-order mirror carries it there.
+   */
+  is_sample?: boolean | null
 }
 
 export type BuildInventoryShipmentOpts = {
@@ -84,6 +148,17 @@ export type BuildInventoryShipmentOpts = {
    * quantity ships.
    */
   deliveredQuantities?: Record<string, number>
+  /**
+   * Declared value for the synthesised samples line (#2009), in the order's
+   * currency. Only consulted when a sample order has no shippable lines.
+   */
+  sampleDeclaredValue?: number
+  /**
+   * Deployment-wide fallback declared value, resolved by the caller from the
+   * `SAMPLE_SHIPMENT_DECLARED_VALUE` env/SSM parameter. Outranked by both an
+   * explicit `sampleDeclaredValue` and the order's `metadata.declared_value`.
+   */
+  defaultSampleDeclaredValue?: number
 }
 
 const lineName = (l: InventoryOrderLineForShipment): string => {
@@ -189,7 +264,7 @@ export function buildInventoryOrderShipmentInput(
   const paymentMode: "prepaid" | "cod" =
     order.metadata?.payment_mode === "cod" ? "cod" : "prepaid"
 
-  const items: ShipmentItem[] = (order.orderlines || [])
+  const lineItems: ShipmentItem[] = (order.orderlines || [])
     .map((l) => {
       const delivered =
         opts.deliveredQuantities && l.id != null
@@ -205,8 +280,42 @@ export function buildInventoryOrderShipmentInput(
     })
     .filter((i) => i.quantity > 0)
 
-  const subTotal =
-    order.total_price != null
+  // An empty manifest reaches no carrier intact, so decide here rather than
+  // letting `items: []` travel (#2009). Shiprocket's domestic create refuses an
+  // empty item array; its INTERNATIONAL builder's missing-HSN guard passes
+  // VACUOUSLY on an empty array and posts the order anyway — a call that looks
+  // like it worked and describes nothing.
+  //
+  // A sample order is empty by design and gets a synthesised contents line.
+  // Anything else with nothing to ship is an operator error — most often every
+  // `deliveredQuantities` entry being 0, which the `quantity > 0` filter above
+  // empties just as thoroughly as a lineless order — and must fail loudly.
+  const synthesizeSampleLine = !lineItems.length && isSampleOrder(order)
+  if (!lineItems.length && !synthesizeSampleLine) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Inventory order ${order.id} has nothing to ship: no order line has a quantity greater than zero. ` +
+        `Add the delivered quantities before creating a shipment.`
+    )
+  }
+
+  const declaredValue = sampleDeclaredValue(order, opts)
+  const items: ShipmentItem[] = synthesizeSampleLine
+    ? [
+        {
+          name: SAMPLE_SHIPMENT_ITEM_NAME,
+          sku: SAMPLE_SHIPMENT_ITEM_SKU,
+          quantity: 1,
+          unit_price: declaredValue,
+        },
+      ]
+    : lineItems
+
+  // A synthesised parcel declares the nominal value, never the order's own 0 —
+  // that is what customs reads. Real lines keep the order's recorded total.
+  const subTotal = synthesizeSampleLine
+    ? declaredValue
+    : order.total_price != null
       ? Number(order.total_price)
       : items.reduce((s, i) => s + i.unit_price * i.quantity, 0)
 

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -311,6 +311,14 @@ secrets:
   S3_REGION: /jyt/prod/S3_REGION
   S3_SECRET_ACCESS_KEY: /jyt/prod/S3_SECRET_ACCESS_KEY
   SENTRY_DSN: /jyt/prod/SENTRY_DSN
+  # #2009 — nominal declared value (INR, major units) for the contents line
+  # SYNTHESISED when a samples/swatch inventory order ships with no lines yet.
+  # A sample order's own total is legitimately 0, and 0 is not a legal customs
+  # value. Read by create-inventory-order-shipment.ts (readEnvDeclaredValue) and
+  # passed to the pure builder; outranked by an order's metadata.declared_value.
+  # Unset → the compiled-in DEFAULT_SAMPLE_DECLARED_VALUE, deliberately the same
+  # 500, so an unset parameter cannot silently change what customs reads.
+  SAMPLE_SHIPMENT_DECLARED_VALUE: /jyt/prod/SAMPLE_SHIPMENT_DECLARED_VALUE
   # #888 — gates POST /webhooks/shipping/track (carrier tracking pushes;
   # Shiprocket has no HMAC, it replays a dashboard-configured header). Unset →
   # endpoint runs open with a warning.

--- a/deploy/aws/secrets.example.env
+++ b/deploy/aws/secrets.example.env
@@ -67,3 +67,7 @@ SENTRY_DSN=
 # AUSPOST_SANDBOX=
 # DELHIVERY_SANDBOX=
 # PAYU_MODE=
+
+# #2009 — nominal declared value for a samples-order parcel with no lines yet.
+# Major units, order currency. Unset → the code's DEFAULT_SAMPLE_DECLARED_VALUE (500).
+SAMPLE_SHIPMENT_DECLARED_VALUE=500


### PR DESCRIPTION
Closes #2009 (partly — the remaining decisions are listed at the bottom).

A samples/swatch inventory order is created **empty on purpose** (#2006): the box is ordered before anyone knows what is in it, and the lines are filled in on arrival. Right shape for procurement, wrong shape for a carrier.

`buildInventoryOrderShipmentInput` could return `items: []` and nothing between it and `provider.createShipment` looked:

| Layer | Before |
|---|---|
| `lib/inventory-order-shipment.ts` | `.filter(i => i.quantity > 0)` → `items: []`, no guard |
| `create-inventory-order-shipment.ts` | calls `provider.createShipment` on it unguarded |
| `shiprocket/client.ts` | `buildShiprocketOrderItems([])` → `[]`; the missing-HSN guard passes **vacuously** |

So an international sample would have posted with no complaint at all — a call that looks like it worked and describes nothing.

## What this does

**Shape (2) from the issue: synthesise at the carrier boundary**, in the one place every inventory-order shipment passes through (the workflow is the only caller). No placeholder row is written to the order — a real line is not inert, and `resolveLineItemDesignId`, production-run creation and the payout path all read lines as goods sold.

**Anything else with nothing to ship throws `INVALID_DATA`.** That closes a second door the issue did not name: all-zero `deliveredQuantities` empties the array just as thoroughly as a lineless order, and is the likelier operator error.

## The declared value

A sample order's own total is legitimately `0`, and `0` is not a legal customs value. The parcel declares a nominal **500**, seeded as `/jyt/prod/SAMPLE_SHIPMENT_DECLARED_VALUE` (String, version 1, us-east-1) and wired into the server manifest + `secrets.example.env`.

`DEFAULT_SAMPLE_DECLARED_VALUE` is deliberately the **same** 500, with a test pinning them together: an unresolved parameter must not silently change what a customs officer reads off the label.

Precedence, one test per rung — **call input → order `metadata.declared_value` → SSM → constant**. The per-order figure outranks the deployment default because whoever typed it knows what is in that parcel. Non-positive and unparseable values are rejected at every rung (`Number(null)` is `0`, the exact value this change exists to prevent).

The env read lives in the workflow, so the builder stays pure.

## Verification

Mutation-checked, not just green: disabling the synthesis turns **7 tests red**, removing the throw turns **2 red**. **201/201** `inventory_orders` unit tests pass; typecheck clean.

One pre-existing test asserted `items: []` on a bare order — updated rather than left to pass silently, since it encoded the old behaviour.

Not affected: `production-runs/lib/goods-transfer-shipment.ts` always emits exactly one item.

## Deploy note

ECS resolves secrets at **task start**, so the parameter takes effect with this deploy. Changing the number later needs a parameter edit **plus** a service restart.

## Still open on #2009

- A sample order that *has* lines but zero prices still declares 0 — inventing per-line money is worse than the gap.
- Parcel weight/dimensions still fall back to the 500g default.
- Whether an empty shipment should be allowed at all before the receiving step is a policy question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp