### PR TITLE
fix(#2030): the partner order list can see collation

### DIFF
--- a/apps/backend/integration-tests/http/partner-orders-design-summary.spec.ts
+++ b/apps/backend/integration-tests/http/partner-orders-design-summary.spec.ts
@@ -290,5 +290,72 @@ setupSharedTestSuite(() => {
       expect(summary.name).toBe(`Design Summary Inlined ${unique}`)
       expect(summary.thumbnail).toBeNull()
     })
+
+    /**
+     * #2030 item 2.3 — the list was BLIND to collation. `PARTNER_ORDER_LIST_FIELDS`
+     * excluded `metadata`, so while the partner's order DETAIL page branches on
+     * `metadata.collated_design_order` to render the "one order, many designs"
+     * view, the list serving the row that links there could not tell a collated
+     * work-order from a per-run mirror. Three mirror orders for one piece of
+     * work rendered as three identical rows of the same design name.
+     *
+     * 🔑 Asserted on the LIST response, not on the order read back through the
+     * order service: the defect was in the field set the list reads with, so a
+     * direct read would pass against the broken contract.
+     */
+    it("carries metadata on the row, so the list can see collation", async () => {
+      const mkDesign = async (label: string) => {
+        const res = await post(
+          "/admin/designs",
+          {
+            name: `Collation Visible ${label} ${unique}`,
+            description: "two designs, one collated work-order",
+            design_type: "Original",
+            status: "Approved",
+            priority: "Medium",
+            estimated_cost: 500,
+          },
+          adminHeaders
+        )
+        expect(res.status).toBe(201)
+        return res.data.design.id as string
+      }
+
+      const dispatch = async (designId: string) => {
+        const res = await post(
+          "/admin/designs/produce",
+          { design_ids: [designId], partner_id: partnerId },
+          adminHeaders
+        )
+        expect(res.status).toBe(200)
+        return res.data.design_production
+      }
+
+      const first = await dispatch(await mkDesign("A"))
+      const second = await dispatch(await mkDesign("B"))
+
+      // Both dispatches land on ONE order (#1597's 14-day collation window).
+      const orderId = first.work_order_id as string
+      expect(second.work_order_id).toBe(orderId)
+
+      const listRes = await api.get(
+        "/partners/orders?kind=design&limit=100",
+        partnerHeaders
+      )
+      expect(listRes.status).toBe(200)
+
+      const row = (listRes.data.orders || []).find(
+        (o: any) => String(o.id) === String(orderId)
+      )
+      expect(row).toBeDefined()
+
+      // The key assertion: metadata arrives at all. Without it every check
+      // below reads `undefined`, which is what the list used to serve.
+      expect(row.metadata).toBeTruthy()
+      expect(row.metadata.collated_design_order).toBe(true)
+      expect(row.metadata.production_run_ids).toEqual(
+        expect.arrayContaining([first.run_ids[0], second.run_ids[0]])
+      )
+    })
   })
 })

--- a/apps/backend/src/api/partners/orders/list-params.ts
+++ b/apps/backend/src/api/partners/orders/list-params.ts
@@ -46,6 +46,25 @@ export const PARTNER_ORDER_LIST_FIELDS = [
   // accessor — now the SOLE source (PR-H retired the `metadata.partner_status`
   // copy and its transitional fallback).
   "unified_order_status.partner_status",
+  /**
+   * #2030 item 2.3 — the list used to be BLIND to collation. The detail page
+   * branches on `metadata.collated_design_order` to render the "one order,
+   * many designs" view, but the list read no metadata at all, so three mirror
+   * orders for one piece of work rendered as three identical-looking rows of
+   * the same design name with nothing saying which run each was.
+   *
+   * A collated order carries `collated_design_order: true` +
+   * `production_run_ids`; a per-run mirror carries `production_run_id` +
+   * `legacy_id`. NOT `parent_run_id` — that is a typed column on the RUN and
+   * the dual-write never copies it onto the order (#2030 says otherwise; it
+   * is wrong). Read the parentage from the run, not from here.
+   *
+   * ⚠️ READ-only. `query.graph` cannot FILTER on a JSON subkey — a filter
+   * written against `metadata.collated_design_order` matches nothing SILENTLY
+   * (see `findOpenPartnerWorkOrder`). Narrow on something filterable and check
+   * the flag in memory.
+   */
+  "metadata",
 ]
 
 // Filters that apply to EVERY order row regardless of kind.


### PR DESCRIPTION
#2030 item 2.3 — "the cheap win. Start here."

## The blindness

`PARTNER_ORDER_LIST_FIELDS` (`api/partners/orders/list-params.ts:32`) excluded `metadata`. The partner order **detail** page has always branched on `metadata.collated_design_order` to render the "one order, many designs" view (`order-detail.tsx:187`) — the **list** that links to it could not tell a collated work-order from a per-run mirror.

In the Sharlho case that means orders 110 and 111, minted fifteen seconds apart, render as two identical rows of the same design name. Three orders for one piece of work is what the partner actually sees.

Adds `metadata` to the field contract. The admin read-proxy (`GET /admin/partners/:id/orders`, #843) reads with the same set by design, so the inspection mirror gains it too and cannot drift from what the partner sees.

## Two corrections recorded in the comment

- **#2030 says the metadata carries `parent_run_id`. It does not.** That is a typed column on the RUN, and the dual-write never copies it onto the order. What is actually there: a collated order carries `collated_design_order: true` + `production_run_ids`; a per-run mirror carries `production_run_id` + `legacy_id`. Parentage must be read from the run.
- **The field is READ-only.** `query.graph` cannot filter on a JSON subkey, and a filter written against `metadata.collated_design_order` matches nothing **silently** — which here would mean "always mint a new order", i.e. the #1597 bug restored invisibly. `findOpenPartnerWorkOrder` already carries this warning; now so does the field set.

## Cover

Asserted on the **LIST response**, not on an order read back through the order service — the defect was in the field set the list reads with, so a direct read would have passed against the broken contract.

```
pnpm test:integration:http:shared \
  ./integration-tests/http/partner-orders-design-summary.spec.ts \
  ./integration-tests/http/orders-unification-partner-list-filter.spec.ts \
  ./integration-tests/http/admin-partner-inspection.spec.ts \
  ./integration-tests/http/partner-orders-api.spec.ts
```
**4 suites, 80 tests, passed.** Plus the `list-params` unit spec (8 tests).

## Mutation check

Dropping `"metadata"` from the field list turns the new test red while the suite's two existing tests stay green:

```
✓ carries the design's name and thumbnail on the work-order row
✓ has no list thumbnail when the only image is an inlined moodboard data URL
✕ carries metadata on the row, so the list can see collation
    Received: undefined
Tests: 1 failed, 2 passed, 3 total
```

## Not in scope

This makes the flag **reachable** by the partner-UI table; no partner-ui rendering change is included. The row can now distinguish a collated order from a mirror — deciding what to show is the rest of #2030 item 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp