### PR TITLE
fix(#2029 item 2): the house store is decided by the link, not a metadata blob

### DIFF
--- a/apps/backend/integration-tests/http/house-store-partner-link.spec.ts
+++ b/apps/backend/integration-tests/http/house-store-partner-link.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * #2029 item 2 — the house store is identified by the partner↔store LINK, not
+ * by `store.metadata.partner_id`.
+ *
+ * 🔑 Why this has to be an integration test. A unit test can assert
+ * `pickHouseStore` prefers a set of ids, but it cannot prove that the link
+ * `create-store-with-defaults` writes is the same relation `readHouseStore`
+ * reads back — `defineLink` registers as an import side effect and a
+ * `query.graph` hop that names the wrong thing returns EMPTY rather than
+ * throwing. An empty result here is indistinguishable from "no store belongs to
+ * a partner", which is exactly the failure mode being designed against, so the
+ * only honest proof is a real store created through the real route.
+ *
+ * The test deliberately STRIPS `metadata.partner_id` after creation. With the
+ * blob gone the old read sees two ownerless stores, calls that ambiguous and
+ * returns null — which silently disables the currency gate. If the link is
+ * genuinely being read, the house store still resolves.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/house-store-partner-link
+ */
+
+import { Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { deletePartnerWorkflow } from "../../src/workflows/partners/delete-partner"
+import {
+  pickHouseStore,
+  readHouseStore,
+} from "../../src/workflows/production-runs/house-store"
+
+const PARTNER_PASSWORD = "supersecret"
+jest.setTimeout(180_000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("house store resolution (#2029 item 2)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("identifies the house store from the link, with the metadata tag removed", async () => {
+      const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+      const email = `house-${unique}@jyt.test`
+
+      await api.post("/auth/partner/emailpass/register", {
+        email,
+        password: PARTNER_PASSWORD,
+      })
+      let login = await api.post("/auth/partner/emailpass", {
+        email,
+        password: PARTNER_PASSWORD,
+      })
+      let headers: Record<string, string> = {
+        Authorization: `Bearer ${login.data.token}`,
+      }
+      const partnerRes = await api.post(
+        "/partners",
+        {
+          name: `House Partner ${unique}`,
+          handle: `housepartner-${unique}`,
+          admin: { email, first_name: "House", last_name: "Partner" },
+        },
+        { headers }
+      )
+      const partnerId = partnerRes.data.partner.id as string
+      login = await api.post("/auth/partner/emailpass", {
+        email,
+        password: PARTNER_PASSWORD,
+      })
+      headers = { Authorization: `Bearer ${login.data.token}` }
+
+      const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+      const currencies = currenciesRes.data.currencies || []
+      const usd = currencies.find((c: any) => c.code?.toLowerCase() === "usd")
+      const currencyCode = String((usd || currencies[0]).code).toLowerCase()
+
+      // The real route: writes the partner↔store link AND the metadata tag.
+      const storeRes = await api.post(
+        "/partners/stores",
+        {
+          store: {
+            name: `House Test Store ${unique}`,
+            supported_currencies: [
+              { currency_code: currencyCode, is_default: true },
+            ],
+          },
+          sales_channel: { name: `HS Channel ${unique}`, description: "Default" },
+          region: {
+            name: "Default Region",
+            currency_code: currencyCode,
+            countries: ["us"],
+          },
+          location: {
+            name: "Warehouse",
+            address: {
+              address_1: "1 Main St",
+              city: "NY",
+              postal_code: "10001",
+              country_code: "US",
+            },
+          },
+        },
+        { headers }
+      )
+      expect(storeRes.status).toBe(201)
+      const partnerStoreId = storeRes.data.store.id as string
+
+      const container = getContainer()
+
+      // Strip the blob. From here the ONLY thing that can identify this store as
+      // a partner's is the link.
+      const storeService: any = container.resolve(Modules.STORE)
+      await storeService.updateStores(partnerStoreId, { metadata: {} })
+
+      // Control: the old, blob-only rule can no longer answer. Two ownerless
+      // stores is ambiguous, and ambiguity turns the currency gate off.
+      const { data: rawStores } = await (
+        container.resolve("query") as any
+      ).graph({ entity: "store", fields: ["id", "metadata"] })
+      const blobOnly = pickHouseStore(rawStores)
+      expect(rawStores.map((s: any) => s.id)).toContain(partnerStoreId)
+      expect(blobOnly).toBeNull()
+
+      // The link still knows.
+      const house = await readHouseStore(container)
+      expect(house).not.toBeNull()
+      expect(house!.id).not.toBe(partnerStoreId)
+
+      /**
+       * Deleting the partner must not make its store look ownerless.
+       *
+       * ⚠️ This assertion is DELIBERATELY weak, and the reason is worth
+       * recording. `resolveBrandLocationId` carries a comment describing a real
+       * prod incident: a soft-deleted partner kept its store and its link, the
+       * store looked ownerless, and the brand-store heuristic threw until
+       * someone cleaned the orphan up by hand. That comment is why
+       * `readHouseStore` reads partners `withDeleted`.
+       *
+       * It could not be reproduced here, and probing said why:
+       *   · `deletePartnerWorkflow` now deletes the partner's STORE as well —
+       *     after the call only the seed store is left.
+       *   · and for the soft-deleted partner row that remains, the `stores.id`
+       *     hop comes back EMPTY even WITH `withDeleted: true`.
+       *
+       * So the orphan this guards against is no longer produced by this path,
+       * and `withDeleted` could not recover the link if it were. Both halves are
+       * asserted below so that if either changes back, this says so.
+       */
+      await deletePartnerWorkflow(container).run({ input: { id: partnerId } })
+
+      const q: any = container.resolve("query")
+      const { data: storesAfter } = await q.graph({
+        entity: "store",
+        fields: ["id"],
+      })
+      expect(storesAfter.map((x: any) => x.id)).not.toContain(partnerStoreId)
+
+      const { data: deletedPartners } = await q.graph({
+        entity: "partners",
+        fields: ["id", "deleted_at", "stores.id"],
+        withDeleted: true,
+      })
+      const gone = deletedPartners.find((x: any) => x.id === partnerId)
+      expect(gone?.deleted_at).toBeTruthy()
+      // The hop is empty even with `withDeleted` — see the note above.
+      expect(gone?.stores ?? []).toEqual([])
+
+      // The house store is still the same store, still unambiguous.
+      const afterDelete = await readHouseStore(container)
+      expect(afterDelete).not.toBeNull()
+      expect(afterDelete!.id).toBe(house!.id)
+    })
+  })
+})

--- a/apps/backend/src/workflows/production-runs/__tests__/house-store.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/house-store.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   currencyIsSellable,
+  partnerStoreIdsFrom,
   pickHouseStore,
   storeCurrencies,
   storeDefaultCurrency,
@@ -21,6 +22,77 @@ const house = (id = "store_house", currencies: string[] = ["eur", "inr"]) => ({
     currency_code: c,
     is_default: i === 0,
   })),
+})
+
+/**
+ * #2029 item 2 — the fact "this store belongs to a partner" has a TYPED home
+ * (`links/partner-stores-link.ts`), and this used to read a metadata blob
+ * instead. The link now decides; metadata survives only as a fallback for the
+ * one case where the link cannot be trusted.
+ */
+describe("pickHouseStore — the link decides", () => {
+  it("uses the link, not the blob, when the link says anything", () => {
+    const stores = [partner("s1", "p1"), house(), partner("s2", "p2")]
+    const ids = new Set(["s1", "s2"])
+    expect(pickHouseStore(stores, ids)?.id).toBe("store_house")
+  })
+
+  /**
+   * The whole point of typing it. A store whose blob was never tagged — an
+   * older tenant, or one created by a path that forgot — is still a partner's
+   * store, and the link knows. Under the old read it looked like a SECOND house
+   * store, which made the answer ambiguous and silently disabled the currency
+   * gate for everyone.
+   */
+  it("catches a partner store whose metadata was never tagged", () => {
+    const untagged = { id: "s_untagged", metadata: null, supported_currencies: [] }
+    const stores = [house(), untagged]
+    // Blob-only: two ownerless stores -> ambiguous -> null -> gate off.
+    expect(pickHouseStore(stores)).toBeNull()
+    // Link: the untagged store has an owner, so the house store is unambiguous.
+    expect(pickHouseStore(stores, new Set(["s_untagged"]))?.id).toBe("store_house")
+  })
+
+  /**
+   * 🔴 The trap `partner-stores-link.ts` documents about itself: an empty link
+   * result is indistinguishable from "no store belongs to a partner". Believing
+   * it would make every store a house store — ambiguous, null, gate off
+   * platform-wide — so an empty set falls back to the blob instead.
+   */
+  it("falls back to metadata when the link says NOTHING", () => {
+    const stores = [partner("s1", "p1"), house(), partner("s2", "p2")]
+    expect(pickHouseStore(stores, new Set())?.id).toBe("store_house")
+    expect(pickHouseStore(stores, null)?.id).toBe("store_house")
+    expect(pickHouseStore(stores, undefined)?.id).toBe("store_house")
+  })
+
+  it("still refuses to guess when the link leaves it ambiguous", () => {
+    const stores = [house("h1"), house("h2"), partner("s1", "p1")]
+    expect(pickHouseStore(stores, new Set(["s1"]))).toBeNull()
+    // And when the link accounts for every store, there is no house at all.
+    expect(pickHouseStore(stores, new Set(["h1", "h2", "s1"]))).toBeNull()
+  })
+})
+
+describe("partnerStoreIdsFrom", () => {
+  it("flattens the partner -> stores hop", () => {
+    expect(
+      partnerStoreIdsFrom([
+        { id: "p1", stores: [{ id: "s1" }, { id: "s2" }] },
+        { id: "p2", stores: [{ id: "s3" }] },
+      ])
+    ).toEqual(new Set(["s1", "s2", "s3"]))
+  })
+
+  it("survives partners with no stores, and junk", () => {
+    expect(partnerStoreIdsFrom([{ id: "p1" }, { id: "p2", stores: [] }])).toEqual(
+      new Set()
+    )
+    expect(partnerStoreIdsFrom(null)).toEqual(new Set())
+    expect(
+      partnerStoreIdsFrom([{ id: "p1", stores: [{ id: "" }, {}, { id: "  " }] }])
+    ).toEqual(new Set())
+  })
 })
 
 /**

--- a/apps/backend/src/workflows/production-runs/house-store.ts
+++ b/apps/backend/src/workflows/production-runs/house-store.ts
@@ -18,12 +18,46 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
  *
  * ── How the house store is identified ─────────────────────────────────────
  *
- * Every partner tenant carries `metadata.partner_id`. The house store is the
- * one that does NOT. On prod that is exactly one row (`JYT Medu Store`) and the
- * other twelve all carry a partner id, so the rule is unambiguous today.
+ * The house store is the one that belongs to no partner. That fact has a TYPED
+ * home — `links/partner-stores-link.ts`, written by `create-store-with-defaults`
+ * at the moment a partner store is made — and this used to ignore it, reading
+ * `store.metadata.partner_id` instead (#2029 item 2). The same route writes both
+ * and its own comment calls the metadata a tag "for auditing", so the blob was
+ * never meant to be the decider; it just happened to be the thing being read.
  *
- * ⚠️ If it is ever ambiguous — no store without a partner id, or more than one —
- * this returns `null` rather than guessing. `stores[0]` is what caused the bug;
+ * The link is now the authority, and `resolveBrandLocationId`
+ * (`consumption-logs/lib/apply-to-inventory.ts`) already answers this exact
+ * question that way in production — which is also the proof the links are
+ * populated: were they not, every partner store would look like a brand store
+ * and that helper would throw on every call. It does not.
+ *
+ * ⚠️ The partner read passes `withDeleted`, mirroring `resolveBrandLocationId`,
+ * whose comment describes a real prod incident: a soft-deleted partner kept its
+ * store and its link, that store looked ownerless, and the brand-store heuristic
+ * threw until the orphan was cleaned up by hand.
+ *
+ * 🔑 That is INHERITED, not verified — and measuring it (see
+ * `house-store-partner-link.spec.ts`) found the premise no longer holds:
+ * `deletePartnerWorkflow` now deletes the partner's STORE too, and for the
+ * soft-deleted partner row that remains the `stores.id` hop comes back EMPTY
+ * even WITH the flag. So the flag cannot in fact recover an orphan's link. It is
+ * kept because it is harmless, costs nothing and matches the sibling helper —
+ * but do not rely on it, and note the same doubt applies to
+ * `resolveBrandLocationId`'s own guard, which is written the same way.
+ *
+ * The real protection is the fallback below: if the link comes back saying
+ * nothing, the blob decides, exactly as it did before this change.
+ *
+ * ⚠️ Metadata survives as a FALLBACK, and only for one specific reason: an empty
+ * link result is indistinguishable from "no store belongs to a partner" — the
+ * exact trap `partner-stores-link.ts` documents about reading links. So when the
+ * link says NOTHING at all, we do not conclude that all 14 stores are ours; we
+ * fall back to the blob, which is what shipped before. When the link says
+ * anything, it wins outright and the blob is not consulted. That is the
+ * #1554/#1557 shape the epic asks every item to land.
+ *
+ * ⚠️ If the answer is ever ambiguous — no candidate, or more than one — this
+ * returns `null` rather than guessing. `stores[0]` is what caused the bug;
  * picking an arbitrary row when the answer is unclear would only re-create it in
  * a new place. Callers must treat null as "unknown", never as a default.
  */
@@ -38,14 +72,46 @@ export type HouseStore = {
 /**
  * PURE: the one store that is not a partner tenant, or null if that is not a
  * single unambiguous row. Exported for tests.
+ *
+ * `partnerStoreIds` is the set of store ids the partner↔store link claims, read
+ * WITH soft-deleted partners included. Pass it and it decides. Omit it, or pass
+ * an empty set, and this falls back to `metadata.partner_id` — see the header:
+ * an empty link result cannot be told apart from a link read that returned
+ * nothing, and treating that as "no store has an owner" would hand back a
+ * platform full of house stores.
  */
-export function pickHouseStore<T extends { metadata?: any }>(
-  stores: T[] | null | undefined
+export function pickHouseStore<T extends { id?: string; metadata?: any }>(
+  stores: T[] | null | undefined,
+  partnerStoreIds?: ReadonlySet<string> | null
 ): T | null {
-  const houses = (stores ?? []).filter(
-    (s) => !String((s as any)?.metadata?.partner_id ?? "").trim()
-  )
+  const byLink = !!partnerStoreIds && partnerStoreIds.size > 0
+  const isPartnerStore = byLink
+    ? (s: T) => partnerStoreIds!.has(String((s as any)?.id ?? ""))
+    : (s: T) => !!String((s as any)?.metadata?.partner_id ?? "").trim()
+
+  const houses = (stores ?? []).filter((s) => !isPartnerStore(s))
   return houses.length === 1 ? houses[0] : null
+}
+
+/**
+ * PURE: every store id the partner↔store link accounts for.
+ *
+ * Shaped for `query.graph({ entity: "partners", fields: ["id", "stores.id"] })`,
+ * which is how `resolveBrandLocationId` reads the same relation.
+ */
+export function partnerStoreIdsFrom(
+  partners: any[] | null | undefined
+): Set<string> {
+  const ids = new Set<string>()
+  for (const p of partners ?? []) {
+    for (const s of (p?.stores ?? []) as any[]) {
+      const id = String(s?.id ?? "").trim()
+      if (id) {
+        ids.add(id)
+      }
+    }
+  }
+  return ids
 }
 
 /** PURE: a store's sellable currency codes, lowercased. Exported for tests. */
@@ -102,11 +168,26 @@ export function currencyIsSellable(
 export async function readHouseStore(container: any): Promise<HouseStore | null> {
   try {
     const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
-    const { data: stores = [] } = await query.graph({
-      entity: "store",
-      fields: ["id", "metadata", "supported_currencies.*"],
-    })
-    const house = pickHouseStore(stores) as any
+    const [{ data: stores = [] }, { data: partners = [] }] = await Promise.all([
+      query.graph({
+        entity: "store",
+        // `metadata` is still fetched: it is the fallback when the link read
+        // comes back empty, and a guard reading a field the query never asked
+        // for is dead code that types perfectly (#1606).
+        fields: ["id", "metadata", "supported_currencies.*"],
+      }),
+      // `withDeleted` mirrors `resolveBrandLocationId`. See the header: the
+      // orphan it was meant to catch is no longer produced by
+      // `deletePartnerWorkflow`, and the hop returns no stores for a
+      // soft-deleted partner anyway — so this is belt-and-braces, not the
+      // guarantee its sibling's comment claims.
+      query.graph({
+        entity: "partners",
+        fields: ["id", "stores.id"],
+        withDeleted: true,
+      }),
+    ])
+    const house = pickHouseStore(stores, partnerStoreIdsFrom(partners)) as any
     if (!house?.id) {
       return null
     }


### PR DESCRIPTION
## The read

`pickHouseStore` answered *"which store is ours"* from `store.metadata.partner_id`. That fact already has a typed home — `links/partner-stores-link.ts`, written by `create-store-with-defaults` the moment a partner store is made.

The same route writes **both**, and its own comment calls the metadata a tag *"for auditing"*. The blob was never meant to be the decider; it was just the thing being read.

## Why it matters

The answer gates money. `approve-run-output.ts:280` mints against the house store, `:420` uses it for `currencyIsSellable`. A wrong *or unknown* house store flips the currency gate on what a design lists for — the #1979 family, where one product came out in EUR at ~110× its cost.

Note the failure is asymmetric: an **ambiguous** answer returns `null`, and `currencyIsSellable` then abstains. So a store the blob failed to tag doesn't cause a loud error — it quietly turns the gate off for everyone.

## The links are populated — and here's the proof

`resolveBrandLocationId` (`consumption-logs/lib/apply-to-inventory.ts`) already answers the identical question via the link, in production, and **throws** when the answer isn't exactly one row. If the links were missing, every partner store would look like a brand store and it would throw on every call. It doesn't.

Prod today: **14 stores, exactly one without a partner tag** (`JYT Medu Store`).

## Metadata stays — as a fallback, for one specific reason

An empty link result is indistinguishable from *"no store belongs to a partner"* — the trap `partner-stores-link.ts` documents **about itself**. Believing it would make all 14 stores house stores → ambiguous → `null` → currency gate off platform-wide.

So: **empty set falls back to the blob; a non-empty set wins outright.** That's the #1554/#1557 shape the epic asks every item to land.

## Mutation-checked

| Mutation | Result |
|---|---|
| ignore the link | 🔴 red — a partner store whose blob was never tagged is caught by the link, not the blob |
| trust an empty link set | 🔴 red — the fallback guard |
| integration test, link ignored | 🔴 red, returns `null` |
| as committed | 🟢 18/18 unit, 1/1 integration |

## 🔑 Why an integration test was necessary

`defineLink` registers as an import side effect, and a `query.graph` hop naming the wrong thing returns **EMPTY rather than throwing** — the very same emptiness that means "no partner owns this". A unit test can only prove `pickHouseStore` prefers a set of ids; it cannot prove the link written on create is the relation read back.

So the test creates a store through the real route, then **strips `metadata.partner_id`**, so nothing but the link can identify it. The control asserts the blob-only rule now returns `null`.

## ⚠️ A correction that came out of writing it

`resolveBrandLocationId` carries a comment about a real prod incident — a soft-deleted partner kept its store and its link, the orphan looked ownerless, the heuristic threw. That's why it reads partners `withDeleted`. I copied the reasoning, then measured it:

- `deletePartnerWorkflow` now deletes the partner's **store** too — after the call only the seed store remains.
- and for the soft-deleted partner row that *does* remain, the `stores.id` hop comes back **empty even with `withDeleted: true`**.

**So the flag cannot recover an orphan's link.** It's kept (harmless, matches the sibling), but the comment now says it's inherited rather than verified, and both facts are asserted so a change back is visible.

**The same doubt applies to `resolveBrandLocationId`'s own guard**, which is written identically — it may be inert. Flagged on the issue rather than changed here, since that helper throws where this one abstains and deserves its own look.

## Verify

```
cd apps/backend
npx jest --config jest.config.js --testPathPattern="production-runs/__tests__/house-store"
pnpm test:integration:http:shared ./integration-tests/http/house-store-partner-link
```

No regression: `admin-run-output-review` 7/7, `production-run-cost-currency` 5/5.

Refs #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp