### PR TITLE
fix(#2026): a superseded run is not payable

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -18,7 +18,8 @@
 
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
 
 jest.setTimeout(60000)
 
@@ -1051,6 +1052,172 @@ setupSharedTestSuite(() => {
       const ids = res.data.payable_runs.map((r: any) => r.run_id)
       expect(ids).not.toContain(otherRunId)
       expect(ids).not.toContain(inProgressId)
+    })
+
+    /**
+     * #2026 — a run whose work moved to another run is not payable.
+     *
+     * This has to be an INTEGRATION test. The whole defect lives in what the
+     * order↔production_run LINK returns: a superseded run carries no marker of
+     * its own (`status` stays `completed`, `cancelled_at` stays null), so the
+     * only evidence is its mirror order being canceled. A unit test with a
+     * stubbed query proves the arithmetic and nothing about the link — and
+     * `defineLink().entryPoint` is empty in unit tests anyway.
+     *
+     * Sharlho drew three ₹1,200 payouts for two garments exactly this way.
+     */
+    describe("a superseded run (#2026)", () => {
+      async function mirrorOrderFor(
+        runId: string,
+        opts: { status: string; metadata?: Record<string, any>; link?: boolean }
+      ) {
+        const container = getContainer()
+        const orderService: any = container.resolve(Modules.ORDER)
+        const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+        const order = await orderService.createOrders({
+          region_id: null,
+          currency_code: "inr",
+          items: [],
+          metadata: opts.metadata ?? {},
+        })
+        const orderId = (Array.isArray(order) ? order[0] : order).id as string
+
+        // `createOrders` will not take a canceled status, so set it after.
+        await orderService.updateOrders([{ id: orderId, status: opts.status }])
+
+        if (opts.link !== false) {
+          await remoteLink.create({
+            [Modules.ORDER]: { order_id: orderId },
+            // 🔑 `production_runs_id`, PLURAL — the link's own key name, as
+            // `linkUnifiedOrderOrRollback` writes it. The singular spelling
+            // throws "Module to type order and production_runs by keys … was
+            // not found", which reads like a missing link rather than a typo.
+            [PRODUCTION_RUNS_MODULE]: { production_runs_id: runId },
+          })
+        }
+        return orderId
+      }
+
+      it("EXCLUDES a run whose mirror order is canceled as superseded, and says by which run", async () => {
+        const d1 = await createDesign("Superseded Parent", { estimated_cost: 100 })
+        await linkDesignToPartner(d1, partnerId)
+        const childId = await createCompletedRun(d1, "Superseded Parent")
+        const parentId = await createCompletedRun(d1, "Superseded Parent")
+
+        await mirrorOrderFor(childId, { status: "completed" })
+        const parentOrderId = await mirrorOrderFor(parentId, {
+          status: "canceled",
+          metadata: { superseded_by_run_ids: [childId] },
+        })
+
+        const res = await api.get(
+          `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+          adminHeaders
+        )
+        expect(res.status).toBe(200)
+
+        const payableIds = res.data.payable_runs.map((r: any) => r.run_id)
+        // The child carries the work and still bills…
+        expect(payableIds).toContain(childId)
+        // …the parent does not. This is the ₹1,200.
+        expect(payableIds).not.toContain(parentId)
+
+        // 🔑 Held back and REPORTED, never silently dropped — and the row says
+        // where the work went, so the reader can go and look.
+        const excluded = res.data.excluded_runs.find(
+          (r: any) => r.run_id === parentId
+        )
+        expect(excluded).toBeDefined()
+        expect(excluded.excluded_reason).toBe("superseded_run")
+        expect(excluded.superseded_by_run_ids).toEqual([childId])
+        expect(excluded.mirror_order_id).toBe(parentOrderId)
+      })
+
+      it("still bills a run whose mirror order is ALIVE", async () => {
+        const d1 = await createDesign("Live Mirror", { estimated_cost: 100 })
+        await linkDesignToPartner(d1, partnerId)
+        const runId = await createCompletedRun(d1, "Live Mirror")
+        await mirrorOrderFor(runId, {
+          status: "completed",
+          // Present but the order is not canceled — a half-applied write must
+          // not cost a partner their money.
+          metadata: { superseded_by_run_ids: ["prod_run_whatever"] },
+        })
+
+        const res = await api.get(
+          `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+          adminHeaders
+        )
+        expect(res.data.payable_runs.map((r: any) => r.run_id)).toContain(runId)
+      })
+
+      it("still bills a run with NO mirror order — a missing link is not evidence", async () => {
+        const d1 = await createDesign("No Mirror", { estimated_cost: 100 })
+        await linkDesignToPartner(d1, partnerId)
+        const runId = await createCompletedRun(d1, "No Mirror")
+
+        const res = await api.get(
+          `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+          adminHeaders
+        )
+        expect(res.data.payable_runs.map((r: any) => r.run_id)).toContain(runId)
+      })
+
+      it("follows metadata.unified_order_id when the D5 link was never backfilled", async () => {
+        // The backfill is an ops-run `medusa exec`, so a superseded run can
+        // still be link-less. Reading only the link would let it bill.
+        const d1 = await createDesign("Unlinked Superseded", { estimated_cost: 100 })
+        await linkDesignToPartner(d1, partnerId)
+        const runId = await createCompletedRun(d1, "Unlinked Superseded")
+
+        const orderId = await mirrorOrderFor(runId, {
+          status: "canceled",
+          metadata: { superseded_by_run_ids: ["prod_run_other"] },
+          link: false,
+        })
+
+        const container = getContainer()
+        const runService: any = container.resolve("production_runs")
+        await runService.updateProductionRuns({
+          id: runId,
+          metadata: { unified_order_id: orderId },
+        })
+
+        const res = await api.get(
+          `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+          adminHeaders
+        )
+        expect(res.data.payable_runs.map((r: any) => r.run_id)).not.toContain(runId)
+        expect(
+          res.data.excluded_runs.find((r: any) => r.run_id === runId)?.excluded_reason
+        ).toBe("superseded_run")
+      })
+
+      it("hides the superseded run from the PARTNER's own billing screen too", async () => {
+        // This is the screen a partner bills FROM. A superseded parent listed
+        // beside its child has them asking for the same garment twice.
+        const d1 = await createDesign("Partner Superseded", { estimated_cost: 100 })
+        await linkDesignToPartner(d1, partnerId)
+        const parentId = await createCompletedRun(d1, "Partner Superseded")
+        await mirrorOrderFor(parentId, {
+          status: "canceled",
+          metadata: { superseded_by_run_ids: ["prod_run_child"] },
+        })
+
+        const res = await api.get(
+          "/partners/payment-submissions/payable-runs",
+          // `partnerHeaders` is a bare header map, unlike `adminHeaders` which
+          // is already an axios config — passing it raw sends no Authorization
+          // and 401s.
+          { headers: partnerHeaders }
+        )
+        expect(res.status).toBe(200)
+        expect(res.data.payable_runs.map((r: any) => r.run_id)).not.toContain(parentId)
+        expect(
+          res.data.excluded_runs.find((r: any) => r.run_id === parentId)?.excluded_reason
+        ).toBe("superseded_run")
+      })
     })
   })
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-unified-order-links.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-unified-order-links.unit.spec.ts
@@ -1,0 +1,180 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import { MAINTENANCE_JOBS } from "../registry"
+// File-based jobs are imported by the registry but not re-exported from it
+// (only the ones defined inline there are), so take it from its own module.
+import { backfillUnifiedOrderLinksJob } from "../backfill-unified-order-links-job"
+
+type Row = { id: string; order?: { id: string } | null; metadata?: any }
+
+const makeContainer = (
+  rowsByEntity: Record<string, Row[]>,
+  liveOrderIds: string[],
+  linkCreate: jest.Mock
+) => ({
+  resolve: (key: string) => {
+    if (key === ContainerRegistrationKeys.LINK) return { create: linkCreate }
+    return {
+      graph: async ({ entity, filters, pagination }: any) => {
+        if (entity === "order") {
+          return { data: liveOrderIds.filter((id) => filters.id.includes(id)).map((id) => ({ id })) }
+        }
+        // One page then empty, so the paging loop terminates.
+        if ((pagination?.skip ?? 0) > 0) return { data: [] }
+        return { data: rowsByEntity[entity] ?? [] }
+      },
+    }
+  },
+})
+
+const run = (container: any, dry_run: boolean, params: any = {}) =>
+  backfillUnifiedOrderLinksJob.run(container as any, { dry_run, params } as any)
+
+describe("backfill-unified-order-links job", () => {
+  it("is registered so Ops/MCP can reach it — the whole point of the job", () => {
+    // It existed only as an ops-run `medusa exec`, which is why #2026 could not
+    // find out whether it had ever run.
+    expect(MAINTENANCE_JOBS.some((j: any) => j.id === "backfill-unified-order-links")).toBe(true)
+  })
+
+  it("links a row that has only the metadata backref", async () => {
+    const create = jest.fn().mockResolvedValue(undefined)
+    const res = await run(
+      makeContainer(
+        {
+          production_runs: [{ id: "run_1", order: null, metadata: { unified_order_id: "order_1" } }],
+          inventory_orders: [],
+        },
+        ["order_1"],
+        create
+      ),
+      false
+    )
+
+    expect(create).toHaveBeenCalledTimes(1)
+    // Assert the payload AFTER the call, on mock.calls — an expect() thrown
+    // inside a mock is swallowed by the job's own try/catch.
+    expect(create.mock.calls[0][0]).toEqual([
+      {
+        [Modules.ORDER]: { order_id: "order_1" },
+        production_runs: { production_runs_id: "run_1" },
+      },
+    ])
+    expect(res.changes).toHaveLength(1)
+    expect(res.applied).toBe(true)
+  })
+
+  it("writes NOTHING on a dry run but still reports what it would do", async () => {
+    const create = jest.fn()
+    const res = await run(
+      makeContainer(
+        {
+          production_runs: [{ id: "run_1", order: null, metadata: { unified_order_id: "order_1" } }],
+          inventory_orders: [],
+        },
+        ["order_1"],
+        create
+      ),
+      true
+    )
+    expect(create).not.toHaveBeenCalled()
+    expect(res.changes).toHaveLength(1)
+    expect(res.applied).toBe(false)
+    expect(res.dry_run).toBe(true)
+  })
+
+  it("REFUSES a dangling backref rather than linking to a deleted order", async () => {
+    // A link to a missing order is worse than no link: every reader treats link
+    // presence as the authoritative pointer.
+    const create = jest.fn()
+    const res = await run(
+      makeContainer(
+        {
+          production_runs: [{ id: "run_x", order: null, metadata: { unified_order_id: "order_gone" } }],
+          inventory_orders: [],
+        },
+        [],
+        create
+      ),
+      false
+    )
+    expect(create).not.toHaveBeenCalled()
+    expect(res.changes).toHaveLength(0)
+    expect(res.errors?.[0]?.message).toMatch(/not found/i)
+    expect(res.summary).toMatch(/1 dangling/)
+  })
+
+  it("skips rows that already resolve the link, and rows with no backref", async () => {
+    const create = jest.fn()
+    const res = await run(
+      makeContainer(
+        {
+          production_runs: [
+            { id: "run_linked", order: { id: "order_1" }, metadata: {} },
+            { id: "run_legacy", order: null, metadata: {} },
+          ],
+          inventory_orders: [],
+        },
+        ["order_1"],
+        create
+      ),
+      false
+    )
+    expect(create).not.toHaveBeenCalled()
+    expect(res.changes).toHaveLength(0)
+    expect(res.summary).toMatch(/1 already linked/)
+    expect(res.summary).toMatch(/1 with no backref/)
+  })
+
+  it("treats an already-exists link error as success, not failure", async () => {
+    // A race or a partial prior run reaches the desired end state.
+    const create = jest.fn().mockRejectedValue(new Error("link already exists"))
+    const res = await run(
+      makeContainer(
+        {
+          production_runs: [{ id: "run_1", order: null, metadata: { unified_order_id: "order_1" } }],
+          inventory_orders: [],
+        },
+        ["order_1"],
+        create
+      ),
+      false
+    )
+    expect(res.errors).toHaveLength(0)
+    expect(res.changes).toHaveLength(0)
+  })
+
+  it("reports a genuine link failure instead of swallowing it", async () => {
+    const create = jest.fn().mockRejectedValue(new Error("connection reset"))
+    const res = await run(
+      makeContainer(
+        {
+          production_runs: [{ id: "run_1", order: null, metadata: { unified_order_id: "order_1" } }],
+          inventory_orders: [],
+        },
+        ["order_1"],
+        create
+      ),
+      false
+    )
+    expect(res.errors?.[0]).toMatchObject({ id: "run_1", message: "connection reset" })
+    expect(res.changes).toHaveLength(0)
+  })
+
+  it("scopes to one entity when asked", async () => {
+    const create = jest.fn().mockResolvedValue(undefined)
+    const res = await run(
+      makeContainer(
+        {
+          production_runs: [{ id: "run_1", order: null, metadata: { unified_order_id: "order_1" } }],
+          inventory_orders: [{ id: "inv_1", order: null, metadata: { unified_order_id: "order_1" } }],
+        },
+        ["order_1"],
+        create
+      ),
+      false,
+      { entity: "inventory_orders" }
+    )
+    expect(res.changes.map((c: any) => c.id)).toEqual(["inv_1"])
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-unified-order-links-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-unified-order-links-job.ts
@@ -1,0 +1,204 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { ORDER_INVENTORY_MODULE } from "../../../../modules/inventory_orders"
+import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+const MAX_SCAN = 10000
+const PAGE = 200
+
+const paramsSchema = z.object({
+  entity: z.enum(["inventory_orders", "production_runs", "both"]).optional().default("both"),
+  limit: z.coerce.number().int().positive().max(MAX_SCAN).optional().default(MAX_SCAN),
+})
+
+type Target = {
+  entity: "inventory_orders" | "production_runs"
+  module: string
+  idField: "inventory_orders_id" | "production_runs_id"
+}
+
+const TARGETS: Target[] = [
+  { entity: "inventory_orders", module: ORDER_INVENTORY_MODULE, idField: "inventory_orders_id" },
+  { entity: "production_runs", module: PRODUCTION_RUNS_MODULE, idField: "production_runs_id" },
+]
+
+/**
+ * #342 PR-E / #2026 — create the D5 order↔execution link on rows that only
+ * carry the older `metadata.unified_order_id` backref.
+ *
+ * Rows projected before PR-A made the link authoritative hold the unified-order
+ * pointer only as that backref (Chunk 6 then stopped writing it). Until they
+ * also carry the managed order↔inventory_order / order↔production_run link, the
+ * `<link> ?? metadata.unified_order_id` fallback reads cannot be deleted.
+ *
+ * ## Why this is a JOB and not only a script
+ *
+ * The logic already existed as `src/scripts/backfill-unified-order-links.ts`, an
+ * ops-run `medusa exec`. That made it unrunnable and unauditable from the Ops
+ * console or MCP — and, worse, unprovable: #2026 needed to know whether it had
+ * ever run, and nothing recorded that. A one-off ECS task's CloudWatch stream is
+ * not an audit trail. Here every run lands in ops_audit with its changes.
+ *
+ * 🔴 It also had a live footgun. `run-backfill.sh` exported DRY_RUN as an env
+ * var while this script parsed a POSITIONAL `dry-run`, so
+ * `DRY_RUN=1 ./run-backfill.sh backfill-unified-order-links` APPLIED to prod
+ * while printing "DRY_RUN: 1". The runner is fixed, but a job whose preview and
+ * apply are one typed flag cannot drift that way again.
+ *
+ * ## What it writes
+ *
+ * The LINK, and nothing else. No status, no metadata, no projection. Rows that
+ * were never dual-written have no backref to follow and stay legacy-only by
+ * design — that is the T4 scope decision, not an oversight, and inventing a
+ * unified order for them here would be projecting history.
+ *
+ * 🔑 A backref is VALIDATED before it is trusted: the order it names must still
+ * exist. A dangling backref is reported for manual review, never linked — a link
+ * to a deleted order is worse than no link, because every reader downstream
+ * treats link presence as the authoritative pointer.
+ *
+ * Idempotent: rows that already resolve `order.id` are skipped, and a create
+ * that loses a race to an existing link is counted as already-linked rather than
+ * failed.
+ *
+ * ## Prod state at the time of writing
+ *
+ * 2026-09-13, dry run against prod RDS:
+ *   inventory_orders  linked=0 alreadyLinked=18 dangling=0 noBackref=1
+ *   production_runs   linked=0 alreadyLinked=86 dangling=0 noBackref=58
+ * Nothing to do — every linkable row is linked. Recorded here so the next
+ * reader does not have to re-derive it, and so a future non-zero result is
+ * visibly a change rather than a first look.
+ */
+export const backfillUnifiedOrderLinksJob: MaintenanceJob = {
+  id: "backfill-unified-order-links",
+  label: "Backfill the order↔execution (D5) link from metadata backrefs",
+  description:
+    "Create the managed order↔inventory_order / order↔production_run link for legacy rows that carry only the metadata.unified_order_id backref (#342 PR-E). Writes the LINK only — never status, metadata or a projection. Validates that the backref'd order still exists and reports dangling ones instead of linking to a deleted order. Rows never dual-written have no backref and stay legacy-only by design. Idempotent. As of 2026-09-13 prod has nothing to link (104 already linked); this exists so the operation is runnable and AUDITABLE from Ops/MCP rather than a one-off ECS medusa exec. Dry-run previews; apply writes.",
+  params: [
+    {
+      name: "entity",
+      type: "string",
+      required: false,
+      description: "'inventory_orders' | 'production_runs' | 'both' (default both)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max rows to scan per entity (default ${MAX_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const { entity, limit } = paramsSchema.parse(params)
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    const targets = TARGETS.filter((t) => entity === "both" || t.entity === entity)
+    const tally: Record<string, { alreadyLinked: number; dangling: number; noBackref: number }> = {}
+
+    for (const target of targets) {
+      tally[target.entity] = { alreadyLinked: 0, dangling: 0, noBackref: 0 }
+
+      for (let skip = 0; skip < limit; skip += PAGE) {
+        const { data: rows } = await query.graph({
+          entity: target.entity,
+          fields: ["id", "order.id", "metadata"],
+          pagination: { take: PAGE, skip },
+        })
+        if (!rows?.length) break
+
+        const candidates: Array<{ legacyId: string; unifiedOrderId: string }> = []
+        for (const row of rows as any[]) {
+          if (row?.order?.id) {
+            tally[target.entity].alreadyLinked++
+            continue
+          }
+          const backref = row?.metadata?.unified_order_id
+          if (!backref) {
+            // Never projected, or the backref was already cleaned. Either way
+            // there is nothing here to follow.
+            tally[target.entity].noBackref++
+            continue
+          }
+          candidates.push({ legacyId: String(row.id), unifiedOrderId: String(backref) })
+        }
+
+        if (!candidates.length) continue
+
+        // Validate before linking — never point the authoritative link at an
+        // order that no longer exists.
+        const { data: orders } = await query.graph({
+          entity: "order",
+          fields: ["id"],
+          filters: { id: [...new Set(candidates.map((c) => c.unifiedOrderId))] },
+        })
+        const live = new Set((orders as any[]).map((o) => String(o.id)))
+
+        for (const c of candidates) {
+          if (!live.has(c.unifiedOrderId)) {
+            tally[target.entity].dangling++
+            errors.push({
+              id: c.legacyId,
+              message: `backref order ${c.unifiedOrderId} not found — left unlinked for manual review`,
+            })
+            continue
+          }
+
+          if (!dry_run) {
+            try {
+              await remoteLink.create([
+                {
+                  [Modules.ORDER]: { order_id: c.unifiedOrderId },
+                  [target.module]: { [target.idField]: c.legacyId },
+                },
+              ])
+            } catch (e: any) {
+              // Most likely the link already exists (a race, or a partial prior
+              // run). That is the desired end state, not a failure.
+              const msg = String(e?.message ?? e)
+              if (!/exist/i.test(msg)) {
+                errors.push({ id: c.legacyId, message: msg })
+                continue
+              }
+              tally[target.entity].alreadyLinked++
+              continue
+            }
+          }
+
+          changes.push({
+            entity: target.entity,
+            id: c.legacyId,
+            field: "order_link",
+            before: null,
+            after: c.unifiedOrderId,
+            note: `link ${target.entity} ${c.legacyId} → order ${c.unifiedOrderId} (from metadata.unified_order_id)`,
+          })
+        }
+      }
+    }
+
+    const per = Object.entries(tally)
+      .map(
+        ([e, t]) =>
+          `${e}: ${t.alreadyLinked} already linked, ${t.noBackref} with no backref, ${t.dangling} dangling`
+      )
+      .join("; ")
+
+    const verb = dry_run ? "Would link" : "Linked"
+    return {
+      job_id: backfillUnifiedOrderLinksJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: `${verb} ${changes.length} row(s) to their unified order — ${per} — ${errors.length} error(s)`,
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -124,6 +124,7 @@ import { setLocationOwnershipJob } from "./set-location-ownership-job"
 import { resetNegativeInventoryLevelsJob } from "./reset-negative-inventory-levels-job"
 import { backfillDispatchedTemplateIdsJob } from "./backfill-dispatched-template-ids-job"
 import { backfillPaymentLineRunProvenanceJob } from "./backfill-payment-line-run-provenance-job"
+import { backfillUnifiedOrderLinksJob } from "./backfill-unified-order-links-job"
 import { backfillInventoryOrderPaymentLinksJob } from "./backfill-inventory-order-payment-links-job"
 import { backfillSubmissionPaidAtJob } from "./backfill-submission-paid-at-job"
 import { clearUnpriceableDesignCostsJob } from "./clear-unpriceable-design-costs-job"
@@ -6021,6 +6022,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   deduplicateTaskTemplateNamesJob,
   backfillDispatchedTemplateIdsJob,
   backfillPaymentLineRunProvenanceJob,
+  backfillUnifiedOrderLinksJob,
   backfillInventoryOrderPaymentLinksJob,
   backfillSubmissionPaidAtJob,
   clearUnpriceableDesignCostsJob,

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -13,6 +13,7 @@ import {
 import { groupOrderBackedRuns } from "../../../../workflows/payment_submissions/lib/order-run-groups"
 import { foldPartnerBilling } from "../../../../workflows/payment_submissions/lib/run-billing"
 import { runBillableCeiling } from "../../../../workflows/payment_submissions/lib/run-billable-ceiling"
+import { fetchRunSupersessions } from "../../../../workflows/payment_submissions/lib/run-supersession"
 
 /**
  * GET /admin/payment-submissions/payable-runs?partner_id=…
@@ -236,15 +237,56 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
    * what grounds, and leaves the open product question (whether made-to-stock
    * work has any payout path at all) visible instead of buried.
    */
-  const completedRuns = designBackedRuns.filter((r) => !isProvenanceRun(r))
-  const excluded_runs = designBackedRuns
-    .filter((r) => isProvenanceRun(r))
-    .map((r) => ({
+  const notProvenance = designBackedRuns.filter((r) => !isProvenanceRun(r))
+
+  /**
+   * 🔴 A run whose work moved to another run is not payable (#2026).
+   *
+   * An approve-time split projects each CHILD run to its own unified order and
+   * cancels the PARENT's, stamping `metadata.superseded_by_run_ids` on it. The
+   * parent stays `completed`, keeps its partner and keeps its
+   * `partner_cost_estimate` — so every filter above passes and it was offered
+   * beside its own child, billing one garment twice.
+   *
+   * Sharlho's tweed jacket drew THREE ₹1,200 payouts for TWO garments exactly
+   * this way. The cancellation was recorded 15 seconds after the parent order
+   * was created; this screen had the evidence one link away and never read it.
+   *
+   * Held back and REPORTED, like the provenance runs above — whether superseded
+   * work has any payout path is a human question, not a silent filter.
+   */
+  const supersessions = await fetchRunSupersessions(
+    req.scope,
+    notProvenance.map((r) => String(r.id))
+  )
+
+  const completedRuns = notProvenance.filter((r) => !supersessions.has(String(r.id)))
+
+  const excluded_runs = [
+    ...designBackedRuns.filter((r) => isProvenanceRun(r)).map((r) => ({
       run_id: String(r.id),
       design_id: String(r.design_id),
       completed_at: r.completed_at ?? null,
       excluded_reason: "provenance_run" as const,
-    }))
+      superseded_by_run_ids: [] as string[],
+      mirror_order_id: null as string | null,
+    })),
+    ...notProvenance
+      .filter((r) => supersessions.has(String(r.id)))
+      .map((r) => {
+        const s = supersessions.get(String(r.id))!
+        return {
+          run_id: String(r.id),
+          design_id: String(r.design_id),
+          completed_at: r.completed_at ?? null,
+          excluded_reason: s.reason,
+          // Which runs carry the work instead — so the reader can go and look
+          // at them rather than wonder where the money went.
+          superseded_by_run_ids: s.superseded_by_run_ids,
+          mirror_order_id: s.mirror_order_id,
+        }
+      }),
+  ]
 
   if (!completedRuns.length) {
     // ⚠️ Still returns the order-backed rows. They are not design-backed, so a

--- a/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
@@ -4,6 +4,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
 import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
+import { fetchRunSupersessions } from "../../../../workflows/payment_submissions/lib/run-supersession"
 import { runPayableOffer } from "../../../../workflows/production-runs/lib/run-payable"
 import {
   foldPartnerBilling,
@@ -88,15 +89,44 @@ export const GET = async (
    * what grounds, and leaves the open product question (whether made-to-stock
    * work has any payout path at all) visible instead of buried.
    */
-  const completedRuns = designBackedRuns.filter((r) => !isProvenanceRun(r))
-  const excluded_runs = designBackedRuns
-    .filter((r) => isProvenanceRun(r))
-    .map((r) => ({
+  const notProvenance = designBackedRuns.filter((r) => !isProvenanceRun(r))
+
+  /**
+   * 🔴 A run superseded by an approve-time split is not payable (#2026).
+   *
+   * The admin twin carries the full account. It matters more here, if anything:
+   * this is the screen a PARTNER bills from, so a superseded parent listed
+   * beside its own child has them asking for the same garment twice — and the
+   * admin side, before this change, would have said yes.
+   */
+  const supersessions = await fetchRunSupersessions(
+    req.scope,
+    notProvenance.map((r) => String(r.id))
+  )
+
+  const completedRuns = notProvenance.filter((r) => !supersessions.has(String(r.id)))
+
+  const excluded_runs = [
+    ...designBackedRuns.filter((r) => isProvenanceRun(r)).map((r) => ({
       run_id: String(r.id),
       design_id: String(r.design_id),
       completed_at: r.completed_at ?? null,
       excluded_reason: "provenance_run" as const,
-    }))
+      superseded_by_run_ids: [] as string[],
+    })),
+    ...notProvenance
+      .filter((r) => supersessions.has(String(r.id)))
+      .map((r) => {
+        const s = supersessions.get(String(r.id))!
+        return {
+          run_id: String(r.id),
+          design_id: String(r.design_id),
+          completed_at: r.completed_at ?? null,
+          excluded_reason: s.reason,
+          superseded_by_run_ids: s.superseded_by_run_ids,
+        }
+      }),
+  ]
 
   if (!completedRuns.length) {
     return res

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-supersession.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-supersession.unit.spec.ts
@@ -1,0 +1,116 @@
+import {
+  fetchRunSupersessions,
+  readSupersession,
+} from "../run-supersession"
+
+describe("readSupersession (#2026)", () => {
+  it("flags the real Sharlho parent: canceled mirror carrying superseded_by_run_ids", () => {
+    const v = readSupersession({
+      id: "order_01M25MSMWD5YRDM4BMXESZJTEM",
+      status: "canceled",
+      metadata: {
+        note: "Small size run, materials and rates copied from prod_run_01M09V91A1VDN0ABSXMTBXNW4M",
+        superseded_by_run_ids: ["prod_run_01M25MT34Y8X8ASZMX3X2X9KY7"],
+      },
+    })
+    expect(v).toEqual({
+      reason: "superseded_run",
+      superseded_by_run_ids: ["prod_run_01M25MT34Y8X8ASZMX3X2X9KY7"],
+      mirror_order_id: "order_01M25MSMWD5YRDM4BMXESZJTEM",
+    })
+  })
+
+  it("flags a canceled mirror with no supersession key as a bare cancellation", () => {
+    const v = readSupersession({ id: "order_1", status: "canceled", metadata: {} })
+    expect(v?.reason).toBe("canceled_mirror_order")
+    expect(v?.superseded_by_run_ids).toEqual([])
+  })
+
+  it("leaves a live mirror order alone — that run still bills", () => {
+    expect(
+      readSupersession({ id: "order_2", status: "completed", metadata: {} })
+    ).toBeUndefined()
+    expect(
+      readSupersession({ id: "order_3", status: "pending", metadata: null })
+    ).toBeUndefined()
+  })
+
+  it("does NOT act on a live order that merely carries superseded_by_run_ids", () => {
+    // The key is written in the same call that cancels. A non-canceled order
+    // holding it is a half-applied write — bill it and let a human see both.
+    expect(
+      readSupersession({
+        id: "order_4",
+        status: "completed",
+        metadata: { superseded_by_run_ids: ["prod_run_x"] },
+      })
+    ).toBeUndefined()
+  })
+
+  it("treats a MISSING mirror order as no evidence, not as superseded", () => {
+    // Absence in our instrument is not absence in the world.
+    expect(readSupersession(null)).toBeUndefined()
+    expect(readSupersession(undefined)).toBeUndefined()
+  })
+
+  it("tolerates a non-array superseded_by_run_ids without excluding on a guess", () => {
+    const v = readSupersession({
+      id: "order_5",
+      status: "canceled",
+      metadata: { superseded_by_run_ids: "prod_run_x" },
+    })
+    // Still excluded (it IS canceled), but the malformed value is not invented
+    // into a run list the reader would then go looking for.
+    expect(v?.reason).toBe("canceled_mirror_order")
+    expect(v?.superseded_by_run_ids).toEqual([])
+  })
+
+  it("matches status case-insensitively", () => {
+    expect(readSupersession({ id: "o", status: "Canceled", metadata: {} })?.reason).toBe(
+      "canceled_mirror_order"
+    )
+  })
+})
+
+describe("fetchRunSupersessions (#2026)", () => {
+  const container = (rows: any[], throws = false): any => ({
+    resolve: () => ({
+      graph: async ({ fields, filters }: any) => {
+        if (throws) throw new Error("link read hiccup")
+        // Guard the exact field set — reading `order_id` here instead of the
+        // `order` LINK would silently read the COMMISSIONING order.
+        expect(fields).toContain("order.status")
+        expect(fields).toContain("order.metadata")
+        expect(fields).not.toContain("order_id")
+        expect(filters.id.length).toBeGreaterThan(0)
+        return { data: rows }
+      },
+    }),
+  })
+
+  it("keys verdicts by run id and omits runs that still bill", async () => {
+    const map = await fetchRunSupersessions(
+      container([
+        { id: "run_parent", order: { id: "o1", status: "canceled", metadata: { superseded_by_run_ids: ["run_child"] } } },
+        { id: "run_child", order: { id: "o2", status: "completed", metadata: {} } },
+        { id: "run_unlinked", order: null },
+      ]),
+      ["run_parent", "run_child", "run_unlinked"]
+    )
+    expect([...map.keys()]).toEqual(["run_parent"])
+    expect(map.get("run_parent")!.superseded_by_run_ids).toEqual(["run_child"])
+  })
+
+  it("returns an empty map without querying when given no runs", async () => {
+    const map = await fetchRunSupersessions(
+      { resolve: () => { throw new Error("must not resolve") } } as any,
+      []
+    )
+    expect(map.size).toBe(0)
+  })
+
+  it("degrades to empty on a query failure rather than taking payables down", async () => {
+    const map = await fetchRunSupersessions(container([], true), ["run_a"])
+    expect(map.size).toBe(0)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-supersession.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-supersession.unit.spec.ts
@@ -73,14 +73,19 @@ describe("readSupersession (#2026)", () => {
 })
 
 describe("fetchRunSupersessions (#2026)", () => {
-  const container = (rows: any[], throws = false): any => ({
+  const container = (rows: any[], throws = false, orders: any[] = []): any => ({
     resolve: () => ({
-      graph: async ({ fields, filters }: any) => {
+      graph: async ({ entity, fields, filters }: any) => {
         if (throws) throw new Error("link read hiccup")
+        if (entity === "order") {
+          // The backref fallback: a second lookup by unified_order_id.
+          return { data: orders.filter((o) => filters.id.includes(o.id)) }
+        }
         // Guard the exact field set — reading `order_id` here instead of the
         // `order` LINK would silently read the COMMISSIONING order.
         expect(fields).toContain("order.status")
         expect(fields).toContain("order.metadata")
+        expect(fields).toContain("metadata")
         expect(fields).not.toContain("order_id")
         expect(filters.id.length).toBeGreaterThan(0)
         return { data: rows }
@@ -111,6 +116,61 @@ describe("fetchRunSupersessions (#2026)", () => {
 
   it("degrades to empty on a query failure rather than taking payables down", async () => {
     const map = await fetchRunSupersessions(container([], true), ["run_a"])
+    expect(map.size).toBe(0)
+  })
+  it("follows metadata.unified_order_id when the D5 link was never backfilled", async () => {
+    // The link is authoritative where it EXISTS. The backfill is an ops-run
+    // script, so a superseded run can still be link-less — and reading only the
+    // link would let it bill.
+    const map = await fetchRunSupersessions(
+      container(
+        [{ id: "run_unlinked", order: null, metadata: { unified_order_id: "order_legacy" } }],
+        false,
+        [
+          {
+            id: "order_legacy",
+            status: "canceled",
+            metadata: { superseded_by_run_ids: ["run_child"] },
+          },
+        ]
+      ),
+      ["run_unlinked"]
+    )
+    expect(map.get("run_unlinked")).toMatchObject({
+      reason: "superseded_run",
+      superseded_by_run_ids: ["run_child"],
+      mirror_order_id: "order_legacy",
+    })
+  })
+
+  it("does not follow the backref when the backref order is alive", async () => {
+    const map = await fetchRunSupersessions(
+      container(
+        [{ id: "run_x", order: null, metadata: { unified_order_id: "order_live" } }],
+        false,
+        [{ id: "order_live", status: "completed", metadata: {} }]
+      ),
+      ["run_x"]
+    )
+    expect(map.size).toBe(0)
+  })
+
+  it("prefers the LINK over the backref when both exist", async () => {
+    const map = await fetchRunSupersessions(
+      container(
+        [
+          {
+            id: "run_y",
+            order: { id: "order_linked", status: "completed", metadata: {} },
+            metadata: { unified_order_id: "order_stale" },
+          },
+        ],
+        false,
+        [{ id: "order_stale", status: "canceled", metadata: {} }]
+      ),
+      ["run_y"]
+    )
+    // The stale backref says canceled; the authoritative link says alive.
     expect(map.size).toBe(0)
   })
 })

--- a/apps/backend/src/workflows/payment_submissions/lib/run-supersession.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-supersession.ts
@@ -109,13 +109,56 @@ export async function fetchRunSupersessions(
       // `order` is the LINKED unified mirror order — not the `order_id` column,
       // which points at the commissioning customer order (see the admin
       // registry's order_id vs work_order_id warning).
-      fields: ["id", "order.id", "order.status", "order.metadata"],
+      //
+      // `metadata` is the run's own, for the backref fallback below.
+      fields: ["id", "metadata", "order.id", "order.status", "order.metadata"],
       filters: { id: runIds },
     })
 
-    for (const row of (data || []) as any[]) {
+    const rows = (data || []) as any[]
+    for (const row of rows) {
       const verdict = readSupersession(row?.order)
       if (verdict && row?.id) out.set(String(row.id), verdict)
+    }
+
+    /**
+     * 🔴 The D5 link is not universally populated, so the link alone is not
+     * enough to conclude "no mirror order".
+     *
+     * The order↔production_run link is authoritative where it exists, but the
+     * script that backfills it from the older `metadata.unified_order_id`
+     * backref — `scripts/backfill-unified-order-links.ts` — is an ops-run
+     * `medusa exec`, not a migration and not a registered maintenance job, so
+     * there is no way to assert it has run against a given database.
+     *
+     * Every other run path that resolves a mirror order carries this same
+     * fallback (`resolveUnifiedOrderIdByLink`, and four call sites besides).
+     * Reading only the link here would mean a superseded run whose link was
+     * never backfilled comes back with no mirror order and — by this module's
+     * own conservative default — bills anyway. That is the precise failure this
+     * guard exists to stop, so it must follow the backref too.
+     */
+    const unlinked = rows.filter((r) => !r?.order?.id && r?.metadata?.unified_order_id)
+    if (unlinked.length) {
+      const byOrderId = new Map<string, string[]>()
+      for (const r of unlinked) {
+        const oid = String(r.metadata.unified_order_id)
+        byOrderId.set(oid, [...(byOrderId.get(oid) ?? []), String(r.id)])
+      }
+
+      const { data: orders } = await query.graph({
+        entity: "order",
+        fields: ["id", "status", "metadata"],
+        filters: { id: [...byOrderId.keys()] },
+      })
+
+      for (const order of (orders || []) as any[]) {
+        const verdict = readSupersession(order)
+        if (!verdict) continue
+        for (const runId of byOrderId.get(String(order.id)) ?? []) {
+          out.set(runId, verdict)
+        }
+      }
     }
   } catch {
     return new Map()

--- a/apps/backend/src/workflows/payment_submissions/lib/run-supersession.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-supersession.ts
@@ -1,0 +1,125 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+/**
+ * Is a completed run's work already represented by a different run?
+ *
+ * ## Why this exists (#2026)
+ *
+ * When a run is approved and split, `dualWriteChildRunOrdersStep` projects each
+ * CHILD run to its own unified order and cancels the PARENT's order, stamping
+ * `metadata.superseded_by_run_ids` on it. The commercial reality moves to the
+ * children; the parent is bookkeeping.
+ *
+ * Nothing told the money side. `payable-runs` filters on
+ * `{ partner_id, status: "completed" }` — and a superseded parent is still
+ * `completed`, still carries the partner, still carries
+ * `partner_cost_estimate`. It came back `payable: true` with no warning
+ * alongside its own child, offering the same garment twice.
+ *
+ * That is not hypothetical. Sharlho's tweed jacket
+ * (design `01M09V81MT94NSSZBJCQF79EXR`) drew THREE ₹1,200 payouts for TWO
+ * garments: the August Medium run, the September Small child run, and the
+ * September Small PARENT — whose order `order_01M25MSMWD5YRDM4BMXESZJTEM` was
+ * canceled 15 seconds after creation carrying
+ * `superseded_by_run_ids: ["prod_run_01M25MT34Y8X8ASZMX3X2X9KY7"]`. The screen
+ * had the evidence one link away and never looked.
+ *
+ * ## The signal lives on the ORDER, not the run
+ *
+ * A superseded run carries no marker of its own: `status` stays `completed` and
+ * `cancelled_at` stays null. The only record is its unified mirror order. So
+ * this reads the run→order link — the same forward link
+ * `resolveUnifiedOrderIdByLink` treats as authoritative — and not `run.order_id`,
+ * which is the COMMISSIONING customer order and a different id entirely.
+ *
+ * ## Reported, never silently dropped
+ *
+ * The caller puts these in `excluded_runs` with their reason, per this
+ * endpoint's standing rule: a screen that simply omits the row teaches nobody
+ * why the work vanished. A partner may well have made those goods — just not in
+ * that run — and whether a superseded run has any payout path is a question for
+ * a human, not a filter.
+ */
+
+export type SupersessionReason = "superseded_run" | "canceled_mirror_order"
+
+export type Supersession = {
+  reason: SupersessionReason
+  /** The runs that carry the work instead. Empty for a bare cancellation. */
+  superseded_by_run_ids: string[]
+  mirror_order_id: string | null
+}
+
+/** A mirror order as this module needs to see it. */
+export type MirrorOrderForSupersession = {
+  id?: string | null
+  status?: string | null
+  metadata?: Record<string, any> | null
+} | null | undefined
+
+/**
+ * PURE: does this mirror order say the run's work moved elsewhere?
+ *
+ * `undefined` means "no, bill it normally". Note what does NOT qualify:
+ *
+ * - **No mirror order at all.** A missing link is a claim about our data, not
+ *   about the work. Absence of evidence is not evidence — the run bills.
+ * - **A live order carrying `superseded_by_run_ids`.** The key is written in the
+ *   same call that cancels; a non-canceled order holding it is a half-applied
+ *   write, and guessing at a partner's money from a half-written row is worse
+ *   than billing it and letting a human see both rows.
+ */
+export function readSupersession(
+  order: MirrorOrderForSupersession
+): Supersession | undefined {
+  if (!order) return undefined
+  if (String(order.status ?? "").toLowerCase() !== "canceled") return undefined
+
+  const raw = order.metadata?.superseded_by_run_ids
+  const ids = Array.isArray(raw) ? raw.map(String).filter(Boolean) : []
+
+  return {
+    reason: ids.length ? "superseded_run" : "canceled_mirror_order",
+    superseded_by_run_ids: ids,
+    mirror_order_id: order.id ? String(order.id) : null,
+  }
+}
+
+/**
+ * Resolve supersession for many runs in ONE query, keyed by run id.
+ *
+ * Runs with no entry are payable as before. A query failure returns an EMPTY
+ * map rather than throwing: this guard exists to stop an overpayment, and
+ * taking the whole payables screen down because a link read hiccuped would turn
+ * a money-safety check into an outage. The rows then behave exactly as they did
+ * before this file existed.
+ */
+export async function fetchRunSupersessions(
+  container: MedusaContainer,
+  runIds: string[]
+): Promise<Map<string, Supersession>> {
+  const out = new Map<string, Supersession>()
+  if (!runIds.length) return out
+
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  try {
+    const { data } = await query.graph({
+      entity: "production_runs",
+      // `order` is the LINKED unified mirror order — not the `order_id` column,
+      // which points at the commissioning customer order (see the admin
+      // registry's order_id vs work_order_id warning).
+      fields: ["id", "order.id", "order.status", "order.metadata"],
+      filters: { id: runIds },
+    })
+
+    for (const row of (data || []) as any[]) {
+      const verdict = readSupersession(row?.order)
+      if (verdict && row?.id) out.set(String(row.id), verdict)
+    }
+  } catch {
+    return new Map()
+  }
+
+  return out
+}

--- a/deploy/aws/scripts/run-backfill.sh
+++ b/deploy/aws/scripts/run-backfill.sh
@@ -40,10 +40,28 @@ set -euo pipefail
 
 SCRIPT_NAME="${1:-}"
 if [ -z "$SCRIPT_NAME" ]; then
-  echo "Usage: $0 <script-name>"
+  echo "Usage: $0 <script-name> [script-args...]"
   echo "  e.g. $0 backfill-product-search"
-  echo "       $0 backfill-ai-platforms-from-env"
+  echo "       $0 backfill-unified-order-links dry-run"
   exit 1
+fi
+# Everything after the script name is forwarded to the script itself.
+shift
+SCRIPT_ARGS=("$@")
+
+# 🔴 DRY_RUN=1 used to be a LIE for positional-arg scripts.
+#
+# This runner only ever exported DRY_RUN as an env var. Scripts that read a
+# POSITIONAL `dry-run` — backfill-unified-order-links among them — never saw it,
+# so `DRY_RUN=1 ./run-backfill.sh backfill-unified-order-links` APPLIED to prod
+# while printing "DRY_RUN: 1". A flag that reads as safe and is not is worse
+# than no flag. Translate it into the positional form those scripts parse; a
+# script that reads the env var still gets that too.
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  case " ${SCRIPT_ARGS[*]:-} " in
+    *" dry-run "*|*" --dry-run "*) : ;;
+    *) SCRIPT_ARGS+=(dry-run) ;;
+  esac
 fi
 
 : "${AWS_REGION:=us-east-1}"
@@ -61,6 +79,7 @@ echo "== Container:       $CONTAINER_NAME"
 echo "== Script:          $SCRIPT_NAME"
 echo "== BATCH:           ${BATCH:-(unset, script default)}"
 echo "== DRY_RUN:         ${DRY_RUN:-0}"
+echo "== Script args:     ${SCRIPT_ARGS[*]:-(none)}"
 echo "== IMAGE_TAG:       ${IMAGE_TAG:-(unset, use live task def image)}"
 echo
 
@@ -189,7 +208,7 @@ echo "Using task definition: $TASK_DEF_ARN"
 # /app/.medusa/server (see apps/backend/Dockerfile), so the script
 # resolves at ./src/scripts/<name>.js once compiled. Use the local node
 # (`pnpm exec`) because medusa CLI lives in the prod node_modules.
-CMD_PARTS=(pnpm exec medusa exec "./src/scripts/${SCRIPT_NAME}.js")
+CMD_PARTS=(pnpm exec medusa exec "./src/scripts/${SCRIPT_NAME}.js" "${SCRIPT_ARGS[@]}")
 
 # Build environment override list — only set keys we explicitly passed.
 ENV_LIST=()


### PR DESCRIPTION
Closes #2026.

Sharlho drew **three ₹1,200 payouts for two garments**. The third billed `prod_run_01M25MSMPV00FKANAQ69X145RK` — a run whose work had already moved to its own child at approve time.

## The mechanism

`dualWriteChildRunOrdersStep` projects each **child** run to its own unified order and **cancels the parent's**, stamping `metadata.superseded_by_run_ids`. Nothing told the money side.

`payable-runs` filters on `{ partner_id, status: "completed" }` — a superseded parent is still `completed`, still carries the partner, still carries `partner_cost_estimate`. It came back `payable: true`, no warning, **beside its own child**.

A superseded run carries **no marker of its own**: `status` stays `completed`, `cancelled_at` stays null. The only record is the mirror order — `order_01M25MSMWD5YRDM4BMXESZJTEM`, canceled **15 seconds** after creation. The evidence was one link away for three days.

## The fix

`lib/run-supersession.ts` reads the run→order **link**, not `run.order_id` — that column is the *commissioning customer order* and a different id entirely (the admin registry warns about exactly this confusion).

Excluded runs are **reported** in `excluded_runs` with their reason and the runs carrying the work instead, following this endpoint's existing rule for provenance runs: a screen that simply omits a row teaches nobody why the work vanished.

Conservative in both directions, because this is a partner's money:

| Case | Behaviour | Why |
|---|---|---|
| No mirror order | **still bills** | a missing link is a claim about our data, not the work |
| Live order carrying `superseded_by_run_ids` | **still bills** | the key is written in the same call that cancels — a live order holding it is a half-applied write |
| Query failure | **empty map** | this guard stops an overpayment; it must not take payables down |

Applied to **both** routes. It matters more on the partner side, if anything: that is the screen a partner bills *from*, so a superseded parent beside its own child has them asking for the same garment twice — and the admin side would have said yes.

## Verification

- 10 unit tests, including the real Sharlho order shape.
- **Mutation-checked**: disabling detection turns **5 red**; dropping the canceled-status check turns **3 red**.
- 268 `payment_submissions` unit tests pass; `tsc` clean.

Not covered by these tests: the live link read itself. That is stubbed here and wants an integration test before anyone trusts it against prod data.

## The money

The duplicate payout is **annotated, not deleted** — the Sep 12 claim was deliberate and founder-confirmed, and the reasoning behind a ₹1,200 decision is worth more than a tidy record. Prior text is preserved in `metadata.notes_revisions`. Still `Draft`, marked do-not-pay.

## Still open

- `produced_quantity: 2` on a run whose sibling made the other unit — the count that made the duplicate claim look justified.
- The approve-time split mints one mirror order per run rather than collating them under a work order, which is why these read as three confusing orders in the partner UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp