### PR TITLE
fix(#2030): a per-run mirror is a joinable work-order

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
@@ -632,5 +632,65 @@ setupSharedTestSuite(() => {
         expect.arrayContaining([firstChild.id, secondChild.id])
       )
     })
+    /**
+     * #2030 item 2.2 — the DISPATCH path joins a per-run mirror too.
+     *
+     * `findOpenPartnerWorkOrder` used to require `collated_design_order`, so
+     * only an order that had ALREADY collected several designs could collect
+     * another. A partner's first job always mints a mirror, which made that
+     * first order permanently ineligible: the common shape — one job, then
+     * another a few days later — could never collate, and every batch minted
+     * its own order.
+     */
+    it("dispatch joins the partner's existing mirror rather than minting another", async () => {
+      await createRegion()
+      const { partnerId } = await createPartner("dispatch-join")
+      const templateName = await createTemplate(
+        `design-unification-dispatch-${unique}`
+      )
+
+      // A first job, dispatched — leaves an UNCOLLATED per-run mirror.
+      const firstDesign = await createDesign()
+      const first = await post(
+        `/admin/designs/${firstDesign}/production-runs`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              quantity: 1,
+              role: "cutting",
+              template_names: [templateName],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect(first.status).toBe(201)
+      const mirrorOrderId = await unifiedOrderIdOf(first.data.children[0].id)
+      expect(mirrorOrderId).toBeTruthy()
+      const mirror = await fetchUnifiedOrder(mirrorOrderId)
+      expect(mirror.metadata.collated_design_order ?? false).toBe(false)
+
+      // A later dispatch through the door the drawer actually uses.
+      const secondDesign = await createDesign()
+      const produce = await post(
+        "/admin/designs/produce",
+        {
+          design_ids: [secondDesign],
+          partner_id: partnerId,
+          template_names: [templateName],
+        },
+        adminHeaders
+      )
+      expect(produce.status).toBe(200)
+
+      // 🔑 It landed on the order that already existed.
+      expect(produce.data.design_production.work_order_id).toBe(mirrorOrderId)
+      expect(produce.data.design_production.work_order_joined).toBe(true)
+
+      const joined = await fetchUnifiedOrder(mirrorOrderId)
+      expect(joined.metadata.collated_design_order).toBe(true)
+      expect(joined.items).toHaveLength(2)
+    })
   })
 })

--- a/apps/backend/src/workflows/production-runs/__tests__/work-order-collation.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/work-order-collation.unit.spec.ts
@@ -103,12 +103,25 @@ describe("findOpenPartnerWorkOrder", () => {
   )
 
   /**
-   * A per-run work-order has no room for another design — only orders minted
-   * BY the collation path can collect more.
+   * #2030 item 2.2 — this used to assert the OPPOSITE: "a per-run work-order
+   * has no room for another design; only orders minted BY the collation path
+   * can collect more."
+   *
+   * That rule could not do the job it was written for. A partner's FIRST job
+   * always mints a per-run mirror, so that first order was permanently
+   * ineligible to collect anything — the common shape (one job, then another
+   * a few days later) could never collate, and every batch minted its own
+   * order. Joining PROMOTES the mirror, so it becomes a proper collated order
+   * the moment it actually holds more than one run.
+   *
+   * What bounds the join is unchanged: the partner link, the order↔run link,
+   * an open status, and the #1597 window — all asserted above.
    */
-  it("skips an order that is not a collated one", async () => {
+  it("joins a per-run mirror, which the join then promotes", async () => {
     const { container } = containerWith([order({ metadata: {} })])
-    expect(await findOpenPartnerWorkOrder(container, "partner_1")).toBeNull()
+    expect(
+      (await findOpenPartnerWorkOrder(container, "partner_1"))?.order_id
+    ).toBe("order_1")
   })
 
   /**

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -647,7 +647,7 @@ export const WORK_ORDER_COLLATION_WINDOW_DAYS = 14
 export const findOpenPartnerWorkOrder = async (
   container: MedusaContainer,
   partnerId: string,
-  opts: { withinDays?: number; includeUncollated?: boolean } = {}
+  opts: { withinDays?: number } = {}
 ): Promise<{ order_id: string; created_at: string } | null> => {
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
   if (!partnerId) return null
@@ -689,24 +689,24 @@ export const findOpenPartnerWorkOrder = async (
           : []
         if (!runs.length) return false
         /**
-         * Collated ones only, by default. A per-run mirror was minted to hold
-         * exactly one run and nothing says it was meant to collect more.
+         * A per-run mirror counts as joinable (#2030 item 2.2).
          *
-         * `includeUncollated` (#2030 item 2.1) lets the APPROVE-SPLIT path
-         * treat a mirror as joinable, so a partner's second batch lands on the
-         * order their first batch made instead of minting a third. Joining
-         * PROMOTES the mirror — `joinRunsIntoWorkOrder` stamps
-         * `collated_design_order` — so it only has to be opted into once.
+         * This check used to require `collated_design_order === true`, i.e.
+         * only an order that had ALREADY collected several designs could
+         * collect another. A partner's first job always mints a mirror, so the
+         * common shape — one job, then another a few days later — could never
+         * collate: the very first order was permanently ineligible and every
+         * batch after it minted its own. Three orders for one piece of work.
          *
-         * ⚠️ Deliberately NOT the default: the dispatch path's behaviour is
-         * #1597's settled policy and is not being rewritten from here.
+         * Joining PROMOTES the mirror (`joinRunsIntoWorkOrder` stamps
+         * `collated_design_order`), so an order becomes a proper collated one
+         * the moment it actually holds more than one run.
+         *
+         * What still bounds this is unchanged and is what makes it safe: the
+         * partner link, the order↔run link that says this is a design order,
+         * an OPEN status, and the #1597 window below. A settled or stale order
+         * is never appended to.
          */
-        if (
-          !opts.includeUncollated &&
-          o?.metadata?.collated_design_order !== true
-        ) {
-          return false
-        }
         // Open. `completed` and `canceled` are settled; anything else collects.
         if (["completed", "canceled", "cancelled"].includes(String(o?.status ?? ""))) {
           return false
@@ -1136,14 +1136,9 @@ export const projectChildRunsCollated = async (
     }
 
     let projected = false
-    /**
-     * `includeUncollated` — a partner's earlier split left a per-run mirror,
-     * and that mirror is exactly the "same order" this batch belongs on. The
-     * join promotes it (see findOpenPartnerWorkOrder).
-     */
-    const open = await findOpenPartnerWorkOrder(container, partnerId, {
-      includeUncollated: true,
-    })
+    // A mirror left by an earlier split is exactly the "same order" this
+    // batch belongs on, and the lookup treats it as joinable.
+    const open = await findOpenPartnerWorkOrder(container, partnerId)
     if (open) {
       try {
         await joinRunsIntoWorkOrder(container, open.order_id, partnerRuns)


### PR DESCRIPTION
#2030 item 2.2 — the open correction from #2033's scope note, now closed.

## The rule that could not do its job

`findOpenPartnerWorkOrder` required `collated_design_order === true`: only an order that had **already** collected several designs could collect another.

A partner's **first** job always mints a per-run mirror. So that first order was permanently ineligible to collect anything, and the common shape — one job, then another a few days later — could never collate. Every batch minted its own order. Three orders for one piece of work.

Joining **promotes** the mirror (`joinRunsIntoWorkOrder` stamps `collated_design_order`), so an order becomes a proper collated one the moment it actually holds more than one run.

## One policy, both paths

This replaces the `includeUncollated` opt-in added for the split path in #2033 with a single shared rule. The approve-split path and the dispatch path now answer *"does this join their open batch, or start another order?"* the same way — including the **dry-run preview** the drawer shows before messaging a partner, which would otherwise have promised a new order and then joined one.

## What still bounds it

Unchanged, and it is what makes this safe: the partner link, the order↔run link that **is** the kind=design discriminator, an **open** status, and #1597's 14-day window. A settled or stale order is never appended to. Those guards are each asserted in the unit spec.

## The reversed test

`skips an order that is not a collated one` asserted the old rule. It is **rewritten, not deleted** — as `joins a per-run mirror, which the join then promotes`, carrying the reason the rule reversed, so the next reader does not restore it as a fix.

## Verify

```
pnpm test:integration:http:shared \
  ./integration-tests/http/orders-unification-design-dual-write.spec.ts \
  ./integration-tests/http/designs-produce-collate-chain.spec.ts \
  ./integration-tests/http/designs-produce-no-customer.spec.ts \
  ./integration-tests/http/design-order-produce-fanout.spec.ts \
  ./integration-tests/http/design-production-runs-multi-partner.spec.ts
```
**5 suites, 28 tests, passed.** Plus `payment-submissions-api`, `production-run-lifecycle`, `production-run-parent-rollup`, `production-run-partner-status`: **4 suites, 165 tests, passed.** Unit: 37. Typecheck unchanged at 84 pre-existing errors.

## Mutation check

Restoring the collated-only requirement:

```
✕ joins a later split onto the partner's earlier order, promoting a mirror
✕ dispatch joins the partner's existing mirror rather than minting another
Tests: 2 failed, 7 passed, 9 total
```

New integration test `dispatch joins the partner's existing mirror rather than minting another` goes through `POST /admin/designs/produce` — the door the drawer actually uses — and asserts `work_order_id` is the pre-existing mirror and `work_order_joined: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp