### PR TITLE
fix(#2029 item 3): a run's reservations have a typed home, not a JSON scan

### DIFF
--- a/apps/backend/integration-tests/http/run-reservation-link.spec.ts
+++ b/apps/backend/integration-tests/http/run-reservation-link.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * #2029 item 3 — the production-run ↔ reservation link, proven against a real
+ * database.
+ *
+ * 🔑 Why integration. `defineLink` registers as an import side effect, and a
+ * `query.graph` hop that names the wrong entry point or the wrong column comes
+ * back EMPTY rather than throwing. Empty is exactly what "this run holds no
+ * reservations" looks like — so a unit test cannot tell a correct link from a
+ * misspelt one, and the fallback would quietly cover for it forever.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/run-reservation-link
+ */
+
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import productionRunReservationsLink from "../../src/links/production-run-reservations-link"
+import {
+  readLinkedReservationIds,
+  selectRunReservations,
+} from "../../src/workflows/production-runs/receive-goods-transfer"
+
+jest.setTimeout(180_000)
+
+/** More than any plausible default page size. */
+const N = 60
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("production run ↔ reservation link (#2029 item 3)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    const seed = async () => {
+      const container = getContainer()
+      const inventory: any = container.resolve(Modules.INVENTORY)
+      const stockLocation: any = container.resolve(Modules.STOCK_LOCATION)
+      const unique = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`
+
+      const loc = await stockLocation.createStockLocations({
+        name: `RL Loc ${unique}`,
+      })
+      const item = await inventory.createInventoryItems({ sku: `RL-${unique}` })
+      await inventory.createInventoryLevels({
+        inventory_item_id: item.id,
+        location_id: loc.id,
+        stocked_quantity: 500,
+      })
+      return { container, inventory, loc, item, unique }
+    }
+
+    it("round-trips: a linked reservation is readable through the entry point", async () => {
+      const { container, inventory, loc, item, unique } = await seed()
+      const runService: any = container.resolve("production_runs")
+      const run = await runService.createProductionRuns({
+        status: "in_progress",
+        quantity: 1,
+        // Required column; contents irrelevant to the link.
+        snapshot: {},
+        captured_at: new Date(),
+      })
+
+      const reservation = await inventory.createReservationItems({
+        inventory_item_id: item.id,
+        location_id: loc.id,
+        quantity: 1,
+        line_item_id: `rl_li_${unique}`,
+        // Deliberately NO metadata: only the link can identify this one, so an
+        // empty read cannot be masked by the blob fallback.
+        metadata: {},
+      })
+
+      const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+      await remoteLink.create({
+        production_runs: { production_runs_id: run.id },
+        [Modules.INVENTORY]: { reservation_item_id: reservation.id },
+      })
+
+      // Read through the REAL function the receipt path uses, not a hand-rolled
+      // copy of its query — a typo in `readLinkedReservationIds` would return
+      // empty and be silently covered by the blob fallback in production, and a
+      // test that re-writes the query here would never see it.
+      const linkedIds = await readLinkedReservationIds(container, run.id)
+
+      // 🔴 The assertion that matters. A wrong entry point or column name gives
+      // an empty set here, indistinguishable from "no reservations".
+      expect([...linkedIds]).toEqual([reservation.id])
+
+      // Sanity: the link's own entry point agrees with what that function read.
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: productionRunReservationsLink.entryPoint,
+        filters: { production_runs_id: run.id },
+        fields: ["reservation_item_id"],
+      })
+      expect(data.map((r: any) => r.reservation_item_id)).toEqual([reservation.id])
+
+      // And the selector picks it although the blob says nothing.
+      const listed = await inventory.listReservationItems({
+        inventory_item_id: item.id,
+        location_id: loc.id,
+      })
+      expect(selectRunReservations(listed, run.id, linkedIds).map((r: any) => r.id)).toEqual([
+        reservation.id,
+      ])
+      // Blob-only would have found nothing — which is the bug the link removes.
+      expect(selectRunReservations(listed, run.id)).toEqual([])
+    })
+
+    /**
+     * `repointReservations` lists reservations by item + location and filters in
+     * app. If the service ever applies a default page size, rows past it are
+     * never seen and their reservations stay behind while the goods move.
+     *
+     * Measured, not assumed: today it returns everything. Kept as a guard so a
+     * Medusa upgrade that introduces a default is caught here rather than by
+     * stranded stock.
+     */
+    it(`lists all ${N} reservations at a location — no silent default page`, async () => {
+      const { inventory, loc, item, unique } = await seed()
+      for (let i = 0; i < N; i++) {
+        await inventory.createReservationItems({
+          inventory_item_id: item.id,
+          location_id: loc.id,
+          quantity: 1,
+          line_item_id: `rl_page_${unique}_${i}`,
+          metadata: { production_run_id: "prod_run_probe" },
+        })
+      }
+      const listed = await inventory.listReservationItems({
+        inventory_item_id: item.id,
+        location_id: loc.id,
+      })
+      expect((listed || []).length).toBe(N)
+      expect(selectRunReservations(listed, "prod_run_probe")).toHaveLength(N)
+    })
+  })
+})

--- a/apps/backend/src/links/production-run-reservations-link.ts
+++ b/apps/backend/src/links/production-run-reservations-link.ts
@@ -1,0 +1,29 @@
+import { defineLink } from "@medusajs/framework/utils"
+import InventoryModule from "@medusajs/medusa/inventory"
+import ProductionRunsModule from "../modules/production_runs"
+
+/**
+ * Link a production run to the reservations it holds (#2029 item 3).
+ *
+ * 🔴 Which reservations belong to a run decides where physical stock ends up.
+ * `repointReservations` (`receive-goods-transfer.ts`) moves them to follow the
+ * goods on a transfer receipt — leave one behind and the origin owes a unit it
+ * no longer has while the destination holds one nothing has claimed.
+ *
+ * That fact lived only in `reservation.metadata.production_run_id`, which is
+ * why the reader had to list every reservation at the location and filter
+ * in-app: JSON cannot be filtered in the query. The reader's own comment said
+ * so. This gives it a typed home so the question can be ASKED instead of
+ * scanned for.
+ *
+ * ⚠️ EXPORTED, and that matters — see `partner-stores-link.ts`. `defineLink`
+ * registers as an import side effect, so a link works without an export, but
+ * nothing can then reach its `entryPoint`, which is the only safe way to READ
+ * it. And a `query.graph` hop that names the wrong thing comes back with no key
+ * rather than an error, so an empty result is indistinguishable from "this run
+ * holds no reservations" — the exact ambiguity this link is meant to remove.
+ */
+export default defineLink(
+  ProductionRunsModule.linkable.productionRuns,
+  { linkable: InventoryModule.linkable.reservationItem, isList: true }
+)

--- a/apps/backend/src/workflows/production-runs/__tests__/select-run-reservations.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/select-run-reservations.unit.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * #2029 item 3 — which reservations follow the goods on a transfer receipt.
+ *
+ * This decides where physical stock ends up. `repointReservations` moves a run's
+ * reservations to the destination; leave one behind and the origin owes a unit
+ * it no longer has while the destination holds one nothing has claimed — the
+ * same negative split, one step later.
+ *
+ * The fact used to live only in `reservation.metadata.production_run_id`, so the
+ * filter had to run in-app over every reservation at the location. It now has a
+ * typed link, and this is the choice between the two.
+ */
+
+import { selectRunReservations } from "../receive-goods-transfer"
+
+const RUN = "prod_run_1"
+
+const res = (id: string, runId?: string | null) => ({
+  id,
+  metadata: runId === undefined ? undefined : { production_run_id: runId },
+})
+
+describe("selectRunReservations", () => {
+  it("uses the link when it says anything", () => {
+    const rows = [res("r1", RUN), res("r2", "other_run"), res("r3", null)]
+    const picked = selectRunReservations(rows, RUN, new Set(["r2", "r3"]))
+    expect(picked.map((r) => r.id)).toEqual(["r2", "r3"])
+  })
+
+  /**
+   * The reason to type it at all: a reservation the link claims but whose blob
+   * was never written — or was written with the wrong run — still belongs to
+   * the run. Under the blob scan it stayed behind when the goods moved.
+   */
+  it("catches a linked reservation the blob does not mention", () => {
+    const rows = [res("r1", RUN), res("r_untagged")]
+    expect(selectRunReservations(rows, RUN).map((r) => r.id)).toEqual(["r1"])
+    expect(
+      selectRunReservations(rows, RUN, new Set(["r1", "r_untagged"])).map((r) => r.id)
+    ).toEqual(["r1", "r_untagged"])
+  })
+
+  /**
+   * 🔴 An empty link result is indistinguishable from "this run holds no
+   * reservations". Believing it would strand every reservation created before
+   * the link existed — which is all of them, today.
+   */
+  it("falls back to the blob when the link says NOTHING", () => {
+    const rows = [res("r1", RUN), res("r2", "other_run")]
+    expect(selectRunReservations(rows, RUN, new Set()).map((r) => r.id)).toEqual(["r1"])
+    expect(selectRunReservations(rows, RUN, null).map((r) => r.id)).toEqual(["r1"])
+    expect(selectRunReservations(rows, RUN).map((r) => r.id)).toEqual(["r1"])
+  })
+
+  /**
+   * ⚠️ The link is intersected with a list already scoped to the ORIGIN
+   * location — it is not used to fetch reservations directly. A reservation the
+   * run holds somewhere else must not be dragged to this destination by a
+   * receipt it had nothing to do with. Expressed here as: nothing outside the
+   * input list can come back, however much the link claims.
+   */
+  it("never returns a reservation that was not in the location's list", () => {
+    const rows = [res("r1", RUN)]
+    const picked = selectRunReservations(rows, RUN, new Set(["r1", "elsewhere_1"]))
+    expect(picked.map((r) => r.id)).toEqual(["r1"])
+  })
+
+  it("survives junk", () => {
+    expect(selectRunReservations(null, RUN)).toEqual([])
+    expect(selectRunReservations(undefined, RUN, new Set(["x"]))).toEqual([])
+    expect(selectRunReservations([], RUN)).toEqual([])
+    // A blob with no run id is not a match for a run whose id is falsy-ish.
+    expect(selectRunReservations([res("r1", "")], RUN)).toEqual([])
+    expect(selectRunReservations([res("r1")], RUN)).toEqual([])
+  })
+})

--- a/apps/backend/src/workflows/production-runs/partner-run-steps.ts
+++ b/apps/backend/src/workflows/production-runs/partner-run-steps.ts
@@ -466,17 +466,49 @@ export const stockFinishedGoodsStep = createStep(
       }
 
       if (lineItemId) {
-        await inventoryService.createReservationItems({
+        const reservation = await inventoryService.createReservationItems({
           inventory_item_id: inventoryItemId,
           location_id: input.location_id,
           quantity: Math.min(input.good_quantity, input.run_quantity || input.good_quantity),
           line_item_id: lineItemId,
           description: `Reserved for order ${input.order_id} from production run ${input.production_run_id}`,
+          // Still written (#2029 item 3). The link below is the typed home and
+          // the reader prefers it, but every reservation created before this
+          // change has only the blob, so it stays the fallback until those are
+          // gone. Dual-write, per the #1554/#1557 model.
           metadata: {
             production_run_id: input.production_run_id,
             order_id: input.order_id,
           },
         })
+
+        /**
+         * The typed home for "this reservation belongs to that run" (#2029
+         * item 3). Without it the receipt path has to list every reservation at
+         * the location and filter on JSON in-app.
+         *
+         * ⚠️ Best-effort on purpose. The reservation is the thing that holds
+         * stock; failing the whole stocking step because a link row could not
+         * be written would leave finished goods unreserved to save an index.
+         * The reader falls back to the blob, which is still written above, so a
+         * missing link costs a scan and nothing else.
+         */
+        const reservationId = (reservation as any)?.id ?? (reservation as any)?.[0]?.id
+        if (reservationId) {
+          try {
+            const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+            await remoteLink.create({
+              [PRODUCTION_RUNS_MODULE]: { production_runs_id: input.production_run_id },
+              [Modules.INVENTORY]: { reservation_item_id: reservationId },
+            })
+          } catch (e: any) {
+            // Local name: `logger` is already imported at module scope here.
+            const log: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+            log?.warn?.(
+              `[stock-finished-goods] reservation ${reservationId} could not be linked to run ${input.production_run_id}: ${e?.message}`
+            )
+          }
+        }
       }
     }
 

--- a/apps/backend/src/workflows/production-runs/receive-goods-transfer.ts
+++ b/apps/backend/src/workflows/production-runs/receive-goods-transfer.ts
@@ -13,6 +13,7 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 
 import { FULLFILLED_ORDERS_MODULE } from "../../modules/fullfilled_orders"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import productionRunReservationsLink from "../../links/production-run-reservations-link"
 
 /**
  * #891 S3 — receiving a goods transfer is what actually moves the inventory.
@@ -253,6 +254,63 @@ async function moveInventory(
  * reconciling a shortfall is a separate decision, and silently shrinking a
  * customer's reservation here would make it invisible.
  */
+/**
+ * PURE: the reservations at this location that belong to this run.
+ *
+ * `linkedIds` is what the typed production-run↔reservation link says. When it
+ * says anything, it decides. When it says NOTHING we fall back to
+ * `metadata.production_run_id` — not for elegance, but because an empty link
+ * result is indistinguishable from "this run holds no reservations", and every
+ * reservation created before #2029 item 3 carries only the blob. Concluding
+ * "none" there would strand exactly the rows this function exists to move.
+ *
+ * Exported for tests: the choice between the two sources is the whole decision,
+ * and it should be assertable without an inventory module behind it.
+ */
+export function selectRunReservations(
+  reservations: any,
+  productionRunId: string,
+  linkedIds?: ReadonlySet<string> | null
+): any[] {
+  const all = Array.isArray(reservations) ? reservations : []
+  if (linkedIds && linkedIds.size > 0) {
+    return all.filter((r: any) => linkedIds.has(String(r?.id ?? "")))
+  }
+  return all.filter(
+    (r: any) => String(r?.metadata?.production_run_id || "") === productionRunId
+  )
+}
+
+/**
+ * The reservation ids the link claims for this run, or an empty set.
+ *
+ * Never throws: a link read that fails must degrade to the blob scan, which is
+ * what shipped before, rather than stranding reservations at the origin.
+ */
+export async function readLinkedReservationIds(
+  container: MedusaContainer,
+  productionRunId: string
+): Promise<Set<string>> {
+  const ids = new Set<string>()
+  try {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: productionRunReservationsLink.entryPoint,
+      filters: { production_runs_id: productionRunId },
+      fields: ["reservation_item_id"],
+    })
+    for (const row of (data || []) as any[]) {
+      const id = String(row?.reservation_item_id ?? "").trim()
+      if (id) {
+        ids.add(id)
+      }
+    }
+  } catch {
+    // Fall through to the blob scan.
+  }
+  return ids
+}
+
 async function repointReservations(
   container: MedusaContainer,
   productionRunId: string,
@@ -268,11 +326,21 @@ async function repointReservations(
     location_id: fromLocationId,
   })
 
-  // `metadata` is JSON, so the run filter happens in-app — the same reason the
-  // partner reservation list filters in-app.
-  const mine = (Array.isArray(reservations) ? reservations : []).filter(
-    (r: any) => String(r?.metadata?.production_run_id || "") === productionRunId
-  )
+  /**
+   * Which of these belong to this run (#2029 item 3).
+   *
+   * The typed link is asked first. It used to be a JSON scan — `metadata` is
+   * not filterable, so every reservation at the location was listed and sifted
+   * in-app, which is what the old comment here admitted.
+   *
+   * ⚠️ The link is read as a SET of ids and intersected with the list above,
+   * rather than used to fetch reservations directly. The list is already scoped
+   * to the origin location, and that scoping is load-bearing: a reservation the
+   * run holds somewhere ELSE must not be dragged to this destination by a
+   * receipt it had nothing to do with.
+   */
+  const linkedIds = await readLinkedReservationIds(container, productionRunId)
+  const mine = selectRunReservations(reservations, productionRunId, linkedIds)
 
   let moved = 0
   for (const reservation of mine) {


### PR DESCRIPTION
## The read

*"Which reservations belong to this run"* lived only in `reservation.metadata.production_run_id`. So `repointReservations` listed every reservation at the origin location and sifted it in-app — and its own comment admitted the filter was in-app **because the fact is JSON**.

This decides where physical stock ends up. On a transfer receipt the goods move and the reservations must follow; leave one behind and the origin owes a unit it no longer has while the destination holds one nothing has claimed.

## The typed home

`InventoryModule.linkable.reservationItem` is linkable, so the fact gets a real one: `links/production-run-reservations-link.ts`. Writer dual-writes (blob + link) per the #1554/#1557 model; reader prefers the link.

## Three decisions worth reviewing — each mutation-checked

**1. The link is intersected with the location-scoped list, not used to fetch reservations.** That scoping is load-bearing: a reservation the run holds *somewhere else* must not be dragged to this destination by a receipt it had nothing to do with. Mutating to a link-driven fetch turns the test red.

**2. An empty link result falls back to the blob.** It's indistinguishable from "this run holds no reservations", and every reservation created before this change carries only the blob. Concluding "none" would strand exactly the rows the function exists to move.

**3. Linking is best-effort at write time.** The reservation is what holds stock; failing the stocking step because a link row couldn't be written would leave finished goods unreserved to save an index. A missing link costs a scan, nothing more.

## 🔑 The integration test reads through the real function

Not a hand-rolled copy of its query — through `readLinkedReservationIds` itself.

`defineLink` registers as an import side effect, and a hop naming the wrong entry point or column returns **EMPTY rather than throwing**. Empty is exactly what "no reservations" looks like, so the blob fallback would cover a typo *forever*. Misspelling the filter column now turns that test red; before, nothing could have caught it.

The reservation in that test is created with **no metadata at all**, so the blob fallback cannot mask a broken link.

## A hypothesis I had, and dropped

I suspected `listReservationItems` applied a default page size — the repo documents that hazard elsewhere (`bulk-resolve-attributions.ts`), and both call sites omit `take`. If true, rows past the page would never be seen and their reservations would strand while the goods moved.

**Measured instead of assumed: there is no default page at 60 rows.** Wrong hypothesis, so no fix — but the measurement is kept as a guard, so a Medusa upgrade that introduces one is caught here rather than by stranded stock.

## Verification

| | |
|---|---|
| Mutation: ignore the link | 🔴 red |
| Mutation: trust an empty link set | 🔴 red |
| Mutation: link-driven fetch (location scope lost) | 🔴 red |
| Mutation: misspell the link column | 🔴 red (integration) |
| production-runs unit suites | 🟢 316/316 across 25 files |
| `production-run-inventory-stocking` | 🟢 2/2 |

## Verify

```
cd apps/backend
npx jest --config jest.config.js --testPathPattern="production-runs/__tests__"
pnpm test:integration:http:shared ./integration-tests/http/run-reservation-link
```

Refs #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp