### PR TITLE
fix(#2030 item 4): a partner's "work order" reaches production tools

### DIFF
--- a/apps/backend/src/api/partners/designs/[designId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/route.ts
@@ -15,7 +15,7 @@
 /**
  * @typedef {Object} PartnerInfo
  * @property {string} assigned_partner_id - The ID of the partner assigned to this design
- * @property {"incoming"|"assigned"|"in_progress"|"finished"|"completed"} partner_status - The current status of the design for this partner
+ * @property {"incoming"|"assigned"|"in_progress"|"awaiting_review"|"finished"|"completed"|"cancelled"} partner_status - The current status of the design for this partner
  * @property {"redo"|null} partner_phase - The current phase of the design (null if not in redo phase)
  * @property {string|null} partner_started_at - When the partner started working on the design (ISO 8601)
  * @property {string|null} partner_finished_at - When the partner finished working on the design (ISO 8601)

--- a/apps/backend/src/api/partners/designs/route.ts
+++ b/apps/backend/src/api/partners/designs/route.ts
@@ -35,7 +35,7 @@
 /**
  * @typedef {Object} PartnerInfo
  * @property {string} assigned_partner_id - The ID of the assigned partner
- * @property {"incoming"|"assigned"|"in_progress"|"finished"|"completed"} partner_status - The status of the design from the partner's perspective
+ * @property {"incoming"|"assigned"|"in_progress"|"awaiting_review"|"finished"|"completed"|"cancelled"} partner_status - The status of the design from the partner's perspective
  * @property {"redo"|null} partner_phase - The current phase of the design
  * @property {string|null} partner_started_at - When the partner started working on the design
  * @property {string|null} partner_finished_at - When the partner finished working on the design

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -123,6 +123,32 @@ describe("partner-mcp per-ask tool slicing", () => {
       expect(matchDomains("cancel this order")).toContain("orders")
     })
 
+    /**
+     * #2030 item 4. A partner's "work order" is the work they were given, and
+     * answering it takes BOTH slices: `orders` for the list itself
+     * (`list_partner_orders`, already reached by the bare "order" keyword) and
+     * `production` for the runs and tasks they then accept, start or finish.
+     * Before this, only `orders` loaded — fulfilment tools and nothing to act
+     * with, which reads as a missing feature.
+     *
+     * NOT `designs`: the issue proposed mirroring the admin slicer, which maps
+     * the phrase there because /admin/design-work-orders lives in it. That
+     * route has no partner equivalent, so the mirror would have loaded design
+     * tools for an ask about the partner's own work.
+     */
+    it("a partner's 'work order' loads both orders and production", () => {
+      for (const ask of [
+        "show me my recent work orders",
+        "what work orders do i have",
+        "is that work order still with me",
+      ]) {
+        const domains = matchDomains(ask)
+        expect(domains).toContain("orders")
+        expect(domains).toContain("production")
+        expect(domains).not.toContain("designs")
+      }
+    })
+
     it("returns nothing for an ask with no operational vocabulary", () => {
       expect(matchDomains("hi, what can you do?")).toEqual([])
     })

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -279,6 +279,11 @@ const DOMAIN_KEYWORDS: Record<Exclude<PartnerToolDomain, "core">, string[]> = {
     "colourway", "colorway", "revision", "revisions", "bom",
     "bill of materials", "consumption", "consumption log", "consumption logs",
     "cost", "recalculate", "design media", "reference", "reference image",
+    // NOT "work order" — deliberately, and unlike the admin slicer, which maps
+    // it to `designs` because /admin/design-work-orders lives there. There is
+    // no partner equivalent of that route, so mirroring it here would load
+    // design tools for an ask that is about the partner's own work. The phrase
+    // belongs to `orders` + `production` — see the production slice below.
     // #1531 — a partner never says "inquiry". They say what was asked of them:
     // "can you make this", "they want to know if". Classification without the
     // words a partner actually types is a tool nobody can reach.
@@ -297,6 +302,14 @@ const DOMAIN_KEYWORDS: Record<Exclude<PartnerToolDomain, "core">, string[]> = {
     "manufacture", "manufacturing", "in progress", "wip",
     "task", "tasks", "assigned task", "assigned tasks", "accept task",
     "finish task",
+    // #2030 item 4. "show me my recent work orders" is a partner asking about
+    // the work they have been given. The bare "order" keyword already carries
+    // it to `orders` — the right list surface (`list_partner_orders`, whose
+    // `kind` switches retail / design / inventory work-orders) — but that slice
+    // is fulfilment tools alone, so the runs and tasks the partner then wants
+    // to accept, start or finish never load and it reads as a missing feature.
+    // Both slices, not one: the list answers "which", these answer "now what".
+    "work order", "work orders",
   ],
   inventory: [
     "inventory", "stock", "stocks", "raw material", "raw materials",

--- a/apps/partner-ui/src/components/work-orders/production-run-card.tsx
+++ b/apps/partner-ui/src/components/work-orders/production-run-card.tsx
@@ -106,13 +106,7 @@ export const ProductionRunCard = ({
   // lingers (cancelling the assignment now also cancels the run, but this
   // guards runs that predate that fix). The run's own status still gates
   // the individual transitions below.
-  // ⚠️ Compared as a STRING on purpose. `partner_status`'s declared union has
-  // no "cancelled" member, so `=== "cancelled"` was a comparison TypeScript
-  // proved could never be true — while the runtime value plainly can be. The
-  // type is the thing that is wrong; widening it is out of scope here, so the
-  // guard is kept honest rather than deleted.
-  const assignmentCancelled =
-    String(design?.partner_info?.partner_status ?? "") === "cancelled"
+  const assignmentCancelled = design?.partner_info?.partner_status === "cancelled"
   const actionable = !isCancelled && !assignmentCancelled
   const canAccept = actionable && status === "sent_to_partner"
   const canStart = actionable && status === "in_progress" && !run.started_at

--- a/apps/partner-ui/src/hooks/api/partner-designs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-designs.tsx
@@ -16,7 +16,18 @@ const PARTNER_DESIGNS_QUERY_KEY = "partner-designs" as const
 export const partnerDesignsQueryKeys = queryKeysFactory(PARTNER_DESIGNS_QUERY_KEY)
 
 export type PartnerDesignPartnerInfo = {
-  partner_status?: "incoming" | "assigned" | "in_progress" | "finished" | "completed"
+  // The full set both partner-designs routes can emit. `awaiting_review` and
+  // `cancelled` were missing (#2018 tail), which made a correct
+  // `=== "cancelled"` guard a comparison TypeScript proved impossible — see
+  // work-orders/production-run-card.tsx, which had to compare as a string.
+  partner_status?:
+    | "incoming"
+    | "assigned"
+    | "in_progress"
+    | "awaiting_review"
+    | "finished"
+    | "completed"
+    | "cancelled"
   partner_phase?: "redo" | null
   partner_started_at?: string | null
   partner_finished_at?: string | null


### PR DESCRIPTION
## Item 4 — the mirror the issue asked for would have been wrong

#2030 item 4 says `"work order"` is in the **admin** slicer (`tool-slice.ts:269`) and not the partner one, and calls the fix "one-line-shaped, mirroring a decision already made on the admin side."

The mirror is the wrong move. Admin maps the phrase to `designs` because `/admin/design-work-orders` lives in that slice. **There is no partner equivalent of that route** — a partner's work order is their own work, not a design record. Mirroring would have loaded design tools for an ask about the partner's job list.

## But the gap the issue describes is real

`"show me my recent work orders"` matched only the bare `order` keyword, which selects `orders` — the right *list* surface (`list_partner_orders`, whose `kind` switches retail / design / inventory work-orders) but fulfilment tools alone. The runs and tasks the partner then wants to accept, start or finish never loaded. Exactly as the issue puts it: "they get the wrong toolbox and it reads as a missing feature."

So the phrase now selects **`production` as well as `orders`**. Both, not one: the list answers *which*, the runs answer *now what*.

## Mutation-checked in both directions

| Mutation | New test |
|---|---|
| remove the keywords (pre-change state) | 🔴 red |
| put them in `designs` (the issue's proposal) | 🔴 red |
| as committed | 🟢 green |

89/89 in `partners/mcp/lib/__tests__/tool-slice.unit.spec.ts`.

## Also: #2018's tail — `partner_status` gains its two missing members

Both partner-designs routes emit seven values (`list-partner-designs.ts:230`, `[designId]/route.ts:178`). The consumer union carried five — `awaiting_review` and `cancelled` were missing. That made a *correct* `=== "cancelled"` guard in `production-run-card.tsx` a comparison TypeScript proved impossible; it had been kept honest by comparing as a string, under a comment saying the type was the thing that was wrong. Union widened, workaround removed, and the two backend JSDoc unions corrected to match.

Neither touched partner-ui file appears in that app's **1,099** pre-existing type errors.

## Verify

```
cd apps/backend && npx jest --config jest.config.js --testPathPattern="partners/mcp/lib/__tests__/tool-slice"
cd apps/partner-ui && npx vitest --run src/components/work-orders src/routes/designs
```

Refs #2030, #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp