### PR TITLE
fix(#2030): a split's child runs collate instead of minting an order each

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
@@ -495,5 +495,142 @@ setupSharedTestSuite(() => {
       expect(cancel.status).toBe(200)
       expect(((await fetchRun(runId)) as any).status).toBe("cancelled")
     })
+
+    /**
+     * #2030 item 2.1 — one order per CHILD run is what minted orders 110 and
+     * 111 fifteen seconds apart for a single design. Three orders for one piece
+     * of work is what the partner saw, and reading them as three jobs is how
+     * ₹1,200 nearly got paid a third time (#2026).
+     *
+     * A partner's children are ONE batch and belong on ONE order.
+     */
+    it("collates a partner's child runs onto ONE order, not one each", async () => {
+      await createRegion()
+      const designId = await createDesign()
+      const { partnerId } = await createPartner("collate")
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [
+            { partner_id: partnerId, quantity: 3, role: "cutting" },
+            { partner_id: partnerId, quantity: 2, role: "stitching" },
+          ],
+        },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+
+      const children = createRes.data.children ?? []
+      expect(children).toHaveLength(2)
+
+      const orderIds = await Promise.all(
+        children.map((c: any) => unifiedOrderIdOf(c.id))
+      )
+      orderIds.forEach((id) => expect(id).toBeTruthy())
+
+      // 🔑 The whole point, in one assertion.
+      expect(new Set(orderIds).size).toBe(1)
+
+      const collated = await fetchUnifiedOrder(orderIds[0])
+      expect(collated.metadata.collated_design_order).toBe(true)
+      expect(collated.metadata.production_run_ids).toEqual(
+        expect.arrayContaining(children.map((c: any) => c.id))
+      )
+      // A line per child — the partner can see both jobs, not just a total.
+      expect(collated.items).toHaveLength(2)
+      expect(
+        collated.items.map((i: any) => Number(i.quantity)).sort()
+      ).toEqual([2, 3])
+
+      // The parent is still superseded, so billing cannot double-count (#2026).
+      const parentOrderId = await unifiedOrderIdOf(
+        createRes.data.production_run.id
+      )
+      const parentOrder = await fetchUnifiedOrder(parentOrderId)
+      expect(parentOrder.status).toBe("canceled")
+      expect(parentOrder.metadata.superseded_by_run_ids).toEqual(
+        expect.arrayContaining(children.map((c: any) => c.id))
+      )
+    })
+
+    /**
+     * #2030 item 2.1, the other half: a LATER split for the same partner must
+     * land on the order the earlier one made — "included in the same order, or
+     * collated from a previous one" — rather than minting another.
+     *
+     * The first split here is a LONE child, so it keeps its per-run mirror
+     * (a collated order of one would only cost the partner the single-design
+     * screen). The second split joins that mirror and PROMOTES it.
+     */
+    it("joins a later split onto the partner's earlier order, promoting a mirror", async () => {
+      await createRegion()
+      const { partnerId } = await createPartner("join")
+      // Templates make the run DISPATCH, and dispatch is what writes the
+      // partner↔order link the open-order lookup reads. Without it the second
+      // split cannot see the first order and mints its own.
+      const templateName = await createTemplate(`design-unification-join-${unique}`)
+
+      const firstDesign = await createDesign()
+      const first = await post(
+        `/admin/designs/${firstDesign}/production-runs`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              quantity: 1,
+              role: "cutting",
+              template_names: [templateName],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect(first.status).toBe(201)
+      const firstChild = first.data.children[0]
+      const firstOrderId = await unifiedOrderIdOf(firstChild.id)
+      expect(firstOrderId).toBeTruthy()
+
+      // A lone child keeps the single-design mirror — NOT collated.
+      const mirror = await fetchUnifiedOrder(firstOrderId)
+      expect(mirror.metadata.collated_design_order ?? false).toBe(false)
+      expect(mirror.items).toHaveLength(1)
+
+      const secondDesign = await createDesign()
+      const second = await post(
+        `/admin/designs/${secondDesign}/production-runs`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              quantity: 2,
+              role: "stitching",
+              template_names: [templateName],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect(second.status).toBe(201)
+      const secondChild = second.data.children[0]
+
+      // 🔑 Same order — not a second one.
+      expect(await unifiedOrderIdOf(secondChild.id)).toBe(firstOrderId)
+
+      const joined = await fetchUnifiedOrder(firstOrderId)
+      // Promoted: it holds two runs now, so it must render as collated.
+      expect(joined.metadata.collated_design_order).toBe(true)
+      expect(joined.items).toHaveLength(2)
+
+      /**
+       * 🔴 The promoted mirror's OWN run must survive into the run list. It was
+       * never in `production_run_ids` (a mirror carries `production_run_id`
+       * singular), so a union that trusted metadata alone would drop it — and
+       * the order's rolled-up status is computed from this list.
+       */
+      expect(joined.metadata.production_run_ids).toEqual(
+        expect.arrayContaining([firstChild.id, secondChild.id])
+      )
+    })
   })
 })

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -647,7 +647,7 @@ export const WORK_ORDER_COLLATION_WINDOW_DAYS = 14
 export const findOpenPartnerWorkOrder = async (
   container: MedusaContainer,
   partnerId: string,
-  opts: { withinDays?: number } = {}
+  opts: { withinDays?: number; includeUncollated?: boolean } = {}
 ): Promise<{ order_id: string; created_at: string } | null> => {
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
   if (!partnerId) return null
@@ -688,8 +688,25 @@ export const findOpenPartnerWorkOrder = async (
           ? [o.production_runs]
           : []
         if (!runs.length) return false
-        // Collated ones only. A per-run order has no room for another design.
-        if (o?.metadata?.collated_design_order !== true) return false
+        /**
+         * Collated ones only, by default. A per-run mirror was minted to hold
+         * exactly one run and nothing says it was meant to collect more.
+         *
+         * `includeUncollated` (#2030 item 2.1) lets the APPROVE-SPLIT path
+         * treat a mirror as joinable, so a partner's second batch lands on the
+         * order their first batch made instead of minting a third. Joining
+         * PROMOTES the mirror — `joinRunsIntoWorkOrder` stamps
+         * `collated_design_order` — so it only has to be opted into once.
+         *
+         * ⚠️ Deliberately NOT the default: the dispatch path's behaviour is
+         * #1597's settled policy and is not being rewritten from here.
+         */
+        if (
+          !opts.includeUncollated &&
+          o?.metadata?.collated_design_order !== true
+        ) {
+          return false
+        }
         // Open. `completed` and `canceled` are settled; anything else collects.
         if (["completed", "canceled", "cancelled"].includes(String(o?.status ?? ""))) {
           return false
@@ -847,9 +864,30 @@ export const joinRunsIntoWorkOrder = async (
    * both recomputed across ALL its runs, old and new. A status derived from
    * only the newly-added runs would report a half-finished order as pending.
    */
+  /**
+   * ⚠️ The order's OWN linked runs are unioned in, not just what metadata
+   * already listed. A per-run mirror being promoted (#2030 item 2.1) carries
+   * `production_run_id` singular and no `production_run_ids` at all, so
+   * trusting metadata alone would write a list that silently OMITS the run the
+   * order was minted for — and the rolled-up status below is computed from
+   * this list, so that order would report the status of everything except its
+   * original job.
+   */
+  const linkedRunIds = (
+    Array.isArray(existingOrder?.production_runs)
+      ? existingOrder.production_runs
+      : existingOrder?.production_runs
+      ? [existingOrder.production_runs]
+      : []
+  )
+    .map((r: any) => r?.id)
+    .filter(Boolean)
+    .map(String)
+
   const allRunIds = Array.from(
     new Set([
       ...((existingOrder?.metadata?.production_run_ids as string[]) || []),
+      ...linkedRunIds,
       ...runs.map((r) => String(r.id)),
     ])
   )
@@ -865,6 +903,13 @@ export const joinRunsIntoWorkOrder = async (
     status: aggregateCoreStatus(allRuns),
     metadata: {
       ...(existingOrder?.metadata || {}),
+      /**
+       * An order holding more than one run IS a collated order, and the
+       * partner's detail page decides which view to render off this flag. A
+       * promoted mirror that kept the flag unset would show the partner a
+       * single-design screen for an order that now has several.
+       */
+      collated_design_order: true,
       production_run_ids: allRunIds,
     },
   })
@@ -1004,11 +1049,164 @@ export const dualWriteUnifiedRunOrderStep = createStep(
   }
 )
 
-// Approve-side step: §4 says one unified order per CHILD run (the
-// partner-facing unit). When approve splits a parent into child runs, each
-// child gets its own order and the parent's order — projected at create time,
-// before we could know it would become a planning artifact — is canceled and
-// marked superseded so billing never double-counts the work.
+/**
+ * Project a split's child runs onto work-orders, COLLATING per partner
+ * (#2030 item 2.1).
+ *
+ * 🔴 What this replaces: one `projectRunToUnifiedOrder` per child, i.e. one
+ * mirror order per child run. That is what minted orders 110 and 111 fifteen
+ * seconds apart for a single design — three orders for one piece of work is
+ * what the partner actually saw, and reading them as three jobs is how ₹1,200
+ * nearly got paid a third time (#2026).
+ *
+ * The rule, per partner, in order:
+ *   1. JOIN their open work-order when they have one — including a per-run
+ *      mirror left by an earlier split, which the join promotes. This is the
+ *      "same order / collated from a previous one" case.
+ *   2. Otherwise COLLATE this partner's children into one new order — when
+ *      there are several. Several children for one partner are one batch.
+ *   3. A LONE child with nothing to join keeps its per-run mirror, which stays
+ *      joinable for the next batch. See the guard below for why a collation of
+ *      one is not harmless.
+ *
+ * ⚠️ Children with NO partner keep the per-run mirror. Collation is a
+ * PARTNER-scoped idea — there is no "their open order" to join and nothing
+ * that says two unassigned children are one batch. Grouping them by absence
+ * would invent a relationship the split never stated.
+ *
+ * ⚠️ The join is attempted, never assumed — same contract as the dispatch
+ * path. The children exist either way, so a failed append must fall back to
+ * minting rather than throw; an exception here would leave approved work with
+ * no line on any order.
+ *
+ * ⚠️ Already-projected children are skipped. `projectRunToUnifiedOrder` is
+ * idempotent on the order↔run link, but `join`/`collate` are NOT — on a step
+ * retry they would add a second line for work already on an order.
+ */
+export const projectChildRunsCollated = async (
+  container: MedusaContainer,
+  childRunIds: string[]
+): Promise<void> => {
+  if (!childRunIds.length) return
+
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const runService: ProductionRunService = container.resolve(
+    PRODUCTION_RUNS_MODULE
+  )
+
+  // `select: ["*"]` — the collated line items are built from the run's
+  // snapshot (design name, cost), so a partial read would title every line
+  // "Design <id>".
+  const runs = (await runService
+    .listProductionRuns({ id: childRunIds } as any, { select: ["*"] })
+    .catch(() => [])) as any[]
+
+  if (!runs.length) {
+    // Fall back rather than silently project nothing.
+    for (const childId of childRunIds) {
+      await projectRunToUnifiedOrder(container, childId)
+    }
+    return
+  }
+
+  const unprojected: any[] = []
+  for (const run of runs) {
+    const existing = await resolveUnifiedOrderIdByLink(
+      container,
+      "production_runs",
+      run.id
+    )
+    if (!existing) unprojected.push(run)
+  }
+  if (!unprojected.length) return
+
+  const byPartner = new Map<string | null, any[]>()
+  for (const run of unprojected) {
+    const key = run.partner_id ? String(run.partner_id) : null
+    if (!byPartner.has(key)) byPartner.set(key, [])
+    byPartner.get(key)!.push(run)
+  }
+
+  for (const [partnerId, partnerRuns] of byPartner) {
+    if (!partnerId) {
+      for (const run of partnerRuns) {
+        await projectRunToUnifiedOrder(container, run.id)
+      }
+      continue
+    }
+
+    let projected = false
+    /**
+     * `includeUncollated` — a partner's earlier split left a per-run mirror,
+     * and that mirror is exactly the "same order" this batch belongs on. The
+     * join promotes it (see findOpenPartnerWorkOrder).
+     */
+    const open = await findOpenPartnerWorkOrder(container, partnerId, {
+      includeUncollated: true,
+    })
+    if (open) {
+      try {
+        await joinRunsIntoWorkOrder(container, open.order_id, partnerRuns)
+        projected = true
+        logger.info(
+          `[orders-unification] ${partnerRuns.length} child run(s) joined partner ${partnerId}'s open work-order ${open.order_id}`
+        )
+      } catch (e: any) {
+        logger.warn(
+          `[orders-unification] could not join work-order ${open.order_id} for partner ${partnerId} (${e?.message}) — minting a new one`
+        )
+      }
+    }
+
+    /**
+     * Nothing to join. Several children for one partner are one batch and get
+     * ONE order between them — but a LONE child keeps the per-run mirror.
+     *
+     * ⚠️ Not an optimisation: `collated_design_order` is what the partner's
+     * detail page branches on, and a collated order of one renders the
+     * many-designs view — losing the single-design screen (media, size sets,
+     * BOM, cost estimate) for what is the most common split there is. A
+     * collation of one collates nothing; it only changes the screen.
+     *
+     * The mirror stays JOINABLE, so the partner's next batch still lands on
+     * it rather than minting another order.
+     */
+    if (!projected && partnerRuns.length < 2) {
+      for (const run of partnerRuns) {
+        await projectRunToUnifiedOrder(container, run.id)
+      }
+      continue
+    }
+
+    if (!projected) {
+      const result = await collateRunsIntoWorkOrder(container, partnerRuns, {
+        // The commissioning order the children inherited from the parent.
+        sourceOrderId: partnerRuns[0]?.order_id ?? null,
+      })
+      if (!result.unified_order_id) {
+        // Collation declined (no region). One mirror each is worse than one
+        // order, but it is better than work with no order at all.
+        logger.warn(
+          `[orders-unification] collation produced no order for partner ${partnerId} (${result.skipped ?? "unknown"}) — falling back to per-run mirrors`
+        )
+        for (const run of partnerRuns) {
+          await projectRunToUnifiedOrder(container, run.id)
+        }
+      }
+    }
+  }
+}
+
+// Approve-side step. When approve splits a parent into child runs, the
+// children are projected COLLATED PER PARTNER (#2030 item 2.1 — see
+// projectChildRunsCollated), and the parent's order — projected at create
+// time, before we could know it would become a planning artifact — is canceled
+// and marked superseded so billing never double-counts the work.
+//
+// §4's original wording was "one unified order per CHILD run". That is what
+// this step used to do, and it is what #2030 corrects: the partner-facing unit
+// is the partner's BATCH, not the individual child. One order per child is how
+// one design became three orders.
 export const dualWriteChildRunOrdersStep = createStep(
   "dual-write-child-run-orders",
   async (
@@ -1017,9 +1215,7 @@ export const dualWriteChildRunOrdersStep = createStep(
   ) => {
     const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
     try {
-      for (const childId of input.child_run_ids) {
-        await projectRunToUnifiedOrder(container, childId)
-      }
+      await projectChildRunsCollated(container, input.child_run_ids)
 
       if (input.child_run_ids.length) {
         // D5-3 — the parent's unified order via the link (forward,


### PR DESCRIPTION
#2030 item 2.1 — the defect behind the three orders.

## What was happening

`dualWriteChildRunOrdersStep` called `projectRunToUnifiedOrder` **once per child**, so an approve-time split minted one mirror order per child run. That is what produced **orders 110 and 111, fifteen seconds apart, for a single design**. Three orders for one piece of work is what the partner actually saw — and reading them as three jobs is how ₹1,200 nearly got paid a third time (#2026).

## The rule now, per partner

1. **JOIN** their open work-order when they have one — including a per-run mirror left by an earlier split, which the join now **promotes** (`collated_design_order`). This is the *"included in the same order, or collated from a previous one"* case.
2. Otherwise **COLLATE** this partner's children into one new order, when there are several. Several children for one partner are one batch.
3. A **lone** child with nothing to join keeps its per-run mirror — and that mirror stays joinable for the next batch.

**3 is deliberate.** `collated_design_order` is what the partner's order detail branches on, and a collated order of one renders the many-designs view — losing the single-design screen (media, size sets, BOM, cost estimate) for the most common split there is. A collation of one collates nothing; it only changes the screen.

## Scope held deliberately

`includeUncollated` is **opt-in, and only the split path passes it**. The dispatch path's open-order lookup is #1597's settled policy and is not being rewritten from underneath. Widening it to dispatch is a separate decision (item 2.2), and the audit that item asks for is below.

## Two things that would have been silent

- **The promoted mirror's OWN run must survive into `production_run_ids`.** A mirror carries `production_run_id` **singular** and no list at all, so the union now reads the order's *linked* runs too. Trusting metadata alone drops the run the order was minted for — and the order's rolled-up status is computed from that list, so it would report the status of everything except its original job.
- **Already-projected children are skipped.** `projectRunToUnifiedOrder` is idempotent on the order↔run link; `join`/`collate` are **not**, so a step retry would add a second line for work already on an order.

Children with **no partner** keep the per-run mirror: collation is a partner-scoped idea, and grouping unassigned children by absence would invent a relationship the split never stated.

## The `skip_unified_projection` audit (#2030 asked for it before any fix)

Six callers opt out, and all six are correct — each already owns its order:

| Caller | Why it opts out |
|---|---|
| `designs/create-runs-for-design-order.ts:109` | collates itself afterwards |
| `designs/produce-designs-as-work-order.ts:207` | collates itself afterwards |
| `lib/reconcile-provenance-runs.ts:141` | reconciliation, order already exists |
| `ops/backfill-fulfilled-retail-runs-job.ts:173` | retail order already exists |
| `subscribers/order-placed.ts:187` | the retail order IS the order |

Five paths do **not** pass it and so mint a per-run mirror: `change-order-item-design`, admin `designs/:id/production-runs`, admin `production-runs`, partner `designs/:designId/production-runs`, and `recreate-production-run`. Those are create-time, where the run usually has no partner yet — there is no "their open order" to join. That is why this PR fixes the **approve-time** path, where children carry `partner_id` from creation.

## Verify

```
pnpm test:integration:http:shared \
  ./integration-tests/http/orders-unification-design-dual-write.spec.ts \
  ./integration-tests/http/design-production-runs-multi-partner.spec.ts \
  ./integration-tests/http/designs-produce-collate-chain.spec.ts \
  ./integration-tests/http/production-run-parent-rollup.spec.ts \
  ./integration-tests/http/production-run-lifecycle.spec.ts \
  ./integration-tests/http/production-run-partner-status.spec.ts
```
**6 suites, 26 tests, passed.** Plus the supersession set — `payment-submissions-api`, `production-run-quantity-correction`, `admin-run-output-review`, `production-run-design-status`: **4 suites, 171 tests, passed.** Unit: 37. Typecheck unchanged at 84 pre-existing errors.

## Mutation check — both halves

Restoring one-order-per-child:
```
✕ collates a partner's child runs onto ONE order, not one each
✕ joins a later split onto the partner's earlier order, promoting a mirror
Tests: 2 failed, 6 passed
```

Dropping the linked-run union — the promoted mirror's own run vanishes:
```
Expected: ArrayContaining ["prod_run_…JBJ2X…", "prod_run_…JV3AG…"]
Received: ["prod_run_…JV3AG…"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp