### PR TITLE
fix(#2030): the partner never sees a superseded planning artifact

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
@@ -12,6 +12,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
 import partnerOrderLink from "../../src/links/partner-order"
+import { PARTNER_MODULE } from "../../src/modules/partner"
 import designOrderLink from "../../src/links/design-order-link"
 
 jest.setTimeout(120000)
@@ -691,6 +692,87 @@ setupSharedTestSuite(() => {
       const joined = await fetchUnifiedOrder(mirrorOrderId)
       expect(joined.metadata.collated_design_order).toBe(true)
       expect(joined.items).toHaveLength(2)
+    })
+    /**
+     * #2030 — the partner must not be shown the planning artifact.
+     *
+     * A split cancels the parent's order and marks it superseded. The run,
+     * though, is untouched, so the order's work-status sidecar keeps whatever
+     * it last said — in Sharlho's portal, order 110 sat there `canceled` while
+     * its badge read `assigned`, i.e. a job they still owed. Three rows for one
+     * jacket, one of them never real work.
+     */
+    it("hides a superseded parent order from the partner's list, but not the child's", async () => {
+      await createRegion()
+      const designId = await createDesign()
+      const { partnerId, partnerHeaders } = await createPartner("superseded-list")
+      const templateName = await createTemplate(
+        `design-unification-superseded-${unique}`
+      )
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              quantity: 2,
+              role: "cutting",
+              template_names: [templateName],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const parentId = createRes.data.production_run.id
+      const childId = createRes.data.children[0].id
+
+      const parentOrderId = await unifiedOrderIdOf(parentId)
+      const childOrderId = await unifiedOrderIdOf(childId)
+
+      // Precondition: the parent order really is the canceled, superseded one.
+      const parentOrder = await fetchUnifiedOrder(parentOrderId)
+      expect(parentOrder.status).toBe("canceled")
+      expect(parentOrder.metadata.superseded_by_run_ids).toEqual([childId])
+
+      /**
+       * 🔴 The parent order must be PARTNER-LINKED or this test proves nothing.
+       *
+       * In this flow the parent run carries no partner (only the children do),
+       * so the parent order gets no D3 link and never reaches the partner's
+       * list in the first place — a filter test against it passes with the
+       * filter REMOVED. Sharlho's parent run did carry the partner, which is
+       * why order 110 was on their screen at all. Link it here so the row is
+       * genuinely reachable, and the exclusion is what removes it.
+       */
+      const remoteLink = getContainer().resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+      await remoteLink.create([
+        {
+          [PARTNER_MODULE]: { partner_id: partnerId },
+          [Modules.ORDER]: { order_id: parentOrderId },
+        },
+      ])
+
+      const listRes = await api.get(
+        "/partners/orders?kind=design&limit=100",
+        partnerHeaders
+      )
+      expect(listRes.status).toBe(200)
+      const ids = (listRes.data.orders || []).map((o: any) => String(o.id))
+
+      // 🔑 The artifact is gone; the work the partner actually has is not.
+      expect(ids).not.toContain(String(parentOrderId))
+      expect(ids).toContain(String(childOrderId))
+
+      /**
+       * `count` must agree with the rows. The exclusion happens on the id set
+       * BEFORE the query, so a hidden order was never counted — filtering after
+       * pagination would leave a count that promises a row the page cannot show.
+       */
+      expect(listRes.data.count).toBe(ids.length)
     })
   })
 })

--- a/apps/backend/src/workflows/orders/list-partner-orders.ts
+++ b/apps/backend/src/workflows/orders/list-partner-orders.ts
@@ -41,6 +41,49 @@ export type ListPartnerOrdersWorkflowInput = {
   take: number
 }
 
+/**
+ * A canceled order that a run split superseded — the planning artifact, not work
+ * the partner was ever asked to do (#2030).
+ *
+ * 🔴 What this fixes, in the partner's own words: Sharlho's portal listed THREE
+ * rows for one jacket. One (order 110) was `canceled` yet its work-status badge
+ * still read `assigned`, because the sidecar is written when the run is
+ * dispatched and the supersession cancels the ORDER without touching the RUN. A
+ * canceled order advertising live work is worse than a redundant row: it reads
+ * as a job the partner still owes.
+ *
+ * ⚠️ It only reaches the partner at all when the PARENT run carried the partner
+ * (Sharlho's did). Where only the children are assigned, the parent order has no
+ * D3 link and was never listed — which is exactly why a test for this must link
+ * the parent deliberately, or it passes with this function deleted.
+ *
+ * ⚠️ Deliberately narrow. Only `canceled` AND superseded is hidden. A canceled
+ * work-order WITHOUT `superseded_by_run_ids` is a real cancellation — something
+ * the partner was asked to do and then told to stop — and they are entitled to
+ * see it.
+ *
+ * 🔑 Filtered HERE, on the id set, not after the page is fetched: this step feeds
+ * `filters.id = { $in: ids }`, so an excluded order never enters the query.
+ * Dropping rows after pagination would return short pages and a `count` that
+ * disagrees with them.
+ *
+ * ⚠️ In memory, necessarily — `query.graph` cannot filter on a JSON subkey, and a
+ * filter written against `metadata.superseded_by_run_ids` matches nothing
+ * SILENTLY, which here would hide every work-order from every partner.
+ *
+ * The admin read-proxy (#843) runs this same workflow and hides them too. That is
+ * the point: it is the mirror of what the partner sees. An admin who needs the
+ * unfiltered truth has the admin orders list, which is unaffected.
+ */
+const isSupersededArtifact = (o: any): boolean => {
+  const status = String(o?.status ?? "")
+  if (status !== "canceled" && status !== "cancelled") {
+    return false
+  }
+  const superseded = o?.metadata?.superseded_by_run_ids
+  return Array.isArray(superseded) && superseded.length > 0
+}
+
 // Resolve THIS partner's work-order order-ids, bucketed by kind, via the D3
 // `partner ↔ order` link + the reverse execution link (D5). Two single-hop
 // `query.graph` reads on confirmed link directions (partner→orders, then
@@ -74,9 +117,17 @@ export const resolvePartnerWorkOrderIdsStep = createStep(
     }
 
     // Reverse, PLURAL accessor — see ORDERS_UNIFICATION_342.md "LINK NAMING FINDING".
+    // `status` + `metadata` ride along for the supersession check below; both
+    // come free with this read rather than costing another round trip.
     const { data: orders } = await query.graph({
       entity: "orders",
-      fields: ["id", "production_runs.id", "inventory_orders.id"],
+      fields: [
+        "id",
+        "status",
+        "metadata",
+        "production_runs.id",
+        "inventory_orders.id",
+      ],
       filters: { id: orderIds },
     })
 
@@ -89,6 +140,9 @@ export const resolvePartnerWorkOrderIdsStep = createStep(
     const design: string[] = []
     const inventory: string[] = []
     for (const o of orders ?? []) {
+      if (isSupersededArtifact(o)) {
+        continue
+      }
       if (linked(o?.production_runs)) {
         design.push(o.id)
       } else if (linked(o?.inventory_orders)) {


### PR DESCRIPTION
The presentational half of the Sharlho thread. Data is left alone, on purpose — see below.

## What the partner actually sees today

Read live from prod, Sharlho's design order list:

| # | Status | Work status | Design |
|---|---|---|---|
| 89 | completed | completed | Hand-Woven Wool Tweed Jacket |
| **110** | **canceled** | **assigned** | Hand-Woven Wool Tweed Jacket |
| 111 | completed | completed | Hand-Woven Wool Tweed Jacket |

Three rows for one jacket. 89 is a genuinely separate August job; 110/111 are the Sep 10 split pair. The real problem is not the duplication — it is that **110 is canceled and still advertises `partner_status: assigned`**, so it reads as a job the partner still owes. The sidecar is written when the run is dispatched, and a split cancels the ORDER without touching the RUN, so nothing ever revisits it.

## The change

A canceled work-order carrying `superseded_by_run_ids` is the planning artifact of a split, not work anyone was asked to do. It is dropped from the partner's work-order id set.

**Narrow on purpose:** only `canceled` **and** superseded is hidden. A canceled work-order *without* supersession is a real cancellation — something the partner was asked to do and then told to stop — and they are entitled to see it.

**Filtered on the id set, before the query.** This step feeds `filters.id = { $in: ids }`, so an excluded order never enters the query. Dropping rows after pagination would give short pages and a `count` that disagrees with them; the test asserts `count` matches the rows returned.

**In memory, necessarily** — `query.graph` cannot filter on a JSON subkey, and a filter against `metadata.superseded_by_run_ids` matches nothing *silently*, which here would hide every work-order from every partner.

## Why not repair the data instead

`remirror-cancelled-run-status` has an explicit `superseded` bucket that **skips** these, with the reason stated in the code: *"order superseded by a run split — the child orders carry the commercial reality."* Previewed against prod today:

```
examined 49: 0 stale, 29 already correct, 0 undeterminable, 0 superseded, 20 unlinked; would re-mirror 0
```

It would change nothing — 110's parent run is `completed`, not cancelled, so it is not even among the 49. The repo already decided this data stays as it is. The fix belongs in presentation.

Also **not** doing: retroactively merging 110 into 111. 111 is completed and is the row the ₹1,200 payout hangs off; order-editing a settled, billed order to relocate lines is money-touching with no upside.

Result: Sharlho sees **two** rows for that jacket — August and September — matching the two garments and the two payable runs.

## 🔴 The first version of this test passed with the fix deleted

Worth stating plainly. In the ordinary split flow only the **children** carry a partner, so the parent order gets no D3 link and was never in the partner's list to begin with — the filter was a no-op and the test proved nothing. Sharlho's parent run *did* carry the partner, which is why 110 was on their screen at all.

The test now links the parent deliberately, and only then does removing the exclusion turn it red:

```
✕ hides a superseded parent order from the partner's list, but not the child's
    Expected value: not "order_01M2CSBXCJ72DEDXSPDGV4R3QB"
    Received array: ["order_01M2CSBXEZD3J8NEX1SJ7WPDA1", "order_01M2CSBXCJ72DEDXSPDGV4R3QB"]
```

## Scope

The admin read-proxy (#843) runs the same workflow and hides them too — that is the point, it is the mirror of what the partner sees. Admin's own orders list is unaffected and still shows everything.

This changes presentation only; no existing row is modified, and there is no backfill that retro-collates history. Merging settled orders is where money gets moved by accident.

## Verify

```
pnpm test:integration:http:shared \
  ./integration-tests/http/orders-unification-design-dual-write.spec.ts \
  ./integration-tests/http/orders-unification-partner-list-filter.spec.ts \
  ./integration-tests/http/partner-orders-api.spec.ts \
  ./integration-tests/http/partner-orders-design-summary.spec.ts \
  ./integration-tests/http/admin-partner-inspection.spec.ts
```
**5 suites, 90 tests, passed.** Typecheck unchanged at 84 pre-existing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp