### PR TITLE
fix(#2028 item 5): the sub-partner executing a run can read it

### DIFF
--- a/apps/backend/integration-tests/http/partner-production-run-create.spec.ts
+++ b/apps/backend/integration-tests/http/partner-production-run-create.spec.ts
@@ -143,6 +143,62 @@ setupSharedTestSuite(() => {
       expect((links || []).length).toBe(1)
     })
 
+    /**
+     * #2028 item 5. The sub-partner is the one actually making the garment, and
+     * `cost-summary` + `transfers` already admitted them — run-detail did not,
+     * so the same actor got a 404 on the resource whose cost they could read.
+     * Founder's call (2026-09-13): the executor may see the run they execute.
+     *
+     * The second assertion is the one that matters. The route scopes its
+     * `query.graph` by partner, and keying that on `partner_id` for a
+     * sub-partner returns NOTHING — the handler then falls back to a bare
+     * retrieve, which has no `tasks` and no `order.id`. That failure is silent:
+     * a 200 with a thinner body. So this asserts the SHAPE, not just the status.
+     */
+    it("lets the outsourced sub-partner read the run they are executing", async () => {
+      const { partnerHeaders: owner } = await createPartner(api, "src")
+      const { partnerId: subId, partnerHeaders: sub } = await createPartner(
+        api,
+        "exec"
+      )
+      const { partnerHeaders: stranger } = await createPartner(api, "outsider")
+      const designId = await ownDesign(owner)
+
+      const created = await api.post(
+        `/partners/designs/${designId}/production-runs`,
+        { quantity: 1, execution_mode: "outsourced", sub_partner_id: subId },
+        { headers: owner }
+      )
+      expect(created.status).toBe(201)
+      const runId = created.data.production_run.id as string
+
+      const asSub = await api.get(`/partners/production-runs/${runId}`, {
+        headers: sub,
+        validateStatus: () => true,
+      })
+      expect(asSub.status).toBe(200)
+      const seen = asSub.data.production_run || asSub.data.productionRun
+      expect(seen.id).toBe(runId)
+      expect(seen.sub_partner_id).toBe(subId)
+      // The full graph payload, not the bare-retrieve fallback.
+      expect(seen).toHaveProperty("tasks")
+
+      // The originator still reads it.
+      const asOwner = await api.get(`/partners/production-runs/${runId}`, {
+        headers: owner,
+        validateStatus: () => true,
+      })
+      expect(asOwner.status).toBe(200)
+
+      // An unrelated partner is still shut out — widening the scope to the
+      // executor must not widen it to everyone.
+      const asStranger = await api.get(`/partners/production-runs/${runId}`, {
+        headers: stranger,
+        validateStatus: () => true,
+      })
+      expect([401, 403, 404]).toContain(asStranger.status)
+    })
+
     it("rejects outsourced without a sub_partner_id, and blocks non-owners", async () => {
       const { partnerHeaders: owner } = await createPartner(api, "validate")
       const { partnerHeaders: intruder } = await createPartner(api, "intruder")

--- a/apps/backend/src/api/partners/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/route.ts
@@ -134,8 +134,16 @@ export async function GET(
     )
   }
 
+  // #2028 item 5 — scope is the originator (`partner_id`) OR the outsourced
+  // executor (`sub_partner_id`). This route used to admit the originator only,
+  // so a sub-partner 404'd on the run they were actually executing while
+  // `cost-summary` and `transfers` — same resource, same actor — let them
+  // straight in. Founder's call (2026-09-13): the executor may see their run.
   const persistedPartnerId = run?.partner_id ?? run?.partnerId ?? null
-  if (!persistedPartnerId || persistedPartnerId !== partnerId) {
+  const persistedSubPartnerId = run?.sub_partner_id ?? run?.subPartnerId ?? null
+  const isOriginator = !!persistedPartnerId && persistedPartnerId === partnerId
+  const isExecutor = !!persistedSubPartnerId && persistedSubPartnerId === partnerId
+  if (!isOriginator && !isExecutor) {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
       `ProductionRun ${id} not found for this partner ${partnerId}`
@@ -148,13 +156,22 @@ export async function GET(
   // (even though the run is present in the partner list query). We therefore use the
   // same query shape as the list endpoint (filter by partner_id) and select the run
   // in application code.
+  //
+  // #2028 item 5 — that shape is kept, but keyed on whichever field admitted
+  // this actor. A sub-partner filtered on `partner_id` matches NOTHING: `node`
+  // then falls back to the bare `retrieveProductionRun` result, which carries
+  // no `tasks` and no `order.id`, so the executor gets a run detail quietly
+  // missing the parts they came for. An empty graph result reads as a thinner
+  // page, never an error, so the scoping key has to follow the guard.
   const { data } = await query.graph({
     entity: "production_runs",
     // `order.id` resolves the order↔production_run link forward (#342 D5) so the
     // partner-ui can redirect the retired `/production-runs/:id` to the unified
     // order detail. Managed link → bidirectional; forward `.order` works here.
     fields: ["*", "tasks.*", "order.id"],
-    filters: { id, partner_id: partnerId },
+    filters: isOriginator
+      ? { id, partner_id: partnerId }
+      : { id, sub_partner_id: partnerId },
     pagination: { skip: 0, take: 1 },
   })
 


### PR DESCRIPTION
## The question item 5 asked

> May an outsourced sub-partner see the run they are executing? Run-detail says no, cost-summary says yes.

**Founder's call (2026-09-13): yes — run-detail was the surface that was wrong.**

`cost-summary/route.ts:37` and `transfers/route.ts:57` both scope to `partner_id` **or** `sub_partner_id`. Run-detail scoped to `partner_id` alone, so the same actor could read a run's *cost* and got a 404 on the run itself.

## The half that would have bitten

Widening the guard alone is not enough. The handler scopes its `query.graph` by partner and falls back to a bare `retrieveProductionRun` when that returns nothing:

```ts
const node = (data || [])[0] || run
```

A sub-partner filtered on `partner_id` matches **nothing** — so they'd get a **200** with no `tasks` and no `order.id`, quietly missing exactly the parts they came for. Not an error; a thinner page. The graph filter is now keyed on whichever field admitted the actor.

The existing `NOTE` warning that an id-only filter behaves unexpectedly here is respected — the two-key shape is kept, only the key changes.

## Mutation-checked

| Mutation | Result |
|---|---|
| guard reverted to originator-only | 🔴 red |
| guard widened, graph left on `partner_id` | 🔴 red — **on the shape assertion**, 200 with `tasks` absent |
| as committed | 🟢 4/4 green |

Mutation B is why the test asserts the body and not just the status. An unrelated partner is still shut out, and that's pinned too.

## ⚠️ Item 5's other half is NOT in this PR

The founder's answer had a second clause with more weight than the read:

> a partner executing their own production with the production cost — that should not record the payment, but be scoped to them.

Verified separately (see the issue): `sub_partner_id` and `execution_mode` appear **zero** times under `src/workflows/payment_submissions/` (control: 34 hits elsewhere in `src/`), and `run-claims.ts:31` states a run belongs to exactly one `partner_id`. **The platform will currently draft a payout for work it did not commission.** That is a selector change on the payable path, and it needs the scope question on the issue answered first.

## Verify

```
pnpm test:integration:http:shared ./integration-tests/http/partner-production-run-create
```

Refs #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp