### PR TITLE
fix(#2028 item 5): a partner's own production is not a platform payable

### DIFF
--- a/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
@@ -69,6 +69,49 @@ describe("assessRunPayout", () => {
     cost_type: "per_unit" as const,
   }
 
+  /**
+   * #2028 item 5. The platform pays for work it commissioned. A run the
+   * partner raised on their own design (`metadata.source: "partner.self_serve"`,
+   * stamped by `POST /partners/designs/:id/production-runs`) is their own cost.
+   *
+   * The marker was written in one place and read in NONE, so a partner's own
+   * job was indistinguishable from commissioned work and auto-drafted a payout
+   * on completion like any other run.
+   */
+  describe("a partner's own production is not a platform payable", () => {
+    const selfServe = {
+      ...completed,
+      metadata: { source: "partner.self_serve" },
+    }
+
+    it("refuses a self-serve run", () => {
+      expect(assessRunPayout(selfServe)).toEqual({
+        eligible: false,
+        reason: "partner_self_serve",
+      })
+    })
+
+    it("refuses it for WHOSE work it is, not for the money on it", () => {
+      // Ordered before the cost checks on purpose: the reason a caller logs
+      // must stay true the day someone fills the cost in, and must not change
+      // when they don't.
+      expect(
+        assessRunPayout({ ...selfServe, partner_cost_estimate: null })
+      ).toEqual({ eligible: false, reason: "partner_self_serve" })
+    })
+
+    it("leaves a commissioned run with other metadata payable", () => {
+      // The guard keys on the marker, not on the presence of metadata — a run
+      // carrying anything else must still bill.
+      expect(
+        assessRunPayout({ ...completed, metadata: { source: "admin.designs.manual" } })
+      ).toMatchObject({ eligible: true, amount: 400 })
+      expect(
+        assessRunPayout({ ...completed, metadata: {} })
+      ).toMatchObject({ eligible: true, amount: 400 })
+    })
+  })
+
   it("accepts a completed run with a design, a partner and a cost", () => {
     expect(assessRunPayout(completed)).toEqual({
       eligible: true,

--- a/apps/backend/src/workflows/production-runs/lib/run-payable.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-payable.ts
@@ -40,6 +40,28 @@ export type RunForPayout = {
 }
 
 /**
+ * #2028 item 5 — a run the PARTNER commissioned for themselves.
+ *
+ * `POST /partners/designs/:id/production-runs` lets a partner raise a
+ * self-approved run on their own design and stamps
+ * `metadata.source: "partner.self_serve"`. Founder's rule (2026-09-13): when a
+ * partner executes their own production, the production cost is THEIRS — it is
+ * scoped to them and the platform does not record a payment for it.
+ *
+ * ⚠️ Written in exactly one place (`partners/designs/[designId]/production-runs`)
+ * and, until this, read in NONE — so a partner's own job was indistinguishable
+ * from work the platform commissioned, and `assessRunPayout` drafted a payout
+ * for it on completion like any other run. The marker existed; nothing consulted
+ * it.
+ *
+ * Same shape of guard as `isProvenanceRun`, and it depends on the same thing:
+ * every caller must actually FETCH `metadata`.
+ */
+export const isPartnerSelfServeRun = (
+  run: Pick<RunForPayout, "metadata"> | null | undefined
+): boolean => run?.metadata?.source === "partner.self_serve"
+
+/**
  * The payable total for a run, or 0 when it has no usable cost.
  */
 export const runPayableAmount = (run: RunForPayout | null | undefined): number => {
@@ -317,6 +339,22 @@ export const assessRunPayout = (
    */
   if (isProvenanceRun(run)) {
     return { eligible: false, reason: "provenance_run" }
+  }
+
+  /**
+   * A partner's OWN production is not a platform payable (#2028 item 5).
+   *
+   * The platform pays for work it commissioned. A run the partner raised
+   * themselves, on their own design, carries a cost that is theirs to bear —
+   * so completing it must not auto-draft a payout in the platform's name.
+   *
+   * ⚠️ Ordered AFTER `provenance_run` and BEFORE the cost checks, for the same
+   * reason the rollup guard is: a self-serve run that HAS a cost must be
+   * refused for whose work it is, not incidentally for the money on it. The
+   * reason a caller logs should stay true the day the field is filled in.
+   */
+  if (isPartnerSelfServeRun(run)) {
+    return { eligible: false, reason: "partner_self_serve" }
   }
 
   /**


### PR DESCRIPTION
## The clause with money on it

Item 5's founder answer had two halves. #2039 shipped the read (a sub-partner may see the run they execute). This is the other:

> when a partner executes their own production with the production cost, that should not record the payment but be scoped to them

## The marker existed. Nothing read it.

`POST /partners/designs/:id/production-runs` — a partner raising a self-approved run on their own design — already stamps `metadata.source: "partner.self_serve"`.

That string is written in **exactly one place and read in none**. So a partner's own job was indistinguishable from work the platform commissioned: it completed, hit `assessRunPayout` like any other run, and **auto-drafted a payout in the platform's name.** The evidence was on the row the whole time.

## Why `assessRunPayout`

It is the auto-draft decision — literally "record the payment". Placed after `provenance_run` and **before** the cost checks, for the same reason the rollup guard is: a self-serve run that *has* a cost must be refused for **whose work it is**, not incidentally for the money on it. The reason a caller logs should stay true the day someone fills that field in. Both halves are asserted.

## Forward-only, deliberately

`refreshUnclaimedDraftPayouts` returns early on an ineligible run and **leaves the Draft alone** rather than zeroing it — a zero payout reads as a decision that the work was worthless (#1564). **No existing payout is rewritten by this.** It stops new ones.

## Mutation-checked

| Mutation | Result |
|---|---|
| guard removed | 🔴 red (both cases) |
| guard moved after the cost check | 🔴 red — on the ordering claim alone |
| as committed | 🟢 52/52 across `run-payable`, `run-kind`, `auto-draft-rollup-guard` |

## ⚠️ Scope — one thing deliberately left open

This changes the **auto-draft** only. The `payable-runs` screens read `runPayableOffer`, a different function, and still offer these runs to an operator. Offering a human the choice is not the same as the platform recording a payment unasked, and the founder's words were about recording.

Whether the screens should *also* hold them back — with an `excluded_runs` reason, exactly as `provenance_run` (#1606) and `superseded_run` (#2026) already do — is a product call. The machinery is there and it is a small follow-on. Flagged on the issue rather than decided here.

**Blast radius unverified:** I have not counted how many completed self-serve runs exist in prod, so I don't know how many auto-drafts this would have prevented historically. Worth a look before release, though nothing existing changes.

## Verify

```
cd apps/backend && npx jest --config jest.config.js \
  --testPathPattern="production-runs/__tests__/run-payable|production-runs/__tests__/run-kind|auto-draft-rollup-guard"
```

Refs #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp