### PR TITLE
fix(inventory-orders): select is_sample so sample shipments synthesise a contents line

### DIFF
--- a/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
@@ -97,7 +97,7 @@ export async function createInventoryOrderShipment(
   const inventoryOrderService: any = container.resolve(ORDER_INVENTORY_MODULE)
 
   const order = await inventoryOrderService.retrieveInventoryOrder(input.orderId, {
-    select: ["id", "total_price", "metadata", "shipping_address"],
+    select: ["id", "total_price", "metadata", "shipping_address", "is_sample"],
     relations: ["orderlines"],
   })
   if (!order) {


### PR DESCRIPTION
## What

The carrier boundary already synthesises a contents line for a samples/swatch order with no lines (#2009) — `"Fabric samples / swatches"`, SKU `SAMPLE-SWATCH`, qty 1, declared value — so the carrier gets a manifest instead of booking an empty one.

But the workflow fetched the order without selecting the `is_sample` column:

```ts
select: ["id", "total_price", "metadata", "shipping_address"]
```

`is_sample` lives on the legacy `inventory_orders` model as a real column (not in its own `metadata`; only the unified core-order mirror carries `metadata.is_sample`). So `isSampleOrder()` always returned `false` in the live path, and a lineless sample order threw `nothing to ship` instead of synthesising the line.

## Fix

Add `is_sample` to the `select` list in `createInventoryOrderShipment`.

## Testing

- `TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern=inventory-order-shipment` — 25/25 pass
- `tsc --noEmit` — no errors