### PR TITLE
feat(#2022): key every design screen under partner.designs and add enum label maps

### DIFF
--- a/apps/partner-ui/src/i18n/translations/$schema.json
+++ b/apps/partner-ui/src/i18n/translations/$schema.json
@@ -14862,6 +14862,1409 @@
           },
           "required": ["businessType", "status"],
           "additionalProperties": false
+        },
+        "designs": {
+          "type": "object",
+          "properties": {
+            "heading": {
+              "type": "string"
+            },
+            "design": {
+              "type": "string"
+            },
+            "notFound": {
+              "type": "string"
+            },
+            "missingId": {
+              "type": "string"
+            },
+            "sizes": {
+              "type": "string"
+            },
+            "overdue": {
+              "type": "string"
+            },
+            "statusOptions": {
+              "type": "object",
+              "properties": {
+                "conceptual": {
+                  "type": "string"
+                },
+                "inDevelopment": {
+                  "type": "string"
+                },
+                "technicalReview": {
+                  "type": "string"
+                },
+                "sampleProduction": {
+                  "type": "string"
+                },
+                "revision": {
+                  "type": "string"
+                },
+                "approved": {
+                  "type": "string"
+                },
+                "rejected": {
+                  "type": "string"
+                },
+                "onHold": {
+                  "type": "string"
+                },
+                "commerceReady": {
+                  "type": "string"
+                },
+                "superseded": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "conceptual",
+                "inDevelopment",
+                "technicalReview",
+                "sampleProduction",
+                "revision",
+                "approved",
+                "rejected",
+                "onHold",
+                "commerceReady",
+                "superseded"
+              ],
+              "additionalProperties": false
+            },
+            "priorityOptions": {
+              "type": "object",
+              "properties": {
+                "low": {
+                  "type": "string"
+                },
+                "medium": {
+                  "type": "string"
+                },
+                "high": {
+                  "type": "string"
+                },
+                "urgent": {
+                  "type": "string"
+                }
+              },
+              "required": ["low", "medium", "high", "urgent"],
+              "additionalProperties": false
+            },
+            "typeOptions": {
+              "type": "object",
+              "properties": {
+                "original": {
+                  "type": "string"
+                },
+                "derivative": {
+                  "type": "string"
+                },
+                "custom": {
+                  "type": "string"
+                },
+                "collaboration": {
+                  "type": "string"
+                }
+              },
+              "required": ["original", "derivative", "custom", "collaboration"],
+              "additionalProperties": false
+            },
+            "workStatusOptions": {
+              "type": "object",
+              "properties": {
+                "incoming": {
+                  "type": "string"
+                },
+                "assigned": {
+                  "type": "string"
+                },
+                "inProgress": {
+                  "type": "string"
+                },
+                "awaitingReview": {
+                  "type": "string"
+                },
+                "finished": {
+                  "type": "string"
+                },
+                "completed": {
+                  "type": "string"
+                },
+                "cancelled": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "incoming",
+                "assigned",
+                "inProgress",
+                "awaitingReview",
+                "finished",
+                "completed",
+                "cancelled"
+              ],
+              "additionalProperties": false
+            },
+            "runStatusOptions": {
+              "type": "object",
+              "properties": {
+                "draft": {
+                  "type": "string"
+                },
+                "pendingReview": {
+                  "type": "string"
+                },
+                "approved": {
+                  "type": "string"
+                },
+                "sentToPartner": {
+                  "type": "string"
+                },
+                "inProgress": {
+                  "type": "string"
+                },
+                "completed": {
+                  "type": "string"
+                },
+                "cancelled": {
+                  "type": "string"
+                },
+                "awaitingReassignment": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "draft",
+                "pendingReview",
+                "approved",
+                "sentToPartner",
+                "inProgress",
+                "completed",
+                "cancelled",
+                "awaitingReassignment"
+              ],
+              "additionalProperties": false
+            },
+            "bucketOptions": {
+              "type": "object",
+              "properties": {
+                "incoming": {
+                  "type": "string"
+                },
+                "inProgress": {
+                  "type": "string"
+                },
+                "yours": {
+                  "type": "string"
+                },
+                "completed": {
+                  "type": "string"
+                },
+                "all": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "incoming",
+                "inProgress",
+                "yours",
+                "completed",
+                "all"
+              ],
+              "additionalProperties": false
+            },
+            "engagementOptions": {
+              "type": "object",
+              "properties": {
+                "owned": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "hint": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["label", "hint"],
+                  "additionalProperties": false
+                },
+                "assigned": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "hint": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["label", "hint"],
+                  "additionalProperties": false
+                },
+                "shared": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "hint": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["label", "hint"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["owned", "assigned", "shared"],
+              "additionalProperties": false
+            },
+            "actionOptions": {
+              "type": "object",
+              "properties": {
+                "accept": {
+                  "type": "string"
+                },
+                "working": {
+                  "type": "string"
+                },
+                "complete": {
+                  "type": "string"
+                },
+                "underReview": {
+                  "type": "string"
+                },
+                "done": {
+                  "type": "string"
+                },
+                "cancelled": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "accept",
+                "working",
+                "complete",
+                "underReview",
+                "done",
+                "cancelled"
+              ],
+              "additionalProperties": false
+            },
+            "confidenceOptions": {
+              "type": "object",
+              "properties": {
+                "exact": {
+                  "type": "string"
+                },
+                "estimated": {
+                  "type": "string"
+                }
+              },
+              "required": ["exact", "estimated"],
+              "additionalProperties": false
+            },
+            "runTypeOptions": {
+              "type": "object",
+              "properties": {
+                "production": {
+                  "type": "string"
+                },
+                "sample": {
+                  "type": "string"
+                }
+              },
+              "required": ["production", "sample"],
+              "additionalProperties": false
+            },
+            "unitOptions": {
+              "type": "object",
+              "properties": {
+                "meter": {
+                  "type": "string"
+                },
+                "yard": {
+                  "type": "string"
+                },
+                "kilogram": {
+                  "type": "string"
+                },
+                "gram": {
+                  "type": "string"
+                },
+                "piece": {
+                  "type": "string"
+                },
+                "roll": {
+                  "type": "string"
+                },
+                "other": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "meter",
+                "yard",
+                "kilogram",
+                "gram",
+                "piece",
+                "roll",
+                "other"
+              ],
+              "additionalProperties": false
+            },
+            "consumptionTypeOptions": {
+              "type": "object",
+              "properties": {
+                "sample": {
+                  "type": "string"
+                },
+                "production": {
+                  "type": "string"
+                },
+                "wastage": {
+                  "type": "string"
+                }
+              },
+              "required": ["sample", "production", "wastage"],
+              "additionalProperties": false
+            },
+            "fields": {
+              "type": "object",
+              "properties": {
+                "priority": {
+                  "type": "string"
+                },
+                "designerNotes": {
+                  "type": "string"
+                },
+                "unit": {
+                  "type": "string"
+                },
+                "color": {
+                  "type": "string"
+                },
+                "composition": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "priority",
+                "designerNotes",
+                "unit",
+                "color",
+                "composition"
+              ],
+              "additionalProperties": false
+            },
+            "list": {
+              "type": "object",
+              "properties": {
+                "subtitle": {
+                  "type": "string"
+                },
+                "loadFailed": {
+                  "type": "string"
+                },
+                "noRecords": {
+                  "type": "string"
+                },
+                "columns": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "nextAction": {
+                      "type": "string"
+                    },
+                    "workStatus": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "string"
+                    },
+                    "due": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "lastUpdated": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "source",
+                    "nextAction",
+                    "workStatus",
+                    "priority",
+                    "due",
+                    "status",
+                    "lastUpdated"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["subtitle", "loadFailed", "noRecords", "columns"],
+              "additionalProperties": false
+            },
+            "detail": {
+              "type": "object",
+              "properties": {
+                "general": {
+                  "type": "string"
+                },
+                "garmentType": {
+                  "type": "string"
+                },
+                "inferred": {
+                  "type": "string"
+                },
+                "partnerStatus": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "string"
+                },
+                "targetDate": {
+                  "type": "string"
+                },
+                "estimatedCost": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "specifications": {
+                  "type": "string"
+                },
+                "specs": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "string"
+                },
+                "colorPalette": {
+                  "type": "string"
+                },
+                "inventoryItems": {
+                  "type": "string"
+                },
+                "noInventoryItems": {
+                  "type": "string"
+                },
+                "designerNotes": {
+                  "type": "string"
+                },
+                "noNotes": {
+                  "type": "string"
+                },
+                "resizeHint": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "general",
+                "garmentType",
+                "inferred",
+                "partnerStatus",
+                "priority",
+                "targetDate",
+                "estimatedCost",
+                "description",
+                "specifications",
+                "specs",
+                "tags",
+                "colorPalette",
+                "inventoryItems",
+                "noInventoryItems",
+                "designerNotes",
+                "noNotes",
+                "resizeHint"
+              ],
+              "additionalProperties": false
+            },
+            "media": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "manage": {
+                  "type": "string"
+                },
+                "empty": {
+                  "type": "string"
+                },
+                "emptyHint": {
+                  "type": "string"
+                },
+                "addMedia": {
+                  "type": "string"
+                },
+                "alt": {
+                  "type": "string"
+                },
+                "preview": {
+                  "type": "string"
+                },
+                "download": {
+                  "type": "string"
+                },
+                "manageMedia": {
+                  "type": "string"
+                },
+                "uploadDescription": {
+                  "type": "string"
+                },
+                "uploadImages": {
+                  "type": "string"
+                },
+                "dropHint": {
+                  "type": "string"
+                },
+                "existing": {
+                  "type": "string"
+                },
+                "selected": {
+                  "type": "string"
+                },
+                "loadingDesign": {
+                  "type": "string"
+                },
+                "addAtLeastOne": {
+                  "type": "string"
+                },
+                "uploadFailed": {
+                  "type": "string"
+                },
+                "attached": {
+                  "type": "string"
+                },
+                "someRejected": {
+                  "type": "string"
+                },
+                "uploadIntro": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "manage",
+                "empty",
+                "emptyHint",
+                "addMedia",
+                "alt",
+                "preview",
+                "download",
+                "manageMedia",
+                "uploadDescription",
+                "uploadImages",
+                "dropHint",
+                "existing",
+                "selected",
+                "loadingDesign",
+                "addAtLeastOne",
+                "uploadFailed",
+                "attached",
+                "someRejected",
+                "uploadIntro"
+              ],
+              "additionalProperties": false
+            },
+            "moodboard": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "open": {
+                  "type": "string"
+                },
+                "generateConfirm": {
+                  "type": "string"
+                },
+                "generating": {
+                  "type": "string"
+                },
+                "generated": {
+                  "type": "string"
+                },
+                "generateFailed": {
+                  "type": "string"
+                },
+                "inserted": {
+                  "type": "string"
+                },
+                "insertFailed": {
+                  "type": "string"
+                },
+                "nothingToInsert": {
+                  "type": "string"
+                },
+                "saving": {
+                  "type": "string"
+                },
+                "saved": {
+                  "type": "string"
+                },
+                "saveFailed": {
+                  "type": "string"
+                },
+                "briefSyncFailed": {
+                  "type": "string"
+                },
+                "insertBlock": {
+                  "type": "string"
+                },
+                "noBlocks": {
+                  "type": "string"
+                },
+                "emptySuffix": {
+                  "type": "string"
+                },
+                "addConstruction": {
+                  "type": "string"
+                },
+                "generate": {
+                  "type": "string"
+                },
+                "layers": {
+                  "type": "string"
+                },
+                "save": {
+                  "type": "string"
+                },
+                "savedLabel": {
+                  "type": "string"
+                },
+                "footerHint": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "description",
+                "open",
+                "generateConfirm",
+                "generating",
+                "generated",
+                "generateFailed",
+                "inserted",
+                "insertFailed",
+                "nothingToInsert",
+                "saving",
+                "saved",
+                "saveFailed",
+                "briefSyncFailed",
+                "insertBlock",
+                "noBlocks",
+                "emptySuffix",
+                "addConstruction",
+                "generate",
+                "layers",
+                "save",
+                "savedLabel",
+                "footerHint"
+              ],
+              "additionalProperties": false
+            },
+            "layers": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "refresh": {
+                  "type": "string"
+                },
+                "close": {
+                  "type": "string"
+                },
+                "noFrames": {
+                  "type": "string"
+                },
+                "untitled": {
+                  "type": "string"
+                },
+                "hasContent": {
+                  "type": "string"
+                },
+                "empty": {
+                  "type": "string"
+                },
+                "jump": {
+                  "type": "string"
+                },
+                "show": {
+                  "type": "string"
+                },
+                "hide": {
+                  "type": "string"
+                },
+                "lockedWhileHidden": {
+                  "type": "string"
+                },
+                "unlock": {
+                  "type": "string"
+                },
+                "lock": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "refresh",
+                "close",
+                "noFrames",
+                "untitled",
+                "hasContent",
+                "empty",
+                "jump",
+                "show",
+                "hide",
+                "lockedWhileHidden",
+                "unlock",
+                "lock"
+              ],
+              "additionalProperties": false
+            },
+            "construction": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "details": {
+                  "type": "string"
+                },
+                "loading": {
+                  "type": "string"
+                },
+                "hint": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "parameters": {
+                  "type": "string"
+                },
+                "fixedGeometry": {
+                  "type": "string"
+                },
+                "fabricRules": {
+                  "type": "string"
+                },
+                "oneRulePerLine": {
+                  "type": "string"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "optional": {
+                  "type": "string"
+                },
+                "addDetail": {
+                  "type": "string"
+                },
+                "added": {
+                  "type": "string"
+                },
+                "addFailed": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "details",
+                "loading",
+                "hint",
+                "label",
+                "parameters",
+                "fixedGeometry",
+                "fabricRules",
+                "oneRulePerLine",
+                "note",
+                "optional",
+                "addDetail",
+                "added",
+                "addFailed"
+              ],
+              "additionalProperties": false
+            },
+            "ownerActions": {
+              "type": "object",
+              "properties": {
+                "yourDesign": {
+                  "type": "string"
+                },
+                "activeOrders_one": {
+                  "type": "string"
+                },
+                "activeOrders_other": {
+                  "type": "string"
+                },
+                "noOrders": {
+                  "type": "string"
+                },
+                "newOrder": {
+                  "type": "string"
+                },
+                "createOrder": {
+                  "type": "string"
+                },
+                "deleteTitle": {
+                  "type": "string"
+                },
+                "deleteDescription": {
+                  "type": "string"
+                },
+                "deleted": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "yourDesign",
+                "activeOrders_one",
+                "activeOrders_other",
+                "noOrders",
+                "newOrder",
+                "createOrder",
+                "deleteTitle",
+                "deleteDescription",
+                "deleted"
+              ],
+              "additionalProperties": false
+            },
+            "production": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "empty": {
+                  "type": "string"
+                },
+                "subtitle": {
+                  "type": "string"
+                },
+                "previous": {
+                  "type": "string"
+                },
+                "viewOrder": {
+                  "type": "string"
+                },
+                "orderType": {
+                  "type": "string"
+                },
+                "qty": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "empty",
+                "subtitle",
+                "previous",
+                "viewOrder",
+                "orderType",
+                "qty"
+              ],
+              "additionalProperties": false
+            },
+            "cost": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "subtitle": {
+                  "type": "string"
+                },
+                "recalculate": {
+                  "type": "string"
+                },
+                "estimatedTotal": {
+                  "type": "string"
+                },
+                "materialCost": {
+                  "type": "string"
+                },
+                "productionCost": {
+                  "type": "string"
+                },
+                "platformFee": {
+                  "type": "string"
+                },
+                "lastCalculated": {
+                  "type": "string"
+                },
+                "yourInput": {
+                  "type": "string"
+                },
+                "estimatedLabel": {
+                  "type": "string"
+                },
+                "yourProductionCost": {
+                  "type": "string"
+                },
+                "autoEstimate": {
+                  "type": "string"
+                },
+                "helper": {
+                  "type": "string"
+                },
+                "noEstimate": {
+                  "type": "string"
+                },
+                "enterValid": {
+                  "type": "string"
+                },
+                "recalculated": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "subtitle",
+                "recalculate",
+                "estimatedTotal",
+                "materialCost",
+                "productionCost",
+                "platformFee",
+                "lastCalculated",
+                "yourInput",
+                "estimatedLabel",
+                "yourProductionCost",
+                "autoEstimate",
+                "helper",
+                "noEstimate",
+                "enterValid",
+                "recalculated"
+              ],
+              "additionalProperties": false
+            },
+            "bom": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "subtitle": {
+                  "type": "string"
+                },
+                "addMaterial": {
+                  "type": "string"
+                },
+                "empty": {
+                  "type": "string"
+                },
+                "emptyOwnerHint": {
+                  "type": "string"
+                },
+                "noImg": {
+                  "type": "string"
+                },
+                "sku": {
+                  "type": "string"
+                },
+                "planned": {
+                  "type": "string"
+                },
+                "consumed": {
+                  "type": "string"
+                },
+                "removeTitle": {
+                  "type": "string"
+                },
+                "removeDescription": {
+                  "type": "string"
+                },
+                "removed": {
+                  "type": "string"
+                },
+                "materialAlt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "subtitle",
+                "addMaterial",
+                "empty",
+                "emptyOwnerHint",
+                "noImg",
+                "sku",
+                "planned",
+                "consumed",
+                "removeTitle",
+                "removeDescription",
+                "removed",
+                "materialAlt"
+              ],
+              "additionalProperties": false
+            },
+            "consumption": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "subtitle": {
+                  "type": "string"
+                },
+                "log": {
+                  "type": "string"
+                },
+                "closedReview": {
+                  "type": "string"
+                },
+                "closedComplete": {
+                  "type": "string"
+                },
+                "closedNone": {
+                  "type": "string"
+                },
+                "drawerTitle": {
+                  "type": "string"
+                },
+                "drawerDescription": {
+                  "type": "string"
+                },
+                "noInventory": {
+                  "type": "string"
+                },
+                "noInventoryHint": {
+                  "type": "string"
+                },
+                "inventoryItem": {
+                  "type": "string"
+                },
+                "selectItem": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "string"
+                },
+                "measuredAs": {
+                  "type": "string"
+                },
+                "perPiece": {
+                  "type": "string"
+                },
+                "totalRun": {
+                  "type": "string"
+                },
+                "perPieceHint": {
+                  "type": "string"
+                },
+                "totalRunHint": {
+                  "type": "string"
+                },
+                "costPerUnit": {
+                  "type": "string"
+                },
+                "optional": {
+                  "type": "string"
+                },
+                "unit": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "notes": {
+                  "type": "string"
+                },
+                "notesPlaceholder": {
+                  "type": "string"
+                },
+                "logUsage": {
+                  "type": "string"
+                },
+                "empty": {
+                  "type": "string"
+                },
+                "required": {
+                  "type": "string"
+                },
+                "logged": {
+                  "type": "string"
+                },
+                "failed": {
+                  "type": "string"
+                },
+                "accessory": {
+                  "type": "string"
+                },
+                "committed": {
+                  "type": "string"
+                },
+                "pending": {
+                  "type": "string"
+                },
+                "totalMaterialCost": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "subtitle",
+                "log",
+                "closedReview",
+                "closedComplete",
+                "closedNone",
+                "drawerTitle",
+                "drawerDescription",
+                "noInventory",
+                "noInventoryHint",
+                "inventoryItem",
+                "selectItem",
+                "quantity",
+                "measuredAs",
+                "perPiece",
+                "totalRun",
+                "perPieceHint",
+                "totalRunHint",
+                "costPerUnit",
+                "optional",
+                "unit",
+                "type",
+                "notes",
+                "notesPlaceholder",
+                "logUsage",
+                "empty",
+                "required",
+                "logged",
+                "failed",
+                "accessory",
+                "committed",
+                "pending",
+                "totalMaterialCost"
+              ],
+              "additionalProperties": false
+            },
+            "create": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "namePlaceholder": {
+                  "type": "string"
+                },
+                "descriptionPlaceholder": {
+                  "type": "string"
+                },
+                "designerNotesPlaceholder": {
+                  "type": "string"
+                },
+                "created": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "namePlaceholder",
+                "descriptionPlaceholder",
+                "designerNotesPlaceholder",
+                "created"
+              ],
+              "additionalProperties": false
+            },
+            "edit": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "updated": {
+                  "type": "string"
+                }
+              },
+              "required": ["heading", "updated"],
+              "additionalProperties": false
+            },
+            "addInventory": {
+              "type": "object",
+              "properties": {
+                "selectedCount": {
+                  "type": "string"
+                },
+                "selectPrompt": {
+                  "type": "string"
+                },
+                "addToDesign": {
+                  "type": "string"
+                },
+                "noRawMaterialsTitle": {
+                  "type": "string"
+                },
+                "noRawMaterialsMessage": {
+                  "type": "string"
+                },
+                "selectAtLeastOne": {
+                  "type": "string"
+                },
+                "added_one": {
+                  "type": "string"
+                },
+                "added_other": {
+                  "type": "string"
+                },
+                "sku": {
+                  "type": "string"
+                },
+                "columns": {
+                  "type": "object",
+                  "properties": {
+                    "material": {
+                      "type": "string"
+                    },
+                    "composition": {
+                      "type": "string"
+                    },
+                    "color": {
+                      "type": "string"
+                    },
+                    "unit": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["material", "composition", "color", "unit"],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "selectedCount",
+                "selectPrompt",
+                "addToDesign",
+                "noRawMaterialsTitle",
+                "noRawMaterialsMessage",
+                "selectAtLeastOne",
+                "added_one",
+                "added_other",
+                "sku",
+                "columns"
+              ],
+              "additionalProperties": false
+            },
+            "runCreate": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "subtitle": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "string"
+                },
+                "runType": {
+                  "type": "string"
+                },
+                "production": {
+                  "type": "string"
+                },
+                "sample": {
+                  "type": "string"
+                },
+                "howMade": {
+                  "type": "string"
+                },
+                "inHouse": {
+                  "type": "string"
+                },
+                "outsourced": {
+                  "type": "string"
+                },
+                "executionHint": {
+                  "type": "string"
+                },
+                "subPartnerId": {
+                  "type": "string"
+                },
+                "subPartnerPlaceholder": {
+                  "type": "string"
+                },
+                "subPartnerHint": {
+                  "type": "string"
+                },
+                "createOrder": {
+                  "type": "string"
+                },
+                "started": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "subtitle",
+                "quantity",
+                "runType",
+                "production",
+                "sample",
+                "howMade",
+                "inHouse",
+                "outsourced",
+                "executionHint",
+                "subPartnerId",
+                "subPartnerPlaceholder",
+                "subPartnerHint",
+                "createOrder",
+                "started"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "heading",
+            "design",
+            "notFound",
+            "missingId",
+            "sizes",
+            "overdue",
+            "statusOptions",
+            "priorityOptions",
+            "typeOptions",
+            "workStatusOptions",
+            "runStatusOptions",
+            "bucketOptions",
+            "engagementOptions",
+            "actionOptions",
+            "confidenceOptions",
+            "runTypeOptions",
+            "unitOptions",
+            "consumptionTypeOptions",
+            "fields",
+            "list",
+            "detail",
+            "media",
+            "moodboard",
+            "layers",
+            "construction",
+            "ownerActions",
+            "production",
+            "cost",
+            "bom",
+            "consumption",
+            "create",
+            "edit",
+            "addInventory",
+            "runCreate"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
@@ -14879,7 +16282,8 @@
         "payments",
         "stripeConnect",
         "paymentProviders",
-        "onboardingSettings"
+        "onboardingSettings",
+        "designs"
       ],
       "additionalProperties": false
     }

--- a/apps/partner-ui/src/i18n/translations/ar.json
+++ b/apps/partner-ui/src/i18n/translations/ar.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "تعذّر بدء عملية التوجيه في Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/bg.json
+++ b/apps/partner-ui/src/i18n/translations/bg.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "Неуспешно стартиране на Stripe инструктажа"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/bs.json
+++ b/apps/partner-ui/src/i18n/translations/bs.json
@@ -3783,6 +3783,360 @@
       "toast": {
         "startFailed": "Nije moguće pokrenuti Stripe uvodni proces"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/cs.json
+++ b/apps/partner-ui/src/i18n/translations/cs.json
@@ -3781,6 +3781,360 @@
       "toast": {
         "startFailed": "Nepodařilo se spustit úvodní průvodce Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/de.json
+++ b/apps/partner-ui/src/i18n/translations/de.json
@@ -3786,6 +3786,360 @@
       "toast": {
         "startFailed": "Stripe-Onboarding konnte nicht gestartet werden"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/el.json
+++ b/apps/partner-ui/src/i18n/translations/el.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "Αδυναμία έναρξης της εισαγωγής στο Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -3936,6 +3936,360 @@
         "notCompleted": "Not completed",
         "open": "Open onboarding"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   }
 }

--- a/apps/partner-ui/src/i18n/translations/es.json
+++ b/apps/partner-ui/src/i18n/translations/es.json
@@ -3801,6 +3801,360 @@
       "toast": {
         "startFailed": "No se pudo iniciar la configuración inicial de Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "views": {

--- a/apps/partner-ui/src/i18n/translations/fa.json
+++ b/apps/partner-ui/src/i18n/translations/fa.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "راه‌اندازی اولیه Stripe امکان‌پذیر نبود"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/fr.json
+++ b/apps/partner-ui/src/i18n/translations/fr.json
@@ -3786,6 +3786,360 @@
       "toast": {
         "startFailed": "Impossible de démarrer la configuration Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "refundReasons": {

--- a/apps/partner-ui/src/i18n/translations/he.json
+++ b/apps/partner-ui/src/i18n/translations/he.json
@@ -3781,6 +3781,360 @@
       "toast": {
         "startFailed": "לא ניתן להתחיל את ההיכרות הראשונית ב-Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/hi.json
+++ b/apps/partner-ui/src/i18n/translations/hi.json
@@ -3856,6 +3856,360 @@
       "toast": {
         "startFailed": "स्ट्राइप ओनबोर्डिंग शुरू नहीं की जा सकी"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   }
 }

--- a/apps/partner-ui/src/i18n/translations/hu.json
+++ b/apps/partner-ui/src/i18n/translations/hu.json
@@ -3784,6 +3784,360 @@
       "toast": {
         "startFailed": "Nem sikerült elindítani a Stripe-bevezetést"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "refundReasons": {

--- a/apps/partner-ui/src/i18n/translations/id.json
+++ b/apps/partner-ui/src/i18n/translations/id.json
@@ -3781,6 +3781,360 @@
       "toast": {
         "startFailed": "Gagal memulai onboarding Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/it.json
+++ b/apps/partner-ui/src/i18n/translations/it.json
@@ -3786,6 +3786,360 @@
       "toast": {
         "startFailed": "Impossibile avviare l'onboarding Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "refundReasons": {

--- a/apps/partner-ui/src/i18n/translations/ja.json
+++ b/apps/partner-ui/src/i18n/translations/ja.json
@@ -3786,6 +3786,360 @@
       "toast": {
         "startFailed": "Stripeオンボーディングを開始できませんでした"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "refundReasons": {

--- a/apps/partner-ui/src/i18n/translations/ko.json
+++ b/apps/partner-ui/src/i18n/translations/ko.json
@@ -3781,6 +3781,360 @@
       "toast": {
         "startFailed": "Stripe 온보딩을 시작할 수 없습니다."
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "refundReasons": {

--- a/apps/partner-ui/src/i18n/translations/lt.json
+++ b/apps/partner-ui/src/i18n/translations/lt.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "Nepavyko pradėti Stripe pradėjimo proceso"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/mk.json
+++ b/apps/partner-ui/src/i18n/translations/mk.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "Не може да се започне Stripe воведниот процес"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/mn.json
+++ b/apps/partner-ui/src/i18n/translations/mn.json
@@ -3663,6 +3663,360 @@
         "stripeApiKeyPlaceholder": "sk_live_... эсвэл sk_test_...",
         "stripeApiKeyHint": "Stripe хянах самбарын Stripe нууц түлхүүр."
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/nl.json
+++ b/apps/partner-ui/src/i18n/translations/nl.json
@@ -3784,6 +3784,360 @@
       "toast": {
         "startFailed": "Kan Stripe-invoering niet starten"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/pl.json
+++ b/apps/partner-ui/src/i18n/translations/pl.json
@@ -3891,6 +3891,360 @@
       "toast": {
         "startFailed": "Nie udało się rozpocząć procesu wprowadzenia Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "views": {

--- a/apps/partner-ui/src/i18n/translations/ptBR.json
+++ b/apps/partner-ui/src/i18n/translations/ptBR.json
@@ -3786,6 +3786,360 @@
       "toast": {
         "startFailed": "Não foi possível iniciar o onboarding no Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/ptPT.json
+++ b/apps/partner-ui/src/i18n/translations/ptPT.json
@@ -3856,6 +3856,360 @@
       "toast": {
         "startFailed": "Não foi possível iniciar a configuração do Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   }
 }

--- a/apps/partner-ui/src/i18n/translations/ro.json
+++ b/apps/partner-ui/src/i18n/translations/ro.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "Nu s-a putut iniția procesul de inițializare Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/ru.json
+++ b/apps/partner-ui/src/i18n/translations/ru.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "Не удалось запустить онбординг Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/th.json
+++ b/apps/partner-ui/src/i18n/translations/th.json
@@ -3786,6 +3786,360 @@
       "toast": {
         "startFailed": "ไม่สามารถเริ่มการแนะนำใช้งาน Stripe ได้"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "refundReasons": {

--- a/apps/partner-ui/src/i18n/translations/tr.json
+++ b/apps/partner-ui/src/i18n/translations/tr.json
@@ -3785,6 +3785,360 @@
       "toast": {
         "startFailed": "Stripe başlangıç süreci başlatılamadı"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/uk.json
+++ b/apps/partner-ui/src/i18n/translations/uk.json
@@ -3786,6 +3786,360 @@
       "toast": {
         "startFailed": "Не вдалося запустити реєстрацію в Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/vi.json
+++ b/apps/partner-ui/src/i18n/translations/vi.json
@@ -3781,6 +3781,360 @@
       "toast": {
         "startFailed": "Không thể bắt đầu quy trình đăng ký Stripe"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "shippingOptionTypes": {

--- a/apps/partner-ui/src/i18n/translations/zhCN.json
+++ b/apps/partner-ui/src/i18n/translations/zhCN.json
@@ -3781,6 +3781,360 @@
       "toast": {
         "startFailed": "无法启动 Stripe 入驻流程"
       }
+    },
+    "designs": {
+      "heading": "Designs",
+      "design": "Design",
+      "notFound": "Design not found.",
+      "missingId": "Missing design id.",
+      "sizes": "Sizes",
+      "overdue": "Overdue",
+      "statusOptions": {
+        "conceptual": "Conceptual",
+        "inDevelopment": "In Development",
+        "technicalReview": "Technical Review",
+        "sampleProduction": "Sample Production",
+        "revision": "Revision",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "onHold": "On Hold",
+        "commerceReady": "Commerce Ready",
+        "superseded": "Superseded"
+      },
+      "priorityOptions": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      },
+      "typeOptions": {
+        "original": "Original",
+        "derivative": "Derivative",
+        "custom": "Custom",
+        "collaboration": "Collaboration"
+      },
+      "workStatusOptions": {
+        "incoming": "Incoming",
+        "assigned": "Assigned",
+        "inProgress": "In progress",
+        "awaitingReview": "Awaiting review",
+        "finished": "Finished",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      },
+      "runStatusOptions": {
+        "draft": "Draft",
+        "pendingReview": "Pending review",
+        "approved": "Approved",
+        "sentToPartner": "Sent to partner",
+        "inProgress": "In progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "awaitingReassignment": "Awaiting reassignment"
+      },
+      "bucketOptions": {
+        "incoming": "Incoming",
+        "inProgress": "In progress",
+        "yours": "Yours",
+        "completed": "Completed",
+        "all": "All"
+      },
+      "engagementOptions": {
+        "owned": {
+          "label": "Yours",
+          "hint": "You created this design."
+        },
+        "assigned": {
+          "label": "Assigned",
+          "hint": "You have a production run on this design — this is work for you."
+        },
+        "shared": {
+          "label": "Shared",
+          "hint": "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner)."
+        }
+      },
+      "actionOptions": {
+        "accept": "Accept",
+        "working": "Working",
+        "complete": "Complete",
+        "underReview": "Under Review",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "confidenceOptions": {
+        "exact": "Exact",
+        "estimated": "Estimated"
+      },
+      "runTypeOptions": {
+        "production": "Production",
+        "sample": "Sample"
+      },
+      "unitOptions": {
+        "meter": "Meter",
+        "yard": "Yard",
+        "kilogram": "Kilogram",
+        "gram": "Gram",
+        "piece": "Piece",
+        "roll": "Roll",
+        "other": "Other"
+      },
+      "consumptionTypeOptions": {
+        "sample": "Sample",
+        "production": "Production",
+        "wastage": "Wastage"
+      },
+      "fields": {
+        "priority": "Priority",
+        "designerNotes": "Designer notes",
+        "unit": "Unit",
+        "color": "Color",
+        "composition": "Composition"
+      },
+      "list": {
+        "subtitle": "Pick a tab to see incoming, in-progress, your own, or completed work.",
+        "loadFailed": "Failed to load designs. Please try refreshing the page.",
+        "noRecords": "No designs in this tab. Try another tab or clear the search.",
+        "columns": {
+          "name": "Name",
+          "source": "Source",
+          "nextAction": "Next Action",
+          "workStatus": "Work Status",
+          "priority": "Priority",
+          "due": "Due",
+          "status": "Design Status",
+          "lastUpdated": "Last Updated"
+        }
+      },
+      "detail": {
+        "general": "General",
+        "garmentType": "Garment type",
+        "inferred": "Inferred",
+        "partnerStatus": "Partner status",
+        "priority": "Priority",
+        "targetDate": "Target date",
+        "estimatedCost": "Estimated cost",
+        "description": "Description",
+        "specifications": "Specifications",
+        "specs": "Specs",
+        "tags": "Tags",
+        "colorPalette": "Color Palette",
+        "inventoryItems": "Inventory Items",
+        "noInventoryItems": "No inventory items linked to this design.",
+        "designerNotes": "Designer Notes",
+        "noNotes": "No notes",
+        "resizeHint": "Drag the bottom edge to resize"
+      },
+      "media": {
+        "heading": "Media",
+        "manage": "Manage",
+        "empty": "No media files yet",
+        "emptyHint": "Add images to showcase your design",
+        "addMedia": "Add Media",
+        "alt": "Design media",
+        "preview": "Preview design media",
+        "download": "Download",
+        "manageMedia": "Manage Media",
+        "uploadDescription": "Upload and attach media to this design",
+        "uploadImages": "Upload images",
+        "dropHint": "Drop files here or click to browse",
+        "existing": "Existing",
+        "selected": "Selected",
+        "loadingDesign": "Loading design...",
+        "addAtLeastOne": "Add at least one file",
+        "uploadFailed": "Failed to upload files",
+        "attached": "Media attached",
+        "someRejected": "Some files were rejected",
+        "uploadIntro": "Upload images to attach to this design."
+      },
+      "moodboard": {
+        "heading": "Moodboard",
+        "description": "Collect references and inspiration.",
+        "open": "Open Moodboard",
+        "generateConfirm": "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced.",
+        "generating": "Generating moodboard…",
+        "generated": "Moodboard generated",
+        "generateFailed": "Failed to generate moodboard",
+        "inserted": "Inserted \"{{label}}\"",
+        "insertFailed": "Failed to insert block",
+        "nothingToInsert": "Nothing to insert for \"{{label}}\" yet.",
+        "saving": "Saving moodboard…",
+        "saved": "Moodboard saved",
+        "saveFailed": "Failed to save moodboard",
+        "briefSyncFailed": "Moodboard saved, but the brief edit couldn't be synced.",
+        "insertBlock": "Insert block",
+        "noBlocks": "No blocks available",
+        "emptySuffix": "· empty",
+        "addConstruction": "Add construction",
+        "generate": "Generate",
+        "layers": "Layers",
+        "save": "Save",
+        "savedLabel": "Saved",
+        "footerHint": "Insert, construction, generate, layers & save are in the dock at the bottom of the canvas."
+      },
+      "layers": {
+        "heading": "Layers",
+        "refresh": "Refresh",
+        "close": "Close",
+        "noFrames": "No frames yet.",
+        "untitled": "Untitled frame",
+        "hasContent": "Has content",
+        "empty": "Empty",
+        "jump": "Jump to frame",
+        "show": "Show",
+        "hide": "Hide",
+        "lockedWhileHidden": "Locked while hidden",
+        "unlock": "Unlock",
+        "lock": "Lock"
+      },
+      "construction": {
+        "heading": "Add construction detail",
+        "details": "Construction details",
+        "loading": "Loading techniques…",
+        "hint": "Pick a technique or a preset on the left — its parameters and fabric rules auto-fill here.",
+        "label": "Label",
+        "parameters": "Parameters",
+        "fixedGeometry": "This technique has fixed geometry — no parameters to set.",
+        "fabricRules": "Fabric / sewing rules",
+        "oneRulePerLine": "one rule per line",
+        "note": "Note",
+        "optional": "optional",
+        "addDetail": "Add detail",
+        "added": "Added \"{{label}}\"",
+        "addFailed": "Failed to add construction detail"
+      },
+      "ownerActions": {
+        "yourDesign": "Your design",
+        "activeOrders_one": "{{count}} design order in progress. Create another or hand one to a sub-partner.",
+        "activeOrders_other": "{{count}} design orders in progress. Create another or hand one to a sub-partner.",
+        "noOrders": "You created this design. Create a design order to start production, or hand it to a sub-partner.",
+        "newOrder": "New order",
+        "createOrder": "Create order",
+        "deleteTitle": "Delete design",
+        "deleteDescription": "Delete \"{{name}}\"? This can't be undone.",
+        "deleted": "Design deleted"
+      },
+      "production": {
+        "heading": "Design orders",
+        "empty": "No design orders yet. Create a design order to start production, or you'll see them here once the admin sends work your way.",
+        "subtitle": "Open a design order to accept work, log materials, and update its status.",
+        "previous": "Previous design orders ({{count}})",
+        "viewOrder": "View order",
+        "orderType": "{{type}} order",
+        "qty": "Qty {{qty}}"
+      },
+      "cost": {
+        "heading": "Cost estimate",
+        "subtitle": "Material + production cost from the linked BOM, plus the JYT platform fee.",
+        "recalculate": "Recalculate",
+        "estimatedTotal": "Estimated total",
+        "materialCost": "Material cost",
+        "productionCost": "Production cost",
+        "platformFee": "Platform fee ({{percent}}%)",
+        "lastCalculated": "Last calculated",
+        "yourInput": "your input",
+        "estimatedLabel": "estimated",
+        "yourProductionCost": "Your production cost (per unit)",
+        "autoEstimate": "Auto-estimate",
+        "helper": "Overrides the auto estimate — leave blank to estimate from history. A {{percent}}% platform fee applies on material cost. Press Recalculate to apply.",
+        "noEstimate": "No estimate yet — add materials to the BOM, then Recalculate.",
+        "enterValid": "Enter a valid production cost (0 or more)",
+        "recalculated": "Cost recalculated: {{amount}} ({{confidence}})"
+      },
+      "bom": {
+        "heading": "Materials (BOM)",
+        "subtitle": "Inventory + raw materials used to make this design.",
+        "addMaterial": "Add material",
+        "empty": "No materials linked yet.",
+        "emptyOwnerHint": " Add the inventory items this design consumes.",
+        "noImg": "No img",
+        "sku": "SKU",
+        "planned": "Planned",
+        "consumed": "Consumed",
+        "removeTitle": "Remove material",
+        "removeDescription": "Remove \"{{name}}\" from this design's bill of materials?",
+        "removed": "Material removed",
+        "materialAlt": "material"
+      },
+      "consumption": {
+        "heading": "Material Usage",
+        "subtitle": "Log raw materials consumed during production",
+        "log": "Log",
+        "closedReview": "Logging closed — run is awaiting review",
+        "closedComplete": "Logging closed — run completed",
+        "closedNone": "Logging not available",
+        "drawerTitle": "Log Material Usage",
+        "drawerDescription": "Record raw material consumed during production.",
+        "noInventory": "No inventory linked yet",
+        "noInventoryHint": "Link raw materials to this design first, then you can log material usage here.",
+        "inventoryItem": "Inventory Item",
+        "selectItem": "Select item",
+        "quantity": "Quantity",
+        "measuredAs": "Measured as",
+        "perPiece": "Per piece",
+        "totalRun": "Total for the run",
+        "perPieceHint": "Material for ONE finished piece — we multiply by how many you make.",
+        "totalRunHint": "Material for the WHOLE run — recorded as entered.",
+        "costPerUnit": "Cost per unit",
+        "optional": "Optional",
+        "unit": "Unit",
+        "type": "Type",
+        "notes": "Notes",
+        "notesPlaceholder": "What was this material used for?",
+        "logUsage": "Log Usage",
+        "empty": "No material usage logged yet",
+        "required": "Inventory item and quantity are required",
+        "logged": "Consumption logged",
+        "failed": "Failed to log consumption",
+        "accessory": "accessory",
+        "committed": "committed",
+        "pending": "pending",
+        "totalMaterialCost": "Total material cost"
+      },
+      "create": {
+        "heading": "Create design",
+        "namePlaceholder": "e.g. Spring Jacket",
+        "descriptionPlaceholder": "What is this design?",
+        "designerNotesPlaceholder": "Internal notes",
+        "created": "Design created"
+      },
+      "edit": {
+        "heading": "Edit design",
+        "updated": "Design updated"
+      },
+      "addInventory": {
+        "selectedCount": "{{count}} selected",
+        "selectPrompt": "Select materials to add",
+        "addToDesign": "Add to design",
+        "noRawMaterialsTitle": "No raw materials",
+        "noRawMaterialsMessage": "No raw materials found. Admin maintains the shared raw-material catalog.",
+        "selectAtLeastOne": "Select at least one material",
+        "added_one": "Added {{count}} material",
+        "added_other": "Added {{count}} materials",
+        "sku": "SKU",
+        "columns": {
+          "material": "Material",
+          "composition": "Composition",
+          "color": "Color",
+          "unit": "Unit"
+        }
+      },
+      "runCreate": {
+        "heading": "Create design order",
+        "subtitle": "Start production for this design. The design order is approved and ready to work immediately.",
+        "quantity": "Quantity",
+        "runType": "Run type",
+        "production": "Production",
+        "sample": "Sample",
+        "howMade": "How is it made?",
+        "inHouse": "In-house (you make it)",
+        "outsourced": "Outsourced (hand to a sub-partner)",
+        "executionHint": "In-house keeps the work with you; outsourced records the vendor for cost tracking.",
+        "subPartnerId": "Sub-partner ID",
+        "subPartnerPlaceholder": "partner_…",
+        "subPartnerHint": "The partner you're handing this production to.",
+        "createOrder": "Create design order",
+        "started": "Production started"
+      }
     }
   },
   "refundReasons": {

--- a/apps/partner-ui/src/lib/design-labels.ts
+++ b/apps/partner-ui/src/lib/design-labels.ts
@@ -1,0 +1,118 @@
+import type { TFunction } from "i18next"
+
+/**
+ * Label maps for the design/work enums (#2022).
+ *
+ * Every design screen used `String(value).replace(/_/g, " ")` — which produces
+ * "Sample Production" in English and nothing anywhere else. These helpers map
+ * the raw enum value to a real, individually-translatable key under
+ * `partner.designs.*` so each status/priority/type renders through `t()`.
+ *
+ * A value with no mapping falls back to the raw string (space-separated), which
+ * keeps an unseen enum value visible rather than silently blank.
+ */
+
+const statusKey: Record<string, string> = {
+  Conceptual: "statusOptions.conceptual",
+  In_Development: "statusOptions.inDevelopment",
+  Technical_Review: "statusOptions.technicalReview",
+  Sample_Production: "statusOptions.sampleProduction",
+  Revision: "statusOptions.revision",
+  Approved: "statusOptions.approved",
+  Rejected: "statusOptions.rejected",
+  On_Hold: "statusOptions.onHold",
+  Commerce_Ready: "statusOptions.commerceReady",
+  Superseded: "statusOptions.superseded",
+}
+
+const priorityKey: Record<string, string> = {
+  low: "priorityOptions.low",
+  medium: "priorityOptions.medium",
+  high: "priorityOptions.high",
+  urgent: "priorityOptions.urgent",
+  Low: "priorityOptions.low",
+  Medium: "priorityOptions.medium",
+  High: "priorityOptions.high",
+  Urgent: "priorityOptions.urgent",
+}
+
+const typeKey: Record<string, string> = {
+  Original: "typeOptions.original",
+  Derivative: "typeOptions.derivative",
+  Custom: "typeOptions.custom",
+  Collaboration: "typeOptions.collaboration",
+}
+
+const workStatusKey: Record<string, string> = {
+  incoming: "workStatusOptions.incoming",
+  assigned: "workStatusOptions.assigned",
+  in_progress: "workStatusOptions.inProgress",
+  awaiting_review: "workStatusOptions.awaitingReview",
+  finished: "workStatusOptions.finished",
+  completed: "workStatusOptions.completed",
+  cancelled: "workStatusOptions.cancelled",
+}
+
+const runStatusKey: Record<string, string> = {
+  draft: "runStatusOptions.draft",
+  pending_review: "runStatusOptions.pendingReview",
+  approved: "runStatusOptions.approved",
+  sent_to_partner: "runStatusOptions.sentToPartner",
+  in_progress: "runStatusOptions.inProgress",
+  completed: "runStatusOptions.completed",
+  cancelled: "runStatusOptions.cancelled",
+  awaiting_reassignment: "runStatusOptions.awaitingReassignment",
+}
+
+const engagementKey: Record<string, string> = {
+  owned: "engagementOptions.owned",
+  assigned: "engagementOptions.assigned",
+  shared: "engagementOptions.shared",
+}
+
+const runTypeKey: Record<string, string> = {
+  production: "runTypeOptions.production",
+  sample: "runTypeOptions.sample",
+}
+
+const confidenceKey: Record<string, string> = {
+  exact: "confidenceOptions.exact",
+  estimated: "confidenceOptions.estimated",
+}
+
+const fallbackLabel = (value: string): string => value.replace(/_/g, " ")
+
+const label = (
+  t: TFunction,
+  value: string | null | undefined,
+  map: Record<string, string>
+): string => {
+  if (value == null || value === "") return "—"
+  const key = map[value]
+  return key ? t(`partner.designs.${key}`) : fallbackLabel(value)
+}
+
+export const designStatusLabel = (t: TFunction, v?: string | null): string =>
+  label(t, v, statusKey)
+
+export const priorityLabel = (t: TFunction, v?: string | null): string =>
+  label(t, v, priorityKey)
+
+export const designTypeLabel = (t: TFunction, v?: string | null): string =>
+  label(t, v, typeKey)
+
+export const workStatusLabel = (t: TFunction, v?: string | null): string =>
+  label(t, v, workStatusKey)
+
+export const runStatusLabel = (t: TFunction, v?: string | null): string =>
+  label(t, v, runStatusKey)
+
+export const runTypeLabel = (t: TFunction, v?: string | null): string =>
+  label(t, v, runTypeKey)
+
+export const confidenceLabel = (t: TFunction, v?: string | null): string =>
+  label(t, v, confidenceKey)
+
+/** The `partner.designs.engagementOptions.*` key for a partner_engagement value. */
+export const engagementKeyFor = (v?: string | null): string =>
+  v ? engagementKey[v] ?? "engagementOptions.shared" : "engagementOptions.shared"

--- a/apps/partner-ui/src/routes/designs/design-add-inventory/components/add-inventory-form/add-inventory-form.tsx
+++ b/apps/partner-ui/src/routes/designs/design-add-inventory/components/add-inventory-form/add-inventory-form.tsx
@@ -6,6 +6,7 @@ import {
   createColumnHelper,
 } from "@tanstack/react-table"
 import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
 
 import { _DataTable } from "../../../../../components/table/data-table"
@@ -23,6 +24,7 @@ const PAGE_SIZE = 20
 type Props = { designId: string }
 
 export const AddInventoryForm = ({ designId }: Props) => {
+  const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
   const [searchParams] = useSearchParams()
   const q = searchParams.get("q") || ""
@@ -57,7 +59,7 @@ export const AddInventoryForm = ({ designId }: Props) => {
 
   const handleAdd = async () => {
     if (!selectedIds.length) {
-      toast.error("Select at least one material")
+      toast.error(t("partner.designs.addInventory.selectAtLeastOne"))
       return
     }
     await mutateAsync(
@@ -67,7 +69,7 @@ export const AddInventoryForm = ({ designId }: Props) => {
       {
         onSuccess: () => {
           toast.success(
-            `Added ${selectedIds.length} material${selectedIds.length > 1 ? "s" : ""}`
+            t("partner.designs.addInventory.added", { count: selectedIds.length })
           )
           handleSuccess()
         },
@@ -82,8 +84,10 @@ export const AddInventoryForm = ({ designId }: Props) => {
         <div className="flex items-center gap-x-2">
           <Text size="small" className="text-ui-fg-subtle">
             {selectedIds.length > 0
-              ? `${selectedIds.length} selected`
-              : "Select materials to add"}
+              ? t("partner.designs.addInventory.selectedCount", {
+                  count: selectedIds.length,
+                })
+              : t("partner.designs.addInventory.selectPrompt")}
           </Text>
         </div>
       </RouteFocusModal.Header>
@@ -100,7 +104,7 @@ export const AddInventoryForm = ({ designId }: Props) => {
           queryObject={{ q, offset }}
           commands={[
             {
-              label: "Add to design",
+              label: t("partner.designs.addInventory.addToDesign"),
               shortcut: "a",
               action: async () => {
                 await handleAdd()
@@ -108,9 +112,8 @@ export const AddInventoryForm = ({ designId }: Props) => {
             },
           ]}
           noRecords={{
-            title: "No raw materials",
-            message:
-              "No raw materials found. Admin maintains the shared raw-material catalog.",
+            title: t("partner.designs.addInventory.noRawMaterialsTitle"),
+            message: t("partner.designs.addInventory.noRawMaterialsMessage"),
           }}
         />
       </RouteFocusModal.Body>
@@ -118,7 +121,7 @@ export const AddInventoryForm = ({ designId }: Props) => {
         <div className="flex items-center justify-end gap-x-2">
           <RouteFocusModal.Close asChild>
             <Button variant="secondary" size="small">
-              Cancel
+              {t("actions.cancel")}
             </Button>
           </RouteFocusModal.Close>
           <Button
@@ -127,7 +130,8 @@ export const AddInventoryForm = ({ designId }: Props) => {
             isLoading={isSaving}
             disabled={!selectedIds.length}
           >
-            Add{selectedIds.length ? ` (${selectedIds.length})` : ""}
+            {t("actions.add")}
+            {selectedIds.length ? ` (${selectedIds.length})` : ""}
           </Button>
         </div>
       </RouteFocusModal.Footer>
@@ -137,8 +141,9 @@ export const AddInventoryForm = ({ designId }: Props) => {
 
 const columnHelper = createColumnHelper<PartnerRawMaterialRow>()
 
-const useColumns = () =>
-  useMemo(
+const useColumns = () => {
+  const { t } = useTranslation()
+  return useMemo(
     () => [
       columnHelper.display({
         id: "select",
@@ -162,7 +167,7 @@ const useColumns = () =>
       }),
       columnHelper.display({
         id: "material",
-        header: () => "Material",
+        header: () => t("partner.designs.addInventory.columns.material"),
         cell: ({ row }) => {
           const r = row.original
           return (
@@ -174,7 +179,7 @@ const useColumns = () =>
                 </span>
                 {r.sku && (
                   <span className="text-ui-fg-subtle truncate text-xs">
-                    SKU: {r.sku}
+                    {t("partner.designs.addInventory.sku")}: {r.sku}
                   </span>
                 )}
               </div>
@@ -183,23 +188,24 @@ const useColumns = () =>
         },
       }),
       columnHelper.accessor("composition", {
-        header: () => "Composition",
+        header: () => t("partner.designs.addInventory.columns.composition"),
         cell: ({ getValue }) => (
           <span className="text-ui-fg-subtle truncate">{getValue() || "-"}</span>
         ),
       }),
       columnHelper.accessor("color", {
-        header: () => "Color",
+        header: () => t("partner.designs.addInventory.columns.color"),
         cell: ({ getValue }) => (
           <span className="text-ui-fg-subtle">{getValue() || "-"}</span>
         ),
       }),
       columnHelper.accessor("unit_of_measure", {
-        header: () => "Unit",
+        header: () => t("partner.designs.addInventory.columns.unit"),
         cell: ({ getValue }) => (
           <span className="text-ui-fg-subtle">{getValue() || "-"}</span>
         ),
       }),
     ],
-    []
+    [t]
   )
+}

--- a/apps/partner-ui/src/routes/designs/design-create/components/design-create-form/design-create-form.tsx
+++ b/apps/partner-ui/src/routes/designs/design-create/components/design-create-form/design-create-form.tsx
@@ -1,11 +1,13 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Button, Heading, Input, Select, Textarea, toast } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
 
 import { Form } from "../../../../../components/common/form"
 import { RouteFocusModal, useRouteModal } from "../../../../../components/modals"
 import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
 import { useCreatePartnerDesign } from "../../../../../hooks/api/partner-designs"
+import { designStatusLabel, designTypeLabel, priorityLabel } from "../../../../../lib/design-labels"
 import { CreateDesignSchema } from "./schema"
 
 const DESIGN_TYPES = ["Original", "Derivative", "Custom", "Collaboration"] as const
@@ -22,6 +24,7 @@ const STATUSES = [
 ] as const
 
 export function DesignCreateForm() {
+  const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
   const form = useForm<CreateDesignSchema>({
     defaultValues: {
@@ -40,7 +43,7 @@ export function DesignCreateForm() {
   const handleSubmit = form.handleSubmit(async (data) => {
     await mutateAsync(data, {
       onSuccess: ({ design }) => {
-        toast.success("Design created")
+        toast.success(t("partner.designs.create.created"))
         handleSuccess(`/designs/${design.id}`)
       },
       onError: (e) => toast.error(e.message),
@@ -56,16 +59,16 @@ export function DesignCreateForm() {
         <RouteFocusModal.Header />
         <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto">
           <div className="flex w-full max-w-[720px] flex-col gap-y-8 px-2 py-16">
-            <Heading>Create design</Heading>
+            <Heading>{t("partner.designs.create.heading")}</Heading>
 
             <Form.Field
               control={form.control}
               name="name"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>Name</Form.Label>
+                  <Form.Label>{t("fields.name")}</Form.Label>
                   <Form.Control>
-                    <Input {...field} placeholder="e.g. Spring Jacket" />
+                    <Input {...field} placeholder={t("partner.designs.create.namePlaceholder")} />
                   </Form.Control>
                   <Form.ErrorMessage />
                 </Form.Item>
@@ -77,9 +80,9 @@ export function DesignCreateForm() {
               name="description"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label optional>Description</Form.Label>
+                  <Form.Label optional>{t("fields.description")}</Form.Label>
                   <Form.Control>
-                    <Textarea {...field} placeholder="What is this design?" />
+                    <Textarea {...field} placeholder={t("partner.designs.create.descriptionPlaceholder")} />
                   </Form.Control>
                 </Form.Item>
               )}
@@ -91,16 +94,16 @@ export function DesignCreateForm() {
                 name="design_type"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label optional>Type</Form.Label>
+                    <Form.Label optional>{t("fields.type")}</Form.Label>
                     <Form.Control>
                       <Select value={field.value} onValueChange={field.onChange}>
                         <Select.Trigger>
-                          <Select.Value placeholder="Select" />
+                          <Select.Value placeholder={t("general.select")} />
                         </Select.Trigger>
                         <Select.Content>
-                          {DESIGN_TYPES.map((t) => (
-                            <Select.Item key={t} value={t}>
-                              {t}
+                          {DESIGN_TYPES.map((v) => (
+                            <Select.Item key={v} value={v}>
+                              {designTypeLabel(t, v)}
                             </Select.Item>
                           ))}
                         </Select.Content>
@@ -115,16 +118,16 @@ export function DesignCreateForm() {
                 name="priority"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label optional>Priority</Form.Label>
+                    <Form.Label optional>{t("partner.designs.fields.priority")}</Form.Label>
                     <Form.Control>
                       <Select value={field.value} onValueChange={field.onChange}>
                         <Select.Trigger>
-                          <Select.Value placeholder="Select" />
+                          <Select.Value placeholder={t("general.select")} />
                         </Select.Trigger>
                         <Select.Content>
-                          {PRIORITIES.map((p) => (
-                            <Select.Item key={p} value={p}>
-                              {p}
+                          {PRIORITIES.map((v) => (
+                            <Select.Item key={v} value={v}>
+                              {priorityLabel(t, v)}
                             </Select.Item>
                           ))}
                         </Select.Content>
@@ -139,16 +142,16 @@ export function DesignCreateForm() {
                 name="status"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label optional>Status</Form.Label>
+                    <Form.Label optional>{t("fields.status")}</Form.Label>
                     <Form.Control>
                       <Select value={field.value} onValueChange={field.onChange}>
                         <Select.Trigger>
-                          <Select.Value placeholder="Select" />
+                          <Select.Value placeholder={t("general.select")} />
                         </Select.Trigger>
                         <Select.Content>
-                          {STATUSES.map((s) => (
-                            <Select.Item key={s} value={s}>
-                              {s.replace(/_/g, " ")}
+                          {STATUSES.map((v) => (
+                            <Select.Item key={v} value={v}>
+                              {designStatusLabel(t, v)}
                             </Select.Item>
                           ))}
                         </Select.Content>
@@ -164,9 +167,9 @@ export function DesignCreateForm() {
               name="designer_notes"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label optional>Designer notes</Form.Label>
+                  <Form.Label optional>{t("partner.designs.fields.designerNotes")}</Form.Label>
                   <Form.Control>
-                    <Textarea {...field} placeholder="Internal notes" />
+                    <Textarea {...field} placeholder={t("partner.designs.create.designerNotesPlaceholder")} />
                   </Form.Control>
                 </Form.Item>
               )}
@@ -177,11 +180,11 @@ export function DesignCreateForm() {
           <div className="flex items-center justify-end gap-x-2">
             <RouteFocusModal.Close asChild>
               <Button variant="secondary" size="small">
-                Cancel
+                {t("actions.cancel")}
               </Button>
             </RouteFocusModal.Close>
             <Button size="small" type="submit" isLoading={isPending}>
-              Create
+              {t("actions.create")}
             </Button>
           </div>
         </RouteFocusModal.Footer>

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-consumption-logs-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-consumption-logs-section.tsx
@@ -13,6 +13,7 @@ import {
   toast,
 } from "@medusajs/ui"
 import { Plus } from "@medusajs/icons"
+import { useTranslation } from "react-i18next"
 import {
   ConsumptionLog,
   usePartnerConsumptionLogs,
@@ -20,26 +21,14 @@ import {
 } from "../../../../hooks/api/partner-consumption-logs"
 import { PartnerDesign } from "../../../../hooks/api/partner-designs"
 import { useStockLocations } from "../../../../hooks/api/stock-locations"
+import { useDate } from "../../../../hooks/use-date"
 
 interface DesignConsumptionLogsSectionProps {
   design: PartnerDesign
 }
 
-const UNIT_OPTIONS = [
-  { value: "Meter", label: "Meter" },
-  { value: "Yard", label: "Yard" },
-  { value: "Kilogram", label: "Kilogram" },
-  { value: "Gram", label: "Gram" },
-  { value: "Piece", label: "Piece" },
-  { value: "Roll", label: "Roll" },
-  { value: "Other", label: "Other" },
-]
-
-const TYPE_OPTIONS = [
-  { value: "sample", label: "Sample" },
-  { value: "production", label: "Production" },
-  { value: "wastage", label: "Wastage" },
-]
+const UNIT_VALUES = ["Meter", "Yard", "Kilogram", "Gram", "Piece", "Roll", "Other"]
+const TYPE_VALUES = ["sample", "production", "wastage"] as const
 
 const typeBadgeColor = (type: string) => {
   switch (type) {
@@ -51,6 +40,8 @@ const typeBadgeColor = (type: string) => {
 }
 
 export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSectionProps) => {
+  const { t } = useTranslation()
+  const { getFullDate } = useDate()
   const [showForm, setShowForm] = useState(false)
 
   const { logs, count, isLoading } = usePartnerConsumptionLogs(design.id)
@@ -79,6 +70,15 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
   const [formType, setFormType] = useState("production")
   const [formNotes, setFormNotes] = useState("")
 
+  const unitOptions = UNIT_VALUES.map((v) => ({
+    value: v,
+    label: t(`partner.designs.unitOptions.${v.toLowerCase()}`),
+  }))
+  const typeOptions = TYPE_VALUES.map((v) => ({
+    value: v,
+    label: t(`partner.designs.consumptionTypeOptions.${v}`),
+  }))
+
   const resetForm = () => {
     setFormInventoryId("")
     setFormQuantity("")
@@ -92,7 +92,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
 
   const handleLogConsumption = async () => {
     if (!formInventoryId || !formQuantity) {
-      toast.error("Inventory item and quantity are required")
+      toast.error(t("partner.designs.consumption.required"))
       return
     }
     try {
@@ -106,21 +106,13 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
         notes: formNotes || undefined,
         locationId: partnerLocationId,
       })
-      toast.success("Consumption logged")
+      toast.success(t("partner.designs.consumption.logged"))
       resetForm()
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to log consumption")
+      toast.error(
+        error instanceof Error ? error.message : t("partner.designs.consumption.failed")
+      )
     }
-  }
-
-  const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      timeZoneName: "short",
-    })
   }
 
   const getInventoryLabel = (itemId: string) => {
@@ -128,19 +120,21 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
     return found?.title || found?.sku || itemId
   }
 
+  const consumptionTypeLabel = (type: string) =>
+    t(`partner.designs.consumptionTypeOptions.${type}`, type)
 
   return (
     <Container className="divide-y p-0">
       <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="flex items-center gap-x-2">
-            <Heading level="h2">Material Usage</Heading>
+            <Heading level="h2">{t("partner.designs.consumption.heading")}</Heading>
             {count > 0 && (
               <Badge size="2xsmall" color="grey">{count}</Badge>
             )}
           </div>
           <Text className="text-ui-fg-subtle" size="small">
-            Log raw materials consumed during production
+            {t("partner.designs.consumption.subtitle")}
             {partnerLocationName ? ` · ${partnerLocationName}` : ""}
           </Text>
         </div>
@@ -151,17 +145,16 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
             onClick={() => setShowForm(true)}
           >
             <Plus className="mr-1.5" />
-            Log
+            {t("partner.designs.consumption.log")}
           </Button>
         ) : (
           partnerStatus && !canLog && (
             <Text size="xsmall" className="text-ui-fg-muted">
               {partnerStatus === "awaiting_review" || partnerStatus === "finished"
-                ? "Logging closed — run is awaiting review"
+                ? t("partner.designs.consumption.closedReview")
                 : partnerStatus === "completed"
-                ? "Logging closed — run completed"
-                : "Logging not available"
-              }
+                ? t("partner.designs.consumption.closedComplete")
+                : t("partner.designs.consumption.closedNone")}
             </Text>
           )
         )}
@@ -171,31 +164,30 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
       <Drawer open={showForm} onOpenChange={(open) => (open ? setShowForm(true) : resetForm())}>
         <Drawer.Content>
           <Drawer.Header>
-            <Drawer.Title>Log Material Usage</Drawer.Title>
+            <Drawer.Title>{t("partner.designs.consumption.drawerTitle")}</Drawer.Title>
             <Drawer.Description>
-              Record raw material consumed during production.
+              {t("partner.designs.consumption.drawerDescription")}
             </Drawer.Description>
           </Drawer.Header>
           <Drawer.Body className="flex flex-col gap-y-4 overflow-y-auto">
             {inventoryItems.length === 0 ? (
               <div className="flex flex-col items-center justify-center gap-y-2 py-10 text-center">
                 <Text size="small" weight="plus">
-                  No inventory linked yet
+                  {t("partner.designs.consumption.noInventory")}
                 </Text>
                 <Text size="small" className="text-ui-fg-subtle">
-                  Link raw materials to this design first, then you can log
-                  material usage here.
+                  {t("partner.designs.consumption.noInventoryHint")}
                 </Text>
               </div>
             ) : (
               <>
                 <div>
                   <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-1">
-                    Inventory Item
+                    {t("partner.designs.consumption.inventoryItem")}
                   </Text>
                   <Select value={formInventoryId} onValueChange={setFormInventoryId}>
                     <Select.Trigger>
-                      <Select.Value placeholder="Select item" />
+                      <Select.Value placeholder={t("partner.designs.consumption.selectItem")} />
                     </Select.Trigger>
                     <Select.Content>
                       {inventoryItems.map((item: any) => (
@@ -209,7 +201,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                 <div className="grid grid-cols-2 gap-3">
                   <div>
                     <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-1">
-                      Quantity
+                      {t("partner.designs.consumption.quantity")}
                     </Text>
                     <Input
                       type="number"
@@ -227,43 +219,47 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                     <div className="mt-1.5">
                       <Select value={formBasis} onValueChange={setFormBasis}>
                         <Select.Trigger>
-                          <Select.Value placeholder="Measured as" />
+                          <Select.Value placeholder={t("partner.designs.consumption.measuredAs")} />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="per_piece">Per piece</Select.Item>
-                          <Select.Item value="total">Total for the run</Select.Item>
+                          <Select.Item value="per_piece">
+                            {t("partner.designs.consumption.perPiece")}
+                          </Select.Item>
+                          <Select.Item value="total">
+                            {t("partner.designs.consumption.totalRun")}
+                          </Select.Item>
                         </Select.Content>
                       </Select>
                     </div>
                     <Text size="xsmall" className="text-ui-fg-muted mt-1">
                       {formBasis === "per_piece"
-                        ? "Material for ONE finished piece — we multiply by how many you make."
-                        : "Material for the WHOLE run — recorded as entered."}
+                        ? t("partner.designs.consumption.perPieceHint")
+                        : t("partner.designs.consumption.totalRunHint")}
                     </Text>
                   </div>
                   <div>
                     <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-1">
-                      Cost per unit
+                      {t("partner.designs.consumption.costPerUnit")}
                     </Text>
                     <Input
                       type="number"
                       step="0.01"
                       min="0"
-                      placeholder="Optional"
+                      placeholder={t("partner.designs.consumption.optional")}
                       value={formUnitCost}
                       onChange={(e) => setFormUnitCost(e.target.value)}
                     />
                   </div>
                   <div>
                     <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-1">
-                      Unit
+                      {t("partner.designs.consumption.unit")}
                     </Text>
                     <Select value={formUnit} onValueChange={setFormUnit}>
                       <Select.Trigger>
                         <Select.Value />
                       </Select.Trigger>
                       <Select.Content>
-                        {UNIT_OPTIONS.map((o) => (
+                        {unitOptions.map((o) => (
                           <Select.Item key={o.value} value={o.value}>
                             {o.label}
                           </Select.Item>
@@ -273,14 +269,14 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                   </div>
                   <div>
                     <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-1">
-                      Type
+                      {t("partner.designs.consumption.type")}
                     </Text>
                     <Select value={formType} onValueChange={setFormType}>
                       <Select.Trigger>
                         <Select.Value />
                       </Select.Trigger>
                       <Select.Content>
-                        {TYPE_OPTIONS.map((o) => (
+                        {typeOptions.map((o) => (
                           <Select.Item key={o.value} value={o.value}>
                             {o.label}
                           </Select.Item>
@@ -291,10 +287,10 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                 </div>
                 <div>
                   <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-1">
-                    Notes
+                    {t("partner.designs.consumption.notes")}
                   </Text>
                   <Textarea
-                    placeholder="What was this material used for?"
+                    placeholder={t("partner.designs.consumption.notesPlaceholder")}
                     value={formNotes}
                     onChange={(e) => setFormNotes(e.target.value)}
                     rows={2}
@@ -305,11 +301,11 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
           </Drawer.Body>
           <Drawer.Footer>
             <Button variant="secondary" onClick={resetForm} disabled={isLogging}>
-              {inventoryItems.length === 0 ? "Close" : "Cancel"}
+              {inventoryItems.length === 0 ? t("actions.close") : t("actions.cancel")}
             </Button>
             {inventoryItems.length > 0 && (
               <Button onClick={handleLogConsumption} isLoading={isLogging}>
-                Log Usage
+                {t("partner.designs.consumption.logUsage")}
               </Button>
             )}
           </Drawer.Footer>
@@ -326,7 +322,9 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
         <div className="flex flex-col gap-2 px-3 pb-4 pt-2">
           {logs.length === 0 ? (
             <div className="flex items-center justify-center py-6">
-              <Text className="text-ui-fg-subtle">No material usage logged yet</Text>
+              <Text className="text-ui-fg-subtle">
+                {t("partner.designs.consumption.empty")}
+              </Text>
             </div>
           ) : (
             logs.map((log: ConsumptionLog) => (
@@ -342,15 +340,21 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                         {(log as any).unit_cost ? ` @ ${(log as any).unit_cost}/unit` : ""}
                       </Text>
                       {log.unit_of_measure === "Piece" && (
-                        <Badge size="2xsmall" color="purple">accessory</Badge>
+                        <Badge size="2xsmall" color="purple">
+                          {t("partner.designs.consumption.accessory")}
+                        </Badge>
                       )}
                       <Badge size="2xsmall" color={typeBadgeColor(log.consumption_type)}>
-                        {log.consumption_type}
+                        {consumptionTypeLabel(log.consumption_type)}
                       </Badge>
                       {log.is_committed ? (
-                        <Badge size="2xsmall" color="green">committed</Badge>
+                        <Badge size="2xsmall" color="green">
+                          {t("partner.designs.consumption.committed")}
+                        </Badge>
                       ) : (
-                        <Badge size="2xsmall" color="grey">pending</Badge>
+                        <Badge size="2xsmall" color="grey">
+                          {t("partner.designs.consumption.pending")}
+                        </Badge>
                       )}
                     </div>
                     <div className="flex items-center gap-2">
@@ -371,7 +375,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                   </div>
                   <div className="flex flex-col items-end">
                     <Text size="xsmall" className="text-ui-fg-muted">
-                      {formatDate(log.consumed_at)}
+                      {getFullDate({ date: log.consumed_at, includeTime: true })}
                     </Text>
                   </div>
                 </div>
@@ -385,7 +389,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
       {logs.length > 0 && logs.some((l: any) => l.unit_cost && l.quantity) && (
         <div className="flex items-center justify-between px-6 py-3 bg-ui-bg-subtle rounded-b-xl">
           <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">
-            Total material cost
+            {t("partner.designs.consumption.totalMaterialCost")}
           </Text>
           <Text size="xsmall" weight="plus">
             {Math.round(

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   toast,
 } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 
 import { SectionRow } from "../../../../components/common/section"
 import { Skeleton } from "../../../../components/common/skeleton"
@@ -18,6 +19,8 @@ import {
   usePartnerDesignCost,
   useRecalculatePartnerDesignCost,
 } from "../../../../hooks/api/partner-design-cost"
+import { useDate } from "../../../../hooks/use-date"
+import { confidenceLabel } from "../../../../lib/design-labels"
 
 type Props = { design: PartnerDesign }
 
@@ -33,6 +36,8 @@ const fmt = (v?: number | null, currency?: string | null) =>
  * their own production cost, which overrides the auto estimate.
  */
 export const DesignCostSection = ({ design }: Props) => {
+  const { t } = useTranslation()
+  const { getFullDate } = useDate()
   const isOwner = !!design.is_owner
   const { cost, isLoading } = usePartnerDesignCost(design.id)
   const { mutateAsync: recalc, isPending } = useRecalculatePartnerDesignCost(
@@ -55,7 +60,7 @@ export const DesignCostSection = ({ design }: Props) => {
     if (trimmed !== "") {
       const n = Number(trimmed)
       if (!Number.isFinite(n) || n < 0) {
-        toast.error("Enter a valid production cost (0 or more)")
+        toast.error(t("partner.designs.cost.enterValid"))
         return
       }
       production_cost = n
@@ -66,7 +71,10 @@ export const DesignCostSection = ({ design }: Props) => {
         onSuccess: (d) => {
           touched.current = false
           toast.success(
-            `Cost recalculated: ${fmt(d.cost_estimate.total_estimated)} (${d.cost_estimate.confidence})`
+            t("partner.designs.cost.recalculated", {
+              amount: fmt(d.cost_estimate.total_estimated),
+              confidence: d.cost_estimate.confidence,
+            })
           )
         },
         onError: (e) => toast.error(e.message),
@@ -84,10 +92,9 @@ export const DesignCostSection = ({ design }: Props) => {
     <Container className="divide-y p-0">
       <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <Heading level="h2">Cost estimate</Heading>
+          <Heading level="h2">{t("partner.designs.cost.heading")}</Heading>
           <Text size="small" className="text-ui-fg-subtle">
-            Material + production cost from the linked BOM, plus the JYT platform
-            fee.
+            {t("partner.designs.cost.subtitle")}
           </Text>
         </div>
         {isOwner && (
@@ -98,7 +105,7 @@ export const DesignCostSection = ({ design }: Props) => {
             onClick={handleRecalc}
           >
             <ArrowPath />
-            Recalculate
+            {t("partner.designs.cost.recalculate")}
           </Button>
         )}
       </div>
@@ -118,7 +125,7 @@ export const DesignCostSection = ({ design }: Props) => {
       ) : (
         <>
           <SectionRow
-            title="Estimated total"
+            title={t("partner.designs.cost.estimatedTotal")}
             value={
               <div className="flex items-center gap-x-2">
                 <Text size="small" weight="plus">
@@ -135,42 +142,44 @@ export const DesignCostSection = ({ design }: Props) => {
                           : "orange"
                     }
                   >
-                    {confidence}
+                    {confidenceLabel(t, confidence)}
                   </Badge>
                 )}
               </div>
             }
           />
           <SectionRow
-            title="Material cost"
+            title={t("partner.designs.cost.materialCost")}
             value={fmt(cost?.material_cost, currency)}
           />
           <SectionRow
-            title="Production cost"
+            title={t("partner.designs.cost.productionCost")}
             value={
               <div className="flex items-center gap-x-2">
                 <Text size="small">{fmt(cost?.production_cost, currency)}</Text>
                 <Badge size="2xsmall" color={prodIsPartnerEntered ? "green" : "grey"}>
-                  {prodIsPartnerEntered ? "your input" : "estimated"}
+                  {prodIsPartnerEntered
+                    ? t("partner.designs.cost.yourInput")
+                    : t("partner.designs.cost.estimatedLabel")}
                 </Badge>
               </div>
             }
           />
           <SectionRow
-            title={`Platform fee (${feePercent}%)`}
+            title={t("partner.designs.cost.platformFee", { percent: feePercent })}
             value={fmt(cost?.platform_fee, currency)}
           />
           {cost?.cost_breakdown?.calculated_at && (
             <SectionRow
-              title="Last calculated"
-              value={new Date(cost.cost_breakdown.calculated_at).toLocaleString()}
+              title={t("partner.designs.cost.lastCalculated")}
+              value={getFullDate({ date: cost.cost_breakdown.calculated_at, includeTime: true })}
             />
           )}
 
           {isOwner && (
             <div className="flex flex-col gap-y-2 px-6 py-4">
               <Label size="small" weight="plus" htmlFor="partner-production-cost">
-                Your production cost (per unit)
+                {t("partner.designs.cost.yourProductionCost")}
               </Label>
               <div className="flex items-center gap-x-2">
                 <Input
@@ -179,7 +188,7 @@ export const DesignCostSection = ({ design }: Props) => {
                   min="0"
                   step="0.01"
                   inputMode="decimal"
-                  placeholder="Auto-estimate"
+                  placeholder={t("partner.designs.cost.autoEstimate")}
                   value={prodInput}
                   onChange={(e) => {
                     touched.current = true
@@ -200,14 +209,12 @@ export const DesignCostSection = ({ design }: Props) => {
                       setProdInput("")
                     }}
                   >
-                    Clear
+                    {t("actions.clear")}
                   </Button>
                 )}
               </div>
               <Text size="xsmall" className="text-ui-fg-subtle">
-                Overrides the auto estimate — leave blank to estimate from
-                history. A {feePercent}% platform fee applies on material cost.
-                Press Recalculate to apply.
+                {t("partner.designs.cost.helper", { percent: feePercent })}
               </Text>
             </div>
           )}
@@ -215,7 +222,7 @@ export const DesignCostSection = ({ design }: Props) => {
           {!cost?.estimated_cost && isOwner && (
             <div className="px-6 py-4">
               <Text size="small" className="text-ui-fg-subtle">
-                No estimate yet — add materials to the BOM, then Recalculate.
+                {t("partner.designs.cost.noEstimate")}
               </Text>
             </div>
           )}

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
@@ -8,6 +8,7 @@ import {
   toast,
   usePrompt,
 } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
 import { Skeleton } from "../../../../components/common/skeleton"
@@ -52,6 +53,7 @@ function extractMedia(line: PartnerDesignInventoryItem): string[] {
 }
 
 export const DesignInventoryBomSection = ({ design }: Props) => {
+  const { t } = useTranslation()
   const prompt = usePrompt()
   const isOwner = !!design.is_owner
   const { inventory_items, isLoading } = usePartnerDesignInventory(design.id)
@@ -59,16 +61,18 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
 
   const handleRemove = async (line: PartnerDesignInventoryItem) => {
     const ok = await prompt({
-      title: "Remove material",
-      description: `Remove "${line.inventory_item?.title ?? line.inventory_item_id}" from this design's bill of materials?`,
-      confirmText: "Remove",
-      cancelText: "Cancel",
+      title: t("partner.designs.bom.removeTitle"),
+      description: t("partner.designs.bom.removeDescription", {
+        name: line.inventory_item?.title ?? line.inventory_item_id,
+      }),
+      confirmText: t("actions.remove"),
+      cancelText: t("actions.cancel"),
     })
     if (!ok) return
     await delink(
       { inventoryIds: [line.inventory_item_id] },
       {
-        onSuccess: () => toast.success("Material removed"),
+        onSuccess: () => toast.success(t("partner.designs.bom.removed")),
         onError: (e) => toast.error(e.message),
       }
     )
@@ -78,9 +82,9 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
     <Container className="divide-y p-0">
       <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <Heading level="h2">Materials (BOM)</Heading>
+          <Heading level="h2">{t("partner.designs.bom.heading")}</Heading>
           <Text size="small" className="text-ui-fg-subtle">
-            Inventory + raw materials used to make this design.
+            {t("partner.designs.bom.subtitle")}
           </Text>
         </div>
         {isOwner && (
@@ -89,7 +93,7 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
           <Link to={`/designs/${design.id}/add-inventory`}>
             <Button size="small" variant="secondary">
               <Plus />
-              Add material
+              {t("partner.designs.bom.addMaterial")}
             </Button>
           </Link>
         )}
@@ -110,8 +114,8 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
       ) : inventory_items.length === 0 ? (
         <div className="px-6 py-6">
           <Text size="small" className="text-ui-fg-subtle">
-            No materials linked yet.
-            {isOwner ? " Add the inventory items this design consumes." : ""}
+            {t("partner.designs.bom.empty")}
+            {isOwner ? t("partner.designs.bom.emptyOwnerHint") : ""}
           </Text>
         </div>
       ) : (
@@ -131,13 +135,13 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
                     <img
                       key={i}
                       src={url}
-                      alt={item?.title ?? "material"}
+                      alt={item?.title ?? t("partner.designs.bom.materialAlt")}
                       className="bg-ui-bg-subtle size-12 rounded-md object-cover"
                     />
                   ))
                 ) : (
                   <div className="bg-ui-bg-subtle text-ui-fg-muted flex size-12 items-center justify-center rounded-md">
-                    <Text size="xsmall">No img</Text>
+                    <Text size="xsmall">{t("partner.designs.bom.noImg")}</Text>
                   </div>
                 )}
               </div>
@@ -150,7 +154,7 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
                   </Text>
                   {item?.sku && (
                     <Badge size="2xsmall" color="grey">
-                      SKU: {item.sku}
+                      {t("partner.designs.bom.sku")}: {item.sku}
                     </Badge>
                   )}
                 </div>
@@ -169,9 +173,9 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
                 )}
 
                 <Text size="xsmall" className="text-ui-fg-muted">
-                  Planned: {line.planned_quantity ?? "—"}
+                  {t("partner.designs.bom.planned")}: {line.planned_quantity ?? "—"}
                   {line.consumed_quantity != null
-                    ? `  ·  Consumed: ${line.consumed_quantity}`
+                    ? `  ·  ${t("partner.designs.bom.consumed")}: ${line.consumed_quantity}`
                     : ""}
                 </Text>
               </div>
@@ -182,7 +186,7 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
                     {
                       actions: [
                         {
-                          label: "Remove",
+                          label: t("actions.remove"),
                           icon: <Trash />,
                           onClick: () => handleRemove(line),
                         },

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-media-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-media-section.tsx
@@ -1,4 +1,5 @@
 import { Button, Container, Heading, Text } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
 import { PartnerDesign } from "../../../../hooks/api/partner-designs"
@@ -24,6 +25,7 @@ export const DesignMediaSection = ({
   design,
   linkBase,
 }: DesignMediaSectionProps) => {
+  const { t } = useTranslation()
   const mediaFiles = (design as any)?.media_files as
     | Array<{ id?: string; url: string; isThumbnail?: boolean }>
     | undefined
@@ -33,9 +35,9 @@ export const DesignMediaSection = ({
   return (
     <Container className="divide-y p-0">
       <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-        <Heading level="h2">Media</Heading>
+        <Heading level="h2">{t("partner.designs.media.heading")}</Heading>
         <Button size="small" variant="secondary" asChild>
-          <Link to={`${base}media`}>Manage</Link>
+          <Link to={`${base}media`}>{t("partner.designs.media.manage")}</Link>
         </Button>
       </div>
       {mediaFiles?.length ? (
@@ -50,7 +52,7 @@ export const DesignMediaSection = ({
               >
                 <img
                   src={media.url}
-                  alt="Design media"
+                  alt={t("partner.designs.media.alt")}
                   className="size-full object-cover"
                 />
               </Link>
@@ -66,14 +68,14 @@ export const DesignMediaSection = ({
               weight="plus"
               className="text-ui-fg-subtle"
             >
-              No media files yet
+              {t("partner.designs.media.empty")}
             </Text>
             <Text size="small" className="text-ui-fg-muted">
-              Add images to showcase your design
+              {t("partner.designs.media.emptyHint")}
             </Text>
           </div>
           <Button size="small" variant="secondary" asChild>
-            <Link to={`${base}media`}>Add Media</Link>
+            <Link to={`${base}media`}>{t("partner.designs.media.addMedia")}</Link>
           </Button>
         </div>
       )}

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-moodboard-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-moodboard-section.tsx
@@ -1,4 +1,5 @@
 import { Button, Container, Heading, Text } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
 import { PartnerDesign } from "../../../../hooks/api/partner-designs"
@@ -8,18 +9,19 @@ type DesignMoodboardSectionProps = {
 }
 
 export const DesignMoodboardSection = ({ design: _design }: DesignMoodboardSectionProps) => {
+  const { t } = useTranslation()
   return (
     <Container className="divide-y p-0">
       <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-        <Heading level="h2">Moodboard</Heading>
+        <Heading level="h2">{t("partner.designs.moodboard.heading")}</Heading>
       </div>
       <div className="px-6 py-4">
         <Text size="small" className="text-ui-fg-subtle">
-          Collect references and inspiration.
+          {t("partner.designs.moodboard.description")}
         </Text>
         <div className="mt-4">
           <Button size="small" variant="secondary" asChild>
-            <Link to="moodboard">Open Moodboard</Link>
+            <Link to="moodboard">{t("partner.designs.moodboard.open")}</Link>
           </Button>
         </div>
       </div>

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
@@ -1,5 +1,6 @@
 import { PencilSquare, PlaySolid, Plus, Trash } from "@medusajs/icons"
 import { Button, Container, Heading, Text, toast, usePrompt } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 import { Link, useNavigate } from "react-router-dom"
 
 import { ActionMenu } from "../../../../components/common/action-menu"
@@ -21,6 +22,7 @@ type Props = { design: PartnerDesign }
  * admin-assigned designs stay read-only on the partner side.
  */
 export const DesignOwnerActionsSection = ({ design }: Props) => {
+  const { t } = useTranslation()
   const navigate = useNavigate()
   const prompt = usePrompt()
   const { mutateAsync } = useDeletePartnerDesign(design.id)
@@ -43,16 +45,18 @@ export const DesignOwnerActionsSection = ({ design }: Props) => {
 
   const handleDelete = async () => {
     const ok = await prompt({
-      title: "Delete design",
-      description: `Delete "${design.name ?? design.id}"? This can't be undone.`,
-      confirmText: "Delete",
-      cancelText: "Cancel",
+      title: t("partner.designs.ownerActions.deleteTitle"),
+      description: t("partner.designs.ownerActions.deleteDescription", {
+        name: design.name ?? design.id,
+      }),
+      confirmText: t("actions.delete"),
+      cancelText: t("actions.cancel"),
     })
     if (!ok) return
 
     await mutateAsync(undefined, {
       onSuccess: () => {
-        toast.success("Design deleted")
+        toast.success(t("partner.designs.ownerActions.deleted"))
         navigate("/designs", { replace: true })
       },
       onError: (e) => toast.error(e.message),
@@ -62,11 +66,13 @@ export const DesignOwnerActionsSection = ({ design }: Props) => {
   return (
     <Container className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <Heading level="h2">{design.name || "Your design"}</Heading>
+        <Heading level="h2">
+          {design.name || t("partner.designs.ownerActions.yourDesign")}
+        </Heading>
         <Text size="small" className="text-ui-fg-subtle">
           {hasActiveRun
-            ? `${activeRuns.length} design order${activeRuns.length > 1 ? "s" : ""} in progress. Create another or hand one to a sub-partner.`
-            : "You created this design. Create a design order to start production, or hand it to a sub-partner."}
+            ? t("partner.designs.ownerActions.activeOrders", { count: activeRuns.length })
+            : t("partner.designs.ownerActions.noOrders")}
         </Text>
       </div>
       <div className="flex items-center gap-x-2">
@@ -80,17 +86,21 @@ export const DesignOwnerActionsSection = ({ design }: Props) => {
             className="whitespace-nowrap"
           >
             {hasActiveRun ? <Plus /> : <PlaySolid />}
-            {hasActiveRun ? "New order" : "Create order"}
+            {hasActiveRun
+              ? t("partner.designs.ownerActions.newOrder")
+              : t("partner.designs.ownerActions.createOrder")}
           </Button>
         </Link>
         <ActionMenu
           groups={[
             {
-              actions: [{ label: "Edit", icon: <PencilSquare />, to: "edit" }],
+              actions: [
+                { label: t("actions.edit"), icon: <PencilSquare />, to: "edit" },
+              ],
             },
             {
               actions: [
-                { label: "Delete", icon: <Trash />, onClick: handleDelete },
+                { label: t("actions.delete"), icon: <Trash />, onClick: handleDelete },
               ],
             },
           ]}

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-production-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-production-section.tsx
@@ -1,12 +1,14 @@
 import { Badge, Container, Heading, Text, clx } from "@medusajs/ui"
 import { ChevronDownMini, ArrowUpRightOnBox } from "@medusajs/icons"
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
 import { PartnerDesign } from "../../../../hooks/api/partner-designs"
 import { usePartnerProductionRuns } from "../../../../hooks/api/partner-production-runs"
 import { GeneralSectionSkeleton } from "../../../../components/common/skeleton"
 import { getStatusBadgeColor } from "../../../../lib/status-badge"
+import { runTypeLabel, runStatusLabel } from "../../../../lib/design-labels"
 
 type DesignProductionSectionProps = {
   design: PartnerDesign
@@ -23,6 +25,7 @@ const TERMINAL_STATUSES = ["completed", "cancelled"]
  * redirects to the unified order.
  */
 export const DesignProductionSection = ({ design }: DesignProductionSectionProps) => {
+  const { t } = useTranslation()
   const { production_runs = [], isPending } = usePartnerProductionRuns({
     design_id: design.id,
     limit: 50,
@@ -37,12 +40,11 @@ export const DesignProductionSection = ({ design }: DesignProductionSectionProps
     return (
       <Container className="divide-y p-0">
         <div className="px-6 py-4">
-          <Heading level="h2">Design orders</Heading>
+          <Heading level="h2">{t("partner.designs.production.heading")}</Heading>
         </div>
         <div className="px-6 py-4">
           <Text size="small" className="text-ui-fg-subtle">
-            No design orders yet. Create a design order to start production, or
-            you'll see them here once the admin sends work your way.
+            {t("partner.designs.production.empty")}
           </Text>
         </div>
       </Container>
@@ -59,10 +61,9 @@ export const DesignProductionSection = ({ design }: DesignProductionSectionProps
   return (
     <Container className="divide-y p-0">
       <div className="px-6 py-4">
-        <Heading level="h2">Design orders</Heading>
+        <Heading level="h2">{t("partner.designs.production.heading")}</Heading>
         <Text size="small" className="text-ui-fg-subtle">
-          Open a design order to accept work, log materials, and update its
-          status.
+          {t("partner.designs.production.subtitle")}
         </Text>
       </div>
 
@@ -78,7 +79,7 @@ export const DesignProductionSection = ({ design }: DesignProductionSectionProps
             className="flex w-full items-center justify-between px-6 py-3 hover:bg-ui-bg-base-hover transition-colors"
           >
             <Text size="small" weight="plus" className="text-ui-fg-subtle">
-              Previous design orders ({previousRuns.length})
+              {t("partner.designs.production.previous", { count: previousRuns.length })}
             </Text>
             <ChevronDownMini
               className={clx("text-ui-fg-muted transition-transform", {
@@ -97,6 +98,7 @@ export const DesignProductionSection = ({ design }: DesignProductionSectionProps
 }
 
 const DesignOrderRow = ({ run, muted }: { run: any; muted?: boolean }) => {
+  const { t } = useTranslation()
   const status = String(run.status || "")
   const to = run.unified_order_id
     ? `/orders/${run.unified_order_id}`
@@ -113,18 +115,20 @@ const DesignOrderRow = ({ run, muted }: { run: any; muted?: boolean }) => {
       <div className="flex min-w-0 flex-col gap-y-1">
         <div className="flex items-center gap-x-2">
           <Text size="small" weight="plus" className="truncate">
-            {run.run_type === "sample" ? "Sample" : "Production"} order
+            {t("partner.designs.production.orderType", {
+              type: runTypeLabel(t, run.run_type),
+            })}
           </Text>
           <Badge size="2xsmall" color={getStatusBadgeColor(status)}>
-            {status.replace(/_/g, " ") || "—"}
+            {runStatusLabel(t, status) || "—"}
           </Badge>
         </div>
         <Text size="xsmall" className="text-ui-fg-subtle">
-          {run.quantity != null ? `Qty ${run.quantity}` : "—"}
+          {run.quantity != null ? t("partner.designs.production.qty", { qty: run.quantity }) : "—"}
         </Text>
       </div>
       <div className="flex shrink-0 items-center gap-x-1 text-ui-fg-interactive">
-        <Text size="small">View order</Text>
+        <Text size="small">{t("partner.designs.production.viewOrder")}</Text>
         <ArrowUpRightOnBox />
       </div>
     </Link>

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-size-sets-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-size-sets-section.tsx
@@ -45,7 +45,7 @@ export const DesignSizeSetsSection = ({ design }: { design: any }) => {
   return (
     <Container className="p-0">
       <div className="flex items-center gap-x-2 px-6 py-4">
-        <Heading level="h2">{t("partner.workOrders.sizes", "Sizes")}</Heading>
+        <Heading level="h2">{t("partner.designs.sizes")}</Heading>
         <Badge size="2xsmall" color="blue">
           {sizes.length}
         </Badge>

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -1,12 +1,20 @@
 import React from "react"
 import { Badge, Container, Heading, Text } from "@medusajs/ui"
 import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 
 import { SectionRow } from "../../../components/common/section"
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage, TwoColumnPage } from "../../../components/layout/pages"
 import { getStatusBadgeColor } from "../../../lib/status-badge"
+import { useDate } from "../../../hooks/use-date"
+import {
+  designStatusLabel,
+  designTypeLabel,
+  priorityLabel,
+  workStatusLabel,
+} from "../../../lib/design-labels"
 import {
   usePartnerDesign,
 } from "../../../hooks/api/partner-designs"
@@ -218,6 +226,8 @@ export type DesignDetailProps = {
 }
 
 export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
+  const { t } = useTranslation()
+  const { getFullDate } = useDate()
   const { id: idParam } = useParams()
   const id = designId ?? idParam
 
@@ -225,9 +235,9 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
     return (
       <SingleColumnPage widgets={{ before: [], after: [] }} hasOutlet={false}>
         <Container className="p-6">
-          <Heading>Design</Heading>
+          <Heading>{t("partner.designs.design")}</Heading>
           <Text size="small" className="text-ui-fg-subtle">
-            Missing design id
+            {t("partner.designs.missingId")}
           </Text>
         </Container>
       </SingleColumnPage>
@@ -303,9 +313,9 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
     return (
       <SingleColumnPage widgets={{ before: [], after: [] }} hasOutlet={false}>
         <Container className="p-6">
-          <Heading>Design</Heading>
+          <Heading>{t("partner.designs.design")}</Heading>
           <Text size="small" className="text-ui-fg-subtle">
-            Design not found
+            {t("partner.designs.notFound")}
           </Text>
         </Container>
       </SingleColumnPage>
@@ -318,16 +328,16 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
         {design && <DesignOwnerActionsSection design={design} />}
         <Container className="divide-y p-0">
           <div className="px-6 py-4">
-            <Heading level="h2">General</Heading>
+            <Heading level="h2">{t("partner.designs.detail.general")}</Heading>
           </div>
-          <SectionRow title="Name" value={design?.name || "-"} />
+          <SectionRow title={t("fields.name")} value={design?.name || "-"} />
           {/* Garment type (#938) — what the thing IS. Distinct from "Type"
               below, which says how original the work is. An inferred value is
               badged as provisional: a model's guess and a designer's decision
               must not look alike, because the guess is the one a human
               correction overwrites. */}
           <SectionRow
-            title="Garment type"
+            title={t("partner.designs.detail.garmentType")}
             value={
               (design as any)?.product_type ? (
                 <div className="flex items-center gap-x-2">
@@ -336,7 +346,7 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
                   </Badge>
                   {(design as any).product_type_source === "inferred" ? (
                     <Badge size="2xsmall" color="orange">
-                      Inferred
+                      {t("partner.designs.detail.inferred")}
                     </Badge>
                   ) : null}
                 </div>
@@ -346,41 +356,41 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
             }
           />
           <SectionRow
-            title="Type"
+            title={t("fields.type")}
             value={
               (design as any)?.design_type ? (
                 <Badge size="2xsmall" color="blue">
-                  {String((design as any).design_type)}
+                  {designTypeLabel(t, String((design as any).design_type))}
                 </Badge>
               ) : "-"
             }
           />
           <SectionRow
-            title="Status"
+            title={t("fields.status")}
             value={
               design?.status ? (
                 <Badge size="2xsmall" color={getStatusBadgeColor(design.status)}>
-                  {String(design.status)}
+                  {designStatusLabel(t, String(design.status))}
                 </Badge>
               ) : "-"
             }
           />
           <SectionRow
-            title="Partner status"
+            title={t("partner.designs.detail.partnerStatus")}
             value={
               design?.partner_info?.partner_status ? (
                 <Badge
                   size="2xsmall"
                   color={getStatusBadgeColor(design.partner_info.partner_status)}
                 >
-                  {String(design.partner_info.partner_status)}
+                  {workStatusLabel(t, String(design.partner_info.partner_status))}
                   {design.partner_info.partner_phase ? ` (${design.partner_info.partner_phase})` : ""}
                 </Badge>
               ) : "-"
             }
           />
           <SectionRow
-            title="Priority"
+            title={t("partner.designs.detail.priority")}
             value={
               (design as any)?.priority ? (
                 <Badge
@@ -391,17 +401,15 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
                     (design as any).priority === "medium" ? "blue" : "grey"
                   }
                 >
-                  {String((design as any).priority)}
+                  {priorityLabel(t, String((design as any).priority))}
                 </Badge>
               ) : "-"
             }
           />
           {(design as any)?.target_completion_date && (
             <SectionRow
-              title="Target date"
-              value={new Date((design as any).target_completion_date).toLocaleDateString("en-US", {
-                month: "short", day: "numeric", year: "numeric",
-              })}
+              title={t("partner.designs.detail.targetDate")}
+              value={getFullDate({ date: (design as any).target_completion_date })}
             />
           )}
           {/*
@@ -411,7 +419,7 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
           */}
           {(design as any)?.estimated_cost != null && (
             <SectionRow
-              title="Estimated cost"
+              title={t("partner.designs.detail.estimatedCost")}
               value={
                 <Text size="small" weight="plus">
                   {(design as any).cost_currency
@@ -428,7 +436,7 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
         {description && (
           <Container className="divide-y p-0">
             <div className="px-6 py-4">
-              <Heading level="h2">Description</Heading>
+              <Heading level="h2">{t("partner.designs.detail.description")}</Heading>
             </div>
             <div className="px-6 py-4">
               <Text size="small" className="text-ui-fg-subtle whitespace-pre-line">
@@ -444,11 +452,11 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
          colorPalette ? (
           <Container className="divide-y p-0">
             <div className="px-6 py-4">
-              <Heading level="h2">Specifications</Heading>
+              <Heading level="h2">{t("partner.designs.detail.specifications")}</Heading>
             </div>
             {Array.isArray((design as any)?.tags) && (design as any).tags.length > 0 && (
               <div className="px-6 py-4">
-                <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-2">Tags</Text>
+                <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-2">{t("partner.designs.detail.tags")}</Text>
                 <div className="flex flex-wrap gap-1.5">
                   {((design as any).tags as string[]).map((tag, i) => (
                     <Badge key={i} size="2xsmall" color="grey">{String(tag)}</Badge>
@@ -459,7 +467,7 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
             {sizes.length > 0 && (
               <div className="px-6 py-4">
                 <div className="flex items-center gap-x-2 mb-2">
-                  <Text size="xsmall" weight="plus" className="text-ui-fg-base">Sizes</Text>
+                  <Text size="xsmall" weight="plus" className="text-ui-fg-base">{t("partner.designs.sizes")}</Text>
                   <Badge size="2xsmall" color="blue">{sizes.length}</Badge>
                 </div>
                 {/* Highlighted so the sizes that come with this design stand out to the partner. */}
@@ -489,7 +497,7 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
             )}
             {colorPalette && (
               <div className="px-6 py-4">
-                <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-2">Color Palette</Text>
+                <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-2">{t("partner.designs.detail.colorPalette")}</Text>
                 <div className="flex flex-wrap gap-2">
                   {(Array.isArray(colorPalette) ? colorPalette : Object.entries(colorPalette).map(([k, v]) => ({ name: k, value: v }))).map((color: any, i: number) => {
                     const colorValue = typeof color === "string" ? color : color?.hex || color?.value || color?.code || String(color?.name || color)
@@ -527,13 +535,13 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
         {/* Inventory Items */}
         <Container className="divide-y p-0">
           <div className="px-6 py-4">
-            <Heading level="h2">Inventory Items</Heading>
+            <Heading level="h2">{t("partner.designs.detail.inventoryItems")}</Heading>
           </div>
 
           {inventoryItemRows.length === 0 ? (
             <div className="px-6 py-4">
               <Text size="small" className="text-ui-fg-subtle">
-                No inventory items linked to this design.
+                {t("partner.designs.detail.noInventoryItems")}
               </Text>
             </div>
           ) : (
@@ -556,12 +564,12 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
 
         <Container className="divide-y p-0">
           <div className="px-6 py-4">
-            <Heading level="h2">Designer Notes</Heading>
+            <Heading level="h2">{t("partner.designs.detail.designerNotes")}</Heading>
           </div>
           <div className="px-6 py-4">
             {!hasNotesContent ? (
               <Text size="small" className="text-ui-fg-subtle">
-                No notes
+                {t("partner.designs.detail.noNotes")}
               </Text>
             ) : (
               <div className="space-y-2">
@@ -569,7 +577,7 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
                   {notesBlocks.map((n, i) => renderBlock(n, i))}
                 </div>
                 <Text size="xsmall" className="text-ui-fg-muted">
-                  Drag the bottom edge to resize
+                  {t("partner.designs.detail.resizeHint")}
                 </Text>
               </div>
             )}
@@ -579,7 +587,7 @@ export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
         {specsValue && (
           <Container className="divide-y p-0">
             <div className="px-6 py-4">
-              <Heading level="h2">Specs</Heading>
+              <Heading level="h2">{t("partner.designs.detail.specs")}</Heading>
             </div>
             {typeof specsValue === "object" && !Array.isArray(specsValue) ? (
               Object.entries(specsValue as Record<string, any>).map(([key, value]) => (

--- a/apps/partner-ui/src/routes/designs/design-edit/components/edit-design-form/edit-design-form.tsx
+++ b/apps/partner-ui/src/routes/designs/design-edit/components/edit-design-form/edit-design-form.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Button, Input, Select, Textarea, toast } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
 
 import { Form } from "../../../../../components/common/form"
 import { RouteDrawer, useRouteModal } from "../../../../../components/modals"
@@ -9,6 +10,7 @@ import {
   PartnerDesign,
   useUpdatePartnerDesign,
 } from "../../../../../hooks/api/partner-designs"
+import { designTypeLabel, priorityLabel } from "../../../../../lib/design-labels"
 import { CreateDesignSchema } from "../../../design-create/components/design-create-form/schema"
 
 const DESIGN_TYPES = ["Original", "Derivative", "Custom", "Collaboration"] as const
@@ -17,6 +19,7 @@ const PRIORITIES = ["Low", "Medium", "High", "Urgent"] as const
 type Props = { design: PartnerDesign }
 
 export const EditDesignForm = ({ design }: Props) => {
+  const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
   const form = useForm<CreateDesignSchema>({
     defaultValues: {
@@ -34,7 +37,7 @@ export const EditDesignForm = ({ design }: Props) => {
   const handleSubmit = form.handleSubmit(async (data) => {
     await mutateAsync(data, {
       onSuccess: () => {
-        toast.success("Design updated")
+        toast.success(t("partner.designs.edit.updated"))
         handleSuccess()
       },
       onError: (e) => toast.error(e.message),
@@ -51,7 +54,7 @@ export const EditDesignForm = ({ design }: Props) => {
               name="name"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>Name</Form.Label>
+                  <Form.Label>{t("fields.name")}</Form.Label>
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>
@@ -64,7 +67,7 @@ export const EditDesignForm = ({ design }: Props) => {
               name="description"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label optional>Description</Form.Label>
+                  <Form.Label optional>{t("fields.description")}</Form.Label>
                   <Form.Control>
                     <Textarea {...field} />
                   </Form.Control>
@@ -76,16 +79,16 @@ export const EditDesignForm = ({ design }: Props) => {
               name="design_type"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label optional>Type</Form.Label>
+                  <Form.Label optional>{t("fields.type")}</Form.Label>
                   <Form.Control>
                     <Select value={field.value} onValueChange={field.onChange}>
                       <Select.Trigger>
-                        <Select.Value placeholder="Select" />
+                        <Select.Value placeholder={t("general.select")} />
                       </Select.Trigger>
                       <Select.Content>
-                        {DESIGN_TYPES.map((t) => (
-                          <Select.Item key={t} value={t}>
-                            {t}
+                        {DESIGN_TYPES.map((v) => (
+                          <Select.Item key={v} value={v}>
+                            {designTypeLabel(t, v)}
                           </Select.Item>
                         ))}
                       </Select.Content>
@@ -99,16 +102,16 @@ export const EditDesignForm = ({ design }: Props) => {
               name="priority"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label optional>Priority</Form.Label>
+                  <Form.Label optional>{t("partner.designs.fields.priority")}</Form.Label>
                   <Form.Control>
                     <Select value={field.value} onValueChange={field.onChange}>
                       <Select.Trigger>
-                        <Select.Value placeholder="Select" />
+                        <Select.Value placeholder={t("general.select")} />
                       </Select.Trigger>
                       <Select.Content>
-                        {PRIORITIES.map((p) => (
-                          <Select.Item key={p} value={p}>
-                            {p}
+                        {PRIORITIES.map((v) => (
+                          <Select.Item key={v} value={v}>
+                            {priorityLabel(t, v)}
                           </Select.Item>
                         ))}
                       </Select.Content>
@@ -122,7 +125,7 @@ export const EditDesignForm = ({ design }: Props) => {
               name="designer_notes"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label optional>Designer notes</Form.Label>
+                  <Form.Label optional>{t("partner.designs.fields.designerNotes")}</Form.Label>
                   <Form.Control>
                     <Textarea {...field} />
                   </Form.Control>
@@ -135,11 +138,11 @@ export const EditDesignForm = ({ design }: Props) => {
           <div className="flex items-center justify-end gap-x-2">
             <RouteDrawer.Close asChild>
               <Button variant="secondary" size="small">
-                Cancel
+                {t("actions.cancel")}
               </Button>
             </RouteDrawer.Close>
             <Button isLoading={isPending} type="submit" variant="primary" size="small">
-              Save
+              {t("actions.save")}
             </Button>
           </div>
         </RouteDrawer.Footer>

--- a/apps/partner-ui/src/routes/designs/design-edit/design-edit.tsx
+++ b/apps/partner-ui/src/routes/designs/design-edit/design-edit.tsx
@@ -1,10 +1,12 @@
 import { Heading } from "@medusajs/ui"
 import { useParams } from "react-router-dom"
+import { useTranslation } from "react-i18next"
 import { RouteDrawer } from "../../../components/modals"
 import { usePartnerDesign } from "../../../hooks/api/partner-designs"
 import { EditDesignForm } from "./components/edit-design-form"
 
 export const DesignEdit = () => {
+  const { t } = useTranslation()
   const { id } = useParams()
   const { design, isLoading, isError, error } = usePartnerDesign(id!)
 
@@ -15,7 +17,7 @@ export const DesignEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>Edit design</Heading>
+        <Heading>{t("partner.designs.edit.heading")}</Heading>
       </RouteDrawer.Header>
       {!isLoading && design && <EditDesignForm design={design} />}
     </RouteDrawer>

--- a/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
+++ b/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
@@ -16,7 +16,14 @@ import {
 } from "../../../hooks/api/partner-designs"
 import { useDataTable } from "../../../hooks/use-data-table"
 import { useQueryParams } from "../../../hooks/use-query-params"
+import { useDate } from "../../../hooks/use-date"
 import { getStatusBadgeColor } from "../../../lib/status-badge"
+import {
+  designStatusLabel,
+  engagementKeyFor,
+  priorityLabel,
+  workStatusLabel,
+} from "../../../lib/design-labels"
 
 const columnHelper = createDataTableColumnHelper<PartnerDesign>()
 
@@ -25,106 +32,26 @@ const PAGE_SIZE = 20
 // #6 — action-oriented work tabs. A single, visible lens over the same
 // partner-scoped set (replacing the buried source + work-status filter
 // dropdowns). Server filters + counts each bucket (see partner designs route).
-const WORK_BUCKETS: Array<{ value: DesignBucket; label: string }> = [
-  { value: "incoming", label: "Incoming" },
-  { value: "in_progress", label: "In progress" },
-  { value: "yours", label: "Yours" },
-  { value: "completed", label: "Completed" },
-  { value: "all", label: "All" },
+const WORK_BUCKETS: DesignBucket[] = [
+  "incoming",
+  "in_progress",
+  "yours",
+  "completed",
+  "all",
 ]
 
-/**
- * The Source badge. A design lands on this dashboard the moment an admin links
- * it, so "listed" never meant "yours to work on": on production one partner had
- * 34 linked designs with only 16 carrying a run of theirs. `partner_engagement`
- * comes from the server (`partner-design-engagement.ts`); the UI only labels it.
- */
-const ENGAGEMENT_BADGES: Record<
-  PartnerDesignEngagement,
-  { label: string; color: "green" | "blue" | "grey"; hint: string }
+/** Map a next-action outcome to its label key + badge color. */
+const NEXT_ACTION: Record<
+  string,
+  { key: string; color: "green" | "blue" | "orange" | "red" | "grey" }
 > = {
-  owned: {
-    label: "Yours",
-    color: "green",
-    hint: "You created this design.",
-  },
-  assigned: {
-    label: "Assigned",
-    color: "blue",
-    hint: "You have a production run on this design — this is work for you.",
-  },
-  shared: {
-    label: "Shared",
-    color: "grey",
-    hint: "Shared with you for reference. No production run is assigned to you (work may be in-house or with another partner).",
-  },
-}
-
-const DESIGN_STATUS_OPTIONS = [
-  { label: "Conceptual", value: "Conceptual" },
-  { label: "In Development", value: "In_Development" },
-  { label: "Technical Review", value: "Technical_Review" },
-  { label: "Sample Production", value: "Sample_Production" },
-  { label: "Revision", value: "Revision" },
-  { label: "Approved", value: "Approved" },
-  { label: "Rejected", value: "Rejected" },
-  { label: "On Hold", value: "On_Hold" },
-  { label: "Commerce Ready", value: "Commerce_Ready" },
-]
-
-function relativeDate(dateStr: string | undefined | null): string {
-  if (!dateStr) return "-"
-  const d = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - d.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  if (diffMins < 1) return "just now"
-  if (diffMins < 60) return `${diffMins}m ago`
-  const diffHrs = Math.floor(diffMins / 60)
-  if (diffHrs < 24) return `${diffHrs}h ago`
-  const diffDays = Math.floor(diffHrs / 24)
-  if (diffDays < 7) return `${diffDays}d ago`
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
-}
-
-/** Derive the next action label from partner_status */
-function getNextAction(partnerStatus: string | undefined | null): {
-  label: string
-  color: "green" | "blue" | "orange" | "red" | "grey"
-} | null {
-  switch (partnerStatus) {
-    case "incoming":
-    case "assigned":
-      return { label: "Accept", color: "blue" }
-    case "in_progress":
-      return { label: "Working", color: "orange" }
-    case "awaiting_review":
-      return { label: "Complete", color: "orange" }
-    case "finished":
-      return { label: "Under Review", color: "blue" }
-    case "completed":
-      return { label: "Done", color: "green" }
-    case "cancelled":
-      return { label: "Cancelled", color: "red" }
-    default:
-      return null
-  }
-}
-
-/** Format target date with urgency indicator */
-function formatTargetDate(dateStr: string | undefined | null): {
-  label: string
-  color: "red" | "orange" | "grey"
-} | null {
-  if (!dateStr) return null
-  const target = new Date(dateStr)
-  const now = new Date()
-  const diffDays = Math.ceil((target.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
-  const formatted = target.toLocaleDateString("en-US", { month: "short", day: "numeric" })
-
-  if (diffDays < 0) return { label: `Overdue`, color: "red" }
-  if (diffDays <= 2) return { label: formatted, color: "orange" }
-  return { label: formatted, color: "grey" }
+  incoming: { key: "accept", color: "blue" },
+  assigned: { key: "accept", color: "blue" },
+  in_progress: { key: "working", color: "orange" },
+  awaiting_review: { key: "complete", color: "orange" },
+  finished: { key: "underReview", color: "blue" },
+  completed: { key: "done", color: "green" },
+  cancelled: { key: "cancelled", color: "red" },
 }
 
 /**
@@ -141,6 +68,7 @@ const WorkBucketTabs = ({
   active: DesignBucket
   facets?: DesignBucketFacets
 }) => {
+  const { t } = useTranslation()
   const [searchParams, setSearchParams] = useSearchParams()
 
   const select = (bucket: DesignBucket) => {
@@ -157,7 +85,7 @@ const WorkBucketTabs = ({
 
   return (
     <div className="flex flex-wrap items-center gap-1 px-4 py-2">
-      {WORK_BUCKETS.map(({ value, label }) => {
+      {WORK_BUCKETS.map((value) => {
         const isActive = active === value
         const n = facets?.[value]
         return (
@@ -172,7 +100,9 @@ const WorkBucketTabs = ({
                 : "text-ui-fg-subtle hover:bg-ui-bg-subtle-hover"
             )}
           >
-            <span className="font-medium">{label}</span>
+            <span className="font-medium">
+              {t(`partner.designs.bucketOptions.${value}`)}
+            </span>
             {typeof n === "number" && (
               <Badge size="2xsmall" color={isActive ? "blue" : "grey"}>
                 {n}
@@ -187,6 +117,7 @@ const WorkBucketTabs = ({
 
 export const DesignList = () => {
   const { t } = useTranslation()
+  const { getFullDate, getRelativeDate } = useDate()
   const raw = useQueryParams(["offset", "q", "status", "bucket", "order"])
   const offset = raw.offset ? Number(raw.offset) : 0
   const q = raw.q?.trim() || ""
@@ -248,7 +179,17 @@ export const DesignList = () => {
         type: "select",
         key: "status",
         label: t("fields.status"),
-        options: DESIGN_STATUS_OPTIONS,
+        options: [
+          { label: t("partner.designs.statusOptions.conceptual"), value: "Conceptual" },
+          { label: t("partner.designs.statusOptions.inDevelopment"), value: "In_Development" },
+          { label: t("partner.designs.statusOptions.technicalReview"), value: "Technical_Review" },
+          { label: t("partner.designs.statusOptions.sampleProduction"), value: "Sample_Production" },
+          { label: t("partner.designs.statusOptions.revision"), value: "Revision" },
+          { label: t("partner.designs.statusOptions.approved"), value: "Approved" },
+          { label: t("partner.designs.statusOptions.rejected"), value: "Rejected" },
+          { label: t("partner.designs.statusOptions.onHold"), value: "On_Hold" },
+          { label: t("partner.designs.statusOptions.commerceReady"), value: "Commerce_Ready" },
+        ],
       },
     ],
     [t]
@@ -257,7 +198,7 @@ export const DesignList = () => {
   const columns = useMemo(
     () => [
       columnHelper.accessor("name", {
-        header: () => "Name",
+        header: () => t("partner.designs.list.columns.name"),
         cell: ({ getValue }) => (
           <span className="font-medium">{getValue() || "-"}</span>
         ),
@@ -266,7 +207,7 @@ export const DesignList = () => {
         (row) => (row as any)?.partner_engagement as PartnerDesignEngagement | undefined,
         {
           id: "source",
-          header: () => "Source",
+          header: () => t("partner.designs.list.columns.source"),
           // Was "Yours"/"Assigned" keyed on is_owner alone — which called every
           // design an admin merely LINKED "Assigned", whether or not the partner
           // was ever given work on it. `partner_engagement` separates the two,
@@ -275,18 +216,22 @@ export const DesignList = () => {
           cell: ({ getValue, row }) => {
             const engagement = getValue()
             const hasRun = !!(row.original as any)?.has_partner_run
-            const badge = ENGAGEMENT_BADGES[engagement ?? "shared"]
+            const key = engagementKeyFor(engagement)
+            const labelKey = `${key}.label`
+            const hintKey = `${key}.hint`
+            const badgeColor =
+              engagement === "owned" ? "green" : engagement === "assigned" ? "blue" : "grey"
             return (
               <div className="flex flex-wrap items-center gap-1">
-                <Tooltip content={badge.hint}>
-                  <Badge size="2xsmall" color={badge.color}>
-                    {badge.label}
+                <Tooltip content={t(hintKey)}>
+                  <Badge size="2xsmall" color={badgeColor}>
+                    {t(labelKey)}
                   </Badge>
                 </Tooltip>
                 {engagement === "owned" && hasRun && (
-                  <Tooltip content={ENGAGEMENT_BADGES.assigned.hint}>
-                    <Badge size="2xsmall" color={ENGAGEMENT_BADGES.assigned.color}>
-                      {ENGAGEMENT_BADGES.assigned.label}
+                  <Tooltip content={t("partner.designs.engagementOptions.assigned.hint")}>
+                    <Badge size="2xsmall" color="blue">
+                      {t("partner.designs.engagementOptions.assigned.label")}
                     </Badge>
                   </Tooltip>
                 )}
@@ -297,33 +242,33 @@ export const DesignList = () => {
       ),
       columnHelper.accessor((row) => row?.partner_info?.partner_status, {
         id: "next_action",
-        header: () => "Next Action",
+        header: () => t("partner.designs.list.columns.nextAction"),
         cell: ({ getValue }) => {
-          const action = getNextAction(getValue())
+          const action = NEXT_ACTION[String(getValue() ?? "")]
           if (!action) return "-"
           return (
             <StatusBadge color={action.color} className="text-nowrap">
-              {action.label}
+              {t(`partner.designs.actionOptions.${action.key}`)}
             </StatusBadge>
           )
         },
       }),
       columnHelper.accessor((row) => row?.partner_info?.partner_status, {
         id: "partner_status",
-        header: () => "Work Status",
+        header: () => t("partner.designs.list.columns.workStatus"),
         cell: ({ getValue }) => {
           const val = getValue()
           if (!val) return "-"
           return (
             <StatusBadge color={getStatusBadgeColor(val) as any} className="text-nowrap">
-              {String(val).replace(/_/g, " ")}
+              {workStatusLabel(t, String(val))}
             </StatusBadge>
           )
         },
       }),
       columnHelper.accessor((row) => (row as any)?.priority, {
         id: "priority",
-        header: () => "Priority",
+        header: () => t("partner.designs.list.columns.priority"),
         cell: ({ getValue }) => {
           const val = getValue()
           if (!val) return "-"
@@ -333,52 +278,53 @@ export const DesignList = () => {
             val === "medium" ? "blue" : "grey"
           return (
             <Badge size="2xsmall" color={color}>
-              {String(val)}
+              {priorityLabel(t, String(val))}
             </Badge>
           )
         },
       }),
       columnHelper.accessor((row) => (row as any)?.target_completion_date, {
         id: "target_date",
-        header: () => "Due",
+        header: () => t("partner.designs.list.columns.due"),
         cell: ({ getValue }) => {
-          const info = formatTargetDate(getValue())
-          if (!info) return "-"
+          const val = getValue() as string | undefined | null
+          if (!val) return "-"
+          const target = new Date(val)
+          const diffDays = Math.ceil(
+            (target.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+          )
+          const color = diffDays < 0 ? "red" : diffDays <= 2 ? "orange" : "grey"
           return (
-            <Badge size="2xsmall" color={info.color}>
-              {info.label}
+            <Badge size="2xsmall" color={color}>
+              {diffDays < 0
+                ? t("partner.designs.overdue")
+                : getFullDate({ date: val })}
             </Badge>
           )
         },
       }),
       columnHelper.accessor("status", {
-        header: () => "Design Status",
+        header: () => t("partner.designs.list.columns.status"),
         cell: ({ getValue }) => {
           const val = getValue()
           if (!val) return "-"
           return (
             <Badge size="2xsmall" color={getStatusBadgeColor(val)}>
-              {String(val).replace(/_/g, " ")}
+              {designStatusLabel(t, String(val))}
             </Badge>
           )
         },
       }),
       columnHelper.accessor("updated_at", {
-        header: () => "Last Updated",
+        header: () => t("partner.designs.list.columns.lastUpdated"),
         cell: ({ getValue }) => {
           const val = getValue() as string
           if (!val) return "-"
-          const fullDate = new Date(val).toLocaleString("en-US", {
-            weekday: "short",
-            month: "short",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-          })
+          const fullDate = getFullDate({ date: val, includeTime: true })
           return (
             <Tooltip content={fullDate}>
               <Text size="small" leading="compact" className="text-ui-fg-subtle cursor-default">
-                {relativeDate(val)}
+                {getRelativeDate(val)}
               </Text>
             </Tooltip>
           )
@@ -386,6 +332,10 @@ export const DesignList = () => {
         enableSorting: true,
       }),
     ],
+    // `t` changes with the language, and the `useDate` formatters follow the
+    // same locale, so depending on `t` alone keeps the memo correct without
+    // churning the table on every render (the date functions are recreated
+    // each render).
     [t]
   )
 
@@ -403,9 +353,9 @@ export const DesignList = () => {
     return (
       <SingleColumnPage widgets={{ before: [], after: [] }} hasOutlet={true}>
         <Container className="p-6">
-          <Heading>Designs</Heading>
+          <Heading>{t("partner.designs.heading")}</Heading>
           <Text size="small" className="text-ui-fg-error mt-2">
-            Failed to load designs. Please try refreshing the page.
+            {t("partner.designs.list.loadFailed")}
           </Text>
         </Container>
       </SingleColumnPage>
@@ -423,14 +373,14 @@ export const DesignList = () => {
       <Container className="divide-y p-0">
         <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <Heading>Designs</Heading>
+            <Heading>{t("partner.designs.heading")}</Heading>
             <span className="text-ui-fg-subtle text-xs">
-              Pick a tab to see incoming, in-progress, your own, or completed work.
+              {t("partner.designs.list.subtitle")}
             </span>
           </div>
           <Link to="/designs/create">
             <Button size="small" variant="secondary">
-              Create
+              {t("actions.create")}
             </Button>
           </Link>
         </div>
@@ -447,14 +397,14 @@ export const DesignList = () => {
           pageSize={PAGE_SIZE}
           filters={filters}
           orderBy={[
-            { key: "updated_at", label: "Last Updated" },
-            { key: "name", label: "Name" },
+            { key: "updated_at", label: t("partner.designs.list.columns.lastUpdated") },
+            { key: "name", label: t("partner.designs.list.columns.name") },
             { key: "created_at", label: t("fields.createdAt") },
           ]}
           search
           queryObject={raw}
           noRecords={{
-            message: "No designs in this tab. Try another tab or clear the search.",
+            message: t("partner.designs.list.noRecords"),
           }}
         />
       </Container>

--- a/apps/partner-ui/src/routes/designs/design-media-preview/design-media-preview.tsx
+++ b/apps/partner-ui/src/routes/designs/design-media-preview/design-media-preview.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownTray, TriangleLeftMini, TriangleRightMini } from "@medusajs/icons"
 import { Heading, IconButton, Text, clx } from "@medusajs/ui"
 import { useCallback, useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { useLocation } from "react-router-dom"
 
 import { RouteFocusModal } from "../../../components/modals"
@@ -14,15 +15,16 @@ type Media = {
 }
 
 export const DesignMediaPreview = () => {
+  const { t } = useTranslation()
   const id = useResolvedDesignId()
 
   return (
     <RouteFocusModal>
       <RouteFocusModal.Title asChild>
-        <span className="sr-only">Design media</span>
+        <span className="sr-only">{t("partner.designs.media.alt")}</span>
       </RouteFocusModal.Title>
       <RouteFocusModal.Description asChild>
-        <span className="sr-only">Preview design media</span>
+        <span className="sr-only">{t("partner.designs.media.preview")}</span>
       </RouteFocusModal.Description>
       {id ? <DesignMediaPreviewWithId id={id} /> : <DesignMediaPreviewMissingId />}
     </RouteFocusModal>
@@ -30,17 +32,18 @@ export const DesignMediaPreview = () => {
 }
 
 const DesignMediaPreviewMissingId = () => {
+  const { t } = useTranslation()
   return (
     <div className="flex size-full flex-col overflow-hidden">
       <RouteFocusModal.Header>
         <RouteFocusModal.Title asChild>
-          <Heading>Media</Heading>
+          <Heading>{t("partner.designs.media.heading")}</Heading>
         </RouteFocusModal.Title>
       </RouteFocusModal.Header>
       <RouteFocusModal.Body className="overflow-auto">
         <div className="px-6 py-4">
           <Text size="small" className="text-ui-fg-subtle">
-            Missing design id.
+            {t("partner.designs.missingId")}
           </Text>
         </div>
       </RouteFocusModal.Body>
@@ -49,6 +52,7 @@ const DesignMediaPreviewMissingId = () => {
 }
 
 const DesignMediaPreviewWithId = ({ id }: { id: string }) => {
+  const { t } = useTranslation()
   const { state } = useLocation()
   const initialCurr = typeof (state as any)?.curr === "number" ? (state as any).curr : 0
 
@@ -152,7 +156,7 @@ const DesignMediaPreviewWithId = ({ id }: { id: string }) => {
       <RouteFocusModal.Header>
         <div className="flex items-center justify-between gap-x-2">
           <RouteFocusModal.Title asChild>
-            <Heading>Media</Heading>
+            <Heading>{t("partner.designs.media.heading")}</Heading>
           </RouteFocusModal.Title>
           <IconButton
             size="small"
@@ -161,7 +165,7 @@ const DesignMediaPreviewWithId = ({ id }: { id: string }) => {
             disabled={noMedia}
           >
             <ArrowDownTray />
-            <span className="sr-only">Download</span>
+            <span className="sr-only">{t("partner.designs.media.download")}</span>
           </IconButton>
         </div>
       </RouteFocusModal.Header>
@@ -183,11 +187,12 @@ const Canvas = ({
   curr: number
   isLoading: boolean
 }) => {
+  const { t } = useTranslation()
   if (isLoading) {
     return (
       <div className="bg-ui-bg-subtle flex size-full items-center justify-center p-6">
         <Text size="small" className="text-ui-fg-subtle">
-          Loading...
+          {t("labels.loading")}
         </Text>
       </div>
     )
@@ -203,10 +208,10 @@ const Canvas = ({
             weight="plus"
             className="text-ui-fg-subtle"
           >
-            No media files yet
+            {t("partner.designs.media.empty")}
           </Text>
           <Text size="small" className="text-ui-fg-muted">
-            Add images to showcase your design
+            {t("partner.designs.media.emptyHint")}
           </Text>
         </div>
       </div>

--- a/apps/partner-ui/src/routes/designs/design-media/design-media.tsx
+++ b/apps/partner-ui/src/routes/designs/design-media/design-media.tsx
@@ -1,5 +1,6 @@
 import { Button, Heading, Text, toast } from "@medusajs/ui"
 import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { useResolvedDesignId } from "../../../hooks/use-resolved-design-id"
 import { FileType, FileUpload } from "../../../components/common/file-upload"
 import { RouteDrawer, useRouteModal } from "../../../components/modals"
@@ -19,16 +20,17 @@ const SUPPORTED_FORMATS = [
 ]
 
 export const DesignMedia = () => {
+  const { t } = useTranslation()
   const id = useResolvedDesignId()
 
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
         <RouteDrawer.Title asChild>
-          <Heading>Manage Media</Heading>
+          <Heading>{t("partner.designs.media.manageMedia")}</Heading>
         </RouteDrawer.Title>
         <RouteDrawer.Description className="sr-only">
-          Upload and attach media to this design
+          {t("partner.designs.media.uploadDescription")}
         </RouteDrawer.Description>
       </RouteDrawer.Header>
       {id ? <DesignMediaContent id={id} /> : <DesignMediaMissingId />}
@@ -37,17 +39,18 @@ export const DesignMedia = () => {
 }
 
 const DesignMediaMissingId = () => {
+  const { t } = useTranslation()
   return (
     <>
       <RouteDrawer.Body>
         <Text size="small" className="text-ui-fg-subtle">
-          Missing design id.
+          {t("partner.designs.missingId")}
         </Text>
       </RouteDrawer.Body>
       <RouteDrawer.Footer>
         <RouteDrawer.Close asChild>
           <Button size="small" variant="secondary">
-            Close
+            {t("actions.close")}
           </Button>
         </RouteDrawer.Close>
       </RouteDrawer.Footer>
@@ -56,6 +59,7 @@ const DesignMediaMissingId = () => {
 }
 
 const DesignMediaContent = ({ id }: { id: string }) => {
+  const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
 
   const { design, isPending: isDesignPending, isError, error } = usePartnerDesign(id)
@@ -80,7 +84,7 @@ const DesignMediaContent = ({ id }: { id: string }) => {
 
   const handleSave = async () => {
     if (!files.length) {
-      toast.error("Add at least one file")
+      toast.error(t("partner.designs.media.addAtLeastOne"))
       return
     }
 
@@ -96,7 +100,7 @@ const DesignMediaContent = ({ id }: { id: string }) => {
     const uploaded = uploadRes?.files || []
 
     if (!uploaded.length) {
-      toast.error("Failed to upload files")
+      toast.error(t("partner.designs.media.uploadFailed"))
       return
     }
 
@@ -110,7 +114,7 @@ const DesignMediaContent = ({ id }: { id: string }) => {
       },
       {
         onSuccess: () => {
-          toast.success("Media attached")
+          toast.success(t("partner.designs.media.attached"))
           handleSuccess()
         },
         onError: (e) => toast.error(e.message),
@@ -124,18 +128,18 @@ const DesignMediaContent = ({ id }: { id: string }) => {
         <div className="flex flex-col gap-y-6">
           <div>
             <Text size="small" className="text-ui-fg-subtle">
-              Upload images to attach to this design.
+              {t("partner.designs.media.uploadIntro")}
             </Text>
           </div>
 
           <div>
             <FileUpload
-              label="Upload images"
-              hint="Drop files here or click to browse"
+              label={t("partner.designs.media.uploadImages")}
+              hint={t("partner.designs.media.dropHint")}
               formats={SUPPORTED_FORMATS}
               onUploaded={(uploaded, rejected) => {
                 if (rejected?.length) {
-                  toast.error("Some files were rejected")
+                  toast.error(t("partner.designs.media.someRejected"))
                 }
                 setFiles((prev) => [...prev, ...uploaded])
               }}
@@ -144,16 +148,16 @@ const DesignMediaContent = ({ id }: { id: string }) => {
 
           <div>
             <Text size="small" className="text-ui-fg-subtle">
-              Existing: {existing.length}
+              {t("partner.designs.media.existing")}: {existing.length}
             </Text>
             <Text size="small" className="text-ui-fg-subtle">
-              Selected: {files.length}
+              {t("partner.designs.media.selected")}: {files.length}
             </Text>
           </div>
 
           {isDesignPending && (
             <Text size="small" className="text-ui-fg-subtle">
-              Loading design...
+              {t("partner.designs.media.loadingDesign")}
             </Text>
           )}
         </div>
@@ -162,7 +166,7 @@ const DesignMediaContent = ({ id }: { id: string }) => {
         <div className="flex items-center gap-x-2">
           <RouteDrawer.Close asChild>
             <Button size="small" variant="secondary">
-              Cancel
+              {t("actions.cancel")}
             </Button>
           </RouteDrawer.Close>
           <Button
@@ -171,7 +175,7 @@ const DesignMediaContent = ({ id }: { id: string }) => {
             isLoading={isUploading || isAttaching}
             disabled={!files.length}
           >
-            Save
+            {t("actions.save")}
           </Button>
         </div>
       </RouteDrawer.Footer>

--- a/apps/partner-ui/src/routes/designs/design-moodboard/construction-picker.tsx
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/construction-picker.tsx
@@ -1,5 +1,6 @@
 import { Badge, Button, FocusModal, Heading, Input, Label, Text, Textarea, toast } from "@medusajs/ui"
 import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 
 import {
   useConstructionTechniques,
@@ -30,6 +31,7 @@ type Props = {
  * moodboard refreshes its construction glyph.
  */
 export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Props) => {
+  const { t } = useTranslation()
   const { data: catalog, isPending } = useConstructionTechniques(designId, {
     enabled: open && !!designId,
   })
@@ -101,12 +103,12 @@ export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Pr
         fabricRules: parseLines(rulesText).length ? parseLines(rulesText) : undefined,
         note: note.trim() || undefined,
       })
-      toast.success(`Added "${label.trim() || selected.label}"`)
+      toast.success(t("partner.designs.construction.added", { label: label.trim() || selected.label }))
       reset()
       onOpenChange(false)
       onAdded()
     } catch (err: any) {
-      toast.error(err?.message || "Failed to add construction detail")
+      toast.error(err?.message || t("partner.designs.construction.addFailed"))
     }
   }
 
@@ -122,13 +124,13 @@ export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Pr
     >
       <FocusModal.Content>
         <FocusModal.Header>
-          <Heading level="h2">Add construction detail</Heading>
+          <Heading level="h2">{t("partner.designs.construction.heading")}</Heading>
         </FocusModal.Header>
         <FocusModal.Body className="flex min-h-0 flex-1 overflow-hidden">
           {isPending ? (
             <div className="p-6">
               <Text size="small" className="text-ui-fg-subtle">
-                Loading techniques…
+                {t("partner.designs.construction.loading")}
               </Text>
             </div>
           ) : (
@@ -192,13 +194,12 @@ export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Pr
               <div className="w-1/2 min-h-0 overflow-y-auto p-6">
                 {!selected ? (
                   <Text size="small" className="text-ui-fg-subtle">
-                    Pick a technique or a preset on the left — its parameters and
-                    fabric rules auto-fill here.
+                    {t("partner.designs.construction.hint")}
                   </Text>
                 ) : (
                   <div className="flex flex-col gap-y-4">
                     <div className="flex flex-col gap-y-1">
-                      <Label size="small">Label</Label>
+                      <Label size="small">{t("partner.designs.construction.label")}</Label>
                       <Input
                         value={label}
                         onChange={(e) => setLabel(e.target.value)}
@@ -208,7 +209,7 @@ export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Pr
 
                     {selected.params.length ? (
                       <div className="flex flex-col gap-y-2">
-                        <Label size="small">Parameters</Label>
+                        <Label size="small">{t("partner.designs.construction.parameters")}</Label>
                         {selected.params.map((p) => (
                           <div key={p.key} className="flex items-center gap-x-3">
                             <Text size="small" className="w-32 shrink-0">
@@ -232,26 +233,26 @@ export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Pr
                       </div>
                     ) : (
                       <Text size="xsmall" className="text-ui-fg-muted">
-                        This technique has fixed geometry — no parameters to set.
+                        {t("partner.designs.construction.fixedGeometry")}
                       </Text>
                     )}
 
                     <div className="flex flex-col gap-y-1">
-                      <Label size="small">Fabric / sewing rules</Label>
+                      <Label size="small">{t("partner.designs.construction.fabricRules")}</Label>
                       <Textarea
                         rows={4}
                         value={rulesText}
                         onChange={(e) => setRulesText(e.target.value)}
-                        placeholder="one rule per line"
+                        placeholder={t("partner.designs.construction.oneRulePerLine")}
                       />
                     </div>
 
                     <div className="flex flex-col gap-y-1">
-                      <Label size="small">Note</Label>
+                      <Label size="small">{t("partner.designs.construction.note")}</Label>
                       <Input
                         value={note}
                         onChange={(e) => setNote(e.target.value)}
-                        placeholder="optional"
+                        placeholder={t("partner.designs.construction.optional")}
                       />
                     </div>
                   </div>
@@ -267,7 +268,7 @@ export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Pr
               variant="secondary"
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              {t("actions.cancel")}
             </Button>
             <Button
               size="small"
@@ -276,7 +277,7 @@ export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Pr
               disabled={!selected || isCreating}
               isLoading={isCreating}
             >
-              Add detail
+              {t("partner.designs.construction.addDetail")}
             </Button>
           </div>
         </FocusModal.Footer>

--- a/apps/partner-ui/src/routes/designs/design-moodboard/design-moodboard.tsx
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/design-moodboard.tsx
@@ -1,4 +1,5 @@
 import { Button, DropdownMenu, Heading, Text, toast } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 import "@excalidraw/excalidraw/index.css"
 // Scoped overrides that map Excalidraw's theme variables onto Medusa tokens —
 // must import after Excalidraw's own CSS so equal-specificity ties resolve to us.
@@ -251,6 +252,7 @@ const getAdminTheme = (): "light" | "dark" =>
     : "light"
 
 export const DesignMoodboard = () => {
+  const { t } = useTranslation()
   const id = useResolvedDesignId()
 
   // Follow the admin theme live — observe the root `.dark` class (and system
@@ -394,23 +396,23 @@ export const DesignMoodboard = () => {
       return
     }
     const proceed = window.confirm(
-      "Generate the moodboard from this design's brief? Your existing cards are merged, not replaced."
+      t("partner.designs.moodboard.generateConfirm")
     )
     if (!proceed) {
       return
     }
-    toast.loading("Generating moodboard…")
+    toast.loading(t("partner.designs.moodboard.generating"))
     try {
       const { moodboard: scene } = await generateMoodboard()
       loadScene(normalizeMoodboard(scene) || (scene as MoodboardData))
       setIsDirty(false)
       toast.dismiss()
-      toast.success("Moodboard generated")
+      toast.success(t("partner.designs.moodboard.generated"))
     } catch (err: any) {
       toast.dismiss()
-      toast.error(err?.message || "Failed to generate moodboard")
+      toast.error(err?.message || t("partner.designs.moodboard.generateFailed"))
     }
-  }, [id, generateMoodboard, loadScene])
+  }, [id, generateMoodboard, loadScene, t])
 
   // The insert-block palette, grouped for the dropdown menu.
   const groupedBlocks = useMemo(() => {
@@ -441,7 +443,7 @@ export const DesignMoodboard = () => {
         const { block } = await insertBlock(key)
         const els = (block?.elements ?? []) as any[]
         if (!els.length) {
-          toast.info(`Nothing to insert for "${label}" yet.`)
+          toast.info(t("partner.designs.moodboard.nothingToInsert", { label }))
           return
         }
 
@@ -491,27 +493,27 @@ export const DesignMoodboard = () => {
         api.scrollToContent(placed as any, { fitToContent: true })
         setIsDirty(true)
         if (!replaceFrameNamed) {
-          toast.success(`Inserted "${label}"`)
+          toast.success(t("partner.designs.moodboard.inserted", { label }))
         }
       } catch (err: any) {
-        toast.error(err?.message || "Failed to insert block")
+        toast.error(err?.message || t("partner.designs.moodboard.insertFailed"))
       }
     },
-    [id, insertBlock]
+    [id, insertBlock, t]
   )
 
   // After a construction detail is added, re-render the construction frame from
   // the design's fresh data (replacing the existing one in place).
   const handleConstructionAdded = useCallback(() => {
-    handleInsert("construction", "Construction details", CONSTRUCTION_FRAME_NAME)
-  }, [handleInsert])
+    handleInsert("construction", t("partner.designs.construction.details"), CONSTRUCTION_FRAME_NAME)
+  }, [handleInsert, t])
 
   const handleSave = useCallback(async () => {
     const api = apiRef.current
     if (!api || !id) {
       return
     }
-    toast.loading("Saving moodboard…")
+    toast.loading(t("partner.designs.moodboard.saving"))
     try {
       const elements = api.getSceneElements()
       const appState = api.getAppState() as any
@@ -550,19 +552,19 @@ export const DesignMoodboard = () => {
           } catch {
             // A brief write-back failure shouldn't lose the saved scene; surface
             // softly and keep the moodboard save.
-            toast.warning("Moodboard saved, but the brief edit couldn't be synced.")
+            toast.warning(t("partner.designs.moodboard.briefSyncFailed"))
           }
         }
       }
 
       setIsDirty(false)
       toast.dismiss()
-      toast.success("Moodboard saved")
+      toast.success(t("partner.designs.moodboard.saved"))
     } catch (err: any) {
       toast.dismiss()
-      toast.error(err?.message || "Failed to save moodboard")
+      toast.error(err?.message || t("partner.designs.moodboard.saveFailed"))
     }
-  }, [id, saveMoodboard, updateBrief, design])
+  }, [id, saveMoodboard, updateBrief, design, t])
 
   const isSaving = isSavingScene
 
@@ -570,10 +572,10 @@ export const DesignMoodboard = () => {
     <RouteFocusModal>
       <RouteFocusModal.Header>
         <RouteFocusModal.Title asChild>
-          <Heading>Moodboard</Heading>
+          <Heading>{t("partner.designs.moodboard.heading")}</Heading>
         </RouteFocusModal.Title>
         <RouteFocusModal.Description className="sr-only">
-          Moodboard
+          {t("partner.designs.moodboard.heading")}
         </RouteFocusModal.Description>
       </RouteFocusModal.Header>
 
@@ -581,13 +583,13 @@ export const DesignMoodboard = () => {
         {!id ? (
           <div className="px-6 py-4">
             <Text size="small" className="text-ui-fg-subtle">
-              Missing design id.
+              {t("partner.designs.missingId")}
             </Text>
           </div>
         ) : isPending ? (
           <div className="px-6 py-4">
             <Text size="small" className="text-ui-fg-subtle">
-              Loading...
+              {t("labels.loading")}
             </Text>
           </div>
         ) : (
@@ -649,13 +651,13 @@ export const DesignMoodboard = () => {
                     disabled={!id || isSaving || isInserting}
                     isLoading={isInserting}
                   >
-                    Insert block
+                    {t("partner.designs.moodboard.insertBlock")}
                   </Button>
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Content side="top" sideOffset={8}>
                   {groupedBlocks.length === 0 ? (
                     <DropdownMenu.Item disabled>
-                      No blocks available
+                      {t("partner.designs.moodboard.noBlocks")}
                     </DropdownMenu.Item>
                   ) : (
                     groupedBlocks.map((grp, gi) => (
@@ -672,7 +674,9 @@ export const DesignMoodboard = () => {
                           >
                             {b.label}
                             {!b.available ? (
-                              <span className="text-ui-fg-muted ml-1">· empty</span>
+                              <span className="text-ui-fg-muted ml-1">
+                                {t("partner.designs.moodboard.emptySuffix")}
+                              </span>
                             ) : null}
                           </DropdownMenu.Item>
                         ))}
@@ -687,7 +691,7 @@ export const DesignMoodboard = () => {
                 onClick={() => setConstructionOpen(true)}
                 disabled={!id || isSaving}
               >
-                Add construction
+                {t("partner.designs.moodboard.addConstruction")}
               </Button>
               <Button
                 size="small"
@@ -696,7 +700,7 @@ export const DesignMoodboard = () => {
                 disabled={!id || isGenerating || isSaving}
                 isLoading={isGenerating}
               >
-                Generate
+                {t("partner.designs.moodboard.generate")}
               </Button>
               <Button
                 size="small"
@@ -704,7 +708,7 @@ export const DesignMoodboard = () => {
                 onClick={() => setLayersOpen((v) => !v)}
                 disabled={!id}
               >
-                Layers
+                {t("partner.designs.moodboard.layers")}
               </Button>
               <Button
                 size="small"
@@ -713,7 +717,9 @@ export const DesignMoodboard = () => {
                 disabled={!id || isSaving || !isDirty}
                 isLoading={isSaving}
               >
-                {isDirty ? "Save" : "Saved"}
+                {isDirty
+                  ? t("partner.designs.moodboard.save")
+                  : t("partner.designs.moodboard.savedLabel")}
               </Button>
             </div>
           </div>
@@ -723,12 +729,11 @@ export const DesignMoodboard = () => {
       <RouteFocusModal.Footer>
         <div className="flex items-center justify-between w-full gap-x-2">
           <Text size="xsmall" className="text-ui-fg-muted">
-            Insert, construction, generate, layers &amp; save are in the dock at
-            the bottom of the canvas.
+            {t("partner.designs.moodboard.footerHint")}
           </Text>
           <RouteFocusModal.Close asChild>
             <Button size="small" variant="secondary">
-              Close
+              {t("actions.close")}
             </Button>
           </RouteFocusModal.Close>
         </div>

--- a/apps/partner-ui/src/routes/designs/design-moodboard/moodboard-layers-panel.tsx
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/moodboard-layers-panel.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types"
 
@@ -25,7 +26,7 @@ const readFrames = (api: ExcalidrawImperativeAPI): FrameRow[] => {
     .filter((e: any) => e.type === "frame")
     .map((f: any) => ({
       id: f.id,
-      name: f.name || "Untitled frame",
+      name: f.name || "",
       hidden: (f.opacity ?? 100) === 0,
       locked: !!f.locked,
       hasContent: els.some((c: any) => c.frameId === f.id),
@@ -41,6 +42,7 @@ export const MoodboardLayersPanel = ({
   tick: number
   onClose: () => void
 }) => {
+  const { t } = useTranslation()
   const [frames, setFrames] = useState<FrameRow[]>([])
   // Remember a frame's lock state before hide so show can restore it.
   const prevLockedRef = useRef<Record<string, boolean>>({})
@@ -109,13 +111,13 @@ export const MoodboardLayersPanel = ({
     <div className="rounded-lg border border-ui-border-base bg-ui-bg-base shadow-elevation-flyout overflow-hidden">
       <div className="flex items-center justify-between px-3 py-2 border-b border-ui-border-base">
         <Text size="small" weight="plus">
-          Layers
+          {t("partner.designs.layers.heading")}
         </Text>
         <div className="flex items-center gap-1">
           <button
             type="button"
             onClick={refresh}
-            title="Refresh"
+            title={t("partner.designs.layers.refresh")}
             className="px-1 text-ui-fg-muted hover:text-ui-fg-base"
           >
             ⟳
@@ -123,7 +125,7 @@ export const MoodboardLayersPanel = ({
           <button
             type="button"
             onClick={onClose}
-            title="Close"
+            title={t("partner.designs.layers.close")}
             className="px-1 text-ui-fg-muted hover:text-ui-fg-base"
           >
             ✕
@@ -132,7 +134,9 @@ export const MoodboardLayersPanel = ({
       </div>
       <div className="max-h-[420px] overflow-y-auto py-1">
         {frames.length === 0 ? (
-          <div className="px-3 py-4 text-ui-fg-muted text-sm">No frames yet.</div>
+          <div className="px-3 py-4 text-ui-fg-muted text-sm">
+            {t("partner.designs.layers.noFrames")}
+          </div>
         ) : (
           frames.map((f) => (
             <div
@@ -143,22 +147,22 @@ export const MoodboardLayersPanel = ({
                 className={`h-1.5 w-1.5 rounded-full shrink-0 ${
                   f.hasContent ? "bg-ui-fg-interactive" : "bg-ui-border-base"
                 }`}
-                title={f.hasContent ? "Has content" : "Empty"}
+                title={f.hasContent ? t("partner.designs.layers.hasContent") : t("partner.designs.layers.empty")}
               />
               <button
                 type="button"
                 onClick={() => jump(f)}
-                title="Jump to frame"
+                title={t("partner.designs.layers.jump")}
                 className={`flex-1 min-w-0 text-left text-sm truncate ${
                   f.hidden ? "text-ui-fg-muted line-through" : "text-ui-fg-base"
                 }`}
               >
-                {f.name}
+                {f.name || t("partner.designs.layers.untitled")}
               </button>
               <button
                 type="button"
                 onClick={() => toggleHidden(f)}
-                title={f.hidden ? "Show" : "Hide"}
+                title={f.hidden ? t("partner.designs.layers.show") : t("partner.designs.layers.hide")}
                 className="text-sm leading-none opacity-80 hover:opacity-100"
               >
                 {f.hidden ? "🚫" : "👁"}
@@ -167,7 +171,13 @@ export const MoodboardLayersPanel = ({
                 type="button"
                 onClick={() => toggleLock(f)}
                 disabled={f.hidden}
-                title={f.hidden ? "Locked while hidden" : f.locked ? "Unlock" : "Lock"}
+                title={
+                  f.hidden
+                    ? t("partner.designs.layers.lockedWhileHidden")
+                    : f.locked
+                      ? t("partner.designs.layers.unlock")
+                      : t("partner.designs.layers.lock")
+                }
                 className="text-sm leading-none opacity-80 hover:opacity-100 disabled:opacity-30"
               >
                 {f.locked ? "🔒" : "🔓"}

--- a/apps/partner-ui/src/routes/designs/design-production-run-create/components/run-create-form/run-create-form.tsx
+++ b/apps/partner-ui/src/routes/designs/design-production-run-create/components/run-create-form/run-create-form.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "@medusajs/framework/zod"
 import { Button, Heading, Input, Select, Text, toast } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
 
 import { Form } from "../../../../../components/common/form"
 import { RouteFocusModal, useRouteModal } from "../../../../../components/modals"
@@ -27,6 +28,7 @@ type RunCreateSchema = z.infer<typeof RunCreateSchema>
 type Props = { designId: string }
 
 export const RunCreateForm = ({ designId }: Props) => {
+  const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
   const form = useForm<RunCreateSchema>({
     defaultValues: {
@@ -54,7 +56,7 @@ export const RunCreateForm = ({ designId }: Props) => {
       },
       {
         onSuccess: () => {
-          toast.success("Production started")
+          toast.success(t("partner.designs.runCreate.started"))
           handleSuccess()
         },
         onError: (e) => toast.error(e.message),
@@ -72,10 +74,9 @@ export const RunCreateForm = ({ designId }: Props) => {
         <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto">
           <div className="flex w-full max-w-[640px] flex-col gap-y-8 px-2 py-16">
             <div className="flex flex-col gap-y-1">
-              <Heading>Create design order</Heading>
+              <Heading>{t("partner.designs.runCreate.heading")}</Heading>
               <Text size="small" className="text-ui-fg-subtle">
-                Start production for this design. The design order is approved
-                and ready to work immediately.
+                {t("partner.designs.runCreate.subtitle")}
               </Text>
             </div>
 
@@ -85,7 +86,7 @@ export const RunCreateForm = ({ designId }: Props) => {
                 name="quantity"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>Quantity</Form.Label>
+                    <Form.Label>{t("partner.designs.runCreate.quantity")}</Form.Label>
                     <Form.Control>
                       <Input
                         type="number"
@@ -104,15 +105,19 @@ export const RunCreateForm = ({ designId }: Props) => {
                 name="run_type"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label optional>Run type</Form.Label>
+                    <Form.Label optional>{t("partner.designs.runCreate.runType")}</Form.Label>
                     <Form.Control>
                       <Select value={field.value} onValueChange={field.onChange}>
                         <Select.Trigger>
-                          <Select.Value placeholder="Select" />
+                          <Select.Value placeholder={t("general.select")} />
                         </Select.Trigger>
                         <Select.Content>
-                          <Select.Item value="production">Production</Select.Item>
-                          <Select.Item value="sample">Sample</Select.Item>
+                          <Select.Item value="production">
+                            {t("partner.designs.runCreate.production")}
+                          </Select.Item>
+                          <Select.Item value="sample">
+                            {t("partner.designs.runCreate.sample")}
+                          </Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -126,26 +131,23 @@ export const RunCreateForm = ({ designId }: Props) => {
               name="execution_mode"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>How is it made?</Form.Label>
+                  <Form.Label>{t("partner.designs.runCreate.howMade")}</Form.Label>
                   <Form.Control>
                     <Select value={field.value} onValueChange={field.onChange}>
                       <Select.Trigger>
-                        <Select.Value placeholder="Select" />
+                        <Select.Value placeholder={t("general.select")} />
                       </Select.Trigger>
                       <Select.Content>
                         <Select.Item value="in_house">
-                          In-house (you make it)
+                          {t("partner.designs.runCreate.inHouse")}
                         </Select.Item>
                         <Select.Item value="outsourced">
-                          Outsourced (hand to a sub-partner)
+                          {t("partner.designs.runCreate.outsourced")}
                         </Select.Item>
                       </Select.Content>
                     </Select>
                   </Form.Control>
-                  <Form.Hint>
-                    In-house keeps the work with you; outsourced records the
-                    vendor for cost tracking.
-                  </Form.Hint>
+                  <Form.Hint>{t("partner.designs.runCreate.executionHint")}</Form.Hint>
                 </Form.Item>
               )}
             />
@@ -156,13 +158,11 @@ export const RunCreateForm = ({ designId }: Props) => {
                 name="sub_partner_id"
                 render={({ field }) => (
                   <Form.Item>
-                    <Form.Label>Sub-partner ID</Form.Label>
+                    <Form.Label>{t("partner.designs.runCreate.subPartnerId")}</Form.Label>
                     <Form.Control>
-                      <Input {...field} placeholder="partner_…" />
+                      <Input {...field} placeholder={t("partner.designs.runCreate.subPartnerPlaceholder")} />
                     </Form.Control>
-                    <Form.Hint>
-                      The partner you're handing this production to.
-                    </Form.Hint>
+                    <Form.Hint>{t("partner.designs.runCreate.subPartnerHint")}</Form.Hint>
                     <Form.ErrorMessage />
                   </Form.Item>
                 )}
@@ -174,11 +174,11 @@ export const RunCreateForm = ({ designId }: Props) => {
           <div className="flex items-center justify-end gap-x-2">
             <RouteFocusModal.Close asChild>
               <Button variant="secondary" size="small">
-                Cancel
+                {t("actions.cancel")}
               </Button>
             </RouteFocusModal.Close>
             <Button size="small" type="submit" isLoading={isPending}>
-              Create design order
+              {t("partner.designs.runCreate.createOrder")}
             </Button>
           </div>
         </RouteFocusModal.Footer>


### PR DESCRIPTION
## What

`en.json` had no `designs` namespace and **21 of 23 design screens never called `t()`** — statuses rendered via `String(v).replace(/_/g, " ")`, dates used `toLocaleDateString("en-US", …)`, and a hand-rolled `"5m ago"/"just now"` relative time.

## Changes

- **New `partner.designs.*` namespace** (~230 keys) with real enum label maps: `statusOptions`, `workStatusOptions`, `runStatusOptions`, `priorityOptions`, `typeOptions`, `bucketOptions`, `engagementOptions`, `actionOptions`, `confidenceOptions`, `runTypeOptions`, `unitOptions`, `consumptionTypeOptions`, plus per-screen sections (`list`, `detail`, `media`, `moodboard`, `layers`, `construction`, `ownerActions`, `production`, `cost`, `bom`, `consumption`, `create`, `edit`, `addInventory`, `runCreate`).
- **New `src/lib/design-labels.ts`** — shared pure helpers mapping a raw enum value to its `t()` key, falling back to the space-separated string for unseen values.
- **All 23 design screens wired through `t()`**, dates/relative times through the existing `useDate()` hook. Generic verbs/field labels reuse `actions.*` / `fields.*` / `general.*` / `labels.*`.
- `$schema.json` regenerated; `pnpm i18n:validate en.json` passes.

## Verification

- `pnpm i18n:validate en.json` → matches schema
- `pnpm test` → 146 tests pass
- esbuild transpile of all touched files → clean

## Notes / follow-ups

- **Non-English locales are seeded with English values** — the schema requires every key in every file. Real translations need the DashScope backfill once a key is present:
  ```
  SUBSECTION=designs ./scripts/i18n/backfill-partner.sh
  ```
  (default `--force` mode, so it retranslates the English-identical section).
- Zod error messages in the two `schema.ts` files remain hardcoded — keying them means threading `t` into the schemas, a separate refactor.
- `apps/partner-ui` has no ESLint config, so `pnpm lint` there doesn't actually run.

Closes #2022