### PR TITLE
test(#2030): first tests for the planner that minted the phantom run

### DIFF
--- a/apps/backend/src/lib/__tests__/plan-fulfillment-production-runs.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/plan-fulfillment-production-runs.unit.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * `planLineItemRunAction` — what happens to a fulfilled retail line's
+ * production run. It had NO tests, and it is the function that decides whether
+ * a provenance run is minted, an existing one is completed, or nothing happens.
+ *
+ * Written after the 2026-09-13 Sharlho audit (#2030 item 1), where it minted a
+ * duplicate run for a garment that had already been made and recorded. The last
+ * describe block below encodes that shape exactly, so the next reader meets it
+ * as an executable statement rather than as five completed runs and a mystery.
+ */
+
+import {
+  planLineItemRunAction,
+  PRE_PRODUCTION_STATUSES,
+} from "../plan-fulfillment-production-runs"
+
+/**
+ * A `query.graph` stub that answers per entity.
+ *
+ * `production_runs` is the only entity this function's own logic reads; the
+ * rest are the design resolver's, defaulted to empty so a test that does not
+ * care about design attribution says nothing about it.
+ */
+const makeQuery = (byEntity: Record<string, any[]> = {}) => ({
+  graph: jest.fn(async ({ entity }: any) => ({
+    data: byEntity[entity] ?? [],
+  })),
+})
+
+const LINE = "ordli_1"
+const PRODUCT = "prod_1"
+
+describe("planLineItemRunAction", () => {
+  it("does nothing without a product — there is nothing to hang a run off", async () => {
+    const q = makeQuery()
+    expect(
+      await planLineItemRunAction(q, { lineItemId: LINE, productId: null, quantity: 1 })
+    ).toBeNull()
+    // And it does not even look.
+    expect(q.graph).not.toHaveBeenCalled()
+  })
+
+  describe("a run already bound to this line", () => {
+    it.each([...PRE_PRODUCTION_STATUSES])(
+      "completes a %s run — the goods shipped from stock, no shop-floor work happened",
+      async (status) => {
+        const q = makeQuery({
+          production_runs: [{ id: "run_1", status, design_id: "des_1" }],
+        })
+        expect(
+          await planLineItemRunAction(q, {
+            lineItemId: LINE,
+            productId: PRODUCT,
+            quantity: 3,
+          })
+        ).toEqual({
+          action: "complete",
+          line_item_id: LINE,
+          product_id: PRODUCT,
+          production_run_id: "run_1",
+          from_status: status,
+          quantity: 3,
+        })
+      }
+    )
+
+    it.each(["in_progress", "completed", "cancelled"])(
+      "leaves a %s run alone — that is real production",
+      async (status) => {
+        const q = makeQuery({
+          production_runs: [{ id: "run_1", status, design_id: "des_1" }],
+        })
+        expect(
+          await planLineItemRunAction(q, {
+            lineItemId: LINE,
+            productId: PRODUCT,
+            quantity: 1,
+          })
+        ).toBeNull()
+      }
+    )
+
+    /**
+     * #1920's veto is checked AFTER this branch on purpose: completing a run an
+     * admin created explicitly is not auto-production, and a shipped design
+     * order should still close its run. Pinned because the ordering is the
+     * decision, and it reads as an accident.
+     */
+    it("still completes a pre-production run even when auto-produce is vetoed", async () => {
+      const q = makeQuery({
+        production_runs: [{ id: "run_1", status: "draft", design_id: "des_1" }],
+      })
+      const plan = await planLineItemRunAction(q, {
+        lineItemId: LINE,
+        productId: PRODUCT,
+        quantity: 1,
+        metadata: { no_auto_produce: true },
+      })
+      expect(plan).toMatchObject({ action: "complete", production_run_id: "run_1" })
+    })
+  })
+
+  describe("no run bound to this line", () => {
+    it("creates a provenance run", async () => {
+      const q = makeQuery()
+      expect(
+        await planLineItemRunAction(q, {
+          lineItemId: LINE,
+          productId: PRODUCT,
+          variantId: "var_1",
+          quantity: 2,
+        })
+      ).toEqual({
+        action: "create",
+        line_item_id: LINE,
+        product_id: PRODUCT,
+        variant_id: "var_1",
+        design_id: null,
+        is_custom_design: false,
+        quantity: 2,
+      })
+    })
+
+    it("respects the #1920 no-auto-produce veto", async () => {
+      const q = makeQuery()
+      for (const raw of [true, "true"]) {
+        expect(
+          await planLineItemRunAction(q, {
+            lineItemId: LINE,
+            productId: PRODUCT,
+            quantity: 1,
+            metadata: { no_auto_produce: raw },
+          })
+        ).toBeNull()
+      }
+      // Anything else is not a veto — the flag is explicit or absent.
+      expect(
+        await planLineItemRunAction(q, {
+          lineItemId: LINE,
+          productId: PRODUCT,
+          quantity: 1,
+          metadata: { no_auto_produce: false },
+        })
+      ).toMatchObject({ action: "create" })
+    })
+  })
+
+  /**
+   * 🔴 THE SHARLHO SHAPE (#2030 item 1).
+   *
+   * Five runs existed for one design and TWO garments. Four of them did the real
+   * work — and every one carried `order_line_item_id: null`, because a run is
+   * bound to a line only at CREATION and these were created before the line
+   * existed (see `getProductionRunForLineItem`, which measured 0 of 53 children
+   * and 0 of 52 parents carrying one).
+   *
+   * So the lookup below found nothing, and this function did what it is told to:
+   * it planned a CREATE. The result was `prod_run_01M25T03…` — born `completed`,
+   * `produced_quantity: 1`, every lifecycle timestamp null, zero activity rows —
+   * recording a second time the very jacket a `produced 1 → 2` correction had
+   * just accounted for.
+   *
+   * These tests assert the CURRENT behaviour deliberately. The planner is not
+   * wrong; it is blind, and the blindness is the #1918 line-item binding hole.
+   * If binding is ever fixed, the first of these goes red and that is the signal
+   * to delete it — not a regression.
+   */
+  describe("🔴 mints a duplicate when the real runs are not bound to the line", () => {
+    it("creates, although the design already has completed runs", async () => {
+      // Runs for the design exist and are completed — but none is bound to THIS
+      // line, so the lookup (which filters on `order_line_item_id`) sees none.
+      const q = makeQuery({ production_runs: [] })
+
+      const plan = await planLineItemRunAction(q, {
+        lineItemId: "ordli_01M25NAT0B8VQCDSD0XWGFHM0A",
+        productId: "prod_01M25K1PBS7XY53REAW6KVX8AW",
+        variantId: "variant_01M25K1PG06AAVWZFVW67CD051",
+        quantity: 1,
+      })
+
+      expect(plan).toMatchObject({ action: "create", quantity: 1 })
+
+      // And the lookup really did filter on the line item — that filter is the
+      // whole reason it cannot see the runs that did the work.
+      const runQuery = q.graph.mock.calls
+        .map(([arg]: any[]) => arg)
+        .find((a: any) => a.entity === "production_runs")
+      expect(runQuery.filters).toEqual({
+        order_line_item_id: "ordli_01M25NAT0B8VQCDSD0XWGFHM0A",
+      })
+    })
+
+    /**
+     * The one thing that WOULD have stopped it. A run bound to the line is seen
+     * and left alone — so the fix for the phantom is binding, not a new guard
+     * inside the planner.
+     */
+    it("does not create once a completed run IS bound to the line", async () => {
+      const q = makeQuery({
+        production_runs: [
+          { id: "prod_run_real", status: "completed", design_id: "des_1" },
+        ],
+      })
+      expect(
+        await planLineItemRunAction(q, {
+          lineItemId: "ordli_01M25NAT0B8VQCDSD0XWGFHM0A",
+          productId: "prod_01M25K1PBS7XY53REAW6KVX8AW",
+          quantity: 1,
+        })
+      ).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Why this file first

You asked about extending production-run coverage with small unit tests that might spot bugs. I went looking for the gap with the worst consequence rather than the biggest number, and it is this:

**`plan-fulfillment-production-runs.ts` had no test file at all** — and it is the function that decides whether a fulfilled retail line mints a provenance run, completes an existing one, or does nothing. It is also what produced `prod_run_01M25T0300FJDTWYK4JFQ9WYAA` in this morning's Sharlho audit: born `completed`, `produced_quantity: 1`, every lifecycle timestamp null, zero activity rows, recording for a second time the jacket a `produced 1 → 2` correction had just accounted for.

11 tests covering the whole decision table. No production code changes.

## Each one mutation-checked

| Mutation | Result |
|---|---|
| veto moved *before* the existing-run branch | 🔴 red |
| a completed run treated as completable | 🔴 red (4 tests) |
| no-product guard removed | 🔴 red |
| as committed | 🟢 11/11 |

The ordering one is worth calling out: `#1920`'s no-auto-produce veto is checked **after** the existing-run branch on purpose — completing a run an admin created explicitly is not auto-production, and a shipped design order should still close its run. That reads like an accident in the source. Now it is pinned.

## 🔴 The last block encodes the Sharlho shape as CURRENT behaviour

Deliberately, and it is worth reading before approving.

The planner is **not wrong**. It is blind. A run is bound to a line only at creation, and `getProductionRunForLineItem`'s own comment records the measurement: **0 of 53 children and 0 of 52 parents carry an `order_line_item_id`**. So the lookup finds nothing and plans a CREATE, exactly as specified — for a garment four other runs already recorded.

The test also asserts the lookup *really does* filter on `order_line_item_id`, because that filter is the entire reason it cannot see the runs that did the work.

The paired test says what would have stopped it: **a run bound to the line is seen and left alone.** So the fix is binding (#1918), not a new guard inside the planner.

If binding ever lands, the first of those two tests goes red. That is the signal to delete it — not a regression. The comment says so.

## What I'd suggest next, if you want to keep going

The same treatment applied to the other scenarios this session turned up, in rough order of consequence:

1. **Parent/child `produced_quantity` mirroring** — the `1` vs `2` that started the audit. `parent-run-rollup.unit.spec.ts` exists but does not cover a child overstating against its parent.
2. **Supersession × payability** — #2027 shipped the guard; a table-driven test over (parent cancelled? metadata present? child exists?) would pin the four corners rather than the one path.
3. **`order_line_item_id` binding itself** — the root of both the phantom and #2030 item 3's wrong-variant binding.

Happy to take any of these; 1 is the one that decided real money.

Refs #2030, #1918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJmsBT4hUYgStjhhHpitfp