### PR TITLE
feat(#2028): a partner's own production shows as their expense, not our payable

### DIFF
--- a/apps/backend/integration-tests/http/partner-production-run-create.spec.ts
+++ b/apps/backend/integration-tests/http/partner-production-run-create.spec.ts
@@ -199,6 +199,87 @@ setupSharedTestSuite(() => {
       expect([401, 403, 404]).toContain(asStranger.status)
     })
 
+    /**
+     * #2028 item 5, end to end. A partner cannot self-pay, so their own
+     * production is an EXPENSE they carry — visible, priced, filterable — and
+     * never a row that can be ticked into a platform payout.
+     *
+     * Both halves are asserted because either alone is a false pass: present in
+     * the expense bucket while ALSO sitting in `payable_runs` is exactly the
+     * bug, and absent from `payable_runs` while invisible everywhere is the
+     * silent drop the bucket exists to prevent.
+     */
+    it("files a partner's own completed production as an expense, not a payable", async () => {
+      const { partnerId, partnerHeaders } = await createPartner(api, "ownexp")
+      const designId = await ownDesign(partnerHeaders)
+
+      const created = await api.post(
+        `/partners/designs/${designId}/production-runs`,
+        { quantity: 2, execution_mode: "in_house" },
+        { headers: partnerHeaders }
+      )
+      expect(created.status).toBe(201)
+      const runId = created.data.production_run.id as string
+      expect(created.data.production_run.metadata?.source).toBe("partner.self_serve")
+
+      // A self-approved run lands `in_progress` with no `started_at`, so the
+      // lifecycle still has to be walked: start, then finish, then complete.
+      const started = await api.post(
+        `/partners/production-runs/${runId}/start`,
+        {},
+        { headers: partnerHeaders, validateStatus: () => true }
+      )
+      expect(started.status).toBeLessThan(300)
+      const finished = await api.post(
+        `/partners/production-runs/${runId}/finish`,
+        {},
+        { headers: partnerHeaders, validateStatus: () => true }
+      )
+      expect(finished.status).toBeLessThan(300)
+      const done = await api.post(
+        `/partners/production-runs/${runId}/complete`,
+        {
+          produced_quantity: 2,
+          partner_cost_estimate: 500,
+          cost_type: "per_unit",
+        },
+        { headers: partnerHeaders, validateStatus: () => true }
+      )
+      expect(done.status).toBeLessThan(300)
+
+      const res = await api.get("/partners/payment-submissions/payable-runs", {
+        headers: partnerHeaders,
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(200)
+
+      // Their own cost, stated — 2 x 500.
+      const expenses = res.data.partner_expense_runs || []
+      expect(expenses.map((r: any) => r.run_id)).toContain(runId)
+      const row = expenses.find((r: any) => r.run_id === runId)
+      expect(row.amount).toBe(1000)
+      expect(row.costed).toBe(true)
+      expect(res.data.partner_expense_total).toBe(1000)
+
+      // And nowhere the platform could pay it from.
+      expect(
+        (res.data.payable_runs || []).map((r: any) => r.run_id)
+      ).not.toContain(runId)
+      // Not an "exclusion" either — it is real work, just not ours.
+      expect(
+        (res.data.excluded_runs || []).map((r: any) => r.run_id)
+      ).not.toContain(runId)
+
+      // ⚠️ The admin twin is NOT asserted here: admin auth does not work in
+      // this spec. A control (`GET /admin/partners`) with freshly-fetched
+      // headers 401s at this point too, so it is the scaffolding, not the
+      // route — the existing email-template POST above swallows the same 401
+      // in a try/catch, which is why nobody had noticed. Agreement between the
+      // two screens is instead guaranteed structurally: both call the same pure
+      // `partner-expense-runs` helper, which is unit-tested directly. That is
+      // why it was extracted rather than the logic being written twice.
+    })
+
     it("rejects outsourced without a sub_partner_id, and blocks non-owners", async () => {
       const { partnerHeaders: owner } = await createPartner(api, "validate")
       const { partnerHeaders: intruder } = await createPartner(api, "intruder")

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -5,6 +5,11 @@ import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissi
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
 import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
 import { runPayableOffer } from "../../../../workflows/production-runs/lib/run-payable"
+import {
+  partnerExpenseRows,
+  partnerExpenseTotal,
+  splitPartnerExpenseRuns,
+} from "../../../../workflows/payment_submissions/lib/partner-expense-runs"
 import { listPartnerSubmissionItems } from "../../../../workflows/payment_submissions/lib/run-claims"
 import {
   runBillableRemaining,
@@ -132,7 +137,25 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   const allRuns = (runs || []) as any[]
-  const designBackedRuns = allRuns.filter((r) => !!r.design_id)
+
+  /**
+   * The partner's OWN production is their expense, not our payable (#2028
+   * item 5). Split out FIRST, before every other rule.
+   *
+   * Deliberately NOT another `excluded_runs` reason. Every entry there names a
+   * defect or an artefact — `provenance_run` (#1606) is work that happened in
+   * another run, `superseded_run` (#2026) is work that moved, and
+   * `no_design_and_no_order` is a run nobody can attribute. A self-serve run is
+   * real work with a real cost; it is simply not OURS. A partner cannot be both
+   * payer and payee, so there is no payout to make — #2040 already stopped it
+   * auto-drafting. Filing it under "excluded" would say something false about
+   * it and bury a figure the partner's own books need.
+   *
+   * So: its own bucket, WITH the money, so admin can see and filter on it.
+   */
+  const { commissioned: commissionedRuns, ownProduction } =
+    splitPartnerExpenseRuns(allRuns)
+  const designBackedRuns = commissionedRuns.filter((r) => !!r.design_id)
 
   /**
    * 🔴 Runs with no design were being dropped on the floor.
@@ -153,7 +176,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
    * ORDER that commissioned them, because that is the unit the payout is
    * agreed in. Order #79 is one payment of ₹8,974, not seven of ₹1,282.
    */
-  const orderBackedRuns = allRuns.filter((r) => !r.design_id && !!r.order_id)
+  // `commissionedRuns`, not `allRuns` — the self-serve split is applied before
+  // every downstream bucket, so a partner's own run can never reappear here as
+  // "real payable labour" just because it happens to lack a design.
+  const orderBackedRuns = commissionedRuns.filter((r) => !r.design_id && !!r.order_id)
 
   /**
    * ⚠️ And runs with neither. Nothing can attribute these — no design to price
@@ -161,7 +187,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
    * same reason: an unattributable run is a data question someone must answer,
    * not a row to hide.
    */
-  const unattributableRuns = allRuns.filter((r) => !r.design_id && !r.order_id)
+  const unattributableRuns = commissionedRuns.filter(
+    (r) => !r.design_id && !r.order_id
+  )
 
   /**
    * Prior payment lines for this PARTNER.
@@ -288,6 +316,45 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       }),
   ]
 
+  /**
+   * Names for both buckets, resolved BEFORE the early return.
+   *
+   * ⚠️ This fetch used to sit below it and cover `completedRuns` alone. A
+   * partner whose only runs are their OWN production has no payable rows at
+   * all, takes that early return, and would have got their expense list back
+   * as bare ids — the exact case the bucket exists to serve.
+   */
+  const designIds = [
+    ...new Set(
+      [...completedRuns, ...ownProduction]
+        .map((r) => (r.design_id ? String(r.design_id) : ""))
+        .filter(Boolean)
+    ),
+  ]
+
+  const { data: designs } = designIds.length
+    ? await query.graph({
+        entity: "designs",
+        fields: ["id", "name", "status", "estimated_cost", "production_cost"],
+        filters: { id: designIds },
+      })
+    : { data: [] as any[] }
+  const designById = new Map(
+    ((designs || []) as any[]).map((d) => [d.id, d])
+  )
+
+  const partner_expense_runs = partnerExpenseRows(
+    ownProduction,
+    new Map(
+      [...designById.entries()].map(([id, d]) => [String(id), String(d?.name ?? "")])
+    )
+  )
+  const partner_expense = {
+    partner_expense_runs,
+    partner_expense_count: partner_expense_runs.length,
+    partner_expense_total: partnerExpenseTotal(partner_expense_runs),
+  }
+
   if (!completedRuns.length) {
     // ⚠️ Still returns the order-backed rows. They are not design-backed, so a
     // partner with no design runs at all can still have real payable work —
@@ -300,21 +367,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       order_runs,
       order_runs_count: order_runs.length,
       unattributable_runs,
+      ...partner_expense,
     })
   }
-
-  const designIds = [
-    ...new Set(completedRuns.map((r) => String(r.design_id))),
-  ]
-
-  const { data: designs } = await query.graph({
-    entity: "designs",
-    fields: ["id", "name", "status", "estimated_cost", "production_cost"],
-    filters: { id: designIds },
-  })
-  const designById = new Map(
-    ((designs || []) as any[]).map((d) => [d.id, d])
-  )
 
   /**
    * 🔴 The fold lives in `lib/run-billing.ts`, not here. #1622 asks the same
@@ -531,5 +586,11 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     order_runs,
     order_runs_count: order_runs.length,
     unattributable_runs,
+    /**
+     * The partner's own production (#2028 item 5) — an EXPENSE they carry, not
+     * a payable we owe. Its own list, with the money on it, so the screen can
+     * show and filter it without any chance of it being ticked into a batch.
+     */
+    ...partner_expense,
   })
 }

--- a/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
@@ -7,6 +7,11 @@ import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reco
 import { fetchRunSupersessions } from "../../../../workflows/payment_submissions/lib/run-supersession"
 import { runPayableOffer } from "../../../../workflows/production-runs/lib/run-payable"
 import {
+  partnerExpenseRows,
+  partnerExpenseTotal,
+  splitPartnerExpenseRuns,
+} from "../../../../workflows/payment_submissions/lib/partner-expense-runs"
+import {
   foldPartnerBilling,
   runBillableRemaining,
   runBillingStatus,
@@ -70,7 +75,21 @@ export const GET = async (
     filters: { partner_id: partner.id, status: "completed" },
   })
 
-  const designBackedRuns = ((runs || []) as any[]).filter((r) => !!r.design_id)
+  const allDesignBacked = ((runs || []) as any[]).filter((r) => !!r.design_id)
+
+  /**
+   * The partner's OWN production is their expense, not our payable (#2028
+   * item 5). Split out FIRST, before every other rule: the exclusions below
+   * name defects (double-counted work, work that never happened in that run),
+   * and this is neither. It is real work with a real cost that simply is not
+   * ours — a partner cannot self-pay, so there is no payout to make.
+   *
+   * Reported with the money on it rather than dropped, so the screen can show
+   * it as an expense and filter on it.
+   */
+  const { commissioned: designBackedRuns, ownProduction } =
+    splitPartnerExpenseRuns(allDesignBacked)
+  const partner_expense_runs = partnerExpenseRows(ownProduction)
 
   /**
    * A run minted by a retail fulfilment is not billable labour (#1606).
@@ -129,9 +148,15 @@ export const GET = async (
   ]
 
   if (!completedRuns.length) {
-    return res
-      .status(200)
-      .json({ payable_runs: [], count: 0, excluded_runs, excluded_count: excluded_runs.length })
+    return res.status(200).json({
+      payable_runs: [],
+      count: 0,
+      excluded_runs,
+      excluded_count: excluded_runs.length,
+      partner_expense_runs,
+      partner_expense_count: partner_expense_runs.length,
+      partner_expense_total: partnerExpenseTotal(partner_expense_runs),
+    })
   }
 
   const designIds = [
@@ -298,5 +323,8 @@ export const GET = async (
     count: payable_runs.length,
     excluded_runs,
     excluded_count: excluded_runs.length,
+    partner_expense_runs,
+    partner_expense_count: partner_expense_runs.length,
+    partner_expense_total: partnerExpenseTotal(partner_expense_runs),
   })
 }

--- a/apps/backend/src/workflows/payment_submissions/__tests__/partner-expense-runs.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/partner-expense-runs.unit.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * #2028 item 5 — a partner's own production is their EXPENSE, not our payable.
+ *
+ * #2040 stopped it auto-drafting. This is the visibility half: it still shows
+ * in admin, with the money on it, in its own bucket — because a partner cannot
+ * self-pay, so the cost is theirs to bear and ours only to display.
+ */
+
+import {
+  splitPartnerExpenseRuns,
+  partnerExpenseRows,
+  partnerExpenseTotal,
+} from "../lib/partner-expense-runs"
+
+const SELF_SERVE = { source: "partner.self_serve" }
+
+const run = (over: Record<string, any> = {}) => ({
+  id: "run_1",
+  design_id: "des_1",
+  partner_id: "part_1",
+  status: "completed",
+  quantity: 2,
+  partner_cost_estimate: 500,
+  cost_type: "per_unit" as const,
+  completed_at: "2026-09-10T12:00:00.000Z",
+  ...over,
+})
+
+describe("splitPartnerExpenseRuns", () => {
+  it("separates the partner's own production from commissioned work", () => {
+    const own = run({ id: "own", metadata: SELF_SERVE })
+    const ours = run({ id: "ours", metadata: { source: "admin.designs.manual" } })
+    const bare = run({ id: "bare" })
+
+    const { commissioned, ownProduction } = splitPartnerExpenseRuns([own, ours, bare])
+
+    expect(ownProduction.map((r) => r.id)).toEqual(["own"])
+    // A run with no marker at all is OURS. Absence of the self-serve stamp is
+    // the default, and defaulting the other way would stop paying for real work.
+    expect(commissioned.map((r) => r.id)).toEqual(["ours", "bare"])
+  })
+
+  it("survives an empty or absent list", () => {
+    expect(splitPartnerExpenseRuns([])).toEqual({ commissioned: [], ownProduction: [] })
+    expect(splitPartnerExpenseRuns(null)).toEqual({ commissioned: [], ownProduction: [] })
+  })
+})
+
+describe("partnerExpenseRows", () => {
+  it("prices the run and names the design", () => {
+    const rows = partnerExpenseRows(
+      [run({ metadata: SELF_SERVE, produced_quantity: 2 })],
+      new Map([["des_1", "Tweed Jacket"]])
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      run_id: "run_1",
+      design_name: "Tweed Jacket",
+      quantity: 2,
+      unit_amount: 500,
+      amount: 1000,
+      costed: true,
+    })
+  })
+
+  it("returns null for an unknown design rather than an id dressed as a name", () => {
+    const rows = partnerExpenseRows([run({ metadata: SELF_SERVE })], new Map())
+    expect(rows[0].design_name).toBeNull()
+    // And with no lookup passed at all.
+    expect(partnerExpenseRows([run({ metadata: SELF_SERVE })])[0].design_name).toBeNull()
+  })
+
+  /**
+   * The one that would quietly put a partner's own job back on the payable
+   * list: a self-serve run with no cost. `costed: false` says the price was
+   * never written down — it does NOT demote the run out of this bucket.
+   */
+  it("keeps an unpriced self-serve run in the bucket, at zero", () => {
+    const rows = partnerExpenseRows([
+      run({ metadata: SELF_SERVE, partner_cost_estimate: null }),
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].amount).toBe(0)
+    expect(rows[0].costed).toBe(false)
+  })
+
+  it("orders newest first", () => {
+    const rows = partnerExpenseRows([
+      run({ id: "old", metadata: SELF_SERVE, completed_at: "2026-01-01T00:00:00.000Z" }),
+      run({ id: "new", metadata: SELF_SERVE, completed_at: "2026-09-01T00:00:00.000Z" }),
+      run({ id: "undated", metadata: SELF_SERVE, completed_at: null }),
+    ])
+    expect(rows.map((r) => r.run_id)).toEqual(["new", "old", "undated"])
+  })
+
+  it("bills a `total` run verbatim, not unit x quantity (#1596)", () => {
+    const rows = partnerExpenseRows([
+      run({
+        metadata: SELF_SERVE,
+        cost_type: "total",
+        partner_cost_estimate: 10000,
+        quantity: 9,
+        produced_quantity: 7,
+      }),
+    ])
+    // The agreed total, NOT a re-priced 7/9 of it.
+    expect(rows[0].amount).toBe(10000)
+    expect(rows[0].unit_is_derived).toBe(true)
+  })
+})
+
+describe("partnerExpenseTotal", () => {
+  it("sums what the partner spent", () => {
+    const rows = partnerExpenseRows([
+      run({ id: "a", metadata: SELF_SERVE, partner_cost_estimate: 500, quantity: 2 }),
+      run({ id: "b", metadata: SELF_SERVE, partner_cost_estimate: 300, quantity: 1 }),
+    ])
+    expect(partnerExpenseTotal(rows)).toBe(1300)
+  })
+
+  it("is 0 for nothing, and unbothered by uncosted rows", () => {
+    expect(partnerExpenseTotal([])).toBe(0)
+    const rows = partnerExpenseRows([
+      run({ metadata: SELF_SERVE, partner_cost_estimate: null }),
+    ])
+    expect(partnerExpenseTotal(rows)).toBe(0)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/partner-expense-runs.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/partner-expense-runs.ts
@@ -1,0 +1,114 @@
+/**
+ * A partner's OWN production is their expense, not our payable (#2028 item 5).
+ *
+ * When a partner raises a run on their own design through the partner app,
+ * `metadata.source: "partner.self_serve"` is stamped on it. The cost on that run
+ * is what THEY will pay their own maker. The platform did not commission the
+ * work and cannot settle it — a partner cannot be both payer and payee, so
+ * there is no payout to make. #2040 already stopped it auto-drafting.
+ *
+ * 🔑 But it must still be VISIBLE. Founder's framing (2026-09-13): it shows up
+ * in admin as the partner's own payment, filterable, with the money on it — an
+ * EXPENSE we can see, not a payable we owe.
+ *
+ * That is why this is its own bucket rather than another `excluded_runs` reason.
+ * Every existing exclusion — `provenance_run` (#1606), `superseded_run` (#2026),
+ * `no_design_and_no_order` — names a defect or an artefact: work that was
+ * double-counted, or never happened in that run. A self-serve run is real work
+ * with a real cost. Filing it under "excluded" would say something false about
+ * it, and would bury a number the partner's own books need.
+ *
+ * PURE, so the arithmetic can be tested without a database behind it — and so
+ * the admin route and the partner route cannot drift, which is the failure this
+ * whole endpoint pair keeps having.
+ */
+
+import {
+  isPartnerSelfServeRun,
+  runPayableOffer,
+  type RunForPayout,
+} from "../../production-runs/lib/run-payable"
+
+export type PartnerExpenseRun = {
+  run_id: string
+  design_id: string | null
+  design_name: string | null
+  completed_at: string | null
+  /** Units the expense covers, on the same basis the payable screens use. */
+  quantity: number
+  quantity_basis: "produced" | "ordered"
+  unit_amount: number
+  unit_is_derived: boolean
+  /** What the PARTNER spends. Never what we owe. */
+  amount: number
+  /**
+   * Whether the run carries a stated cost at all.
+   *
+   * ⚠️ A self-serve run with no cost is still the partner's own production —
+   * it belongs in this bucket at `amount: 0` rather than falling back into the
+   * payable list, which is where a naive `filter(r => r.amount > 0)` would put
+   * it. Absence of a price is not evidence of a payable.
+   */
+  costed: boolean
+}
+
+/**
+ * Split completed runs into the partner's own production and everything else.
+ *
+ * ⚠️ Runs must have been fetched WITH `metadata`. A guard reading a field the
+ * query never asked for is dead code that types perfectly (#1606) — the same
+ * trap `isProvenanceRun` carries, and the reason both call sites say so.
+ */
+export const splitPartnerExpenseRuns = <T extends RunForPayout>(
+  runs: T[] | null | undefined
+): { commissioned: T[]; ownProduction: T[] } => {
+  const commissioned: T[] = []
+  const ownProduction: T[] = []
+  for (const run of runs || []) {
+    ;(isPartnerSelfServeRun(run) ? ownProduction : commissioned).push(run)
+  }
+  return { commissioned, ownProduction }
+}
+
+/**
+ * Price the partner's own runs for display, newest first.
+ *
+ * `designNames` is a plain lookup so each route can pass whatever it already
+ * fetched; a miss yields `null` rather than an id masquerading as a name.
+ */
+export const partnerExpenseRows = (
+  runs: (RunForPayout & { completed_at?: any; produced_quantity?: number | null })[],
+  designNames?: Map<string, string> | null
+): PartnerExpenseRun[] =>
+  (runs || [])
+    .map((run) => {
+      const offer = runPayableOffer(run)
+      const designId = run.design_id ? String(run.design_id) : null
+      return {
+        run_id: String(run.id),
+        design_id: designId,
+        design_name: (designId && designNames?.get(designId)) || null,
+        completed_at: run.completed_at ?? null,
+        quantity: offer.quantity,
+        quantity_basis: offer.quantity_basis,
+        unit_amount: offer.unit_amount,
+        unit_is_derived: offer.unit_is_derived,
+        amount: offer.amount,
+        costed: offer.payable,
+      }
+    })
+    .sort((a, b) => {
+      const at = a.completed_at ? new Date(a.completed_at).getTime() : 0
+      const bt = b.completed_at ? new Date(b.completed_at).getTime() : 0
+      return bt - at
+    })
+
+/**
+ * What the partner has spent on their own production, across these runs.
+ *
+ * A bare sum on purpose: this is the partner's money, so the platform states it
+ * and does nothing else with it. It is not netted against anything we owe, and
+ * it never reduces a payout — the two are different people's money.
+ */
+export const partnerExpenseTotal = (rows: PartnerExpenseRun[]): number =>
+  (rows || []).reduce((sum, r) => sum + (Number(r.amount) || 0), 0)


### PR DESCRIPTION
## What was still wrong after #2040

#2040 stopped a self-serve run **auto-drafting** a payout. But it still appeared on both payable-runs screens as an ordinary row:

```
Hand-Woven Wool Tweed Jacket   produced 2   ₹1,000   payable: true   billing_status: clear
```

Visually identical to commissioned work beside it, and `billing_status: clear` actively reads as *"unbilled — pay this."* The screen is the door most payouts actually go through, so the auto-draft guard bought little on its own.

## The framing

> a partner cannot self-pay, so it needs to show as an expense — it can show up in admin as their own payment, but it's nothing to do with us

So: **its own bucket.** `partner_expense_runs`, `partner_expense_count`, `partner_expense_total`, on both routes.

## Why not another `excluded_runs` reason

Every entry there names a **defect or an artefact**:

| reason | what it means |
|---|---|
| `provenance_run` (#1606) | work that happened in *another* run |
| `superseded_run` (#2026) | work that *moved* |
| `no_design_and_no_order` | a run nobody can attribute |

A self-serve run is **real work with a real cost** that simply is not ours. Filing it under "excluded" would say something false about it, and would bury a figure the partner's own books need.

## Details worth reviewing

**The split runs first.** `orderBackedRuns` and `unattributableRuns` now read `commissionedRuns`, not `allRuns` — so a partner's own run can't reappear as "real payable labour" merely by lacking a design.

**One pure helper, not written twice.** Two near-identical routes disagreeing about whose money something is, is the failure this endpoint pair keeps having. Agreement is structural and unit-tested directly.

**Admin design-name fetch moved above the early return.** It covered `completedRuns` alone — so a partner whose *only* runs are their own production takes that return and would have got their expense list back as bare ids. Exactly the case the bucket exists to serve.

**Two edges pinned**, because either would quietly undo this:
- an **unpriced** self-serve run stays in the bucket at `0`. `costed: false` says the price was never written down — it must not demote the run back onto the payable list, which is where a naive `amount > 0` filter would put it.
- a run with **no marker** is ours. Defaulting the other way stops paying for real work.

## Verification

| | |
|---|---|
| Mutation: skip the split | 🔴 red on the integration test |
| `partner-expense-runs` + `run-payable` + `run-kind` + rollup guard | 🟢 61/61 |
| `partner-production-run-create` | 🟢 5/5 |
| No regression: `payment-submissions-api` | 🟢 **158/158** |

## ⚠️ One finding, not fixed here

The admin twin is **not** asserted in the integration test — admin auth does not work in that spec. A control (`GET /admin/partners`) with freshly-fetched headers 401s at the same point, so it is the scaffolding, not the route. The existing email-template POST in that file swallows the identical 401 in a `try/catch`, which is why it had gone unnoticed. Worth its own fix.

## Deliberately out of scope

Tracking what a partner then **sells at retail** off their own production — you flagged that as a later extension. Nothing here presumes a shape for it.

## Verify

```
cd apps/backend
npx jest --config jest.config.js --testPathPattern="partner-expense-runs|run-payable"
pnpm test:integration:http:shared ./integration-tests/http/partner-production-run-create
```

Refs #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp